### PR TITLE
Authorize node/namespace mutations in the deployment path

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -40,6 +40,11 @@ from datajunction_server.errors import (
     DJWarning,
     ErrorCode,
 )
+from datajunction_server.internal.access.authorization import (
+    AccessChecker,
+    AccessDenialMode,
+)
+from datajunction_server.internal.access.authorization.context import AuthContext
 from datajunction_server.internal.deployment.utils import (
     classify_parents,
     extract_node_graph,
@@ -60,6 +65,7 @@ from datajunction_server.sql.dag import get_metric_parents_map
 from datajunction_server.internal.nodes import (
     derive_frozen_measures_bulk,
 )
+from datajunction_server.models.access import ResourceAction
 from datajunction_server.models.base import labelize
 from datajunction_server.models.deployment import (
     ColumnSpec,
@@ -436,12 +442,8 @@ class DeploymentOrchestrator:
 
         self._guard_against_accidental_wipe(deployment_plan)
 
-        # Fail-closed authorization in the internal mutation path. The HTTP
-        # entrypoint only checked WRITE on the deployment's root namespace, but
-        # the orchestrator runs detached and bulk-mutates nodes/namespaces;
-        # #2234 step 0 requires every mutation path to authorize with the
-        # correct action. A denial raises inside the SAVEPOINT, rolling back
-        # setup-phase writes.
+        # Authorize before any of the plan is applied; a denial raises inside the
+        # SAVEPOINT, so setup-phase writes roll back too.
         await self._authorize_deployment_plan(deployment_plan)
 
         if deployment_plan.is_empty() and not self.deployment_spec.hierarchies:
@@ -481,15 +483,6 @@ class DeploymentOrchestrator:
         removed. Names are the rendered (fully-qualified) names, since that is
         what the deploy actually mutates and what RBAC scopes match against.
         """
-        from datajunction_server.internal.access.authorization import (
-            AccessChecker,
-            AccessDenialMode,
-        )
-        from datajunction_server.internal.access.authorization.context import (
-            AuthContext,
-        )
-        from datajunction_server.models.access import ResourceAction
-
         auth_context = await AuthContext.from_user(
             self.session,
             self.context.current_user,

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -436,6 +436,14 @@ class DeploymentOrchestrator:
 
         self._guard_against_accidental_wipe(deployment_plan)
 
+        # Fail-closed authorization in the internal mutation path. The HTTP
+        # entrypoint only checked WRITE on the deployment's root namespace, but
+        # the orchestrator runs detached and bulk-mutates nodes/namespaces;
+        # #2234 step 0 requires every mutation path to authorize with the
+        # correct action. A denial raises inside the SAVEPOINT, rolling back
+        # setup-phase writes.
+        await self._authorize_deployment_plan(deployment_plan)
+
         if deployment_plan.is_empty() and not self.deployment_spec.hierarchies:
             # Pre-aggregations still need reconciling on an otherwise-empty
             # deploy: to register specs, or to delete external pre-aggs that were
@@ -461,6 +469,50 @@ class DeploymentOrchestrator:
             results=self.deployed_results,
             downstream_impacts=downstream,
         )
+
+    async def _authorize_deployment_plan(self, plan: DeploymentPlan) -> None:
+        """
+        Fail-closed authorization for the mutations this deploy will perform.
+
+        Deploys run in a detached background task and bulk-create/update/delete
+        nodes and namespaces, so re-authorize here against the deploying user,
+        matching how the HTTP endpoints govern each resource: WRITE on the
+        namespace a node is written into, DELETE on nodes and namespaces being
+        removed. Names are the rendered (fully-qualified) names, since that is
+        what the deploy actually mutates and what RBAC scopes match against.
+        """
+        from datajunction_server.internal.access.authorization import (
+            AccessChecker,
+            AccessDenialMode,
+        )
+        from datajunction_server.internal.access.authorization.context import (
+            AuthContext,
+        )
+        from datajunction_server.models.access import ResourceAction
+
+        auth_context = await AuthContext.from_user(
+            self.session,
+            self.context.current_user,
+        )
+        access_checker = AccessChecker(auth_context)
+
+        # WRITE: the deployment root plus the namespace each deployed node lands in.
+        namespaces_to_write = {self.deployment_spec.namespace}
+        for node_spec in plan.to_deploy:
+            namespaces_to_write.add(get_namespace_from_name(node_spec.rendered_name))
+        for namespace in sorted(namespaces_to_write):
+            access_checker.add_namespace(namespace, ResourceAction.WRITE)
+
+        # DELETE: nodes and namespaces removed by this deploy.
+        for node_spec in plan.to_delete:
+            access_checker.add_request_by_node_name(
+                node_spec.rendered_name,
+                ResourceAction.DELETE,
+            )
+        for namespace in plan.to_delete_namespaces:
+            access_checker.add_namespace(namespace, ResourceAction.DELETE)
+
+        await access_checker.check(on_denied=AccessDenialMode.RAISE)
 
     async def _update_deployment_status(self):
         """

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -36,7 +36,38 @@ from datajunction_server.models.node import (
     NodeMode,
     NodeType,
 )
+from datajunction_server.internal.access.authorization import AuthorizationService
+from datajunction_server.models import access
 import pytest
+
+
+# Patch target: the name as imported into the validator module, where
+# AccessChecker.check() looks the authorization service up.
+_VALIDATOR_AUTH_SERVICE = (
+    "datajunction_server.internal.access.authorization."
+    "validator.get_authorization_service"
+)
+
+
+class _DenyDeleteAuthorizationService(AuthorizationService):
+    """
+    Approves everything except DELETE -- a caller with WRITE but not DELETE.
+
+    The deployment HTTP entrypoint only checks WRITE on the root namespace, so
+    such a caller passes the entrypoint; this isolates the orchestrator's own
+    DELETE authorization on nodes/namespaces it removes.
+    """
+
+    name = "test_deny_delete_deploy"
+
+    def authorize(self, auth_context, requests):
+        return [
+            access.AccessDecision(
+                request=request,
+                approved=request.verb != access.ResourceAction.DELETE,
+            )
+            for request in requests
+        ]
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -1283,6 +1314,50 @@ async def deploy_and_wait(client, deployment_spec: DeploymentSpec):
         response = await client.get(f"/deployments/{deployment_uuid}")
         data = response.json()
     return data
+
+
+@pytest.mark.xdist_group(name="deployments")
+class TestDeploymentAuthorization:
+    @pytest.mark.asyncio
+    async def test_deploy_delete_denied_without_delete_is_fail_closed(
+        self,
+        client,
+        default_hard_hats,
+        mocker,
+    ):
+        """
+        A deploy runs detached and can DELETE nodes/namespaces, but the HTTP
+        entrypoint only checks WRITE on the root namespace -- and WRITE does not
+        imply DELETE. So a WRITE-but-not-DELETE caller passes the entrypoint yet
+        must be denied by the orchestrator's internal DELETE authorization; the
+        deletion fails and the node survives (fail-closed).
+        """
+        namespace = "deploy_delete_denied"
+
+        # First deploy (default passthrough auth) creates the node.
+        created = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=[default_hard_hats]),
+        )
+        assert created["status"] == "success", created
+
+        # Now deny DELETE (WRITE still allowed, so the HTTP entrypoint passes) and
+        # try to delete everything via an empty spec.
+        mocker.patch(
+            _VALIDATOR_AUTH_SERVICE,
+            lambda: _DenyDeleteAuthorizationService(),
+        )
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=[], allow_empty=True),
+        )
+
+        assert data["status"] == DeploymentStatus.FAILED.value, data
+        assert "Access denied" in json.dumps(data["results"])
+
+        # Fail-closed: the node was not deleted.
+        node_check = await client.get(f"/nodes/{namespace}.default.hard_hats/")
+        assert node_check.status_code == 200
 
 
 @pytest.mark.xdist_group(name="deployments")

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -780,6 +780,7 @@ class TestOrchestrationFlow:
             mock_plan.is_empty.return_value = False
             mock_plan.to_deploy = []
             mock_plan.to_delete = []
+            mock_plan.to_delete_namespaces = []
             mock_create_plan.return_value = (mock_plan, [])
 
             # Execute
@@ -806,6 +807,7 @@ class TestOrchestrationFlow:
             mock_plan.is_empty.return_value = True
             mock_plan.to_deploy = []
             mock_plan.to_delete = []
+            mock_plan.to_delete_namespaces = []
             mock_create_plan.return_value = (mock_plan, [])
 
             mock_handle_no_changes.return_value = []


### PR DESCRIPTION
Tracking: #2234 (step 0, internal mutation paths). This is the deployment slice; background propagation, the availability service-identity model, and remaining internal paths are separate follow-ups.

Deployments are declarative bulk syncs: the orchestrator creates/updates nodes and namespaces and deletes whatever the spec drops. It runs in a detached background task (`asyncio.create_task`) after the HTTP response, so the actual mutations happen outside the request scope where `AccessChecker` lives. The `POST /deployments` entrypoint only authorizes `WRITE` on the deployment's root namespace — and since `WRITE` does not imply `DELETE`, a `WRITE`-only caller could delete nodes via an empty re-deploy.

This re-authorizes inside the orchestrator (fail-closed) against the deploying user (`context.current_user`), after the plan is built and before it is applied:

- `WRITE` on the deployment root and the namespace each deployed node lands in
- `DELETE` on nodes and namespaces the deploy removes

Names are the rendered (fully-qualified) names — what the deploy actually mutates and what RBAC scopes match against. The check runs inside the deployment SAVEPOINT, so a denial rolls back any setup-phase writes. Git sync inherits this via the shared `DeploymentOrchestrator`.

---

Why this won't take effect now: DJ's default access policy is permissive, so the check allows requests unless an explicit restrictive grant/policy denies them.

When this will start taking effect: once a deployment enables restrictive RBAC. Until then this is a no-op.

Out of scope (internal-path follow-ups): `_maybe_autolock_git_namespace` (namespace git-fields mutated after the orchestrator returns), per-preagg-parent authorization within a deploy, background revalidation/propagation, and the availability service-identity model.

---

Verification:

1. Denial test — a `WRITE`-but-not-`DELETE` caller passes the HTTP entrypoint (WRITE allowed), then an empty re-deploy that would delete a node is denied by the orchestrator; the deploy fails and the node survives. Fails before this change (node deleted), passes after.