### PR TITLE
Fix cube role playing declarative deploy

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -462,22 +462,6 @@ def dimension_roles_in_order(dimensions: List[str]) -> List[Optional[str]]:
     return roles
 
 
-def cube_element_roles(
-    num_metrics: int,
-    dimension_refs: List[str],
-) -> List[Optional[str]]:
-    """
-    Role suffix (or None) for each cube element, aligned to the cube's
-    node_columns.
-
-    A cube's node_columns are built metrics-first, then dimensions, so the result
-    is `num_metrics` Nones (metrics carry no role) followed by one `[role]`-or-None
-    per dimension reference. Callers index this by each node_column's position.
-    """
-    metric_roles: List[Optional[str]] = [None] * num_metrics
-    return metric_roles + dimension_roles_in_order(dimension_refs)
-
-
 def dedupe_cube_elements(columns: List[Column]) -> List[Column]:
     """
     Dedupe cube element columns by column id.
@@ -500,9 +484,23 @@ async def validate_cube(
     metric_names: List[str],
     dimension_names: List[str],
     require_dimensions: bool = False,
-) -> Tuple[List[Column], List[Node], List[Node], List[Column], Optional[Catalog]]:
+) -> Tuple[
+    List[Column],
+    List[Node],
+    List[Node],
+    List[Column],
+    List[Optional[str]],
+    Optional[Catalog],
+]:
     """
     Validate that a set of metrics and dimensions can be built together.
+
+    Returns (in order): metric columns, metric nodes, dimension nodes, resolved
+    dimension columns, the "[role]"-or-None suffix for each resolved dimension
+    column (kept strictly 1:1 with it), and the shared catalog. The roles are
+    returned alongside their columns rather than recomputed by position because
+    unresolvable references are skipped below — a position-based alignment would
+    drop or mis-bind roles on cubes that reach one dimension via two FK roles.
     """
     metric_nodes = await check_metrics_exist(session, metric_names)
     catalogs = [metric.current.catalog for metric in metric_nodes]
@@ -543,6 +541,7 @@ async def validate_cube(
         for attr in dimension_attributes
     }
     dimensions: List[Column] = []
+    dimension_roles: List[Optional[str]] = []
     for attr in dimension_attributes:
         dimension_node = dimension_mapping[
             f"{attr.node_name}{SEPARATOR}{attr.column_name}"
@@ -556,6 +555,7 @@ async def validate_cube(
 
         if column_name_without_role in columns:  # pragma: no cover
             dimensions.append(columns[column_name_without_role])
+            dimension_roles.append(f"[{attr.role}]" if attr.role else None)
 
     if require_dimensions and not dimensions:
         raise DJInvalidInputException(  # pragma: no cover
@@ -582,7 +582,14 @@ async def validate_cube(
             metric_nodes,
             dimension_names,
         )
-    return metrics, metric_nodes, list(dimension_nodes.values()), dimensions, catalog
+    return (
+        metrics,
+        metric_nodes,
+        list(dimension_nodes.values()),
+        dimensions,
+        dimension_roles,
+        catalog,
+    )
 
 
 async def check_metrics_exist(session: AsyncSession, metrics: list[str]) -> list[Node]:

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -447,21 +447,6 @@ async def resolve_downstream_references(
     return newly_valid_nodes
 
 
-def dimension_roles_in_order(dimensions: List[str]) -> List[Optional[str]]:
-    """
-    The `[role]` suffix (or None) for each dimension reference, in order.
-
-    One entry per reference (keyed by position, not column name), so two roles on
-    the same column are not collapsed. E.g.
-    `["a.x[start]", "a.x[end]", "b.y"]` -> `["[start]", "[end]", None]`.
-    """
-    roles: List[Optional[str]] = []
-    for dim in dimensions:
-        attr = FullColumnName(dim)
-        roles.append(f"[{attr.role}]" if attr.role else None)
-    return roles
-
-
 def dedupe_cube_elements(columns: List[Column]) -> List[Column]:
     """
     Dedupe cube element columns by column id.

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2595,11 +2595,17 @@ class DeploymentOrchestrator:
             column_name_without_role = column_name
             role = None
             match = re.fullmatch(COLUMN_NAME_REGEX, column_name)
-            if match:  # pragma: no cover
+            # no branch: the regex matches every valid column identifier, so the
+            # `not match` path is effectively unreachable — but the body (role
+            # extraction) is exercised, so keep it under line coverage.
+            if match:  # pragma: no branch
                 column_name_without_role = match.groups()[0]
                 role = match.groups()[1]
 
-            if column_name_without_role in columns:  # pragma: no cover
+            # no branch: the resolve-succeeds path is exercised; the silent-skip
+            # (column missing) path is a defensive guard that keeps
+            # cube_dimension_roles 1:1 with cube_dimensions.
+            if column_name_without_role in columns:  # pragma: no branch
                 cube_dimensions.append(columns[column_name_without_role])
                 cube_dimension_roles.append(role)
 

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -14,7 +14,6 @@ from datajunction_server.api.helpers import (
     get_node_namespace,
     COLUMN_NAME_REGEX,
     _resolve_required_dimensions,
-    cube_element_roles,
     dedupe_cube_elements,
 )
 from datajunction_server.construction.build_v2 import FullColumnName
@@ -2570,9 +2569,15 @@ class DeploymentOrchestrator:
                             ),
                         )
 
-        # Get dimensions for this cube from batch-loaded data
+        # Get dimensions for this cube from batch-loaded data.
+        # cube_dimension_roles is kept strictly 1:1 with cube_dimensions so the
+        # "[role]" suffix travels with each resolved column. References that don't
+        # resolve are skipped, so downstream code must NOT recompute roles by
+        # position from rendered_dimensions (that off-by-one drops/mis-binds roles
+        # on cubes that reach one dimension via two FK roles).
         cube_dimension_nodes = []
         cube_dimensions = []
+        cube_dimension_roles = []
         dimension_attributes = [
             dimension_attribute.rsplit(SEPARATOR, 1)
             for dimension_attribute in (cube_spec.rendered_dimensions or [])
@@ -2588,12 +2593,15 @@ class DeploymentOrchestrator:
             # Get the actual column
             columns = {col.name: col for col in dimension_node.current.columns}
             column_name_without_role = column_name
+            role = None
             match = re.fullmatch(COLUMN_NAME_REGEX, column_name)
             if match:  # pragma: no cover
                 column_name_without_role = match.groups()[0]
+                role = match.groups()[1]
 
             if column_name_without_role in columns:  # pragma: no cover
                 cube_dimensions.append(columns[column_name_without_role])
+                cube_dimension_roles.append(role)
 
         invalid_dims = [
             d for d in cube_dimension_nodes if d.current.status == NodeStatus.INVALID
@@ -2624,6 +2632,7 @@ class DeploymentOrchestrator:
                 metric_nodes=cube_metric_nodes,
                 dimension_nodes=cube_dimension_nodes,
                 dimension_columns=cube_dimensions,
+                dimension_column_roles=cube_dimension_roles,
                 catalog=catalog,
             ),
         )
@@ -2659,8 +2668,12 @@ class DeploymentOrchestrator:
             if node.current and node.current.columns
         }
 
+        # cube_dimension_roles stays 1:1 with cube_dimensions (see
+        # _validate_single_cube / CubeValidationData) so the "[role]" suffix
+        # travels with each resolved column instead of being aligned by position.
         cube_dimension_nodes: list[Node] = []
         cube_dimensions: list[Column] = []
+        cube_dimension_roles: list = []
         for dim_attr in cube_spec.rendered_dimensions or []:
             node_name, col_name_raw = dim_attr.rsplit(SEPARATOR, 1)
             node = self.registry.nodes.get(node_name)
@@ -2670,9 +2683,11 @@ class DeploymentOrchestrator:
                 cube_dimension_nodes.append(node)
             match = re.fullmatch(COLUMN_NAME_REGEX, col_name_raw)
             col_name = match.groups()[0] if match else col_name_raw
+            role = match.groups()[1] if match else None
             for col in node.current.columns or []:  # pragma: no branch
                 if col.name == col_name:  # pragma: no branch
                     cube_dimensions.append(col)
+                    cube_dimension_roles.append(role)
                     col_to_node[col] = node
                     break
 
@@ -2690,6 +2705,7 @@ class DeploymentOrchestrator:
                 metric_nodes=cube_metric_nodes,
                 dimension_nodes=cube_dimension_nodes,
                 dimension_columns=cube_dimensions,
+                dimension_column_roles=cube_dimension_roles,
                 catalog=catalog,
                 col_to_node=col_to_node,
             ),
@@ -2838,12 +2854,27 @@ class DeploymentOrchestrator:
         node_columns = []
 
         # Role suffix per cube element, aligned to metric_columns + dimension_columns.
-        element_roles = cube_element_roles(
-            len(validation_data.metric_columns),
-            cube_spec.rendered_dimensions or [],
-        )
+        # Metrics never carry a role; each resolved dimension column carries the
+        # "[role]" it was referenced under, which was captured 1:1 during validation
+        # (dimension_column_roles). This must NOT be recomputed by position from
+        # rendered_dimensions: unresolvable references are skipped during
+        # validation, so a position-based alignment goes off-by-one and drops the
+        # role on cubes that reach one dimension via two FK roles.
+        dimension_roles = list(validation_data.dimension_column_roles)
+        # Guard against legacy/partial validation data (e.g. built directly without
+        # roles): pad so a missing role never IndexErrors the deploy — an unpaired
+        # dimension column is simply treated as unroled. Production validation
+        # paths always populate this 1:1 with dimension_columns.
+        if len(dimension_roles) < len(validation_data.dimension_columns):
+            dimension_roles += [None] * (
+                len(validation_data.dimension_columns) - len(dimension_roles)
+            )
+        element_roles = [None] * len(validation_data.metric_columns) + dimension_roles
 
-        # Build a mapping from column name to column spec for partition lookups
+        # Build a mapping from column spec name to column spec for partition
+        # lookups. col_spec.name keeps the "[role]" suffix (e.g.
+        # "...dt_date_d.dateint[epoch_date]"), so the lookup below must key by the
+        # same role-qualified identity.
         column_spec_map = {}
         if cube_spec.columns:
             for col_spec in cube_spec.rendered_columns:
@@ -2881,9 +2912,14 @@ class DeploymentOrchestrator:
             if element_roles[idx]:
                 node_column.dimension_column = element_roles[idx]
 
-            # Apply partition from column spec if specified
-            if full_element_name in column_spec_map:
-                col_spec = column_spec_map[full_element_name]
+            # Apply partition from column spec if specified. Key by the
+            # role-qualified identity (bare element name + "[role]") — the same
+            # identity DJ uses for cube elements — so a partition declared on a
+            # role-played column (e.g. "...dateint[epoch_date]") lands on the right
+            # role instead of being silently dropped.
+            element_key = full_element_name + (node_column.dimension_column or "")
+            if element_key in column_spec_map:
+                col_spec = column_spec_map[element_key]
                 if col_spec.partition:  # pragma: no branch
                     node_column.partition = Partition(
                         type_=col_spec.partition.type,

--- a/datajunction-server/datajunction_server/internal/deployment/validation.py
+++ b/datajunction-server/datajunction_server/internal/deployment/validation.py
@@ -77,6 +77,14 @@ class CubeValidationData:
     dimension_nodes: list
     dimension_columns: list
     catalog: Optional[object]
+    # Role suffix ("[role]" or None) for each entry in dimension_columns, kept
+    # strictly 1:1 with it. The role must travel WITH its resolved column: a cube
+    # can reference the same dimension column under two FK roles (e.g.
+    # dt_date_d.dateint[epoch_date] and dt_date_d.dateint[region_date]), and
+    # unresolvable references are skipped during validation, so aligning roles by
+    # position against the original dimension list goes off-by-one and drops or
+    # mis-binds them.
+    dimension_column_roles: list = field(default_factory=list)
     # Optional: Column → Node mapping. When provided, _create_cube_node_revision...
     # uses it instead of session.refresh(col, ["node_revision"]) to get the owning
     # node. Populated by the copy fast-path to avoid per-column DB round-trips.

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -21,7 +21,6 @@ from datajunction_server.internal.caching.interface import Cache
 from datajunction_server.models.deployment import DeploymentResult
 from datajunction_server.models.query import QueryCreate
 from datajunction_server.api.helpers import (
-    cube_element_roles,
     dedupe_cube_elements,
     get_attribute_type,
     get_catalog_by_name,
@@ -644,6 +643,7 @@ async def create_cube_node_revision(
         metric_nodes,
         dimension_nodes,
         dimension_columns,
+        dimension_roles,
         catalog,
     ) = await validate_cube(
         session,
@@ -664,7 +664,10 @@ async def create_cube_node_revision(
     # for marking partition columns when the cube gets materialized.
     node_columns = []
     # Role suffix per cube element, aligned to metric_columns + dimension_columns.
-    element_roles = cube_element_roles(len(metric_columns), data.dimensions or [])
+    # Metrics never carry a role; validate_cube returns dimension_roles 1:1 with
+    # the resolved dimension_columns, so a silently-skipped (unresolvable)
+    # dimension reference can't shift roles onto the wrong column.
+    element_roles = [None] * len(metric_columns) + dimension_roles
     for idx, col in enumerate(metric_columns + dimension_columns):
         await session.refresh(col, ["node_revision"])
         referenced_node = col.node_revision

--- a/datajunction-server/datajunction_server/internal/sql.py
+++ b/datajunction-server/datajunction_server/internal/sql.py
@@ -305,7 +305,7 @@ async def build_sql_for_multiple_metrics(
     if not orderby:
         orderby = []
 
-    metric_columns, metric_nodes, _, dimension_columns, _ = await validate_cube(
+    metric_columns, metric_nodes, _, dimension_columns, _, _ = await validate_cube(
         session,
         metrics,
         dimensions,

--- a/datajunction-server/tests/api/helpers_test.py
+++ b/datajunction-server/tests/api/helpers_test.py
@@ -13,7 +13,6 @@ from sqlalchemy.orm import selectinload
 from datajunction_server.api import helpers
 from datajunction_server.api.helpers import (
     dedupe_cube_elements,
-    dimension_roles_in_order,
     find_required_dimensions,
 )
 from datajunction_server.database.column import Column
@@ -24,18 +23,6 @@ from datajunction_server.errors import DJDoesNotExistException, DJException
 from datajunction_server.internal.nodes import propagate_valid_status
 from datajunction_server.models.node import NodeStatus
 from datajunction_server.sql.parsing.types import IntegerType
-
-
-def test_dimension_roles_in_order():
-    """One [role] suffix (or None) per reference — two roles on the same column
-    are NOT collapsed."""
-    assert dimension_roles_in_order(
-        [
-            "v3.location.country[from]",
-            "v3.location.country[to]",
-            "v3.product.category",
-        ],
-    ) == ["[from]", "[to]", None]
 
 
 def test_dedupe_cube_elements_same_object():

--- a/datajunction-server/tests/api/helpers_test.py
+++ b/datajunction-server/tests/api/helpers_test.py
@@ -197,6 +197,7 @@ async def test_build_sql_for_multiple_metrics(
         mock_metric_nodes,
         _,
         dimension_columns,
+        [None, None],
         _,
     )
     mock_session = AsyncMock()

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -1378,6 +1378,168 @@ class TestCubeDeployment:
         await session.refresh(revision_2, ["columns"])
         assert len(revision_2.columns) == 2
 
+    @pytest.mark.asyncio
+    async def test_cube_role_played_dimension_roles_and_partition(
+        self,
+        session,
+        current_user,
+    ):
+        """
+        Regression (AIE-3105): a cube that reaches one date dimension via two FK
+        roles produces two cube columns with the same bare name
+        (``test.date.dateint``) distinguished only by ``dimension_column``
+        (``[epoch_date]`` vs ``[region_date]``).
+
+        The declarative deploy path must (1) preserve BOTH roles and (2) apply a
+        YAML-declared partition to the role it was declared on
+        (``...dateint[epoch_date]``) and to that role only. Previously the role
+        was dropped (positional off-by-one against the resolved-dimension list)
+        and the partition was keyed by the bare element name, so it never matched
+        a role-qualified column and was silently dropped.
+        """
+        catalog = Catalog(name="test_catalog")
+        session.add(catalog)
+
+        date_node = Node(
+            name="test.date",
+            type="dimension",
+            current_version="v1.0",
+            created_by_id=current_user.id,
+        )
+        revenue_node = Node(
+            name="test.revenue",
+            type="metric",
+            current_version="v1.0",
+            created_by_id=current_user.id,
+        )
+        session.add_all([date_node, revenue_node])
+
+        date_revision = NodeRevision(
+            name="test.date",
+            display_name="Date",
+            type="dimension",
+            node=date_node,
+            version="v1.0",
+            query="SELECT dateint FROM dates",
+            created_by_id=current_user.id,
+        )
+        revenue_revision = NodeRevision(
+            name="test.revenue",
+            display_name="Revenue",
+            type="metric",
+            node=revenue_node,
+            version="v1.0",
+            query="SELECT SUM(amount) FROM sales",
+            created_by_id=current_user.id,
+        )
+        session.add_all([date_revision, revenue_revision])
+        await session.commit()
+
+        date_column = Column(
+            name="dateint",
+            type="int",
+            node_revision_id=date_revision.id,
+            node_revision=date_revision,
+            attributes=[],
+        )
+        revenue_column = Column(
+            name="revenue",
+            type="bigint",
+            node_revision_id=revenue_revision.id,
+            node_revision=revenue_revision,
+            attributes=[],
+        )
+        session.add_all([date_column, revenue_column])
+        await session.commit()
+
+        await session.refresh(date_column, ["node_revision", "attributes"])
+        await session.refresh(revenue_column, ["node_revision", "attributes"])
+
+        # The same date column resolved under two roles -> two dimension columns,
+        # with the roles captured 1:1 alongside them (as the validation path does).
+        validation_data = CubeValidationData(
+            metric_columns=[revenue_column],
+            dimension_columns=[date_column, date_column],
+            dimension_column_roles=["[epoch_date]", "[region_date]"],
+            metric_nodes=[revenue_node],
+            dimension_nodes=[date_node],
+            catalog=catalog,
+        )
+
+        cube_node = Node(
+            name="test.role_cube",
+            type="cube",
+            current_version="v1.0",
+            created_by_id=current_user.id,
+        )
+        session.add(cube_node)
+        await session.commit()
+
+        # Partition declared on the epoch_date role only.
+        cube_spec = CubeSpec(
+            name="test.role_cube",
+            node_type="cube",
+            metrics=["test.revenue"],
+            dimensions=[
+                "test.date.dateint[epoch_date]",
+                "test.date.dateint[region_date]",
+            ],
+            namespace="test",
+            columns=[
+                ColumnSpec(
+                    name="test.date.dateint[epoch_date]",
+                    partition=PartitionSpec(
+                        type=PartitionType.TEMPORAL,
+                        granularity=Granularity.DAY,
+                        format="yyyyMMdd",
+                    ),
+                ),
+            ],
+        )
+
+        context = DeploymentContext(
+            current_user=current_user,
+            request=Mock(),
+            query_service_client=Mock(),
+            background_tasks=Mock(),
+            cache=Mock(),
+        )
+        orchestrator = DeploymentOrchestrator(
+            deployment_id="test-deployment",
+            deployment_spec=DeploymentSpec(namespace="test", nodes=[]),
+            session=session,
+            context=context,
+        )
+
+        node_revision = (
+            await orchestrator._create_cube_node_revision_from_validation_data(
+                cube_spec=cube_spec,
+                validation_data=validation_data,
+                new_node=cube_node,
+            )
+        )
+        session.add(node_revision)
+        await session.commit()
+        await session.refresh(node_revision, ["columns"])
+
+        # Bug 2: both roles preserved (neither dropped nor mis-bound).
+        date_cols = [
+            col for col in node_revision.columns if col.name == "test.date.dateint"
+        ]
+        assert len(date_cols) == 2
+        by_role = {col.dimension_column: col for col in date_cols}
+        assert set(by_role) == {"[epoch_date]", "[region_date]"}
+
+        # Bug 1: the YAML partition lands on the epoch_date role, and ONLY there.
+        await session.refresh(by_role["[epoch_date]"], ["partition"])
+        await session.refresh(by_role["[region_date]"], ["partition"])
+        epoch_partition = by_role["[epoch_date]"].partition
+        assert epoch_partition is not None
+        assert epoch_partition.type_ == PartitionType.TEMPORAL
+        assert epoch_partition.granularity == Granularity.DAY
+        assert epoch_partition.format == "yyyyMMdd"
+        assert by_role["[region_date]"].partition is None
+
 
 @pytest.mark.asyncio
 async def test_auto_register_sources_disabled(


### PR DESCRIPTION
### Summary

A cube that reaches one dimension through two FK roles  produces two cube columns with the same bare name (no role identifier), distinguished only by dimension_column ([epoch_date] vs [region_date]). The declarative deploy path mishandled these in two ways, and the imperative cube-creation path had the same latent bug. Both stem from one root cause: cube columns were addressed by bare name / list position instead of by their role-qualified identity (name + dimension_column).

### The bugs

Declarative deploy (internal/deployment/orchestrator.py)
1. Roles dropped / mis-bound (non-deterministic). Element roles were recomputed positionally from rendered_dimensions, then indexed against the resolved-dimension list. That list silently skips references that don't resolve, so a single skip shifts every subsequent role off by one — dropping or mis-binding the dimension_column.
2. YAML partition never applied. The per-column partition map is keyed by the role-qualified spec name (…dateint[epoch_date]) but was looked up by the bare element name, so it never matched a role-played column and the partition was silently dropped.

Imperative creation (create_cube_node_revision) — same positional-role scheme via cube_element_roles(...) against validate_cube's resolved dimensions. Correct today only because its callers pass fully-resolvable dimensions; hardened defensively.

### The fix

Resolve and apply cube columns by their role-qualified identity, never by bare name or list position:

- CubeValidationData gains dimension_column_roles, kept strictly 1:1 with dimension_columns so each role travels with its resolved column. Populated in _validate_single_cube and the copy fast-path _build_copy_cube_validation_data.
- _create_cube_node_revision_from_validation_data builds element_roles from that 1:1 list (with a defensive pad for legacy/partial validation data) and keys the partition lookup by full_element_name + (dimension_column or "").
- validate_cube now returns dimension_roles 1:1 with resolved dims; create_cube_node_revision consumes it instead of cube_element_roles. The now-dead cube_element_roles helper is removed; the remaining caller (internal/sql.py) and the test mock are updated for the new return arity.

### Testing

- New regression test (test_cube_role_played_dimension_roles_and_partition): deploys a cube whose date dim is reached via [epoch_date] + [region_date] with a partition on [epoch_date] — asserts both roles survive and the partition lands on [epoch_date] only. Fails on the pre-fix code, passes now.
- Imperative two-role path is covered by existing TestCubeRoleQualifiedDimensions.
