### PR TITLE
Support dimension column mapping for externally-registered pre-aggregations

### DIFF
--- a/datajunction-server/datajunction_server/api/preaggregations.py
+++ b/datajunction-server/datajunction_server/api/preaggregations.py
@@ -728,6 +728,7 @@ async def register_preaggregations(
         dimensions=data.dimensions,
         table=data.table,
         measure_columns=data.measure_columns,
+        dimension_columns=data.dimension_columns,
     )
     await session.commit()
 

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -72,6 +72,7 @@ from datajunction_server.construction.build_v3.dimensions import (
 )
 from datajunction_server.construction.build_v3.preagg_matcher import (
     find_matching_preagg,
+    get_preagg_dimension_column,
     get_preagg_measure_column,
 )
 from datajunction_server.internal.scan_estimation import calculate_scan_estimate
@@ -1785,16 +1786,35 @@ def build_grain_group_from_preagg(
     unique_components: list[MetricComponent] = []
     seen_components: set[str] = set()
 
-    # Add dimension columns (grain columns)
+    # Add dimension columns (grain columns).
+    # grain_col_names holds the logical (output) grain column names; group_by_cols
+    # holds the physical columns actually read from the table. They diverge only
+    # when an externally-registered pre-agg maps a dimension to a differently
+    # named physical column.
     grain_col_names: list[str] = []
+    group_by_cols: list[str] = []
     for dim in resolved_dimensions:
         col_name = dim.column_name
         grain_col_names.append(col_name)
 
-        col_ref = ast.Column(name=ast.Name(col_name))
-        select_items.append(col_ref)
+        # Externally-registered pre-aggs may store this dimension under a
+        # different physical column name; read the physical column and alias it
+        # back to the DJ column name so downstream references are unchanged.
+        physical_col = get_preagg_dimension_column(preagg, dim.original_ref, col_name)
+        group_by_cols.append(physical_col)
 
-        # Get type from pre-agg columns if available
+        if physical_col == col_name:
+            select_items.append(ast.Column(name=ast.Name(col_name)))
+        else:
+            select_items.append(
+                ast.Alias(
+                    child=ast.Column(name=ast.Name(physical_col)),
+                    alias=ast.Name(col_name),
+                ),
+            )
+
+        # Type metadata is stored under the DJ column name (source_column is
+        # separate), so look it up by col_name, not the physical column.
         col_type = preagg.get_column_type(col_name, default="string")
         columns.append(
             ColumnMetadata(
@@ -1843,6 +1863,7 @@ def build_grain_group_from_preagg(
             # No merge - output grain column directly, add to GROUP BY
             select_items.append(col_ref)
             grain_col_names.append(measure_col)
+            group_by_cols.append(measure_col)
             output_alias = measure_col
             component_aliases[component.name] = output_alias
 
@@ -1857,10 +1878,10 @@ def build_grain_group_from_preagg(
             ),
         )
 
-    # Build GROUP BY clause (list of column references)
+    # Build GROUP BY clause (physical columns actually read from the table)
     group_by: list[ast.Expression] = []
-    if grain_col_names:
-        group_by = [ast.Column(name=ast.Name(col)) for col in grain_col_names]
+    if group_by_cols:
+        group_by = [ast.Column(name=ast.Name(col)) for col in group_by_cols]
 
     # Build FROM clause using the helper method
     preagg_table = SEPARATOR.join(table_parts)

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -1786,20 +1786,16 @@ def build_grain_group_from_preagg(
     unique_components: list[MetricComponent] = []
     seen_components: set[str] = set()
 
-    # Add dimension columns (grain columns).
-    # grain_col_names holds the logical (output) grain column names; group_by_cols
-    # holds the physical columns actually read from the table. They diverge only
-    # when an externally-registered pre-agg maps a dimension to a differently
-    # named physical column.
+    # Dimension (grain) columns. grain_col_names = logical output names;
+    # group_by_cols = physical columns read (they differ only when an external
+    # pre-agg remaps a dimension's column).
     grain_col_names: list[str] = []
     group_by_cols: list[str] = []
     for dim in resolved_dimensions:
         col_name = dim.column_name
         grain_col_names.append(col_name)
 
-        # Externally-registered pre-aggs may store this dimension under a
-        # different physical column name; read the physical column and alias it
-        # back to the DJ column name so downstream references are unchanged.
+        # Read the physical column (may be remapped) and alias to the DJ name.
         physical_col = get_preagg_dimension_column(preagg, dim.original_ref, col_name)
         group_by_cols.append(physical_col)
 
@@ -1813,8 +1809,7 @@ def build_grain_group_from_preagg(
                 ),
             )
 
-        # Type metadata is stored under the DJ column name (source_column is
-        # separate), so look it up by col_name, not the physical column.
+        # Type metadata is keyed by the DJ name, not the physical column.
         col_type = preagg.get_column_type(col_name, default="string")
         columns.append(
             ColumnMetadata(

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -181,6 +181,27 @@ def get_preagg_measure_column(
     return None
 
 
+def get_preagg_dimension_column(
+    preagg: PreAggregation,
+    dimension_ref: str,
+    default_column: str,
+) -> str:
+    """
+    Physical column in the pre-agg that backs a resolved grain dimension.
+
+    Externally-registered pre-aggs may store a dimension under a column name that
+    differs from the DJ dimension's; the binding is recorded on the pre-agg's
+    column metadata (``source_column``). Matched by the dimension reference
+    (``semantic_name`` == the resolved dimension's ``original_ref``, so it is
+    role-safe), falling back to the DJ column name for unmapped dimensions and
+    DJ-materialized pre-aggs.
+    """
+    for col in preagg.columns or []:
+        if col.semantic_type == "dimension" and col.semantic_name == dimension_ref:
+            return col.source_column or col.name
+    return default_column
+
+
 def get_temporal_partitions(preagg: PreAggregation) -> list[TemporalPartitionColumn]:
     """
     Get temporal partition columns for a pre-aggregation.

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -187,14 +187,11 @@ def get_preagg_dimension_column(
     default_column: str,
 ) -> str:
     """
-    Physical column in the pre-agg that backs a resolved grain dimension.
+    Physical column in the pre-agg backing a resolved grain dimension.
 
-    Externally-registered pre-aggs may store a dimension under a column name that
-    differs from the DJ dimension's; the binding is recorded on the pre-agg's
-    column metadata (``source_column``). Matched by the dimension reference
-    (``semantic_name`` == the resolved dimension's ``original_ref``, so it is
-    role-safe), falling back to the DJ column name for unmapped dimensions and
-    DJ-materialized pre-aggs.
+    External pre-aggs may store a dimension under a different column name (kept as
+    source_column). Matched by dimension reference (semantic_name == original_ref,
+    so role-safe), falling back to the DJ column name.
     """
     for col in preagg.columns or []:
         if col.semantic_type == "dimension" and col.semantic_name == dimension_ref:

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -1155,6 +1155,7 @@ class DeploymentOrchestrator:
                             valid_through_ts=spec.valid_through_ts,
                         ),
                         measure_columns=spec.rendered_measure_columns,
+                        dimension_columns=spec.rendered_dimension_columns,
                     )
                     upserted_ids.update(preagg.id for preagg in created)
                     for preagg in created:

--- a/datajunction-server/datajunction_server/internal/preaggregations.py
+++ b/datajunction-server/datajunction_server/internal/preaggregations.py
@@ -43,16 +43,14 @@ def assert_column_type_compatible(
     table: ExternalPreAggTable,
 ) -> None:
     """
-    Reject a mapping whose physical column type is incompatible with the expected
-    type of the element it backs (e.g. a SUM measure, or a numeric dimension,
-    bound to a string column). ``subject`` names the element in the error message,
-    e.g. ``"measure 'x'"`` or ``"dimension 'ns.d.attr'"``.
+    Reject a mapping whose physical column type is incompatible with the element
+    it backs (e.g. a SUM measure, or numeric dimension, bound to a string
+    column). subject names the element in the error message.
 
-    Conservative by design: both types are re-parsed into concrete ``ColumnType``
-    subclasses (the query service wraps physical types as a bare ``ColumnType``
-    string, which ``is_compatible`` cannot reason about), and the check is skipped
-    whenever a type is unknown or unparseable. Only clear cross-family mismatches
-    are rejected, so int-vs-bigint never false-fails.
+    Conservative: both types are re-parsed to concrete ColumnType subclasses (the
+    query service returns a bare type string is_compatible can't reason about),
+    and the check is skipped on unknown/unparseable types, so int-vs-bigint never
+    false-fails.
     """
     from datajunction_server.sql.parsing.backends.antlr4 import parse_rule
     from datajunction_server.sql.parsing.types import ColumnType
@@ -224,11 +222,8 @@ async def register_external_preaggregations(
                 ),
             )
 
-        # Bind grain/dimension columns to physical columns where the external
-        # table names them differently (dimension_columns), keyed by the
-        # dimension reference (col.semantic_name == the requested dim ref). The
-        # measure columns keep source_column=None here; their physical binding
-        # travels on the PreAggMeasure above.
+        # Bind dimension columns to physical columns via dimension_columns, keyed
+        # by dimension reference. Measures carry their binding on PreAggMeasure.
         columns = []
         for col in grain_group.columns:
             source_column = None

--- a/datajunction-server/datajunction_server/internal/preaggregations.py
+++ b/datajunction-server/datajunction_server/internal/preaggregations.py
@@ -34,24 +34,25 @@ from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.decompose import MetricComponentExtractor
 
 
-def assert_measure_column_compatible(
+def assert_column_type_compatible(
     *,
-    measure_name: str,
+    subject: str,
     physical_column: str,
     expected_type: Optional[str],
     actual_type: object,
     table: ExternalPreAggTable,
 ) -> None:
     """
-    Reject a ``measure_columns`` mapping whose physical column type is
-    incompatible with the measure's expected type (e.g. a SUM measure bound to
-    a string column).
+    Reject a mapping whose physical column type is incompatible with the expected
+    type of the element it backs (e.g. a SUM measure, or a numeric dimension,
+    bound to a string column). ``subject`` names the element in the error message,
+    e.g. ``"measure 'x'"`` or ``"dimension 'ns.d.attr'"``.
 
-    Conservative by design: both types are re-parsed into concrete
-    ``ColumnType`` subclasses (the query service wraps physical types as a bare
-    ``ColumnType`` string, which ``is_compatible`` cannot reason about), and the
-    check is skipped whenever a type is unknown or unparseable. Only clear
-    cross-family mismatches are rejected, so int-vs-bigint never false-fails.
+    Conservative by design: both types are re-parsed into concrete ``ColumnType``
+    subclasses (the query service wraps physical types as a bare ``ColumnType``
+    string, which ``is_compatible`` cannot reason about), and the check is skipped
+    whenever a type is unknown or unparseable. Only clear cross-family mismatches
+    are rejected, so int-vs-bigint never false-fails.
     """
     from datajunction_server.sql.parsing.backends.antlr4 import parse_rule
     from datajunction_server.sql.parsing.types import ColumnType
@@ -68,8 +69,7 @@ def assert_measure_column_compatible(
             message=(
                 f"Column '{physical_column}' (type {actual}) in table "
                 f"{table.catalog}.{table.schema_}.{table.table} is not "
-                f"type-compatible with measure '{measure_name}' "
-                f"(expected {expected})."
+                f"type-compatible with {subject} (expected {expected})."
             ),
         )
 
@@ -84,6 +84,7 @@ async def register_external_preaggregations(
     dimensions: list[str],
     table: ExternalPreAggTable,
     measure_columns: dict[str, str],
+    dimension_columns: dict[str, str] | None = None,
 ) -> list[PreAggregation]:
     """
     Core logic for adopting an externally-built pre-aggregation table.
@@ -146,17 +147,27 @@ async def register_external_preaggregations(
         request_headers,
         catalog.engines[0] if catalog.engines else None,
     )
+    dimension_columns = dimension_columns or {}
+    unknown_dims = sorted(set(dimension_columns) - set(dimensions))
+    if unknown_dims:
+        raise DJInvalidInputException(
+            message=(
+                f"dimension_columns references {unknown_dims}, which are not in "
+                f"the pre-aggregation's dimensions {sorted(dimensions)}."
+            ),
+        )
     table_columns_by_name = {col.name: col.type for col in table_columns}
     missing_columns = sorted(
         column
-        for column in measure_hash_to_column.values()
+        for column in (*measure_columns.values(), *dimension_columns.values())
         if column not in table_columns_by_name
     )
     if missing_columns:
         raise DJInvalidInputException(
             message=(
-                f"Columns {missing_columns} declared in measure_columns were not "
-                f"found in table {table.catalog}.{table.schema_}.{table.table}."
+                f"Columns {missing_columns} declared in measure_columns/"
+                f"dimension_columns were not found in table "
+                f"{table.catalog}.{table.schema_}.{table.table}."
             ),
         )
 
@@ -194,8 +205,8 @@ async def register_external_preaggregations(
                 component.name,
                 component.name,
             )
-            assert_measure_column_compatible(
-                measure_name=component.name,
+            assert_column_type_compatible(
+                subject=f"measure '{component.name}'",
                 physical_column=physical_column,
                 expected_type=measure_types.get(measure_name)
                 or measure_types.get(component.name),
@@ -213,15 +224,33 @@ async def register_external_preaggregations(
                 ),
             )
 
-        columns = [
-            V3ColumnMetadata(
-                name=col.name,
-                type=col.type,
-                semantic_type=col.semantic_type,
-                semantic_name=col.semantic_name,
+        # Bind grain/dimension columns to physical columns where the external
+        # table names them differently (dimension_columns), keyed by the
+        # dimension reference (col.semantic_name == the requested dim ref). The
+        # measure columns keep source_column=None here; their physical binding
+        # travels on the PreAggMeasure above.
+        columns = []
+        for col in grain_group.columns:
+            source_column = None
+            if col.semantic_type == "dimension":
+                source_column = dimension_columns.get(col.semantic_name)
+                if source_column is not None:
+                    assert_column_type_compatible(
+                        subject=f"dimension '{col.semantic_name}'",
+                        physical_column=source_column,
+                        expected_type=col.type,
+                        actual_type=table_columns_by_name[source_column],
+                        table=table,
+                    )
+            columns.append(
+                V3ColumnMetadata(
+                    name=col.name,
+                    type=col.type,
+                    semantic_type=col.semantic_type,
+                    semantic_name=col.semantic_name,
+                    source_column=source_column,
+                ),
             )
-            for col in grain_group.columns
-        ]
         grain_group_hash = compute_grain_group_hash(node_revision_id, grain_columns)
         existing = await PreAggregation.find_matching(
             session=session,

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -131,9 +131,8 @@ class PreAggSpec(NamespacedSpec):
     table: str
     valid_through_ts: int | None = None
     measure_columns: dict[str, str] = Field(default_factory=dict)
-    # Optional physical-column binding for grain/dimension columns, keyed by the
-    # dimension reference (same strings used in ``dimensions``). Unmapped
-    # dimensions default to their DJ column name.
+    # Physical-column binding for dimensions, keyed by dimension reference.
+    # Unmapped dimensions default to their DJ column name.
     dimension_columns: dict[str, str] = Field(default_factory=dict)
 
     model_config = ConfigDict(populate_by_name=True)

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -131,6 +131,10 @@ class PreAggSpec(NamespacedSpec):
     table: str
     valid_through_ts: int | None = None
     measure_columns: dict[str, str] = Field(default_factory=dict)
+    # Optional physical-column binding for grain/dimension columns, keyed by the
+    # dimension reference (same strings used in ``dimensions``). Unmapped
+    # dimensions default to their DJ column name.
+    dimension_columns: dict[str, str] = Field(default_factory=dict)
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -147,6 +151,13 @@ class PreAggSpec(NamespacedSpec):
         return {
             render_prefixes(metric, self.namespace): column
             for metric, column in self.measure_columns.items()
+        }
+
+    @property
+    def rendered_dimension_columns(self) -> dict[str, str]:
+        return {
+            render_prefixes(dimension, self.namespace): column
+            for dimension, column in self.dimension_columns.items()
         }
 
 

--- a/datajunction-server/datajunction_server/models/preaggregation.py
+++ b/datajunction-server/datajunction_server/models/preaggregation.py
@@ -140,6 +140,14 @@ class RegisterPreAggregationsRequest(BaseModel):
             "measure of the requested metrics must be covered."
         ),
     )
+    dimension_columns: Dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Optional map of dimension reference to the physical column in the "
+            "external table backing it, when the column name differs from the "
+            "dimension's. Unmapped dimensions default to their DJ column name."
+        ),
+    )
 
 
 class UpdatePreAggregationAvailabilityRequest(BaseModel):

--- a/datajunction-server/datajunction_server/models/query.py
+++ b/datajunction-server/datajunction_server/models/query.py
@@ -11,6 +11,7 @@ from pydantic import (
     AnyHttpUrl,
     Field,
     field_serializer,
+    model_serializer,
     RootModel,
     ConfigDict,
 )
@@ -83,6 +84,14 @@ class V3ColumnMetadata(BaseModel):
     source_column: str | None = None
 
     model_config = ConfigDict(populate_by_name=True)
+
+    @model_serializer(mode="wrap")
+    def _omit_null_source_column(self, handler):
+        # Keep output backward-compatible: only surface source_column when set.
+        data = handler(self)
+        if isinstance(data, dict) and data.get("source_column") is None:
+            data.pop("source_column", None)
+        return data
 
     def __hash__(self):
         return hash((self.name, self.type, self.semantic_name))  # pragma: no cover

--- a/datajunction-server/datajunction_server/models/query.py
+++ b/datajunction-server/datajunction_server/models/query.py
@@ -78,6 +78,11 @@ class V3ColumnMetadata(BaseModel):
         serialization_alias="semantic_entity",
     )
     semantic_type: str  # "dimension" or "metric"
+    # For externally-registered pre-aggregations: the physical column in the
+    # external table backing this element, when it differs from ``name``. None
+    # means the physical column matches ``name`` (the default / DJ-materialized
+    # case). Mirrors ``PreAggMeasure.source_column`` for dimension/grain columns.
+    source_column: str | None = None
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/datajunction-server/datajunction_server/models/query.py
+++ b/datajunction-server/datajunction_server/models/query.py
@@ -78,10 +78,8 @@ class V3ColumnMetadata(BaseModel):
         serialization_alias="semantic_entity",
     )
     semantic_type: str  # "dimension" or "metric"
-    # For externally-registered pre-aggregations: the physical column in the
-    # external table backing this element, when it differs from ``name``. None
-    # means the physical column matches ``name`` (the default / DJ-materialized
-    # case). Mirrors ``PreAggMeasure.source_column`` for dimension/grain columns.
+    # Physical column backing this element when it differs from name (external
+    # pre-aggs); None means it matches name. Mirrors PreAggMeasure.source_column.
     source_column: str | None = None
 
     model_config = ConfigDict(populate_by_name=True)

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -5498,7 +5498,7 @@ def _clear_query_service(client):
     client.app.dependency_overrides.pop(get_query_service_client, None)
 
 
-def _preagg_spec(name, table, measure_columns, dimensions=None):
+def _preagg_spec(name, table, measure_columns, dimensions=None, dimension_columns=None):
     return PreAggSpec(
         name=name,
         metrics=["${prefix}default.count_hard_hats"],
@@ -5508,6 +5508,7 @@ def _preagg_spec(name, table, measure_columns, dimensions=None):
         table=table,
         valid_through_ts=1700000000,
         measure_columns=measure_columns,
+        dimension_columns=dimension_columns or {},
     )
 
 
@@ -5838,6 +5839,59 @@ class TestExternalPreAggDeploy:
             assert data["status"] == "success", data["results"]
             listing = await client.get("/preaggs/", params={"node_name": fact_node})
             assert listing.json()["items"] == []
+        finally:
+            _clear_query_service(client)
+
+    @pytest.mark.asyncio
+    async def test_deploy_preagg_with_dimension_columns(
+        self,
+        client,
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+    ):
+        """dimension_columns on a deployed pre-agg flows through reconcile so the
+        renamed physical dimension column is read at query time."""
+        _override_query_service(
+            client,
+            {"hh_state": "string", "hard_hat_count": "bigint"},
+        )
+        try:
+            nodes = _hard_hat_deploy_nodes(
+                default_hard_hats,
+                default_us_states,
+                default_us_state,
+            )
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace="preagg_dimcol",
+                    nodes=nodes,
+                    preaggregations=[
+                        _preagg_spec(
+                            "hh_by_state",
+                            "hh_by_state_agg",
+                            {"${prefix}default.count_hard_hats": "hard_hat_count"},
+                            dimension_columns={
+                                "${prefix}default.us_state.state_name": "hh_state",
+                            },
+                        ),
+                    ],
+                ),
+            )
+            assert data["status"] == "success", data["results"]
+            # The registered pre-agg reads the renamed physical dimension column.
+            response = await client.get(
+                "/sql/measures/v3/",
+                params={
+                    "metrics": ["preagg_dimcol.default.count_hard_hats"],
+                    "dimensions": ["preagg_dimcol.default.us_state.state_name"],
+                },
+            )
+            assert response.status_code == 200
+            sql = response.json()["grain_groups"][0]["sql"]
+            assert "default.analytics.hh_by_state_agg" in sql
+            assert "hh_state" in sql
         finally:
             _clear_query_service(client)
 

--- a/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
@@ -8,10 +8,12 @@ from sqlalchemy.orm import joinedload, selectinload
 
 from datajunction_server.construction.build_v3.preagg_matcher import (
     find_matching_preagg,
+    get_preagg_dimension_column,
     get_preagg_measure_column,
     get_required_measure_hashes,
     get_temporal_partitions,
 )
+from datajunction_server.models.query import V3ColumnMetadata
 from datajunction_server.construction.build_v3.types import BuildContext, GrainGroup
 from datajunction_server.database.availabilitystate import AvailabilityState
 from datajunction_server.database.column import Column
@@ -67,6 +69,33 @@ def make_preagg_measure(
         rule=AggregationRule(type=Aggregability.FULL),
         expr_hash=compute_expression_hash(expression),
     )
+
+
+def test_get_preagg_dimension_column():
+    """Returns the mapped physical column when present, else the DJ column name."""
+    preagg = PreAggregation(
+        columns=[
+            V3ColumnMetadata(
+                name="status",
+                type="string",
+                semantic_name="v3.order_details.status",
+                semantic_type="dimension",
+                source_column="order_status",
+            ),
+        ],
+    )
+    # Mapped dimension -> its physical source column.
+    assert (
+        get_preagg_dimension_column(preagg, "v3.order_details.status", "status")
+        == "order_status"
+    )
+    # A dimension not in the pre-agg's columns falls back to the DJ column name.
+    assert (
+        get_preagg_dimension_column(preagg, "v3.order_details.other", "other")
+        == "other"
+    )
+    # No columns at all also falls back.
+    assert get_preagg_dimension_column(PreAggregation(columns=None), "x", "y") == "y"
 
 
 @pytest_asyncio.fixture

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -741,6 +741,90 @@ class TestExternalPreAggRouting:
             in bad_type.json()["message"]
         )
 
+    @pytest.mark.asyncio
+    async def test_external_preagg_joined_attribute_read_directly(
+        self,
+        client_with_build_v3,
+    ):
+        """A joined dimension attribute stored (denormalized) in the external
+        table is read directly from it via dimension_columns -- no join back to
+        the dimension node."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.product.category"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_category",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.product.category": "cat"},
+            table_columns={"cat": "string", "rev_sum": "double"},
+        )
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.product.category"],
+            },
+        )
+        assert measures_response.status_code == 200
+        measures_sql = get_first_grain_group(measures_response.json())["sql"]
+        # No JOIN to the product dimension -- the attribute is read from the agg.
+        assert "join" not in measures_sql.lower()
+        assert_sql_equal(
+            measures_sql,
+            """
+            SELECT cat category, SUM(rev_sum) rev_sum
+            FROM default.analytics.revenue_by_category
+            GROUP BY cat
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_renamed_measure_and_dimensions(
+        self,
+        client_with_build_v3,
+    ):
+        """Renamed measure and multiple renamed dimensions (a local column and a
+        joined attribute) coexist on one external table."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status", "v3.product.category"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_status_category",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={
+                "v3.order_details.status": "st",
+                "v3.product.category": "cat",
+            },
+            table_columns={"st": "string", "cat": "string", "rev_sum": "double"},
+        )
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status", "v3.product.category"],
+            },
+        )
+        assert measures_response.status_code == 200
+        measures_sql = get_first_grain_group(measures_response.json())["sql"]
+        assert_sql_equal(
+            measures_sql,
+            """
+            SELECT st status, cat category, SUM(rev_sum) rev_sum
+            FROM default.analytics.revenue_by_status_category
+            GROUP BY st, cat
+            """,
+        )
+
 
 class TestMetricsSQLWithPreAggregation:
     """

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -47,11 +47,13 @@ async def _register_external_preagg(
     table_ref,
     measure_columns,
     table_columns,
+    dimension_columns=None,
+    expected_status=201,
 ):
     """
     Register an externally-built pre-aggregation via /preaggs/register with a
     mocked query service that reports ``table_columns`` for the external table.
-    Returns the created pre-agg payloads.
+    Returns the response (asserts ``expected_status``).
     """
 
     items = (
@@ -67,17 +69,17 @@ async def _register_external_preagg(
     mock_qs.get_columns_for_table = _fake_columns
     client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
     try:
-        response = await client.post(
-            "/preaggs/register",
-            json={
-                "metrics": metrics,
-                "dimensions": dimensions,
-                "table": table_ref,
-                "measure_columns": measure_columns,
-            },
-        )
-        assert response.status_code == 201, response.text
-        return response.json()["preaggs"]
+        payload = {
+            "metrics": metrics,
+            "dimensions": dimensions,
+            "table": table_ref,
+            "measure_columns": measure_columns,
+        }
+        if dimension_columns is not None:
+            payload["dimension_columns"] = dimension_columns
+        response = await client.post("/preaggs/register", json=payload)
+        assert response.status_code == expected_status, response.text
+        return response
     finally:
         del client.app.dependency_overrides[get_query_service_client]
 
@@ -651,6 +653,92 @@ class TestExternalPreAggRouting:
                 ON order_details_0.customer_id = page_views_enriched_0.customer_id
             GROUP BY 1
             """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_renamed_dimension_column(
+        self,
+        client_with_build_v3,
+    ):
+        """A grain dimension stored under a different physical column name is read
+        via dimension_columns and aliased back to the DJ name."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "revenue_sum"},
+            dimension_columns={"v3.order_details.status": "order_status"},
+            table_columns={"order_status": "string", "revenue_sum": "double"},
+        )
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert measures_response.status_code == 200
+        measures_sql = get_first_grain_group(measures_response.json())["sql"]
+        assert_sql_equal(
+            measures_sql,
+            """
+            SELECT order_status status, SUM(revenue_sum) revenue_sum
+            FROM default.analytics.revenue_by_status
+            GROUP BY order_status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_dimension_column_must_exist(
+        self,
+        client_with_build_v3,
+    ):
+        """A dimension_columns mapping to a column absent from the table is
+        rejected; an unknown dimension key is rejected too."""
+        missing = await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={"catalog": "default", "schema": "analytics", "table": "t"},
+            measure_columns={"v3.total_revenue": "revenue_sum"},
+            dimension_columns={"v3.order_details.status": "nope"},
+            table_columns=["order_status", "revenue_sum"],
+            expected_status=422,
+        )
+        assert "not found in table" in missing.json()["message"]
+
+        unknown = await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={"catalog": "default", "schema": "analytics", "table": "t"},
+            measure_columns={"v3.total_revenue": "revenue_sum"},
+            dimension_columns={"v3.order_details.not_a_dim": "x"},
+            table_columns=["order_status", "revenue_sum", "x"],
+            expected_status=422,
+        )
+        assert "not in the pre-aggregation's dimensions" in unknown.json()["message"]
+
+        # A string dimension bound to a numeric column is type-incompatible.
+        bad_type = await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={"catalog": "default", "schema": "analytics", "table": "t"},
+            measure_columns={"v3.total_revenue": "revenue_sum"},
+            dimension_columns={"v3.order_details.status": "status_num"},
+            table_columns={"status_num": "bigint", "revenue_sum": "double"},
+            expected_status=422,
+        )
+        assert (
+            "not type-compatible with dimension 'v3.order_details.status'"
+            in bad_type.json()["message"]
         )
 
 

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -628,3 +628,21 @@ def test_deployment_spec_preserves_explicit_preagg_namespace():
     )
     assert spec.preaggregations[0].namespace == "explicit"
     assert spec.preaggregations[1].namespace == "ns"
+
+
+def test_preagg_spec_renders_dimension_columns():
+    """dimension_columns keys are prefix-rendered against the namespace, like
+    measure_columns; values (physical columns) are left as-is."""
+    spec = PreAggSpec(
+        name="p",
+        namespace="ns",
+        metrics=["${prefix}count"],
+        dimensions=["${prefix}d.attr"],
+        catalog="c",
+        schema="s",
+        table="t",
+        measure_columns={"${prefix}count": "cnt"},
+        dimension_columns={"${prefix}d.attr": "phys_attr"},
+    )
+    assert spec.rendered_dimension_columns == {"ns.d.attr": "phys_attr"}
+    assert spec.rendered_measure_columns == {"ns.count": "cnt"}


### PR DESCRIPTION
### Summary

Extends external pre-aggregation registration so a dimension/grain column can bind to a physical column whose name differs from DJ's, a parallel to how `measure_columns` already binds measures. Externally-built aggregate tables rarely name their grain columns exactly as DJ's dimension attributes, and without this they won't be able to route correctly. This builds on the external pre-agg registration + `source_column` work.

In this PR we add an optional `dimension_columns` map, keyed by any valid dimension reference. Unmapped dimensions default to their DJ column name, so existing registrations are unaffected.
```yaml
  kind: preagg
  name: revenue_by_status_category
  metrics: [${prefix}total_revenue]
  dimensions:
    - ${prefix}order_details.status
    - ${prefix}product.category          # a joined attribute works too
  measure_columns:
    ${prefix}total_revenue: rev_sum
  dimension_columns:                      # dimension reference -> physical column
    ${prefix}order_details.status: st
    ${prefix}product.category: cat
```

At query time the pre-agg is read as `SELECT st status, cat category, SUM(rev_sum) rev_sum FROM ... GROUP BY st, cat` -- the physical columns are read and aliased back to the DJ names.

The mapping is stored on the pre-agg's column metadata as a `source_column`, which is omitted from serialized output when unset, so `/sql` responses for normal (non-mapped) columns are unchanged, and no migration is needed.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #2118  
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
