### PR TITLE
Resolve reference (denormalized) dimensions without a join

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -283,18 +283,8 @@ def _resolve_filter_only_dim(
     parent_cols = {col.name for col in parent_node.current.columns}
     target_fqn = f"{dim_ref.node_name}{SEPARATOR}{dim_ref.column_name}"
 
-    # Cheap parent-side check: column annotation pointing at this dim col.
-    # In practice the simple-dimension-link API also creates a dim link, so
-    # `find_join_path` resolves first and this branch only fires when the
-    # annotation exists without a corresponding link (e.g., partial state
-    # from a non-API deserialize).
-    for col in parent_node.current.columns:
-        if col.dimension is None or col.dimension.name != dim_ref.node_name:
-            continue
-        if (
-            col.dimension_column or col.name
-        ) == dim_ref.column_name:  # pragma: no cover
-            return col.name
+    # (Reference/denormalized dimensions are resolved earlier in resolve_dimensions
+    # via _local_reference_dimension_column, so they never reach this function.)
 
     # BFS up parent_map in sorted order so resolution is deterministic across
     # processes (never set/hash order). Passthrough is only valid for DIRECT
@@ -556,6 +546,39 @@ def _rewrite_filter_col_refs(
     return rewritten
 
 
+def _local_reference_dimension_column(
+    ctx: BuildContext,
+    parent_node: Node,
+    dim_ref: DimensionRef,
+) -> Optional[str]:
+    """
+    Return the parent column that supplies dim_ref via a column-level dimension
+    annotation (a reference / denormalized dimension), or None.
+
+    A column tagged with a dimension node carries that dimension's attribute
+    directly on the parent, so it needs no join. This mirrors the column-to-dimension
+    edge that commonDimensions traverses, so discovery and the builder agree.
+    Resolution uses the reliably-loaded dimension_id / dimension_column scalars plus
+    the ctx id-to-name map, since the Column.dimension relationship doesn't reliably
+    eager-load in this build.
+    """
+    from datajunction_server.construction.build_v3.cte import strip_role_suffix
+
+    if not parent_node.current or not parent_node.current.columns:  # pragma: no cover
+        return None
+    for col in parent_node.current.columns:
+        if col.dimension_id is None:
+            continue
+        if ctx.reference_dimension_names.get(col.dimension_id) != dim_ref.node_name:
+            continue
+        # dimension_column may carry a "[role]" suffix; fall back to the column's
+        # own name when unset.
+        target = strip_role_suffix(col.dimension_column or col.name)
+        if target == dim_ref.column_name:
+            return col.name
+    return None
+
+
 def resolve_dimensions(
     ctx: BuildContext,
     parent_node: Node,
@@ -629,6 +652,24 @@ def resolve_dimensions(
 
             # Validate that we found a join path
             if not join_path:
+                # Reference (denormalized) dimension: the parent may carry the
+                # attribute directly on a column tagged with the dimension node, so
+                # no join is needed. commonDimensions advertises these, so the
+                # builder must serve them too.
+                ref_col = _local_reference_dimension_column(ctx, parent_node, dim_ref)
+                if ref_col is not None:
+                    resolved.append(
+                        ResolvedDimension(
+                            original_ref=dim,
+                            node_name=parent_node.name,
+                            column_name=ref_col,
+                            role=dim_ref.role,
+                            join_path=None,
+                            is_local=True,
+                        ),
+                    )
+                    continue
+
                 # Upstream filter-only resolution: the fact may not link to
                 # this dim, but an upstream of the fact might — and if the
                 # upstream's FK is preserved on the parent's projection, the

--- a/datajunction-server/datajunction_server/construction/build_v3/loaders.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/loaders.py
@@ -93,9 +93,15 @@ async def batch_load_nodes_with_dependencies(
                 # mapped and downstream code (get_native_grain) reads
                 # col.has_primary_key_attribute().
                 selectinload(NodeRevision.columns).options(
+                    # dimension_id / dimension_column carry column-level reference
+                    # (denormalized) dimension links; load_nodes() maps the ids to
+                    # names so resolve_dimensions can serve them from the local
+                    # column without a node join, matching commonDimensions.
                     load_only(
                         Column.name,
                         Column.type,
+                        Column.dimension_id,
+                        Column.dimension_column,
                     ),
                 ),
                 # NOTE: don't noload Catalog.engines — see load_dimension_links_batch.
@@ -474,6 +480,25 @@ async def load_nodes(ctx: BuildContext) -> None:
     # Cache all loaded nodes
     for node in nodes:
         ctx.nodes[node.name] = node
+
+    # Map column-level reference-dimension ids -> dimension node names. The
+    # Column.dimension relationship doesn't reliably eager-load in this build,
+    # so resolve_dimensions uses this map (plus the reliably-loaded
+    # dimension_id/dimension_column scalars) to serve reference dimensions.
+    ref_dim_ids = {
+        col.dimension_id
+        for node in ctx.nodes.values()
+        if node.current
+        for col in node.current.columns
+        if col.dimension_id is not None
+    }
+    if ref_dim_ids:
+        rows = (
+            await ctx.session.execute(
+                select(Node.id, Node.name).where(Node.id.in_(ref_dim_ids)),
+            )
+        ).all()
+        ctx.reference_dimension_names = {row[0]: row[1] for row in rows}
 
     # Collect required dimensions from metrics and add to context
     # Required dimensions are stored as Column objects, so they don't have role info.

--- a/datajunction-server/datajunction_server/construction/build_v3/types.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/types.py
@@ -73,6 +73,12 @@ class BuildContext:
     # needing to eager-load the parents relationship
     parent_map: dict[str, list[str]] = field(default_factory=dict)
 
+    # Reference (denormalized) dimensions: column.dimension_id -> dimension node
+    # name. Populated by load_nodes() so resolve_dimensions can serve a column
+    # tagged with a dimension node from the local column, without depending on the
+    # Column.dimension relationship (which doesn't reliably eager-load here).
+    reference_dimension_names: dict[int, str] = field(default_factory=dict)
+
     # Table alias counter for generating unique aliases
     _table_alias_counter: int = field(default=0)
 

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -21,6 +21,7 @@ from datajunction_server.construction.build_v3.decomposition import (
     get_native_grain,
 )
 from datajunction_server.construction.build_v3.dimensions import (
+    _local_reference_dimension_column,
     parse_dimension_ref,
 )
 from datajunction_server.construction.build_v3.filters import (
@@ -34,6 +35,8 @@ from datajunction_server.construction.build_v3.measures import (
     collect_cte_nodes_and_needed_columns,
 )
 from datajunction_server.construction.build_v3.types import (
+    BuildContext,
+    DimensionRef,
     JoinPath,
     ResolvedDimension,
 )
@@ -104,6 +107,106 @@ class TestDimensionRefParsing:
         with an empty ``node_name`` that would silently match the wrong node."""
         with pytest.raises(DJInvalidInputException, match="not fully qualified"):
             parse_dimension_ref("status")
+
+
+def _make_ref_column(
+    name: str,
+    dimension_id: int | None,
+    dimension_column: str | None,
+) -> MagicMock:
+    """Build a Column mock exposing the reference-dimension scalars."""
+    col = MagicMock()
+    col.name = name
+    col.dimension_id = dimension_id
+    col.dimension_column = dimension_column
+    return col
+
+
+def _make_ref_ctx(
+    columns: list[MagicMock],
+    reference_dimension_names: dict[int, str],
+) -> tuple[MagicMock, MagicMock]:
+    """Build a (ctx, parent_node) pair for reference-dimension resolution."""
+    rev = MagicMock()
+    rev.columns = columns
+    parent_node = MagicMock()
+    parent_node.name = "v3.fact"
+    parent_node.current = rev
+
+    ctx = MagicMock(spec=BuildContext)
+    ctx.reference_dimension_names = reference_dimension_names
+    return ctx, parent_node
+
+
+class TestLocalReferenceDimensionColumn:
+    """Branch coverage for ``_local_reference_dimension_column``."""
+
+    def test_resolves_from_tagged_column(self):
+        """A column tagged with the requested dim node + attribute resolves locally."""
+        col = _make_ref_column(
+            "page_type",
+            dimension_id=7,
+            dimension_column="plan_label",
+        )
+        ctx, parent_node = _make_ref_ctx([col], {7: "v3.plan_dim"})
+        dim_ref = DimensionRef(node_name="v3.plan_dim", column_name="plan_label")
+        assert (
+            _local_reference_dimension_column(ctx, parent_node, dim_ref) == "page_type"
+        )
+
+    def test_falls_back_to_column_name_when_dimension_column_unset(self):
+        """When ``dimension_column`` is None, the column's own name is the target."""
+        col = _make_ref_column("plan_label", dimension_id=7, dimension_column=None)
+        ctx, parent_node = _make_ref_ctx([col], {7: "v3.plan_dim"})
+        dim_ref = DimensionRef(node_name="v3.plan_dim", column_name="plan_label")
+        assert (
+            _local_reference_dimension_column(ctx, parent_node, dim_ref) == "plan_label"
+        )
+
+    def test_strips_role_suffix_from_dimension_column(self):
+        """A ``[role]`` suffix on ``dimension_column`` is stripped before matching."""
+        col = _make_ref_column(
+            "page_type",
+            dimension_id=7,
+            dimension_column="plan_label[order]",
+        )
+        ctx, parent_node = _make_ref_ctx([col], {7: "v3.plan_dim"})
+        dim_ref = DimensionRef(node_name="v3.plan_dim", column_name="plan_label")
+        assert (
+            _local_reference_dimension_column(ctx, parent_node, dim_ref) == "page_type"
+        )
+
+    def test_skips_column_without_dimension_id(self):
+        """A column with no ``dimension_id`` is skipped; only the tagged one matches."""
+        untagged = _make_ref_column("view_id", dimension_id=None, dimension_column=None)
+        tagged = _make_ref_column(
+            "page_type",
+            dimension_id=7,
+            dimension_column="plan_label",
+        )
+        ctx, parent_node = _make_ref_ctx([untagged, tagged], {7: "v3.plan_dim"})
+        dim_ref = DimensionRef(node_name="v3.plan_dim", column_name="plan_label")
+        assert (
+            _local_reference_dimension_column(ctx, parent_node, dim_ref) == "page_type"
+        )
+
+    def test_skips_column_tagged_with_different_dimension_node(self):
+        """A column tagged with a *different* dim node than requested is skipped."""
+        col = _make_ref_column(
+            "page_type",
+            dimension_id=9,
+            dimension_column="plan_label",
+        )
+        ctx, parent_node = _make_ref_ctx([col], {9: "v3.other_dim"})
+        dim_ref = DimensionRef(node_name="v3.plan_dim", column_name="plan_label")
+        assert _local_reference_dimension_column(ctx, parent_node, dim_ref) is None
+
+    def test_returns_none_when_attribute_does_not_match(self):
+        """A column tagged with the right node but a different attribute doesn't match."""
+        col = _make_ref_column("page_type", dimension_id=7, dimension_column="plan_key")
+        ctx, parent_node = _make_ref_ctx([col], {7: "v3.plan_dim"})
+        dim_ref = DimensionRef(node_name="v3.plan_dim", column_name="plan_label")
+        assert _local_reference_dimension_column(ctx, parent_node, dim_ref) is None
 
 
 def _make_node_with_columns(name: str, columns: list[str]) -> MagicMock:

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -6366,3 +6366,153 @@ class TestCrossParentDerivedRatio:
             GROUP BY 1
             """,
         )
+
+
+class TestReferenceDimensionResolution:
+    @pytest.mark.asyncio
+    async def test_reference_dimension_resolved_locally(self, client_with_build_v3):
+        """
+        A column tagged with a dimension node (a reference / denormalized dimension)
+        must be groupable by the dimension's canonical name, even though the metric's
+        parent has no *join link* to that dimension node.
+
+        Regression: commonDimensions advertises such an attribute (Column->dimension
+        edge), but the builder raised "Cannot find join path" because it only resolved
+        node-level dimension links. It should read the local tagged column instead.
+        """
+        # A standalone dimension node that nothing links to (no join path exists).
+        resp = await client_with_build_v3.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.plan_src",
+                "description": "Plan catalog",
+                "columns": [
+                    {"name": "plan_key", "type": "string"},
+                    {"name": "plan_label", "type": "string"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "plans",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client_with_build_v3.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.plan_dim",
+                "description": "Plan dimension (unlinked)",
+                "query": "SELECT plan_key, plan_label FROM v3.plan_src",
+                "mode": "published",
+                "primary_key": ["plan_key"],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Tag page_views_enriched.page_type as the plan_label attribute of the
+        # unlinked v3.plan_dim -- a reference dimension, with NO node join link.
+        resp = await client_with_build_v3.post(
+            "/nodes/v3.page_views_enriched/columns/page_type/link",
+            params={"dimension_node": "v3.plan_dim", "dimension_column": "plan_label"},
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        # Grouping by the dimension's canonical name resolves to the local column
+        # (page_type) -- no join to v3.plan_dim, which is unreachable.
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.page_view_count"],
+                "dimensions": ["v3.plan_dim.plan_label"],
+                "dialect": "trino",
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = response.json()["sql"]
+
+        # Resolved from the local tagged column (page_type -> plan_label); NO join
+        # to the unreachable v3.plan_dim node.
+        assert "plan_dim" not in sql, sql
+        assert_sql_equal(
+            sql,
+            """
+            WITH
+            v3_page_views_enriched AS (
+              SELECT view_id, page_type FROM default.v3.page_views
+            ),
+            page_views_enriched_0 AS (
+              SELECT t1.page_type plan_label, COUNT(t1.view_id) view_id_count_f41e2db4
+              FROM v3_page_views_enriched t1
+              GROUP BY t1.page_type
+            )
+            SELECT
+              page_views_enriched_0.plan_label AS plan_label,
+              SUM(page_views_enriched_0.view_id_count_f41e2db4) AS page_view_count
+            FROM page_views_enriched_0
+            GROUP BY page_views_enriched_0.plan_label
+            """,
+        )
+
+
+class TestMetricOnDimensionNode:
+    @pytest.mark.asyncio
+    async def test_metric_on_dimension_node_groups_and_filters_by_its_columns(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        A metric declared on a dimension node can group by / filter on any other
+        column of that same dimension node -- they're local to the metric's parent,
+        so no join is needed.
+        """
+        # Metric whose parent IS the v3.product dimension node.
+        resp = await client_with_build_v3.post(
+            "/nodes/metric/",
+            json={
+                "name": "v3.avg_product_price",
+                "description": "Average product price (defined on the product dimension)",
+                "query": "SELECT AVG(price) FROM v3.product",
+                "mode": "published",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.avg_product_price"],
+                "dimensions": ["v3.product.category"],
+                "filters": ["v3.product.subcategory = 'phones'"],
+                "dialect": "trino",
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = response.json()["sql"]
+
+        # Both the group-by (category) and the filter (subcategory) are served
+        # from the dimension node's own columns, locally -- no self-join.
+        assert_sql_equal(
+            sql,
+            """
+            WITH
+            v3_product AS (
+              SELECT category, subcategory, price
+              FROM default.v3.products
+              WHERE subcategory = 'phones'
+            ),
+            product_0 AS (
+              SELECT
+                t1.category,
+                COUNT(t1.price) price_count_78363aa6,
+                SUM(t1.price) price_sum_78363aa6
+              FROM v3_product t1
+              GROUP BY t1.category
+            )
+            SELECT
+              product_0.category AS category,
+              SUM(product_0.price_sum_78363aa6)
+                / NULLIF(SUM(product_0.price_count_78363aa6), 0) AS avg_product_price
+            FROM product_0
+            GROUP BY product_0.category
+            """,
+        )

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -6453,6 +6453,76 @@ class TestReferenceDimensionResolution:
             """,
         )
 
+    @pytest.mark.asyncio
+    async def test_reference_dimension_used_only_as_filter(self, client_with_build_v3):
+        """
+        A reference dimension used purely as a filter (not grouped) also resolves
+        from the local tagged column: the predicate is pushed onto the parent CTE,
+        with no join to the unreachable dimension node. Filter-only dims flow
+        through resolve_dimensions, so the same reference resolution applies.
+        """
+        resp = await client_with_build_v3.post(
+            "/nodes/source/",
+            json={
+                "name": "v3.plan_src",
+                "description": "Plan catalog",
+                "columns": [
+                    {"name": "plan_key", "type": "string"},
+                    {"name": "plan_label", "type": "string"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "plans",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client_with_build_v3.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.plan_dim",
+                "description": "Plan dimension (unlinked)",
+                "query": "SELECT plan_key, plan_label FROM v3.plan_src",
+                "mode": "published",
+                "primary_key": ["plan_key"],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.json()
+        resp = await client_with_build_v3.post(
+            "/nodes/v3.page_views_enriched/columns/page_type/link",
+            params={"dimension_node": "v3.plan_dim", "dimension_column": "plan_label"},
+        )
+        assert resp.status_code in (200, 201), resp.json()
+
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.page_view_count"],
+                "filters": ["v3.plan_dim.plan_label = 'checkout'"],
+                "dialect": "trino",
+            },
+        )
+        assert response.status_code == 200, response.json()
+        sql = response.json()["sql"]
+        assert "plan_dim" not in sql, sql
+        assert_sql_equal(
+            sql,
+            """
+            WITH
+            v3_page_views_enriched AS (
+              SELECT view_id, page_type
+              FROM default.v3.page_views
+              WHERE page_type = 'checkout'
+            ),
+            page_views_enriched_0 AS (
+              SELECT COUNT(t1.view_id) view_id_count_f41e2db4
+              FROM v3_page_views_enriched t1
+            )
+            SELECT SUM(page_views_enriched_0.view_id_count_f41e2db4) AS page_view_count
+            FROM page_views_enriched_0
+            """,
+        )
+
 
 class TestMetricOnDimensionNode:
     @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

A metric can't group by or filter on a dimension attribute that `commonDimensions` advertises, when that attribute is a reference (denormalized) dimension. The build fails with:
```
Cannot find join path from <parent> to dimension <dim node>. Please create a dimension link between these nodes.
```
even though the value lives on the parent's own column and needs no join.

This is because discovery and the builder disagree on reachability. `commonDimensions` walks both dimension-link edges and column to dimension edges, so it offers reference link attributes. But the v3 builder's `resolve_dimensions` only treated a dimension as "local" when the requested node name equals the metric's parent, otherwise it required a node-level join path via `find_join_path`, which only knows about dimension join links.

The fix is to resolve a reference dimension from the local tagged column in `resolve_dimensions`: when there's no join path, check whether a parent column's `column.dimension` points at the requested dim node and its `dimension_column` matches the requested attribute. If so, read that column directly. Filter-only dims are already added to the requested-dimensions list, so this covers both group-by and filter.

### Test Plan

Added SQL-assertions over `/sql/metrics/v3/` for reference dimensions in a group-by and reference dimensions as a filter-only ref. Added an additional test for a metric defined on a dimension node + group-by and filter on that node's own columns (this path already worked).

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
