### PR TITLE
Don't reject cross-parent derived metrics when their shared dimension comes from links in the same deployment

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -3501,14 +3501,12 @@ class DeploymentOrchestrator:
 
     def _deployment_link_targets(self) -> dict[str, set[str]]:
         """Map each linkable node to the dimension nodes it links to, across the
-        ENTIRE deployment (all topological levels).
+        whole deployment (rendered names, to match node_graph).
 
-        Dimension links are deployed only after every node level, so per-level
-        validation cannot observe links declared on nodes in other levels via the
-        committed graph. The cross-fact derived-metric check consults this
-        spec-derived map to avoid a false negative when two base metrics share a
-        dimension only through links this deployment will create. Keyed and valued
-        by rendered names to match node_graph / dependency_nodes.
+        Links deploy only after every node level, so per-level validation can't
+        see links on nodes in other levels via the committed graph. The
+        cross-fact check uses this to avoid a false negative when base metrics
+        share a dimension only through links this deployment will create.
         """
         targets: dict[str, set[str]] = {}
         for node_spec in self.deployment_spec.nodes:

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -3499,6 +3499,26 @@ class DeploymentOrchestrator:
 
         return to_deploy, []
 
+    def _deployment_link_targets(self) -> dict[str, set[str]]:
+        """Map each linkable node to the dimension nodes it links to, across the
+        ENTIRE deployment (all topological levels).
+
+        Dimension links are deployed only after every node level, so per-level
+        validation cannot observe links declared on nodes in other levels via the
+        committed graph. The cross-fact derived-metric check consults this
+        spec-derived map to avoid a false negative when two base metrics share a
+        dimension only through links this deployment will create. Keyed and valued
+        by rendered names to match node_graph / dependency_nodes.
+        """
+        targets: dict[str, set[str]] = {}
+        for node_spec in self.deployment_spec.nodes:
+            if isinstance(node_spec, LinkableNodeSpec) and node_spec.dimension_links:
+                for link in node_spec.dimension_links:
+                    targets.setdefault(node_spec.rendered_name, set()).add(
+                        link.rendered_dimension_node,
+                    )
+        return targets
+
     async def bulk_deploy_nodes_in_level(
         self,
         node_specs: list[NodeSpec],
@@ -3542,6 +3562,7 @@ class DeploymentOrchestrator:
                     self.session,
                     dependency_nodes=dependency_nodes,
                     deployment_namespace=self.deployment_spec.namespace,
+                    deployment_link_targets=self._deployment_link_targets(),
                 )
             p.append(f"{len(validation_results)} results")
 

--- a/datajunction-server/datajunction_server/internal/deployment/validation.py
+++ b/datajunction-server/datajunction_server/internal/deployment/validation.py
@@ -66,13 +66,10 @@ class ValidationContext:
     node_graph: Dict[str, List[str]]
     dependency_nodes: Dict[str, Node]
     deployment_namespace: Optional[str] = None
-    # Source node name -> set of dimension node names it links to via
-    # dimension_links declared ANYWHERE in this deployment (all topological
-    # levels), keyed and valued by rendered names. Dimension links are deployed
-    # after all node levels, so the committed graph cannot yet reveal them; the
-    # cross-fact derived-metric check consults this to avoid a false negative
-    # when the shared dimension only materializes once the deployment's links
-    # land. Empty for non-deployment (single-node) validation.
+    # Source node name -> dimension nodes it links to, across the whole
+    # deployment (rendered names). Links deploy after all node levels, so the
+    # cross-fact check uses this to see dimensions the committed graph can't yet.
+    # Empty for single-node validation.
     deployment_link_targets: Dict[str, set] = field(default_factory=dict)
 
 
@@ -814,16 +811,11 @@ class NodeSpecBulkValidator:
         if shared:
             return None
 
-        # Fail-open: dimension links are deployed AFTER nodes (orchestrator runs
-        # _deploy_nodes before _deploy_links), so at validation time the committed
-        # graph does not yet reflect links being created in this same deployment.
-        # get_dimensions can therefore only see each base metric's parent-local
-        # columns, yielding an empty intersection even when the base metrics will
-        # share a dimension once the pending links land. Before reporting a false
-        # negative, check whether the base metrics can reach a common dimension
-        # node once this deployment's links are applied; if so, suppress the
-        # error. A genuine offender (no common dimension even with pending links)
-        # still fails below.
+        # Fail-open: links deploy after nodes, so get_dimensions can't yet see
+        # links created in this same deployment and the intersection above is
+        # spuriously empty. Suppress the error if the base metrics can reach a
+        # common dimension node once those links land; a genuine offender (no
+        # common dimension even then) still fails below.
         reachable = [
             self._reachable_dimension_nodes(node.name) for node in metric_parents
         ]
@@ -848,25 +840,13 @@ class NodeSpecBulkValidator:
 
     def _reachable_dimension_nodes(self, base_metric_name: str) -> set[str]:
         """
-        The set of dimension node names a base metric can be sliced by, combining
-        the committed graph with dimension links created in THIS deployment.
+        Dimension nodes a base metric can be sliced by: committed dimensions
+        (from get_dimensions, reduced from ``<dim_node>.<col>[role]`` to the node
+        name) unioned with dimension nodes reachable from the metric's parent(s)
+        via this deployment's links (walked transitively for multi-hop chains).
 
-        Two sources are unioned:
-          * committed dimensions (from get_dimensions, stored in
-            self._metric_dimensions), reduced to their dimension-node names — a
-            dimension attribute name looks like ``<dim_node>.<col>`` with an
-            optional ``[role]`` suffix; only the node portion matters for
-            join-feasibility.
-          * dimension nodes reachable from the base metric's parent node(s) via
-            dimension_links declared anywhere in this deployment
-            (context.deployment_link_targets), walked transitively so multi-hop
-            link chains created in the same deployment are covered. Links are
-            deployed after all node levels, so this spec-derived map — not the
-            committed graph — is what reveals the pending links.
-
-        Used only as a fail-open guard: if two base metrics reach a common
-        dimension node here, they can be joined once the deployment completes, so
-        the cross-fact check must not reject them mid-deploy.
+        Node-level granularity is what join-feasibility needs. Used only as a
+        fail-open guard for the cross-fact check while links are still pending.
         """
         nodes: set[str] = set()
         for dim_name in self._metric_dimensions.get(base_metric_name, set()):
@@ -874,7 +854,7 @@ class NodeSpecBulkValidator:
             if "." in base:
                 nodes.add(base.rsplit(".", 1)[0])
 
-        # Walk pending links starting from the base metric's parent node(s).
+        # Walk this deployment's links from the base metric's parent node(s).
         pending = self.context.deployment_link_targets
         frontier = list(self.context.node_graph.get(base_metric_name, []))
         seen = set(frontier)

--- a/datajunction-server/datajunction_server/internal/deployment/validation.py
+++ b/datajunction-server/datajunction_server/internal/deployment/validation.py
@@ -66,6 +66,14 @@ class ValidationContext:
     node_graph: Dict[str, List[str]]
     dependency_nodes: Dict[str, Node]
     deployment_namespace: Optional[str] = None
+    # Source node name -> set of dimension node names it links to via
+    # dimension_links declared ANYWHERE in this deployment (all topological
+    # levels), keyed and valued by rendered names. Dimension links are deployed
+    # after all node levels, so the committed graph cannot yet reveal them; the
+    # cross-fact derived-metric check consults this to avoid a false negative
+    # when the shared dimension only materializes once the deployment's links
+    # land. Empty for non-deployment (single-node) validation.
+    deployment_link_targets: Dict[str, set] = field(default_factory=dict)
 
 
 @dataclass
@@ -806,6 +814,27 @@ class NodeSpecBulkValidator:
         if shared:
             return None
 
+        # Fail-open: dimension links are deployed AFTER nodes (orchestrator runs
+        # _deploy_nodes before _deploy_links), so at validation time the committed
+        # graph does not yet reflect links being created in this same deployment.
+        # get_dimensions can therefore only see each base metric's parent-local
+        # columns, yielding an empty intersection even when the base metrics will
+        # share a dimension once the pending links land. Before reporting a false
+        # negative, check whether the base metrics can reach a common dimension
+        # node once this deployment's links are applied; if so, suppress the
+        # error. A genuine offender (no common dimension even with pending links)
+        # still fails below.
+        reachable = [
+            self._reachable_dimension_nodes(node.name) for node in metric_parents
+        ]
+        reachable = [nodes for nodes in reachable if nodes]
+        if len(reachable) >= 2:
+            common = reachable[0]
+            for nodes in reachable[1:]:
+                common = common & nodes
+            if common:
+                return None
+
         metric_names = [m.name for m in metric_parents]
         return DJError(
             code=ErrorCode.INVALID_PARENT,
@@ -816,6 +845,47 @@ class NodeSpecBulkValidator:
                 f"at least one shared dimension for joining."
             ),
         )
+
+    def _reachable_dimension_nodes(self, base_metric_name: str) -> set[str]:
+        """
+        The set of dimension node names a base metric can be sliced by, combining
+        the committed graph with dimension links created in THIS deployment.
+
+        Two sources are unioned:
+          * committed dimensions (from get_dimensions, stored in
+            self._metric_dimensions), reduced to their dimension-node names — a
+            dimension attribute name looks like ``<dim_node>.<col>`` with an
+            optional ``[role]`` suffix; only the node portion matters for
+            join-feasibility.
+          * dimension nodes reachable from the base metric's parent node(s) via
+            dimension_links declared anywhere in this deployment
+            (context.deployment_link_targets), walked transitively so multi-hop
+            link chains created in the same deployment are covered. Links are
+            deployed after all node levels, so this spec-derived map — not the
+            committed graph — is what reveals the pending links.
+
+        Used only as a fail-open guard: if two base metrics reach a common
+        dimension node here, they can be joined once the deployment completes, so
+        the cross-fact check must not reject them mid-deploy.
+        """
+        nodes: set[str] = set()
+        for dim_name in self._metric_dimensions.get(base_metric_name, set()):
+            base = dim_name.split("[", 1)[0]
+            if "." in base:
+                nodes.add(base.rsplit(".", 1)[0])
+
+        # Walk pending links starting from the base metric's parent node(s).
+        pending = self.context.deployment_link_targets
+        frontier = list(self.context.node_graph.get(base_metric_name, []))
+        seen = set(frontier)
+        while frontier:
+            current = frontier.pop()
+            for target in pending.get(current, set()):
+                nodes.add(target)
+                if target not in seen:
+                    seen.add(target)
+                    frontier.append(target)
+        return nodes
 
     def _create_error_result(
         self,
@@ -903,6 +973,7 @@ async def bulk_validate_node_data(
     session: AsyncSession,
     dependency_nodes: Dict[str, Node],
     deployment_namespace: Optional[str] = None,
+    deployment_link_targets: Optional[Dict[str, set]] = None,
 ) -> List[NodeValidationResult]:
     """
     Bulk validate node specifications.
@@ -925,6 +996,7 @@ async def bulk_validate_node_data(
         node_graph=node_graph,
         dependency_nodes=dependency_nodes,
         deployment_namespace=deployment_namespace,
+        deployment_link_targets=deployment_link_targets or {},
     )
     validator = NodeSpecBulkValidator(context)
 

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -5853,17 +5853,17 @@ class TestCrossParentRatioDeployment:
     get_dimensions sees only each base metric's parent-local columns and the
     shared-dimension intersection is empty. The cross-fact check must not reject
     the derived metric mid-deploy when the pending links establish a common
-    dimension. Mirrors the production repro (visit-rate: fact ÷ dimension-node).
+    dimension. Mirrors the minimal fact ÷ dimension-node repro.
     """
 
     def _nodes(self):
         return [
             SourceSpec(
-                name="visit_raw",
-                description="Raw account-day visit facts",
+                name="fd_fact_raw",
+                description="Raw fact rows",
                 catalog="default",
                 schema="roads",
-                table="visit_raw",
+                table="fd_fact_raw",
                 columns=[
                     ColumnSpec(name="account_id", type="bigint"),
                     ColumnSpec(name="dateint", type="int"),
@@ -5873,11 +5873,11 @@ class TestCrossParentRatioDeployment:
                 owners=["dj"],
             ),
             SourceSpec(
-                name="stream_raw",
-                description="Raw account-day streaming eligibility",
+                name="fd_dim_raw",
+                description="Raw dimension rows",
                 catalog="default",
                 schema="roads",
-                table="stream_raw",
+                table="fd_dim_raw",
                 columns=[
                     ColumnSpec(name="account_id", type="bigint"),
                     ColumnSpec(name="dateint", type="int"),
@@ -5887,77 +5887,72 @@ class TestCrossParentRatioDeployment:
                 owners=["dj"],
             ),
             SourceSpec(
-                name="dates_raw",
+                name="dt_date_raw",
                 description="Raw dates",
                 catalog="default",
                 schema="roads",
-                table="dates_raw",
+                table="dt_date_raw",
                 columns=[ColumnSpec(name="dateint", type="int")],
                 dimension_links=[],
                 owners=["dj"],
             ),
             DimensionSpec(
-                name="dates_d",
+                name="dt_date_d_v2",
                 description="Conformed date dimension",
-                query="SELECT dateint FROM ${prefix}dates_raw",
+                query="SELECT dateint FROM ${prefix}dt_date_raw",
                 primary_key=["dateint"],
                 dimension_links=[],
                 owners=["dj"],
             ),
             # Numerator parent: a TRANSFORM, linked to the shared date dim.
             TransformSpec(
-                name="visit_f",
-                description="Account-day visit fact",
-                query="SELECT account_id, dateint, visited FROM ${prefix}visit_raw",
+                name="fd_fact",
+                description="Fact transform",
+                query="SELECT account_id, dateint, visited FROM ${prefix}fd_fact_raw",
                 dimension_links=[
                     DimensionJoinLinkSpec(
-                        dimension_node="${prefix}dates_d",
+                        dimension_node="${prefix}dt_date_d_v2",
                         join_type="left",
-                        join_on="${prefix}visit_f.dateint = ${prefix}dates_d.dateint",
+                        join_on="${prefix}fd_fact.dateint = ${prefix}dt_date_d_v2.dateint",
                     ),
                 ],
                 owners=["dj"],
             ),
             # Denominator parent: a DIMENSION node, linked to the same date dim.
             DimensionSpec(
-                name="stream_d",
-                description="Account-day streaming-eligibility dimension",
-                query=(
-                    "SELECT account_id, dateint, can_stream FROM ${prefix}stream_raw"
-                ),
+                name="fd_dim",
+                description="Dimension node holding the denominator",
+                query="SELECT account_id, dateint, can_stream FROM ${prefix}fd_dim_raw",
                 primary_key=["account_id", "dateint"],
                 dimension_links=[
                     DimensionJoinLinkSpec(
-                        dimension_node="${prefix}dates_d",
+                        dimension_node="${prefix}dt_date_d_v2",
                         join_type="left",
-                        join_on="${prefix}stream_d.dateint = ${prefix}dates_d.dateint",
+                        join_on="${prefix}fd_dim.dateint = ${prefix}dt_date_d_v2.dateint",
                     ),
                 ],
                 owners=["dj"],
             ),
             MetricSpec(
-                name="visited_count",
-                description="Accounts that visited",
-                query="SELECT SUM(visited) FROM ${prefix}visit_f",
+                name="fd_num",
+                description="Numerator (parent = transform)",
+                query="SELECT SUM(visited) FROM ${prefix}fd_fact",
                 dimension_links=[],
                 owners=["dj"],
             ),
             MetricSpec(
-                name="can_stream_count",
-                description="Accounts that can stream",
-                query="SELECT SUM(can_stream) FROM ${prefix}stream_d",
+                name="fd_den",
+                description="Denominator (parent = dimension node)",
+                query="SELECT SUM(can_stream) FROM ${prefix}fd_dim",
                 dimension_links=[],
                 owners=["dj"],
             ),
             # Cross-parent ratio: numerator (transform) ÷ denominator (dim node),
-            # sharing dates_d only through links deployed in this same batch.
+            # sharing dt_date_d_v2 only through links deployed in this same batch.
             MetricSpec(
-                name="visit_rate",
-                description="Visit rate = visited / can_stream",
-                query=(
-                    "SELECT CAST(${prefix}visited_count AS DOUBLE) "
-                    "/ ${prefix}can_stream_count"
-                ),
+                name="fd_ratio_cross",
+                description="fd_num / fd_den",
+                query=("SELECT CAST(${prefix}fd_num AS DOUBLE) / ${prefix}fd_den"),
                 dimension_links=[],
                 owners=["dj"],
             ),
@@ -5974,7 +5969,7 @@ class TestCrossParentRatioDeployment:
             DeploymentSpec(namespace=namespace, nodes=self._nodes()),
         )
         ratio_result = next(
-            r for r in data["results"] if r["name"] == f"{namespace}.visit_rate"
+            r for r in data["results"] if r["name"] == f"{namespace}.fd_ratio_cross"
         )
         # Before the fix this deployed with node status INVALID and the message
         # "[invalid] ... no shared dimensions"; the result status is the deploy
@@ -5983,6 +5978,6 @@ class TestCrossParentRatioDeployment:
         assert "invalid" not in ratio_result["message"], ratio_result
 
         # Deploy-time status must match what a fresh read/revalidation computes.
-        response = await client.get(f"/nodes/{namespace}.visit_rate/")
+        response = await client.get(f"/nodes/{namespace}.fd_ratio_cross/")
         assert response.status_code == 200, response.json()
         assert response.json()["status"] == "valid"

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -5840,3 +5840,149 @@ class TestExternalPreAggDeploy:
             assert listing.json()["items"] == []
         finally:
             _clear_query_service(client)
+
+
+@pytest.mark.xdist_group(name="deployments")
+class TestCrossParentRatioDeployment:
+    """Cross-parent ratio metric (numerator on a transform, denominator on a
+    DIMENSION node) whose base metrics share a dimension ONLY via dimension
+    links created in the same deployment.
+
+    Regression for the deploy-time false negative: dimension links are deployed
+    after nodes (_deploy_nodes runs before _deploy_links), so at validation time
+    get_dimensions sees only each base metric's parent-local columns and the
+    shared-dimension intersection is empty. The cross-fact check must not reject
+    the derived metric mid-deploy when the pending links establish a common
+    dimension. Mirrors the production repro (visit-rate: fact ÷ dimension-node).
+    """
+
+    def _nodes(self):
+        return [
+            SourceSpec(
+                name="visit_raw",
+                description="Raw account-day visit facts",
+                catalog="default",
+                schema="roads",
+                table="visit_raw",
+                columns=[
+                    ColumnSpec(name="account_id", type="bigint"),
+                    ColumnSpec(name="dateint", type="int"),
+                    ColumnSpec(name="visited", type="int"),
+                ],
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            SourceSpec(
+                name="stream_raw",
+                description="Raw account-day streaming eligibility",
+                catalog="default",
+                schema="roads",
+                table="stream_raw",
+                columns=[
+                    ColumnSpec(name="account_id", type="bigint"),
+                    ColumnSpec(name="dateint", type="int"),
+                    ColumnSpec(name="can_stream", type="int"),
+                ],
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            SourceSpec(
+                name="dates_raw",
+                description="Raw dates",
+                catalog="default",
+                schema="roads",
+                table="dates_raw",
+                columns=[ColumnSpec(name="dateint", type="int")],
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            DimensionSpec(
+                name="dates_d",
+                description="Conformed date dimension",
+                query="SELECT dateint FROM ${prefix}dates_raw",
+                primary_key=["dateint"],
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            # Numerator parent: a TRANSFORM, linked to the shared date dim.
+            TransformSpec(
+                name="visit_f",
+                description="Account-day visit fact",
+                query="SELECT account_id, dateint, visited FROM ${prefix}visit_raw",
+                dimension_links=[
+                    DimensionJoinLinkSpec(
+                        dimension_node="${prefix}dates_d",
+                        join_type="left",
+                        join_on="${prefix}visit_f.dateint = ${prefix}dates_d.dateint",
+                    ),
+                ],
+                owners=["dj"],
+            ),
+            # Denominator parent: a DIMENSION node, linked to the same date dim.
+            DimensionSpec(
+                name="stream_d",
+                description="Account-day streaming-eligibility dimension",
+                query=(
+                    "SELECT account_id, dateint, can_stream FROM ${prefix}stream_raw"
+                ),
+                primary_key=["account_id", "dateint"],
+                dimension_links=[
+                    DimensionJoinLinkSpec(
+                        dimension_node="${prefix}dates_d",
+                        join_type="left",
+                        join_on="${prefix}stream_d.dateint = ${prefix}dates_d.dateint",
+                    ),
+                ],
+                owners=["dj"],
+            ),
+            MetricSpec(
+                name="visited_count",
+                description="Accounts that visited",
+                query="SELECT SUM(visited) FROM ${prefix}visit_f",
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            MetricSpec(
+                name="can_stream_count",
+                description="Accounts that can stream",
+                query="SELECT SUM(can_stream) FROM ${prefix}stream_d",
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            # Cross-parent ratio: numerator (transform) ÷ denominator (dim node),
+            # sharing dates_d only through links deployed in this same batch.
+            MetricSpec(
+                name="visit_rate",
+                description="Visit rate = visited / can_stream",
+                query=(
+                    "SELECT CAST(${prefix}visited_count AS DOUBLE) "
+                    "/ ${prefix}can_stream_count"
+                ),
+                dimension_links=[],
+                owners=["dj"],
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_cross_parent_ratio_shared_dim_via_pending_links_is_valid(
+        self,
+        client,
+    ):
+        namespace = "cross_parent_ratio"
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=self._nodes()),
+        )
+        ratio_result = next(
+            r for r in data["results"] if r["name"] == f"{namespace}.visit_rate"
+        )
+        # Before the fix this deployed with node status INVALID and the message
+        # "[invalid] ... no shared dimensions"; the result status is the deploy
+        # outcome ("success"), the node validity is asserted via GET below.
+        assert ratio_result["status"] == "success", ratio_result
+        assert "invalid" not in ratio_result["message"], ratio_result
+
+        # Deploy-time status must match what a fresh read/revalidation computes.
+        response = await client.get(f"/nodes/{namespace}.visit_rate/")
+        assert response.status_code == 200, response.json()
+        assert response.json()["status"] == "valid"

--- a/datajunction-server/tests/internal/deployment/validation_test.py
+++ b/datajunction-server/tests/internal/deployment/validation_test.py
@@ -940,6 +940,92 @@ class TestCrossFactDimensions:
         validator = NodeSpecBulkValidator(context)
         assert validator._check_cross_fact_dimensions(spec) is None
 
+    def test_pending_links_suppress_false_negative(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """Shared dimension reachable only via links created in the SAME deploy.
+
+        Dimension links are deployed after nodes (orchestrator: _deploy_nodes runs
+        before _deploy_links), so at validation time get_dimensions can only see
+        each base metric's parent-local columns — no shared dimension yet. The
+        check must not emit a false negative when the pending links in this deploy
+        would establish a common dimension node.
+        """
+        num = _make_metric_node("test.fd_num")  # parent transform test.fd_fact
+        den = _make_metric_node("test.fd_den")  # parent dimension test.fd_dim
+        context = ValidationContext(
+            session=session,
+            node_graph={
+                "test.fd_ratio": [num.name, den.name],
+                "test.fd_num": ["test.fd_fact"],
+                "test.fd_den": ["test.fd_dim"],
+            },
+            dependency_nodes={num.name: num, den.name: den},
+            # Dimension links declared in THIS deploy: both parents link the
+            # conformed date dim, so the base metrics can share it once the
+            # links land.
+            deployment_link_targets={
+                "test.fd_fact": {"test.dt_date_d_v2", "test.fd_dim"},
+                "test.fd_dim": {"test.dt_date_d_v2"},
+            },
+        )
+        spec = MetricSpec(
+            name="test.fd_ratio",
+            query="SELECT test_fd_num / test_fd_den FROM test.fd_num, test.fd_den",
+        )
+        validator = NodeSpecBulkValidator(context)
+        # Committed graph (links not created yet): each base metric only sees its
+        # own parent's local/PK columns — no shared dimension at column level.
+        validator._metric_dimensions = {
+            num.name: {"test.fd_fact.account_id", "test.fd_fact.dateint"},
+            den.name: {
+                "test.fd_dim.account_id",
+                "test.fd_dim.dateint",
+                "test.fd_dim.plan",
+            },
+        }
+
+        assert validator._check_cross_fact_dimensions(spec) is None
+
+    def test_pending_links_unrelated_still_invalid(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """Fail-open must not disable the check: base metrics that cannot share a
+        dimension even with the deploy's pending links still fail."""
+        ma = _make_metric_node("test.metric_a")  # parent test.fact_a
+        mb = _make_metric_node("test.metric_b")  # parent test.fact_b
+        context = ValidationContext(
+            session=session,
+            node_graph={
+                "test.derived": [ma.name, mb.name],
+                "test.metric_a": ["test.fact_a"],
+                "test.metric_b": ["test.fact_b"],
+            },
+            dependency_nodes={ma.name: ma, mb.name: mb},
+            # Pending links go to different dimension nodes — no common dimension.
+            deployment_link_targets={
+                "test.fact_a": {"test.dim_a"},
+                "test.fact_b": {"test.dim_b"},
+            },
+        )
+        spec = MetricSpec(
+            name="test.derived",
+            query="SELECT test_metric_a + test_metric_b FROM test.metric_a, test.metric_b",
+        )
+        validator = NodeSpecBulkValidator(context)
+        validator._metric_dimensions = {
+            ma.name: {"test.fact_a.x"},
+            mb.name: {"test.fact_b.y"},
+        }
+
+        err = validator._check_cross_fact_dimensions(spec)
+        assert err is not None
+        assert err.code == ErrorCode.INVALID_PARENT
+
     # ------------------------------------------------------------------ prefetch tests
 
     @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

Deploying a derived metric whose two base metrics have different parents (e.g. the numerator defined on a transform and the denominator defined on a dimension node) fails validation with:
```
Cannot create derived metric from base metrics with no shared dimensions.
The following metrics have no dimensions in common: ...
Cross-fact derived metrics require at least one shared dimension for joining.
```
even when the base metrics do share a dimension. The node deploys as `INVALID`, but a subsequent re-deploy of the exact same specs validates cleanly, so the check is order-dependent and not a real modeling error.

This is because within a deployment, nodes are deployed level-by-level and all dimension links are deployed afterward. The cross-fact shared-dimension check runs during per-level node validation, so `get_dimensions()` for each base metric can only see its parent's local/PK columns -- the dimension links that would make the shared dimension reachable don't exist in the committed graph yet. The intersection of the base metrics' dimension sets is therefore spuriously empty, and the derived metric is flagged invalid. On a later deploy the links already exist, so the same specs validate.

Two compounding factors:
- Validation is per topological level, so the link-bearing parent specs aren't even in the batch being validated when the derived metric is checked.
- The check compares dimension attribute names (<dim_node>.<col>), so two metrics that reach the same dimension node via different columns wouldn't intersect regardless.

The fix is to make the check aware of links that this deployment will create:

- Thread a deployment-wide `deployment_link_targets` map (source node to dimension nodes it links to, across all levels) into `ValidationContext`, built once from the deployment specs.
- The happy path is unchanged: if the base metrics already intersect on a committed dimension, return valid.
- Only when that intersection is empty, consult `_reachable_dimension_nodes()`, the union of each base metric's committed dimensions and the dimension nodes reachable from its parent(s) via this deployment's pending links (walked transitively), compared at dimension-node granularity (which is what join-feasibility actually requires). If the base metrics can reach a common dimension node once links land, suppress the error.
- A non-joinable pair still fails.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
