### PR TITLE
Fix feature-branch nodes being wrongly read-only in the UI

### DIFF
--- a/datajunction-ui/src/app/components/NamespaceHeader.jsx
+++ b/datajunction-ui/src/app/components/NamespaceHeader.jsx
@@ -302,7 +302,13 @@ export default function NamespaceHeader({
     !!sources &&
     sources.total_deployments > 0 &&
     sources.primary_source?.type === 'git';
-  const isGitManaged = isGitDeployed || isReadOnly;
+  // A non-default (feature) branch and its sub-namespaces stay editable even
+  // when git-deployed — editing then syncing back is the point. The
+  // git-deployed lock only applies elsewhere (default branch, 1:1 flat, git
+  // root, or an unrecognized-but-git-deployed shape), which `isReadOnly`
+  // already covers for the recognized cases.
+  const isFeatureBranch = onSubBranch && !isDefaultBranch;
+  const isGitManaged = isReadOnly || (isGitDeployed && !isFeatureBranch);
   // Repo config is owned by the git root. On a branch, edits target the root
   // (its config is parentGitConfig — branches sit one level below the root); a
   // flat or plain namespace owns its own config. This keeps flat namespaces

--- a/datajunction-ui/src/app/components/NamespaceHeader.jsx
+++ b/datajunction-ui/src/app/components/NamespaceHeader.jsx
@@ -292,8 +292,7 @@ export default function NamespaceHeader({
   // editable. `rootDefaultBranch` is resolved above from the git root's config
   // (parentGitConfig), which has finished loading by the time the verdict fires
   // below — setGitConfigLoading(false) runs after that fetch.
-  const onSubBranch =
-    !!branchNamespace && branchNamespace !== gitRootNamespace;
+  const onSubBranch = !!branchNamespace && branchNamespace !== gitRootNamespace;
   const isDefaultBranch = onSubBranch
     ? gitConfig?.git_branch === rootDefaultBranch
     : gitShape === 'root' || gitShape === 'flat';

--- a/datajunction-ui/src/app/components/NamespaceHeader.jsx
+++ b/datajunction-ui/src/app/components/NamespaceHeader.jsx
@@ -282,8 +282,22 @@ export default function NamespaceHeader({
 
   // Git state derivations
   const gitShape = detectShape(gitConfig || {});
-  const isReadOnly =
-    !!gitConfig?.git_only || gitShape === 'flat' || gitShape === 'root';
+  // Read-only follows the branch, not the resolved config's flat/root shape.
+  // A sub-namespace inside a feature branch resolves as `flat` (it inherits
+  // github_repo_path + git_branch from the branch but carries no
+  // parent_namespace of its own), so the shape test alone wrongly locks
+  // editable feature branches — the actual regression here. Instead: content
+  // on the repo's default branch, on a git root, or in a 1:1 flat namespace is
+  // read-only; a non-default (feature) branch and its sub-namespaces are
+  // editable. `rootDefaultBranch` is resolved above from the git root's config
+  // (parentGitConfig), which has finished loading by the time the verdict fires
+  // below — setGitConfigLoading(false) runs after that fetch.
+  const onSubBranch =
+    !!branchNamespace && branchNamespace !== gitRootNamespace;
+  const isDefaultBranch = onSubBranch
+    ? gitConfig?.git_branch === rootDefaultBranch
+    : gitShape === 'root' || gitShape === 'flat';
+  const isReadOnly = !!gitConfig?.git_only || isDefaultBranch;
   const isGitDeployed =
     !!sources &&
     sources.total_deployments > 0 &&

--- a/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
+++ b/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
@@ -71,9 +71,7 @@ const renderReadOnlyVerdict = ({ namespace, configByNamespace, sources }) => {
         sources || { total_deployments: 0, primary_source: null },
       ),
     listDeployments: vi.fn().mockResolvedValue([]),
-    getNamespaceGitConfig: vi.fn(ns =>
-      Promise.resolve(configByNamespace[ns]),
-    ),
+    getNamespaceGitConfig: vi.fn(ns => Promise.resolve(configByNamespace[ns])),
     getNamespaceBranches: vi.fn().mockResolvedValue([]),
     getPullRequest: vi.fn().mockResolvedValue(null),
   };
@@ -784,17 +782,19 @@ describe('<NamespaceHeader />', () => {
       },
     ];
 
-    cases.forEach(({ what, namespace, configByNamespace, sources, expectedReadOnly }) => {
-      it(`reports ${what}`, async () => {
-        const { onReadOnlyChange } = renderReadOnlyVerdict({
-          namespace,
-          configByNamespace,
-          sources,
+    cases.forEach(
+      ({ what, namespace, configByNamespace, sources, expectedReadOnly }) => {
+        it(`reports ${what}`, async () => {
+          const { onReadOnlyChange } = renderReadOnlyVerdict({
+            namespace,
+            configByNamespace,
+            sources,
+          });
+          await waitFor(() => expect(onReadOnlyChange).toHaveBeenCalled());
+          expect(onReadOnlyChange).toHaveBeenLastCalledWith(expectedReadOnly);
         });
-        await waitFor(() => expect(onReadOnlyChange).toHaveBeenCalled());
-        expect(onReadOnlyChange).toHaveBeenLastCalledWith(expectedReadOnly);
-      });
-    });
+      },
+    );
   });
 
   it('should open Create Branch modal when button is clicked', async () => {

--- a/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
+++ b/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
@@ -697,6 +697,120 @@ describe('<NamespaceHeader />', () => {
     ).toBeInTheDocument();
   });
 
+  it('reports a sub-namespace of a feature branch as EDITABLE (not read-only)', async () => {
+    // Regression: a sub-namespace inside a feature branch resolves with an
+    // inherited github_repo_path + git_branch but NO parent_namespace of its
+    // own, so detectShape returns 'flat'. The old shape-based check locked it,
+    // bouncing the node editor. It must be editable because 'feature' is not
+    // the repo's default branch ('main').
+    const onReadOnlyChange = vi.fn();
+    const mockDjClient = {
+      namespaceSources: vi.fn().mockResolvedValue({
+        total_deployments: 0,
+        primary_source: null,
+      }),
+      listDeployments: vi.fn().mockResolvedValue([]),
+      getNamespaceGitConfig: vi
+        .fn()
+        // 1) the sub-namespace itself — flat shape (no parent_namespace)
+        .mockResolvedValueOnce({
+          github_repo_path: 'test/repo',
+          git_branch: 'feature',
+          git_path: 'nodes/',
+          git_only: false,
+          parent_namespace: null,
+          branch_namespace: 'test.feature',
+          git_root_namespace: 'test',
+        })
+        // 2) the branch namespace (carries the FK to the git root)
+        .mockResolvedValueOnce({
+          github_repo_path: 'test/repo',
+          git_branch: 'feature',
+          parent_namespace: 'test',
+          branch_namespace: 'test.feature',
+          git_root_namespace: 'test',
+        })
+        // 3) the git root (carries default_branch)
+        .mockResolvedValueOnce({
+          github_repo_path: 'test/repo',
+          git_branch: null,
+          default_branch: 'main',
+          git_root_namespace: 'test',
+        }),
+      getNamespaceBranches: vi.fn().mockResolvedValue([]),
+      getPullRequest: vi.fn().mockResolvedValue(null),
+    };
+
+    render(
+      <MemoryRouter>
+        <DJClientContext.Provider value={{ DataJunctionAPI: mockDjClient }}>
+          <NamespaceHeader
+            namespace="test.feature.metrics"
+            onReadOnlyChange={onReadOnlyChange}
+          />
+        </DJClientContext.Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(onReadOnlyChange).toHaveBeenCalled();
+    });
+    expect(onReadOnlyChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('reports a sub-namespace of the default branch as READ-ONLY', async () => {
+    const onReadOnlyChange = vi.fn();
+    const mockDjClient = {
+      namespaceSources: vi.fn().mockResolvedValue({
+        total_deployments: 0,
+        primary_source: null,
+      }),
+      listDeployments: vi.fn().mockResolvedValue([]),
+      getNamespaceGitConfig: vi
+        .fn()
+        .mockResolvedValueOnce({
+          github_repo_path: 'test/repo',
+          git_branch: 'main',
+          git_path: 'nodes/',
+          git_only: false,
+          parent_namespace: null,
+          branch_namespace: 'test.main',
+          git_root_namespace: 'test',
+        })
+        .mockResolvedValueOnce({
+          github_repo_path: 'test/repo',
+          git_branch: 'main',
+          parent_namespace: 'test',
+          branch_namespace: 'test.main',
+          git_root_namespace: 'test',
+        })
+        .mockResolvedValueOnce({
+          github_repo_path: 'test/repo',
+          git_branch: null,
+          default_branch: 'main',
+          git_root_namespace: 'test',
+        }),
+      getNamespaceBranches: vi.fn().mockResolvedValue([]),
+      getPullRequest: vi.fn().mockResolvedValue(null),
+    };
+
+    render(
+      <MemoryRouter>
+        <DJClientContext.Provider value={{ DataJunctionAPI: mockDjClient }}>
+          <NamespaceHeader
+            namespace="test.main.metrics"
+            onReadOnlyChange={onReadOnlyChange}
+          />
+        </DJClientContext.Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(onReadOnlyChange).toHaveBeenCalled();
+    });
+    expect(onReadOnlyChange).toHaveBeenLastCalledWith(true);
+  });
+
   it('should open Create Branch modal when button is clicked', async () => {
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({

--- a/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
+++ b/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
@@ -59,6 +59,55 @@ const renderHeaderState = ({ namespace, gitConfig, sources }) => {
   );
 };
 
+// Render for the read-only verdict (onReadOnlyChange). `configByNamespace` maps
+// each namespace NamespaceHeader fetches (the target, its branch, the git root)
+// to its git config — namespace-keyed so it's independent of fetch order.
+const renderReadOnlyVerdict = ({ namespace, configByNamespace, sources }) => {
+  const onReadOnlyChange = vi.fn();
+  const mockDjClient = {
+    namespaceSources: vi
+      .fn()
+      .mockResolvedValue(
+        sources || { total_deployments: 0, primary_source: null },
+      ),
+    listDeployments: vi.fn().mockResolvedValue([]),
+    getNamespaceGitConfig: vi.fn(ns =>
+      Promise.resolve(configByNamespace[ns]),
+    ),
+    getNamespaceBranches: vi.fn().mockResolvedValue([]),
+    getPullRequest: vi.fn().mockResolvedValue(null),
+  };
+  render(
+    <MemoryRouter>
+      <DJClientContext.Provider value={{ DataJunctionAPI: mockDjClient }}>
+        <NamespaceHeader
+          namespace={namespace}
+          onReadOnlyChange={onReadOnlyChange}
+        />
+      </DJClientContext.Provider>
+    </MemoryRouter>,
+  );
+  return { onReadOnlyChange };
+};
+
+// Git configs for a repo `test` whose default branch is `main`, a feature
+// branch `feature`, and their sub-namespaces. Reused across the verdict cases.
+const GIT_ROOT = {
+  github_repo_path: 'test/repo',
+  git_branch: null,
+  default_branch: 'main',
+  git_root_namespace: 'test',
+};
+const branchCfg = (branch, ns, extra = {}) => ({
+  github_repo_path: 'test/repo',
+  git_branch: branch,
+  git_only: false,
+  branch_namespace: `test.${branch}`,
+  git_root_namespace: 'test',
+  ...(ns === `test.${branch}` ? { parent_namespace: 'test' } : {}),
+  ...extra,
+});
+
 describe('<NamespaceHeader />', () => {
   it('should render and match the snapshot', async () => {
     const mockDjClient = {
@@ -697,169 +746,55 @@ describe('<NamespaceHeader />', () => {
     ).toBeInTheDocument();
   });
 
-  it('reports a sub-namespace of a feature branch as EDITABLE (not read-only)', async () => {
-    // Regression: a sub-namespace inside a feature branch resolves with an
-    // inherited github_repo_path + git_branch but NO parent_namespace of its
-    // own, so detectShape returns 'flat'. The old shape-based check locked it,
-    // bouncing the node editor. It must be editable because 'feature' is not
-    // the repo's default branch ('main').
-    const onReadOnlyChange = vi.fn();
-    const mockDjClient = {
-      namespaceSources: vi.fn().mockResolvedValue({
-        total_deployments: 0,
-        primary_source: null,
-      }),
-      listDeployments: vi.fn().mockResolvedValue([]),
-      getNamespaceGitConfig: vi
-        .fn()
-        // 1) the sub-namespace itself — flat shape (no parent_namespace)
-        .mockResolvedValueOnce({
-          github_repo_path: 'test/repo',
-          git_branch: 'feature',
-          git_path: 'nodes/',
-          git_only: false,
-          parent_namespace: null,
-          branch_namespace: 'test.feature',
-          git_root_namespace: 'test',
-        })
-        // 2) the branch namespace (carries the FK to the git root)
-        .mockResolvedValueOnce({
-          github_repo_path: 'test/repo',
-          git_branch: 'feature',
-          parent_namespace: 'test',
-          branch_namespace: 'test.feature',
-          git_root_namespace: 'test',
-        })
-        // 3) the git root (carries default_branch)
-        .mockResolvedValueOnce({
-          github_repo_path: 'test/repo',
-          git_branch: null,
-          default_branch: 'main',
-          git_root_namespace: 'test',
-        }),
-      getNamespaceBranches: vi.fn().mockResolvedValue([]),
-      getPullRequest: vi.fn().mockResolvedValue(null),
-    };
+  describe('read-only verdict (onReadOnlyChange)', () => {
+    // Regression: a sub-namespace inside a feature branch resolves as `flat`
+    // (inherited git_branch, no parent_namespace of its own). It must be
+    // editable (its branch isn't the default), while the default branch — and
+    // a git-deployed feature branch stays editable too.
+    const cases = [
+      {
+        what: 'a sub-namespace of a feature branch as EDITABLE',
+        namespace: 'test.feature.metrics',
+        configByNamespace: {
+          'test.feature.metrics': branchCfg('feature', 'test.feature.metrics'),
+          'test.feature': branchCfg('feature', 'test.feature'),
+          test: GIT_ROOT,
+        },
+        expectedReadOnly: false,
+      },
+      {
+        what: 'a sub-namespace of the default branch as READ-ONLY',
+        namespace: 'test.main.metrics',
+        configByNamespace: {
+          'test.main.metrics': branchCfg('main', 'test.main.metrics'),
+          'test.main': branchCfg('main', 'test.main'),
+          test: GIT_ROOT,
+        },
+        expectedReadOnly: true,
+      },
+      {
+        what: 'a git-deployed feature branch as EDITABLE (deploy status does not lock it)',
+        namespace: 'test.feature',
+        configByNamespace: {
+          'test.feature': branchCfg('feature', 'test.feature'),
+          test: GIT_ROOT,
+        },
+        sources: { total_deployments: 2, primary_source: { type: 'git' } },
+        expectedReadOnly: false,
+      },
+    ];
 
-    render(
-      <MemoryRouter>
-        <DJClientContext.Provider value={{ DataJunctionAPI: mockDjClient }}>
-          <NamespaceHeader
-            namespace="test.feature.metrics"
-            onReadOnlyChange={onReadOnlyChange}
-          />
-        </DJClientContext.Provider>
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => {
-      expect(onReadOnlyChange).toHaveBeenCalled();
+    cases.forEach(({ what, namespace, configByNamespace, sources, expectedReadOnly }) => {
+      it(`reports ${what}`, async () => {
+        const { onReadOnlyChange } = renderReadOnlyVerdict({
+          namespace,
+          configByNamespace,
+          sources,
+        });
+        await waitFor(() => expect(onReadOnlyChange).toHaveBeenCalled());
+        expect(onReadOnlyChange).toHaveBeenLastCalledWith(expectedReadOnly);
+      });
     });
-    expect(onReadOnlyChange).toHaveBeenLastCalledWith(false);
-  });
-
-  it('reports a sub-namespace of the default branch as READ-ONLY', async () => {
-    const onReadOnlyChange = vi.fn();
-    const mockDjClient = {
-      namespaceSources: vi.fn().mockResolvedValue({
-        total_deployments: 0,
-        primary_source: null,
-      }),
-      listDeployments: vi.fn().mockResolvedValue([]),
-      getNamespaceGitConfig: vi
-        .fn()
-        .mockResolvedValueOnce({
-          github_repo_path: 'test/repo',
-          git_branch: 'main',
-          git_path: 'nodes/',
-          git_only: false,
-          parent_namespace: null,
-          branch_namespace: 'test.main',
-          git_root_namespace: 'test',
-        })
-        .mockResolvedValueOnce({
-          github_repo_path: 'test/repo',
-          git_branch: 'main',
-          parent_namespace: 'test',
-          branch_namespace: 'test.main',
-          git_root_namespace: 'test',
-        })
-        .mockResolvedValueOnce({
-          github_repo_path: 'test/repo',
-          git_branch: null,
-          default_branch: 'main',
-          git_root_namespace: 'test',
-        }),
-      getNamespaceBranches: vi.fn().mockResolvedValue([]),
-      getPullRequest: vi.fn().mockResolvedValue(null),
-    };
-
-    render(
-      <MemoryRouter>
-        <DJClientContext.Provider value={{ DataJunctionAPI: mockDjClient }}>
-          <NamespaceHeader
-            namespace="test.main.metrics"
-            onReadOnlyChange={onReadOnlyChange}
-          />
-        </DJClientContext.Provider>
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => {
-      expect(onReadOnlyChange).toHaveBeenCalled();
-    });
-    expect(onReadOnlyChange).toHaveBeenLastCalledWith(true);
-  });
-
-  it('reports a git-deployed feature branch as EDITABLE (deploy status does not lock feature branches)', async () => {
-    // A feature branch that has been deployed from git is still editable in the
-    // UI (edit, then sync/PR back). Only the default branch / 1:1 / root are
-    // locked — git-deployment alone must not lock a feature branch.
-    const onReadOnlyChange = vi.fn();
-    const mockDjClient = {
-      namespaceSources: vi.fn().mockResolvedValue({
-        total_deployments: 2,
-        primary_source: { type: 'git' },
-      }),
-      listDeployments: vi.fn().mockResolvedValue([]),
-      getNamespaceGitConfig: vi
-        .fn()
-        // 1) the branch root itself (branch_namespace === namespace, so no
-        //    extra branch fetch — it carries the FK to the git root directly)
-        .mockResolvedValueOnce({
-          github_repo_path: 'test/repo',
-          git_branch: 'feature',
-          git_only: false,
-          parent_namespace: 'test',
-          branch_namespace: 'test.feature',
-          git_root_namespace: 'test',
-        })
-        // 2) the git root (carries default_branch)
-        .mockResolvedValueOnce({
-          github_repo_path: 'test/repo',
-          git_branch: null,
-          default_branch: 'main',
-          git_root_namespace: 'test',
-        }),
-      getNamespaceBranches: vi.fn().mockResolvedValue([]),
-      getPullRequest: vi.fn().mockResolvedValue(null),
-    };
-
-    render(
-      <MemoryRouter>
-        <DJClientContext.Provider value={{ DataJunctionAPI: mockDjClient }}>
-          <NamespaceHeader
-            namespace="test.feature"
-            onReadOnlyChange={onReadOnlyChange}
-          />
-        </DJClientContext.Provider>
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => {
-      expect(onReadOnlyChange).toHaveBeenCalled();
-    });
-    expect(onReadOnlyChange).toHaveBeenLastCalledWith(false);
   });
 
   it('should open Create Branch modal when button is clicked', async () => {

--- a/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
+++ b/datajunction-ui/src/app/components/__tests__/NamespaceHeader.test.jsx
@@ -811,6 +811,57 @@ describe('<NamespaceHeader />', () => {
     expect(onReadOnlyChange).toHaveBeenLastCalledWith(true);
   });
 
+  it('reports a git-deployed feature branch as EDITABLE (deploy status does not lock feature branches)', async () => {
+    // A feature branch that has been deployed from git is still editable in the
+    // UI (edit, then sync/PR back). Only the default branch / 1:1 / root are
+    // locked — git-deployment alone must not lock a feature branch.
+    const onReadOnlyChange = vi.fn();
+    const mockDjClient = {
+      namespaceSources: vi.fn().mockResolvedValue({
+        total_deployments: 2,
+        primary_source: { type: 'git' },
+      }),
+      listDeployments: vi.fn().mockResolvedValue([]),
+      getNamespaceGitConfig: vi
+        .fn()
+        // 1) the branch root itself (branch_namespace === namespace, so no
+        //    extra branch fetch — it carries the FK to the git root directly)
+        .mockResolvedValueOnce({
+          github_repo_path: 'test/repo',
+          git_branch: 'feature',
+          git_only: false,
+          parent_namespace: 'test',
+          branch_namespace: 'test.feature',
+          git_root_namespace: 'test',
+        })
+        // 2) the git root (carries default_branch)
+        .mockResolvedValueOnce({
+          github_repo_path: 'test/repo',
+          git_branch: null,
+          default_branch: 'main',
+          git_root_namespace: 'test',
+        }),
+      getNamespaceBranches: vi.fn().mockResolvedValue([]),
+      getPullRequest: vi.fn().mockResolvedValue(null),
+    };
+
+    render(
+      <MemoryRouter>
+        <DJClientContext.Provider value={{ DataJunctionAPI: mockDjClient }}>
+          <NamespaceHeader
+            namespace="test.feature"
+            onReadOnlyChange={onReadOnlyChange}
+          />
+        </DJClientContext.Provider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(onReadOnlyChange).toHaveBeenCalled();
+    });
+    expect(onReadOnlyChange).toHaveBeenLastCalledWith(false);
+  });
+
   it('should open Create Branch modal when button is clicked', async () => {
     const mockDjClient = {
       namespaceSources: vi.fn().mockResolvedValue({
@@ -1027,13 +1078,15 @@ describe('<NamespaceHeader />', () => {
     // to start a new branch is the branch switcher on the branch page. Creating
     // one must still target the git root (`test`), not the current branch.
     const gitConfigByNamespace = {
-      'test.feature': {
+      // The default-branch page (the git root redirects here). It's read-only,
+      // so it renders the inline "New Branch" toolbar flow this test drives.
+      'test.main': {
         github_repo_path: 'test/repo',
-        git_branch: 'feature',
+        git_branch: 'main',
         git_path: 'nodes/',
         git_only: false,
         parent_namespace: 'test',
-        branch_namespace: 'test.feature',
+        branch_namespace: 'test.main',
         git_root_namespace: 'test',
       },
       test: {
@@ -1076,7 +1129,7 @@ describe('<NamespaceHeader />', () => {
     render(
       <MemoryRouter>
         <DJClientContext.Provider value={{ DataJunctionAPI: mockDjClient }}>
-          <NamespaceHeader namespace="test.feature" />
+          <NamespaceHeader namespace="test.main" />
         </DJClientContext.Provider>
       </MemoryRouter>,
     );
@@ -1089,7 +1142,7 @@ describe('<NamespaceHeader />', () => {
     // Click the branch-crumb button (not the <code> in the git strip).
     fireEvent.click(
       screen
-        .getAllByText('feature')
+        .getAllByText('main')
         .find(el => el.closest('button') && el.tagName !== 'CODE'),
     );
     expect(await screen.findByText('New branch')).toBeInTheDocument();

--- a/datajunction-ui/src/app/pages/NamespacePage/__tests__/index.test.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/__tests__/index.test.jsx
@@ -636,8 +636,10 @@ describe('NamespacePage', () => {
         },
         { timeout: 3000 },
       );
-      // ...where the branch-creation entry point is still present (inside the Git menu).
-      expect(await screen.findByText('+ New Branch')).toBeInTheDocument();
+      // ...where the branch-creation entry point is still present. The default
+      // branch is read-only, so it renders the read-only menu's inline
+      // "New Branch" rather than the editable Git menu's "+ New Branch".
+      expect(await screen.findByText('New Branch')).toBeInTheDocument();
     });
   });
 
@@ -849,7 +851,20 @@ describe('NamespacePage', () => {
         branch_namespace: 'ads.main',
         git_root_namespace: 'ads',
       };
-      mockDjClient.getNamespaceGitConfig.mockResolvedValue(branchConfig);
+      // The git root carries default_branch, so `ads.main` is recognized as the
+      // default branch — read-only. (A git-deployed *feature* branch would be
+      // editable; only the default branch / 1:1 / git root are locked.)
+      const adsRootConfig = {
+        github_repo_path: 'org/repo',
+        git_branch: null,
+        default_branch: 'main',
+        parent_namespace: null,
+        git_only: false,
+        git_root_namespace: 'ads',
+      };
+      mockDjClient.getNamespaceGitConfig.mockImplementation(ns =>
+        Promise.resolve(ns === 'ads' ? adsRootConfig : branchConfig),
+      );
       mockDjClient.namespaceSources.mockResolvedValue({
         total_deployments: 1,
         primary_source: { type: 'git', repository: 'org/repo', branch: 'main' },

--- a/datajunction-ui/src/app/pages/NamespacePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NamespacePage/index.jsx
@@ -25,7 +25,6 @@ import NamespaceNav from './NamespaceNav';
 import { isHiddenNamespace } from './namespaceOptions';
 import { NODE_TYPE_ORDER, NODE_TYPE_COLORS } from './nodeTypes';
 import { getDJUrl } from '../../services/DJService';
-import { detectShape } from '../../components/git/gitShape';
 
 import 'styles/node-list.css';
 import 'styles/sorted-table.css';
@@ -383,12 +382,14 @@ export function NamespacePage() {
     gitConfigLoaded &&
     !!gitConfig?.github_repo_path &&
     gitConfig?.git_root_namespace === namespace;
-  // Edit controls are only shown for editable shapes: plain (not-git) namespaces
-  // and branch namespaces. Flat and root git-backed namespaces are read-only in
-  // the UI — their nodes are managed via git.
-  const gitShape = gitConfigLoaded ? detectShape(gitConfig || {}) : null;
-  const showEditControls =
-    gitConfigLoaded && (gitShape === 'not-git' || gitShape === 'branch');
+  // Node-edit controls follow the single read-only verdict from NamespaceHeader
+  // (`headerReadOnly`), which correctly treats the default branch, 1:1/root git
+  // namespaces, git_only, and git-deployed non-feature content as read-only
+  // while leaving feature branches (and plain namespaces) editable. It's
+  // `undefined` until the header reports, so controls stay hidden until the
+  // verdict is known (no flash). Deriving a second, shape-based verdict here is
+  // what let the default branch (shape 'branch') wrongly show edit controls.
+  const showEditControls = headerReadOnly === false;
   // Sub-namespaces can be created from the rail only for plain (non-git-backed)
   // namespaces; git-backed ones are managed via git, not the UI. The git config
   // endpoint returns an object with null fields (not null) for non-git
@@ -1308,9 +1309,7 @@ export function NamespacePage() {
                 </button>
               </Tooltip>
             )}
-            {showEditControls && headerReadOnly === false && (
-              <AddNodeDropdown namespace={namespace} />
-            )}
+            {showEditControls && <AddNodeDropdown namespace={namespace} />}
           </NamespaceHeader>
 
           <div className="table-responsive">


### PR DESCRIPTION
### Summary

This fixes feature-branch nodes being wrongly kept as read-only in the UI. The Edit button showed, but clicking it bounced straight back to the node page.

`AddEditNodePage` was set up to redirect when `isReadOnly` is true, and `NamespaceHeader` computed that from the git-config *shape*: `isReadOnly = git_only || gitShape === 'flat' || gitShape === 'root'`.

A sub-namespace inside a feature branch resolves with an inherited `github_repo_path` + `git_branch` but no `parent_namespace` of its own, so `detectShape()` returns `'flat'`, which is the same shape as a genuinely read-only 1:1
namespace. Every sub-namespace under a branch was therefore locked, while the branch root (shape `'branch'`) stayed editable. 

The fix is for read-only to follow the branch -- if we're on the repo's default branch, a git root, or a 1:1 flat namespace it should be read-only, but a non-default (feature) branch and its sub-namespaces should be editable. 

### Test Plan

Added regression tests for a feature-branch sub-namespace (editable) and a default-branch sub-namespace (read-only). 

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
