### PR TITLE
build-v3: match cubes only when they cover filter dimensions

### DIFF
--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -483,6 +483,7 @@ async def get_data_for_metrics(
         engine_name=engine_name,
         engine_version=engine_version,
         dialect_override=dialect,
+        filters=filters if filters else None,
     )
 
     # Build SQL with the resolved dialect
@@ -564,6 +565,7 @@ async def get_data_stream_for_metrics(
         use_materialized=use_materialized,
         engine_name=engine_name,
         engine_version=engine_version,
+        filters=filters if filters else None,
     )
 
     # Build SQL with the resolved dialect

--- a/datajunction-server/datajunction_server/api/djsql.py
+++ b/datajunction-server/datajunction_server/api/djsql.py
@@ -223,6 +223,7 @@ async def _build_djsql_query(
         use_materialized=use_materialized,
         engine_name=engine_name,
         engine_version=engine_version,
+        filters=filters if filters else None,
     )
     generated_sql = await build_metrics_sql(
         session=session,

--- a/datajunction-server/datajunction_server/construction/build_v3/__init__.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/__init__.py
@@ -21,6 +21,7 @@ from datajunction_server.construction.build_v3.cube_matcher import (
     build_sql_from_cube,
     find_matching_cube,
     resolve_dialect_and_engine_for_metrics,
+    validate_pinned_cube_covers_filters,
 )
 from datajunction_server.construction.build_v3.types import (
     BuildContext,
@@ -45,6 +46,7 @@ __all__ = [
     "find_matching_cube",
     "build_sql_from_cube",
     "resolve_dialect_and_engine_for_metrics",
+    "validate_pinned_cube_covers_filters",
     # Combiners
     "build_combiner_sql",
     "CombinedGrainGroupResult",

--- a/datajunction-server/datajunction_server/construction/build_v3/builder.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/builder.py
@@ -536,6 +536,7 @@ async def build_metrics_sql(
                     metrics,
                     dimensions,
                     require_availability=True,
+                    filters=filters,
                 )
             )
             if probe_cube:
@@ -585,6 +586,7 @@ async def build_metrics_sql(
                 metrics,
                 dimensions,
                 require_availability=True,
+                filters=filters,
             )
         )
     else:

--- a/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
@@ -19,6 +19,7 @@ from datajunction_server.construction.build_v3.decomposition import is_derived_m
 from datajunction_server.models.dialect import Dialect
 from datajunction_server.construction.build_v3.dimensions import parse_dimension_ref
 from datajunction_server.construction.build_v3.filters import (
+    get_filter_column_references,
     parse_and_resolve_filters,
 )
 from datajunction_server.construction.build_v3.metrics import (
@@ -41,6 +42,7 @@ from datajunction_server.database.partition import Partition
 from datajunction_server.models.decompose import Aggregability
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.naming import amenable_name
+from datajunction_server.utils import SEPARATOR
 from datajunction_server.sql.parsing import ast
 from datajunction_server.instrumentation.provider import timed
 
@@ -50,12 +52,60 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _filter_dimension_refs(filters: list[str] | None) -> list[str]:
+    """
+    Extract the dimension references used in a set of filter predicates.
+
+    Only columns that look like dimension references (i.e. namespaced,
+    ``node.column``) are returned — bare column names cannot identify a
+    dimension node and are ignored. Role subscripts (``dim.col[role]``) are
+    stripped by ``get_filter_column_references``, so the returned refs are the
+    role-less ``node.column`` form.
+    """
+    refs: list[str] = []
+    for filter_str in filters or []:
+        try:
+            for ref in get_filter_column_references(filter_str):
+                if SEPARATOR in ref and ref not in refs:
+                    refs.append(ref)
+        except Exception:  # pragma: no cover
+            # A filter we can't parse can't be proven covered by the cube; skip
+            # it here (build-time will surface any real parse error).
+            logger.warning("[BuildV3] Failed to parse filter: %s", filter_str)
+    return refs
+
+
+def _cube_covers_filter_dims(
+    cube_dims: set[str],
+    filter_dim_refs: list[str],
+) -> bool:
+    """
+    Return True when every filter-referenced dimension is covered by the cube.
+
+    Filter refs are role-less ``node.column`` strings; cube dimensions may carry
+    a role suffix, so coverage is checked on the (node_name, column_name) pair
+    rather than exact string equality.
+    """
+    if not filter_dim_refs:
+        return True
+    cube_dim_keys = {
+        (parsed.node_name, parsed.column_name)
+        for parsed in (parse_dimension_ref(d) for d in cube_dims)
+    }
+    for ref in filter_dim_refs:
+        parsed = parse_dimension_ref(ref)
+        if (parsed.node_name, parsed.column_name) not in cube_dim_keys:
+            return False
+    return True
+
+
 @timed("dj.cube_matching.ms")
 async def find_matching_cube(
     session: AsyncSession,
     metrics: list[str],
     dimensions: list[str],
     require_availability: bool = True,
+    filters: list[str] | None = None,
 ) -> Optional[NodeRevision]:
     """
     Find a cube that covers all requested metrics and dimensions.
@@ -63,19 +113,28 @@ async def find_matching_cube(
     A cube matches if:
     1. It contains all requested metrics (by node name)
     2. It contains all requested dimensions
-    3. Cube has availability state (materialized) - configurable with require_availability
+    3. It covers every dimension referenced in ``filters`` (a filter on a
+       dimension the cube's materialized table lacks would produce invalid SQL,
+       so such cubes are rejected and the query falls back to the metric's own
+       engine)
+    4. Cube has availability state (materialized) - configurable with require_availability
 
     Args:
         session: Database session
         metrics: List of metric node names
         dimensions: List of dimension references (e.g., "default.date_dim.date_id")
         require_availability: If True, only consider cubes with availability defined
+        filters: Optional filter predicates. Any dimension referenced here must
+            also be covered by the cube, even when it is not a requested
+            ``dimension``.
 
     Returns:
         Matching cube NodeRevision if found, None otherwise
     """
     if not metrics:
         return None
+
+    filter_dim_refs = _filter_dimension_refs(filters)
 
     # Build query for cubes
     statement = (
@@ -154,6 +213,17 @@ async def find_matching_cube(
             )
             continue
 
+        # Filter coverage: every dimension referenced in a filter must exist in
+        # the cube's materialized table, even when it isn't a requested grouping
+        # dimension. Otherwise the generated Druid SQL references a column the
+        # cube table lacks and fails at execution.
+        if not _cube_covers_filter_dims(cube_dims, filter_dim_refs):
+            logger.debug(
+                f"[BuildV3] Cube {cube_rev.name} dims {cube_dims} "
+                f"don't cover filter dimensions {filter_dim_refs}",
+            )
+            continue
+
         # Found a match - prefer smallest grain (less roll-up work)
         if len(cube_dims) < best_grain_size:
             best_match = cube_rev
@@ -181,6 +251,7 @@ async def resolve_dialect_and_engine_for_metrics(
     engine_version: Optional[str] = None,
     dialect_override: Optional[Dialect] = None,
     matched_cube: Optional[NodeRevision] = None,
+    filters: Optional[list[str]] = None,
 ) -> ResolvedExecutionContext:
     """
     Resolve dialect and engine for a metrics query in a single lookup.
@@ -210,6 +281,11 @@ async def resolve_dialect_and_engine_for_metrics(
         matched_cube: When provided, resolve the dialect from THIS cube's
             availability instead of discovering one via find_matching_cube — so a
             pinned query's dialect matches the cube it actually builds from.
+        filters: Optional filter predicates, threaded into cube discovery so a
+            cube is only chosen when it also covers every filter-referenced
+            dimension (see find_matching_cube). A filter on an uncovered
+            dimension therefore resolves to the metric's own engine instead of
+            an unusable Druid cube.
 
     Returns:
         ResolvedExecutionContext with dialect, engine, catalog_name, and optional cube
@@ -237,6 +313,7 @@ async def resolve_dialect_and_engine_for_metrics(
                 metrics,
                 dimensions,
                 require_availability=True,
+                filters=filters,
             )
         )
 

--- a/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload, noload
+from sqlalchemy.orm import joinedload, selectinload, noload, load_only
 
 from datajunction_server.construction.build_v3.decomposition import is_derived_metric
 from datajunction_server.models.dialect import Dialect
@@ -89,7 +89,13 @@ async def _required_filter_dimensions(
     # A filter ref whose FULL name is a metric node (e.g. "v3.total_revenue" in
     # "v3.total_revenue > 100") is a HAVING predicate, not a dimension the cube
     # must materialize — mirrors classify_filters' metric/dimension split.
-    metric_nodes = await Node.get_by_names(session, refs)
+    # Only name/type are needed to spot metric refs; skip the default heavy
+    # NodeRevision eager-load tree.
+    metric_nodes = await Node.get_by_names(
+        session,
+        refs,
+        options=[load_only(Node.name, Node.type)],
+    )
     metric_ref_names = {
         node.name for node in metric_nodes if node.type == NodeType.METRIC
     }
@@ -244,7 +250,7 @@ async def validate_pinned_cube_covers_filters(
     filters: list[str] | None,
 ) -> None:
     """
-    Ensure an EXPLICITLY PINNED cube covers every filtered dimension.
+    Ensure an explicitly pinned cube covers every filtered dimension.
 
     Cube matching (find_matching_cube) already rejects cubes that don't cover a
     filtered dimension and falls back. But when the caller pins a specific cube

--- a/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
@@ -19,11 +19,13 @@ from datajunction_server.construction.build_v3.decomposition import is_derived_m
 from datajunction_server.models.dialect import Dialect
 from datajunction_server.construction.build_v3.dimensions import parse_dimension_ref
 from datajunction_server.construction.build_v3.filters import (
-    get_filter_column_references,
     parse_and_resolve_filters,
 )
 from datajunction_server.construction.build_v3.metrics import (
     generate_metrics_sql,
+)
+from datajunction_server.construction.build_v3.utils import (
+    extract_filter_dimension_refs,
 )
 from datajunction_server.construction.build_v3.types import (
     BuildContext,
@@ -42,7 +44,6 @@ from datajunction_server.database.partition import Partition
 from datajunction_server.models.decompose import Aggregability
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.naming import amenable_name
-from datajunction_server.utils import SEPARATOR
 from datajunction_server.sql.parsing import ast
 from datajunction_server.instrumentation.provider import timed
 
@@ -52,51 +53,47 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _filter_dimension_refs(filters: list[str] | None) -> list[str]:
-    """
-    Extract the dimension references used in a set of filter predicates.
-
-    Only columns that look like dimension references (i.e. namespaced,
-    ``node.column``) are returned — bare column names cannot identify a
-    dimension node and are ignored. Role subscripts (``dim.col[role]``) are
-    stripped by ``get_filter_column_references``, so the returned refs are the
-    role-less ``node.column`` form.
-    """
-    refs: list[str] = []
-    for filter_str in filters or []:
-        try:
-            for ref in get_filter_column_references(filter_str):
-                if SEPARATOR in ref and ref not in refs:
-                    refs.append(ref)
-        except Exception:  # pragma: no cover
-            # A filter we can't parse can't be proven covered by the cube; skip
-            # it here (build-time will surface any real parse error).
-            logger.warning("[BuildV3] Failed to parse filter: %s", filter_str)
-    return refs
+# Sentinel returned by _required_filter_dimensions when a filter cannot be
+# parsed: coverage can't be proven, so cube matching must fail SAFE (reject the
+# cube and fall back) rather than fail open and emit invalid SQL.
+_FILTER_COVERAGE_UNKNOWN = object()
 
 
-def _cube_covers_filter_dims(
-    cube_dims: set[str],
-    filter_dim_refs: list[str],
-) -> bool:
+async def _required_filter_dimensions(
+    session: AsyncSession,
+    filters: list[str] | None,
+) -> list[str] | object:
     """
-    Return True when every filter-referenced dimension is covered by the cube.
+    The role-qualified dimension refs a cube must cover for a set of filters.
 
-    Filter refs are role-less ``node.column`` strings; cube dimensions may carry
-    a role suffix, so coverage is checked on the (node_name, column_name) pair
-    rather than exact string equality.
+    Uses the shared ``extract_filter_dimension_refs`` normalization (so this
+    can't drift from the builder's filter→dimension handling) and then drops
+    refs that point at METRIC nodes: those are HAVING predicates applied on the
+    aggregated result, not columns that must exist in the cube's table.
+
+    Returns the list of required dimension refs, or ``_FILTER_COVERAGE_UNKNOWN``
+    if any filter cannot be parsed (caller must then reject the cube).
     """
-    if not filter_dim_refs:
-        return True
-    cube_dim_keys = {
-        (parsed.node_name, parsed.column_name)
-        for parsed in (parse_dimension_ref(d) for d in cube_dims)
+    if not filters:
+        return []
+    try:
+        refs = extract_filter_dimension_refs(filters)
+    except Exception:  # noqa: BLE001
+        # A filter we can't parse can't be proven covered — fail safe.
+        logger.warning("[BuildV3] Unparseable filter; skipping cube match")
+        return _FILTER_COVERAGE_UNKNOWN
+
+    if not refs:
+        return []
+
+    # A filter ref whose FULL name is a metric node (e.g. "v3.total_revenue" in
+    # "v3.total_revenue > 100") is a HAVING predicate, not a dimension the cube
+    # must materialize — mirrors classify_filters' metric/dimension split.
+    metric_nodes = await Node.get_by_names(session, refs)
+    metric_ref_names = {
+        node.name for node in metric_nodes if node.type == NodeType.METRIC
     }
-    for ref in filter_dim_refs:
-        parsed = parse_dimension_ref(ref)
-        if (parsed.node_name, parsed.column_name) not in cube_dim_keys:
-            return False
-    return True
+    return [ref for ref in refs if ref not in metric_ref_names]
 
 
 @timed("dj.cube_matching.ms")
@@ -112,21 +109,22 @@ async def find_matching_cube(
 
     A cube matches if:
     1. It contains all requested metrics (by node name)
-    2. It contains all requested dimensions
-    3. It covers every dimension referenced in ``filters`` (a filter on a
-       dimension the cube's materialized table lacks would produce invalid SQL,
-       so such cubes are rejected and the query falls back to the metric's own
-       engine)
-    4. Cube has availability state (materialized) - configurable with require_availability
+    2. It covers every REQUIRED dimension — the union of requested ``dimensions``
+       and the dimension refs used in ``filters`` (a filter on a dimension the
+       cube's materialized table lacks would produce invalid SQL, so such cubes
+       are rejected and the query falls back to the metric's own engine).
+       Coverage is role-sensitive (``date_id[order]`` is not satisfied by
+       ``date_id[ship]``). Metric-threshold filters (HAVING) are NOT required.
+    3. Cube has availability state (materialized) - configurable with require_availability
 
     Args:
         session: Database session
         metrics: List of metric node names
         dimensions: List of dimension references (e.g., "default.date_dim.date_id")
         require_availability: If True, only consider cubes with availability defined
-        filters: Optional filter predicates. Any dimension referenced here must
+        filters: Optional filter predicates. Any DIMENSION referenced here must
             also be covered by the cube, even when it is not a requested
-            ``dimension``.
+            ``dimension``. Metric (HAVING) filters impose no coverage requirement.
 
     Returns:
         Matching cube NodeRevision if found, None otherwise
@@ -134,7 +132,12 @@ async def find_matching_cube(
     if not metrics:
         return None
 
-    filter_dim_refs = _filter_dimension_refs(filters)
+    required_filter_dims = await _required_filter_dimensions(session, filters)
+    if required_filter_dims is _FILTER_COVERAGE_UNKNOWN:
+        # Couldn't prove filter coverage — fail safe, don't match any cube.
+        return None
+    # The full role-sensitive coverage requirement: requested dims ∪ filter dims.
+    required_dims = set(dimensions) | set(required_filter_dims)  # type: ignore[arg-type]
 
     # Build query for cubes
     statement = (
@@ -202,25 +205,17 @@ async def find_matching_cube(
             )
             continue
 
-        # Check dimension coverage: requested dims must be subset of cube dims
+        # Coverage: the cube must cover every REQUIRED dimension — requested
+        # grouping dims AND dimensions referenced in filters. A single
+        # role-sensitive subset check keeps grouping and filter coverage
+        # consistent (a filter on a dim the cube lacks would otherwise emit
+        # Druid SQL referencing a missing column).
         cube_dims = set(cube_rev.cube_dimensions())
-        requested_dims = set(dimensions)
 
-        if not requested_dims.issubset(cube_dims):
+        if not required_dims.issubset(cube_dims):
             logger.debug(
                 f"[BuildV3] Cube {cube_rev.name} dims {cube_dims} "
-                f"don't cover requested {requested_dims}",
-            )
-            continue
-
-        # Filter coverage: every dimension referenced in a filter must exist in
-        # the cube's materialized table, even when it isn't a requested grouping
-        # dimension. Otherwise the generated Druid SQL references a column the
-        # cube table lacks and fails at execution.
-        if not _cube_covers_filter_dims(cube_dims, filter_dim_refs):
-            logger.debug(
-                f"[BuildV3] Cube {cube_rev.name} dims {cube_dims} "
-                f"don't cover filter dimensions {filter_dim_refs}",
+                f"don't cover required {required_dims}",
             )
             continue
 
@@ -240,6 +235,46 @@ async def find_matching_cube(
         )
 
     return best_match
+
+
+async def validate_pinned_cube_covers_filters(
+    session: AsyncSession,
+    cube: NodeRevision,
+    dimensions: list[str],
+    filters: list[str] | None,
+) -> None:
+    """
+    Ensure an EXPLICITLY PINNED cube covers every filtered dimension.
+
+    Cube matching (find_matching_cube) already rejects cubes that don't cover a
+    filtered dimension and falls back. But when the caller pins a specific cube
+    (``cube=`` param), that discovery is skipped — so a filter on a dimension the
+    pinned cube's table lacks would silently produce invalid Druid SQL.
+
+    Here we fail LOUD instead of falling back: the caller asked for THIS cube, so
+    a clear error is more useful than quietly running on a different engine.
+
+    Raises:
+        DJInvalidInputException: if a filter references a dimension the pinned
+            cube does not materialize (or a filter can't be parsed).
+    """
+    required = await _required_filter_dimensions(session, filters)
+    if required is _FILTER_COVERAGE_UNKNOWN:
+        raise DJInvalidInputException(
+            f"Cannot verify that pinned cube `{cube.name}` covers the requested "
+            "filters because a filter could not be parsed.",
+            http_status_code=422,
+        )
+    required_dims = set(dimensions) | set(required)  # type: ignore[arg-type]
+    cube_dims = set(cube.cube_dimensions())
+    missing = required_dims - cube_dims
+    if missing:
+        raise DJInvalidInputException(
+            f"Pinned cube `{cube.name}` does not cover dimension(s) "
+            f"{sorted(missing)} referenced by the query. Remove the filter/"
+            "dimension, or pick a cube that materializes it.",
+            http_status_code=422,
+        )
 
 
 async def resolve_dialect_and_engine_for_metrics(

--- a/datajunction-server/datajunction_server/construction/build_v3/utils.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/utils.py
@@ -324,36 +324,43 @@ def add_dimensions_from_metric_expressions(
                         )
 
 
-def add_dimensions_from_filters(ctx: "BuildContext") -> None:
+def extract_filter_dimension_refs(
+    filters: list[str] | None,
+    include_bare: bool = False,
+) -> list[str]:
     """
-    Scan filter expressions for dimension references and add them to ctx.dimensions.
+    Extract the column references from a set of filter predicates.
 
-    Dimensions referenced in filters but not in the GROUP BY dimensions are needed
-    for filter resolution but should not appear in the output projection. These are
-    tracked in ctx.filter_dimensions.
+    Returns role-qualified refs in the ``node.column`` / ``node.column[role]``
+    form — the SAME normalization used to auto-add filter-only dimensions to the
+    build context. Subscript role markers are always excluded.
 
-    This function processes ALL filters (both dimension and metric filters) because
-    it's called BEFORE filter classification. Metric filters that reference dimensions
-    (rare but possible) will have those dimensions added, which is correct.
+    ``include_bare`` controls handling of non-namespaced (bare) column refs:
+      - False (default): bare refs are dropped — used by cube matching, where a
+        bare ref can't identify a cube dimension.
+      - True: bare refs are included — used by ``add_dimensions_from_filters``,
+        which must still SEE them to reject the unqualified ``node.column``
+        contract (v3 requires fully-qualified filter refs).
 
-    Args:
-        ctx: BuildContext with filters and dimensions lists to update
+    This is a pure, DB-free helper shared by ``add_dimensions_from_filters`` and
+    cube matching, so the two paths can't drift on how filters map to dimensions.
+
+    Raises ``DJInvalidInputException`` (via ``parse_filter``) only for a filter
+    that cannot be parsed at all; callers decide how to treat that.
     """
     # Import here to avoid circular imports (cte.py imports utils.py)
     from datajunction_server.construction.build_v3.cte import get_column_full_name
-    from datajunction_server.construction.build_v3.dimensions import parse_dimension_ref
 
-    if not ctx.filters:
-        return
+    refs: list[str] = []
 
-    existing_dims = set(ctx.dimensions)
+    def _add(ref: str) -> None:
+        if not ref or ref in refs:
+            return
+        if include_bare or SEPARATOR in ref:
+            refs.append(ref)
 
-    for filter_str in ctx.filters:
-        try:
-            filter_ast = parse_filter(filter_str)
-        except Exception:  # pragma: no cover
-            logger.warning("[BuildV3] Failed to parse filter: %s", filter_str)
-            continue
+    for filter_str in filters or []:
+        filter_ast = parse_filter(filter_str)
 
         # Track base column refs handled via role-qualified subscript notation
         # (e.g., "v3.location.country" from "v3.location.country[customer->home]")
@@ -363,7 +370,7 @@ def add_dimensions_from_filters(ctx: "BuildContext") -> None:
         # Role markers inside subscripts are parsed as Column nodes (e.g. the
         # `to` in `v3.location.country[to]`) but are not real filter column
         # references — identify them so the second pass doesn't treat them
-        # as bare column refs and reject them.
+        # as bare column refs.
         role_marker_ids: set[int] = set()
 
         # First pass: handle Subscript nodes for role-qualified dimension refs.
@@ -386,8 +393,8 @@ def add_dimensions_from_filters(ctx: "BuildContext") -> None:
             # Mark this base ref as handled so the Column pass skips it
             subscript_handled_refs.add(base_col_ref)
 
-            # Mark any Column nodes used as the role marker so we don't raise
-            # on them as bare refs.
+            # Mark any Column nodes used as the role marker so we don't treat
+            # them as bare refs.
             if isinstance(subscript.index, ast.Column):
                 role_marker_ids.add(id(subscript.index))
             for inner_col in (
@@ -397,78 +404,82 @@ def add_dimensions_from_filters(ctx: "BuildContext") -> None:
             ):
                 role_marker_ids.add(id(inner_col))
 
-            if full_name in existing_dims:
-                continue
+            _add(full_name)
 
-            if full_name in ctx.metrics:  # pragma: no cover
-                continue
-
-            dim_ref = parse_dimension_ref(full_name)
-            is_covered = False
-            for existing_dim in ctx.dimensions:
-                existing_ref = parse_dimension_ref(existing_dim)
-                if (
-                    existing_ref.node_name == dim_ref.node_name
-                    and existing_ref.column_name == dim_ref.column_name
-                    and existing_ref.role == dim_ref.role
-                ):
-                    is_covered = True  # pragma: no cover
-                    break  # pragma: no cover
-
-            if not is_covered:  # pragma: no branch
-                logger.info(
-                    "[BuildV3] Auto-adding filter-only dimension %s",
-                    full_name,
-                )
-                ctx.dimensions.append(full_name)
-                ctx.filter_dimensions.add(full_name)
-                existing_dims.add(full_name)
-
-        # Second pass: handle regular Column references.
-        # Skip columns that were already added via the subscript pass above.
+        # Second pass: handle regular Column references. This also catches
+        # columns wrapped in functions (e.g. DATE(v3.date.date_id)) or inside
+        # IN / BETWEEN predicates, since find_all(ast.Column) walks the whole tree.
         for col in filter_ast.find_all(ast.Column):
             # Role markers inside subscripts (e.g. `to` in `dim.col[to]`) are
             # parsed as Columns but don't refer to real data columns.
             if id(col) in role_marker_ids:
                 continue
             full_name = get_column_full_name(col)
-            if not full_name:
-                continue  # pragma: no cover
-
             # Skip if already handled as a role-qualified subscript ref
             if full_name in subscript_handled_refs:
                 continue
+            _add(full_name)
 
-            if full_name in existing_dims:
-                # Already in dimensions, no need to add
-                continue
+    return refs
 
-            # Skip if this is a metric reference, not a dimension
-            # Metrics in WHERE clauses should be treated as HAVING conditions,
-            # not dimension joins
-            if full_name in ctx.metrics:
-                continue
 
-            # Check if any existing dimension already covers this (node, column)
-            dim_ref = parse_dimension_ref(full_name)
-            is_covered = False
-            for existing_dim in ctx.dimensions:
-                existing_ref = parse_dimension_ref(existing_dim)
-                if (
-                    existing_ref.node_name == dim_ref.node_name
-                    and existing_ref.column_name == dim_ref.column_name
-                ):
-                    is_covered = True  # pragma: no cover
-                    break  # pragma: no cover
+def add_dimensions_from_filters(ctx: "BuildContext") -> None:
+    """
+    Scan filter expressions for dimension references and add them to ctx.dimensions.
 
-            if not is_covered:  # pragma: no branch
-                logger.info(
-                    "[BuildV3] Auto-adding filter-only dimension %s",
-                    full_name,
-                )
-                ctx.dimensions.append(full_name)
-                ctx.filter_dimensions.add(full_name)
-                existing_dims.add(full_name)
+    Dimensions referenced in filters but not in the GROUP BY dimensions are needed
+    for filter resolution but should not appear in the output projection. These are
+    tracked in ctx.filter_dimensions.
+
+    This function processes ALL filters (both dimension and metric filters) because
+    it's called BEFORE filter classification. Metric filters that reference dimensions
+    (rare but possible) will have those dimensions added, which is correct.
+
+    Args:
+        ctx: BuildContext with filters and dimensions lists to update
+    """
+    from datajunction_server.construction.build_v3.dimensions import parse_dimension_ref
+
+    if not ctx.filters:
+        return
+
+    existing_dims = set(ctx.dimensions)
+
+    # include_bare=True so unqualified refs still reach parse_dimension_ref below,
+    # which rejects them (v3 requires the fully-qualified node.column form).
+    for full_name in extract_filter_dimension_refs(ctx.filters, include_bare=True):
+        if full_name in existing_dims:
+            continue
+
+        # Skip if this is a metric reference, not a dimension. Metrics in WHERE
+        # clauses are treated as HAVING conditions, not dimension joins.
+        if full_name in ctx.metrics:
+            continue
+
+        # Check if any existing dimension already covers this (node, column[, role]).
+        # Role-qualified refs match role-sensitively; role-less refs ignore role.
+        # parse_dimension_ref raises DJInvalidInputException for a bare (unqualified)
+        # ref, enforcing the node.column contract.
+        dim_ref = parse_dimension_ref(full_name)
+        is_covered = False
+        for existing_dim in ctx.dimensions:
+            existing_ref = parse_dimension_ref(existing_dim)
+            if (
+                existing_ref.node_name == dim_ref.node_name
+                and existing_ref.column_name == dim_ref.column_name
+                and (dim_ref.role is None or existing_ref.role == dim_ref.role)
+            ):
+                is_covered = True  # pragma: no cover
+                break  # pragma: no cover
+
+        if not is_covered:  # pragma: no branch
+            logger.info(
+                "[BuildV3] Auto-adding filter-only dimension %s",
+                full_name,
+            )
+            ctx.dimensions.append(full_name)
+            ctx.filter_dimensions.add(full_name)
+            existing_dims.add(full_name)
 
 
 def build_join_from_clause(

--- a/datajunction-server/datajunction_server/internal/sql.py
+++ b/datajunction-server/datajunction_server/internal/sql.py
@@ -212,6 +212,7 @@ async def generate_metrics_sql(
     from datajunction_server.construction.build_v3 import (  # noqa: PLC0415
         build_metrics_sql,
         resolve_dialect_and_engine_for_metrics,
+        validate_pinned_cube_covers_filters,
     )
 
     _t0 = time.monotonic()
@@ -229,6 +230,18 @@ async def generate_metrics_sql(
             metrics = matched_cube.cube_node_metrics
             if not dimensions:
                 dimensions = matched_cube.cube_node_dimensions
+
+        # A pinned cube bypasses find_matching_cube's coverage check. When that
+        # cube will actually back the build (materialized, Druid or auto-dialect),
+        # verify it covers every filtered dimension so we fail loud here instead
+        # of emitting Druid SQL that references a column the cube table lacks.
+        if use_materialized and dialect in (None, Dialect.DRUID):
+            await validate_pinned_cube_covers_filters(
+                session,
+                matched_cube,
+                dimensions,
+                merged_filters,
+            )
 
     # Auto-resolve dialect if not explicitly provided.
     resolved_dialect = dialect

--- a/datajunction-server/datajunction_server/internal/sql.py
+++ b/datajunction-server/datajunction_server/internal/sql.py
@@ -239,6 +239,7 @@ async def generate_metrics_sql(
             dimensions=dimensions,
             use_materialized=use_materialized,
             matched_cube=matched_cube,
+            filters=merged_filters,
         )
         resolved_dialect = execution_ctx.dialect
         # Only reuse the resolved cube if the caller didn't provide one.

--- a/datajunction-server/datajunction_server/mcp/tools.py
+++ b/datajunction-server/datajunction_server/mcp/tools.py
@@ -415,6 +415,7 @@ async def _execute_metrics_query(
         metrics=metrics,
         dimensions=dimensions or [],
         use_materialized=True,
+        filters=filters or None,
     )
 
     generated_sql = await build_metrics_sql(

--- a/datajunction-server/tests/construction/build_v3/cube_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/cube_matcher_test.py
@@ -11,7 +11,10 @@ import time
 
 import pytest
 
+from datajunction_server.construction.build_v3.builder import build_metrics_sql
 from datajunction_server.construction.build_v3.cube_matcher import (
+    _cube_covers_filter_dims,
+    _filter_dimension_refs,
     build_sql_from_cube,
     build_synthetic_grain_group,
     find_matching_cube,
@@ -25,6 +28,52 @@ from datajunction_server.models.decompose import Aggregability
 from datajunction_server.models.dialect import Dialect
 
 from tests.construction.build_v3 import assert_sql_equal
+
+
+class TestFilterDimensionCoverageHelpers:
+    """Unit tests for the filter-dimension coverage helpers."""
+
+    def test_filter_dimension_refs_extracts_qualified_only(self):
+        """Only namespaced (node.column) refs are returned; bare cols ignored."""
+        refs = _filter_dimension_refs(
+            [
+                "v3.product.category = 'Electronics'",
+                # A bare column ref has no owning node and cannot identify a
+                # dimension — it must be dropped (exercises the non-SEPARATOR branch).
+                "status = 'active'",
+            ],
+        )
+        assert refs == ["v3.product.category"]
+
+    def test_filter_dimension_refs_empty(self):
+        """No filters -> no refs."""
+        assert _filter_dimension_refs(None) == []
+        assert _filter_dimension_refs([]) == []
+
+    def test_cube_covers_filter_dims_empty_is_true(self):
+        """A cube trivially covers an empty set of filter dims."""
+        assert _cube_covers_filter_dims({"v3.product.category"}, []) is True
+
+    def test_cube_covers_filter_dims_ignores_role_suffix(self):
+        """Coverage matches on (node, column), so a role-qualified cube dim
+        still covers a role-less filter ref for the same column."""
+        assert (
+            _cube_covers_filter_dims(
+                {"v3.date.date_id[order]"},
+                ["v3.date.date_id"],
+            )
+            is True
+        )
+
+    def test_cube_covers_filter_dims_missing_is_false(self):
+        """An uncovered filter dim makes coverage fail."""
+        assert (
+            _cube_covers_filter_dims(
+                {"v3.product.category"},
+                ["v3.product.subcategory"],
+            )
+            is False
+        )
 
 
 class TestFindMatchingCube:
@@ -583,6 +632,163 @@ class TestFindMatchingCube:
 
         assert result is not None
         assert result.name == "v3.test_cube_large"
+
+    # --------------------------------------------
+    # Tests for filter-dimension coverage in cube matching (GitHub issue: a
+    # FILTER on a dimension the cube doesn't materialize must not match the cube,
+    # otherwise the generated Druid SQL references a missing column).
+    # --------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_rejects_cube_when_filter_dim_not_covered(
+        self,
+        client_with_build_v3,
+        session,
+    ):
+        """Should NOT match a cube when a filter references an uncovered dim.
+
+        The cube only materializes ``v3.product.category``. A query with no
+        requested dimensions but a filter on ``v3.product.subcategory`` (which
+        the cube does not materialize) must be rejected — otherwise the cube
+        SQL would reference a column that doesn't exist in the Druid table.
+        """
+        response = await client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": "v3.test_cube_filter_coverage",
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "mode": "published",
+                "description": "Cube for filter-coverage matching",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        valid_through_ts = int(time.time() * 1000)
+        response = await client_with_build_v3.post(
+            "/data/v3.test_cube_filter_coverage/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "analytics",
+                "table": "cube_filter_coverage",
+                "valid_through_ts": valid_through_ts,
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        # No requested dimensions, but a filter on an uncovered dimension.
+        result = await find_matching_cube(
+            session,
+            metrics=["v3.total_revenue"],
+            dimensions=[],
+            filters=["v3.product.subcategory = 'Smartphones'"],
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_matches_cube_when_filter_dim_is_covered(
+        self,
+        client_with_build_v3,
+        session,
+    ):
+        """Should still match when the filter references a covered dimension.
+
+        The filter is on ``v3.product.subcategory`` which the cube DOES
+        materialize (even though it isn't a requested grouping dimension), so
+        the cube remains a valid match.
+        """
+        response = await client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": "v3.test_cube_filter_covered",
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.product.category",
+                    "v3.product.subcategory",
+                ],
+                "mode": "published",
+                "description": "Cube covering the filtered dimension",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        valid_through_ts = int(time.time() * 1000)
+        response = await client_with_build_v3.post(
+            "/data/v3.test_cube_filter_covered/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "analytics",
+                "table": "cube_filter_covered",
+                "valid_through_ts": valid_through_ts,
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        result = await find_matching_cube(
+            session,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.product.category"],
+            filters=["v3.product.subcategory = 'Smartphones'"],
+        )
+        assert result is not None
+        assert result.name == "v3.test_cube_filter_covered"
+
+    @pytest.mark.asyncio
+    async def test_filter_on_uncovered_dim_falls_back_to_metric_engine(
+        self,
+        client_with_build_v3,
+        session,
+    ):
+        """End-to-end: a filter on an uncovered dim must fall back off the cube.
+
+        Regression for the AHT-style bug: a metrics query that only FILTERS on a
+        dimension the matched cube does not materialize used to match the cube
+        and emit Druid SQL referencing a missing column. It must instead fall
+        back to the metric's own (Trino) engine and produce valid SQL that reads
+        from the fact source, not the cube table.
+        """
+        response = await client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": "v3.test_cube_fallback",
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "mode": "published",
+                "description": "Cube that must NOT be used for the uncovered filter",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        valid_through_ts = int(time.time() * 1000)
+        response = await client_with_build_v3.post(
+            "/data/v3.test_cube_fallback/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "analytics",
+                "table": "cube_fallback",
+                "valid_through_ts": valid_through_ts,
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        # Filter references a dimension the cube does NOT materialize; with
+        # dialect auto-detection, build_metrics_sql should reject the cube and
+        # fall back to Trino rather than emitting cube SQL with a missing column.
+        result = await build_metrics_sql(
+            session=session,
+            metrics=["v3.total_revenue"],
+            dimensions=[],
+            filters=["v3.product.subcategory = 'Smartphones'"],
+            use_materialized=True,
+        )
+
+        assert result is not None
+        assert result.sql is not None
+        # The generated SQL must NOT read from the cube's materialized table.
+        assert "cube_fallback" not in result.sql
+        assert result.cube_name is None
+        # The filter must still be applied on the (fact-derived) subcategory.
+        assert "subcategory" in result.sql
 
 
 class TestBuildSqlFromCube:

--- a/datajunction-server/tests/construction/build_v3/cube_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/cube_matcher_test.py
@@ -13,67 +13,83 @@ import pytest
 
 from datajunction_server.construction.build_v3.builder import build_metrics_sql
 from datajunction_server.construction.build_v3.cube_matcher import (
-    _cube_covers_filter_dims,
-    _filter_dimension_refs,
     build_sql_from_cube,
     build_synthetic_grain_group,
     find_matching_cube,
+    validate_pinned_cube_covers_filters,
 )
 from datajunction_server.construction.build_v3.decomposition import (
     decompose_and_group_metrics,
 )
 from datajunction_server.construction.build_v3.loaders import load_nodes
 from datajunction_server.construction.build_v3.types import BuildContext
+from datajunction_server.construction.build_v3.utils import (
+    extract_filter_dimension_refs,
+)
+from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models.decompose import Aggregability
 from datajunction_server.models.dialect import Dialect
 
 from tests.construction.build_v3 import assert_sql_equal
 
 
-class TestFilterDimensionCoverageHelpers:
-    """Unit tests for the filter-dimension coverage helpers."""
+class TestExtractFilterDimensionRefs:
+    """Unit tests for the shared filter-dimension extraction helper.
 
-    def test_filter_dimension_refs_extracts_qualified_only(self):
-        """Only namespaced (node.column) refs are returned; bare cols ignored."""
-        refs = _filter_dimension_refs(
+    These are pure/DB-free and cover predicate shapes that could otherwise be
+    silent no-ops in cube coverage: IN, BETWEEN, function-wrapped columns, and
+    role subscripts.
+    """
+
+    def test_extracts_qualified_only(self):
+        """Only namespaced (node.column) refs are returned; bare cols dropped."""
+        refs = extract_filter_dimension_refs(
             [
                 "v3.product.category = 'Electronics'",
-                # A bare column ref has no owning node and cannot identify a
-                # dimension — it must be dropped (exercises the non-SEPARATOR branch).
+                # A bare column ref has no owning node — must be dropped.
                 "status = 'active'",
             ],
         )
         assert refs == ["v3.product.category"]
 
-    def test_filter_dimension_refs_empty(self):
+    def test_empty(self):
         """No filters -> no refs."""
-        assert _filter_dimension_refs(None) == []
-        assert _filter_dimension_refs([]) == []
+        assert extract_filter_dimension_refs(None) == []
+        assert extract_filter_dimension_refs([]) == []
 
-    def test_cube_covers_filter_dims_empty_is_true(self):
-        """A cube trivially covers an empty set of filter dims."""
-        assert _cube_covers_filter_dims({"v3.product.category"}, []) is True
+    def test_in_predicate(self):
+        """IN predicates expose their column ref."""
+        assert extract_filter_dimension_refs(
+            ["v3.product.category IN ('Electronics', 'Clothing')"],
+        ) == ["v3.product.category"]
 
-    def test_cube_covers_filter_dims_ignores_role_suffix(self):
-        """Coverage matches on (node, column), so a role-qualified cube dim
-        still covers a role-less filter ref for the same column."""
-        assert (
-            _cube_covers_filter_dims(
-                {"v3.date.date_id[order]"},
-                ["v3.date.date_id"],
-            )
-            is True
+    def test_between_predicate(self):
+        """BETWEEN predicates expose their column ref."""
+        assert extract_filter_dimension_refs(
+            ["v3.product.subcategory BETWEEN 'A' AND 'M'"],
+        ) == ["v3.product.subcategory"]
+
+    def test_function_wrapped_column(self):
+        """A column wrapped in a function (e.g. UPPER(...)) is still extracted."""
+        assert extract_filter_dimension_refs(
+            ["UPPER(v3.product.category) = 'ELECTRONICS'"],
+        ) == ["v3.product.category"]
+
+    def test_role_subscript_is_preserved(self):
+        """Role-qualified refs keep their [role] suffix (role-sensitive coverage)."""
+        assert extract_filter_dimension_refs(
+            ["v3.date.date_id[order] = 20240101"],
+        ) == ["v3.date.date_id[order]"]
+
+    def test_multiple_refs_deduped(self):
+        """Refs across predicates are collected and de-duplicated."""
+        refs = extract_filter_dimension_refs(
+            [
+                "v3.product.category = 'Electronics'",
+                "v3.product.category != 'Books' AND v3.product.subcategory = 'X'",
+            ],
         )
-
-    def test_cube_covers_filter_dims_missing_is_false(self):
-        """An uncovered filter dim makes coverage fail."""
-        assert (
-            _cube_covers_filter_dims(
-                {"v3.product.category"},
-                ["v3.product.subcategory"],
-            )
-            is False
-        )
+        assert refs == ["v3.product.category", "v3.product.subcategory"]
 
 
 class TestFindMatchingCube:
@@ -686,6 +702,49 @@ class TestFindMatchingCube:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_bare_column_filter_imposes_no_coverage(
+        self,
+        client_with_build_v3,
+        session,
+    ):
+        """A filter with only bare (non-namespaced) column refs yields no required
+        dimensions, so an otherwise-covered cube still matches (exercises the
+        'no namespaced refs' branch in _required_filter_dimensions)."""
+        response = await client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": "v3.test_cube_bare_filter",
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "mode": "published",
+                "description": "Cube for bare-column-filter coverage",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        valid_through_ts = int(time.time() * 1000)
+        response = await client_with_build_v3.post(
+            "/data/v3.test_cube_bare_filter/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "analytics",
+                "table": "cube_bare_filter",
+                "valid_through_ts": valid_through_ts,
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        # "1 = 1" has no column refs at all -> no required filter dims.
+        result = await find_matching_cube(
+            session,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.product.category"],
+            filters=["1 = 1"],
+        )
+        assert result is not None
+        assert result.name == "v3.test_cube_bare_filter"
+
+    @pytest.mark.asyncio
     async def test_matches_cube_when_filter_dim_is_covered(
         self,
         client_with_build_v3,
@@ -784,11 +843,323 @@ class TestFindMatchingCube:
 
         assert result is not None
         assert result.sql is not None
-        # The generated SQL must NOT read from the cube's materialized table.
+        # The generated SQL must NOT read from the cube's materialized table...
         assert "cube_fallback" not in result.sql
         assert result.cube_name is None
-        # The filter must still be applied on the (fact-derived) subcategory.
-        assert "subcategory" in result.sql
+        # ...and must instead read the fact source that backs v3.total_revenue,
+        # joining the product dimension so the subcategory filter is valid.
+        sql_lower = result.sql.lower()
+        assert "order_details" in sql_lower, result.sql
+        assert "join" in sql_lower and "product" in sql_lower, result.sql
+        # The subcategory filter must still be applied.
+        assert "subcategory" in sql_lower
+
+    @pytest.mark.asyncio
+    async def test_metric_having_filter_still_matches_cube(
+        self,
+        client_with_build_v3,
+        session,
+    ):
+        """A metric-threshold (HAVING) filter must NOT reject an otherwise-covered cube.
+
+        Regression: ``v3.total_revenue > 100`` references a METRIC node, not a
+        dimension the cube must materialize (it's applied as HAVING on the
+        aggregated result). Treating it as a required dimension would wrongly
+        reject the cube and force a fallback even though the cube fully covers
+        the query.
+        """
+        response = await client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": "v3.test_cube_having_filter",
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "mode": "published",
+                "description": "Cube for HAVING-filter matching",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        valid_through_ts = int(time.time() * 1000)
+        response = await client_with_build_v3.post(
+            "/data/v3.test_cube_having_filter/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "analytics",
+                "table": "cube_having_filter",
+                "valid_through_ts": valid_through_ts,
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        result = await find_matching_cube(
+            session,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.product.category"],
+            filters=["v3.total_revenue > 100"],
+        )
+        assert result is not None
+        assert result.name == "v3.test_cube_having_filter"
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_filter_role_differs_from_cube_role(
+        self,
+        client_with_build_v3,
+        session,
+    ):
+        """Role-sensitive filter coverage: a cube materialized for one role must
+        NOT match a filter that needs a different role of the same column."""
+        response = await client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": "v3.test_cube_role_order",
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.date.date_id[order]"],
+                "mode": "published",
+                "description": "Cube materialized for the order role",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        valid_through_ts = int(time.time() * 1000)
+        response = await client_with_build_v3.post(
+            "/data/v3.test_cube_role_order/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "analytics",
+                "table": "cube_role_order",
+                "valid_through_ts": valid_through_ts,
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        # Filter needs the ship role — the cube only has the order role.
+        result = await find_matching_cube(
+            session,
+            metrics=["v3.total_revenue"],
+            dimensions=[],
+            filters=["v3.date.date_id[ship] = 20240101"],
+        )
+        assert result is None
+
+        # Same role as the cube -> matches.
+        result = await find_matching_cube(
+            session,
+            metrics=["v3.total_revenue"],
+            dimensions=[],
+            filters=["v3.date.date_id[order] = 20240101"],
+        )
+        assert result is not None
+        assert result.name == "v3.test_cube_role_order"
+
+    @pytest.mark.asyncio
+    async def test_unparseable_filter_fails_safe(
+        self,
+        client_with_build_v3,
+        session,
+        monkeypatch,
+    ):
+        """If a filter can't be parsed, coverage can't be proven -> reject (fail safe).
+
+        We can't easily craft a string that the parser rejects but the router
+        accepts, so we force ``extract_filter_dimension_refs`` to raise and assert
+        the matcher declines rather than fails open onto the cube.
+        """
+        response = await client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": "v3.test_cube_failsafe",
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "mode": "published",
+                "description": "Cube for fail-safe test",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        valid_through_ts = int(time.time() * 1000)
+        response = await client_with_build_v3.post(
+            "/data/v3.test_cube_failsafe/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "analytics",
+                "table": "cube_failsafe",
+                "valid_through_ts": valid_through_ts,
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        def _boom(_filters):
+            raise ValueError("unparseable filter")
+
+        monkeypatch.setattr(
+            "datajunction_server.construction.build_v3.cube_matcher."
+            "extract_filter_dimension_refs",
+            _boom,
+        )
+
+        result = await find_matching_cube(
+            session,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.product.category"],
+            filters=["v3.product.category = 'Electronics'"],
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_pinned_cube_uncovered_filter_raises(
+        self,
+        client_with_build_v3,
+        session,
+    ):
+        """A pinned cube that doesn't cover a filtered dim must fail LOUD.
+
+        find_matching_cube's coverage check is bypassed when a cube is pinned,
+        so validate_pinned_cube_covers_filters guards that path with a clear error.
+        """
+        response = await client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": "v3.test_cube_pinned",
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "mode": "published",
+                "description": "Pinned cube missing the filtered dimension",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        valid_through_ts = int(time.time() * 1000)
+        response = await client_with_build_v3.post(
+            "/data/v3.test_cube_pinned/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "analytics",
+                "table": "cube_pinned",
+                "valid_through_ts": valid_through_ts,
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        cube = await find_matching_cube(
+            session,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.product.category"],
+        )
+        assert cube is not None
+
+        # Uncovered filter -> raises.
+        with pytest.raises(DJInvalidInputException) as exc:
+            await validate_pinned_cube_covers_filters(
+                session,
+                cube,
+                dimensions=[],
+                filters=["v3.product.subcategory = 'Smartphones'"],
+            )
+        assert "does not cover" in str(exc.value)
+
+        # Covered filter (a HAVING metric filter imposes no coverage) -> no raise.
+        await validate_pinned_cube_covers_filters(
+            session,
+            cube,
+            dimensions=["v3.product.category"],
+            filters=["v3.total_revenue > 100"],
+        )
+
+    @pytest.mark.asyncio
+    async def test_validate_pinned_cube_unparseable_filter_raises(
+        self,
+        client_with_build_v3,
+        session,
+        monkeypatch,
+    ):
+        """Pinned-cube validation also fails loud on an unparseable filter."""
+        response = await client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": "v3.test_cube_pinned_failsafe",
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "mode": "published",
+                "description": "Pinned cube for unparseable-filter validation",
+            },
+        )
+        assert response.status_code == 201, response.json()
+        cube = await find_matching_cube(
+            session,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.product.category"],
+            require_availability=False,
+        )
+        assert cube is not None
+
+        def _boom(_filters):
+            raise ValueError("unparseable filter")
+
+        monkeypatch.setattr(
+            "datajunction_server.construction.build_v3.cube_matcher."
+            "extract_filter_dimension_refs",
+            _boom,
+        )
+        with pytest.raises(DJInvalidInputException) as exc:
+            await validate_pinned_cube_covers_filters(
+                session,
+                cube,
+                dimensions=[],
+                filters=["v3.product.category = 'Electronics'"],
+            )
+        assert "could not be parsed" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_pinned_cube_non_druid_dialect_skips_validation(
+        self,
+        client_with_build_v3,
+        session,
+    ):
+        """When a pinned cube won't back the build (non-Druid dialect), the
+        pinned-cube filter-coverage validation is skipped — an uncovered filter
+        does NOT raise, because the query runs on the metric's own engine."""
+        from datajunction_server.internal.sql import generate_metrics_sql
+
+        response = await client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": "v3.test_cube_pinned_trino",
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+                "mode": "published",
+                "description": "Pinned cube, queried via non-Druid dialect",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        valid_through_ts = int(time.time() * 1000)
+        response = await client_with_build_v3.post(
+            "/data/v3.test_cube_pinned_trino/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "analytics",
+                "table": "cube_pinned_trino",
+                "valid_through_ts": valid_through_ts,
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        # Pin the cube but force a non-Druid dialect: the cube won't be used, so
+        # the uncovered subcategory filter must NOT raise (validation skipped).
+        result = await generate_metrics_sql(
+            session,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.product.category"],
+            filters=["v3.product.subcategory = 'Smartphones'"],
+            cube="v3.test_cube_pinned_trino",
+            dialect=Dialect.TRINO,
+            use_materialized=True,
+        )
+        assert result is not None
+        assert result.sql is not None
+        # Ran off the cube (Trino source), not the materialized cube table.
+        assert "cube_pinned_trino" not in result.sql
 
 
 class TestBuildSqlFromCube:


### PR DESCRIPTION
### Summary

A metrics query that filters on a dimension the matched cube doesn't materialize produces invalid SQL against the cube's engine. Example: a metric plus filters=["some.dim.attr = 'x'"] with no requested dimensions and use_materialized=true. `find_matching_cube` matches a materialized cube, and the generated Druid SQL references `attr` (a column the cube's materialized table doesn't have), so execution fails with `Column 'attr' not found in any table`.

The issue here is that `find_matching_cube` only requires the cube to cover all requested dimensions, but never checks columns referenced only in filters. When a query has no requested dimensions (filters only), the dimension-coverage check is vacuously satisfied, so a cube is selected even though it can't satisfy the filter. Because a matched cube also drives dialect/engine resolution to the cube's engine, the query is dispatched there with SQL referencing a nonexistent column.

The fix is for `find_matching_cube` to also require the cube to cover every dimension referenced in filters:
- a new `filters` parameter, with a helper that extracts the namespaced (`node.column`) dimension refs from the filter predicates and checks coverage on the `(node_name, column_name)` pair, tolerant of role suffixes on cube dimensions
- the matching loop rejects any candidate cube that fails this check, alongside the existing requested-dimension check
- filters is threaded into both of `build_metrics_sql`'s internal cube lookups and into `resolve_dialect_and_engine_for_metrics`, so dialect/engine resolution and SQL generation agree.

### Test Plan

Three integration tests (cube rejected when a filter dim isn't covered, cube still matched when it is, an end-to-end case asserting the cube table is absent from the generated SQL) plus unit tests for the filter-dim extraction/coverage helpers.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
