### PR TITLE
Scope availability posting to the node revision it was built for

### DIFF
--- a/datajunction-server/datajunction_server/api/data.py
+++ b/datajunction-server/datajunction_server/api/data.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, List, Optional, cast
 
 from fastapi import BackgroundTasks, Depends, Query, Request
 from fastapi.responses import JSONResponse
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 from sse_starlette.sse import EventSourceResponse
@@ -37,6 +38,9 @@ from datajunction_server.internal.access.authorization import (
 )
 from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.models import access
+from datajunction_server.models.cube_materialization import (
+    version_from_materialized_table,
+)
 from datajunction_server.models.dialect import Dialect
 from datajunction_server.models.node import AvailabilityStateBase
 from datajunction_server.models.node_type import NodeType
@@ -99,6 +103,52 @@ async def add_availability_state(
         ),
     )
     await access_checker.check(on_denied=AccessDenialMode.RAISE)
+
+    # Scope the availability to the revision it was produced for. A
+    # materialization workflow left running after a non-trivial redefinition
+    # (e.g. a cube whose dimensions/metrics changed) posts for a superseded
+    # version; that data belongs on its own revision — still valid for pinned
+    # queries — not on the current revision, whose schema differs. The target
+    # version is an explicit node_version if the producer sends one, else it is
+    # derived from the materialized table name (which encodes
+    # <node>_<version>_<hash>); absent both, the current revision is used (prior
+    # behavior). An explicitly-supplied unknown version is rejected; a derived
+    # version that resolves to no revision falls back to the current revision.
+    target_version = data.node_version or version_from_materialized_table(
+        data.table,
+        node_name,
+    )
+    if target_version and target_version != node_revision.version:
+        resolved = (
+            await session.execute(
+                select(NodeRevision)
+                .where(
+                    NodeRevision.name == node_name,
+                    NodeRevision.version == target_version,
+                )
+                .options(
+                    selectinload(NodeRevision.catalog),
+                    selectinload(NodeRevision.availability),
+                ),
+            )
+        ).scalar_one_or_none()
+        if resolved is not None:
+            node_revision = resolved
+            _logger.warning(
+                "Availability for node=%s targets non-current version %s "
+                "(current=%s); scoping it to that revision. A materialization "
+                "workflow may still be running against a superseded revision.",
+                node_name,
+                target_version,
+                node.current.version,  # type: ignore
+            )
+        elif data.node_version:
+            raise DJInvalidInputException(
+                message=(
+                    f"Cannot set availability state: node {node_name} has no "
+                    f"version {data.node_version}."
+                ),
+            )
 
     if node.current.type == NodeType.SOURCE:  # type: ignore
         if (

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -31,6 +31,48 @@ __all__ = [
 ]
 
 
+def materialized_table_name(
+    node_name: str,
+    node_version: str,
+    unique_hash: str,
+) -> str:
+    """Canonical output table name for a materialized node revision.
+
+    Format: ``<node_name>_<node_version>_<hash>`` with dots replaced by
+    underscores. The Druid datasource additionally carries the
+    ``druid_datasource_prefix``. ``version_from_materialized_table`` is the
+    inverse; keep the two in lock-step (a round-trip test enforces it).
+    """
+    return f"{node_name}_{node_version}_{unique_hash}".replace(".", "_")
+
+
+def version_from_materialized_table(
+    table: str,
+    node_name: str,
+) -> Optional[str]:
+    """Recover the node version encoded in a materialized table/datasource name.
+
+    Inverse of ``materialized_table_name``. Tolerates an optional
+    ``druid_datasource_prefix`` (Druid datasources are prefixed; other engines
+    report the bare table). Returns ``None`` when ``table`` is not a
+    materialized name for ``node_name`` (e.g. a source table or another node),
+    so callers can fall back safely.
+    """
+    from datajunction_server.utils import get_settings  # noqa: PLC0415
+
+    candidate = table
+    prefix = get_settings().druid_datasource_prefix
+    if prefix and candidate.startswith(prefix):
+        candidate = candidate[len(prefix) :]
+    stem = f"{node_name}_".replace(".", "_")
+    if not candidate.startswith(stem):
+        return None
+    version_part, sep, hash_part = candidate[len(stem) :].rpartition("_")
+    if not sep or not version_part or not hash_part:
+        return None
+    return version_part.replace("_", ".")
+
+
 class MetricMeasures(BaseModel):
     """
     Represent a metric as a set of measures, along with the expression for
@@ -115,7 +157,11 @@ class MeasuresMaterialization(BaseModel):
             ],
         )
         unique_hash = hashlib.sha256(unique_string.encode()).hexdigest()[:16]
-        return f"{self.node.name}_{self.node.version}_{unique_hash}".replace(".", "_")
+        return materialized_table_name(
+            self.node.name,
+            str(self.node.version),
+            unique_hash,
+        )
 
     def model_dump(self, **kwargs):  # pragma: no cover
         base = super().model_dump(**kwargs)
@@ -303,7 +349,11 @@ class CombineMaterialization(BaseModel):
             ],
         )
         unique_hash = hashlib.sha256(unique_string.encode()).hexdigest()[:16]
-        return f"{self.node.name}_{self.node.version}_{unique_hash}".replace(".", "_")
+        return materialized_table_name(
+            self.node.name,
+            str(self.node.version),
+            unique_hash,
+        )
 
     def metrics_spec(self) -> list[dict[str, Any]]:
         """

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -331,6 +331,16 @@ class AvailabilityStateBase(TemporalPartitionRange):
     url: str | None = Field(default=None)
     links: Dict[str, Any] | None = Field(default_factory=dict)
 
+    # Optional explicit override for the node version this availability was
+    # produced for. The POST scopes availability to the matching revision so a
+    # workflow left running after a non-trivial redefinition (e.g. a cube whose
+    # dimensions/metrics changed) updates its own revision rather than stamping a
+    # stale, schema-mismatched table onto the new revision. Usually unnecessary:
+    # the version is derived from the materialized table name when absent. When
+    # supplied, an unknown version is rejected (vs. a best-effort derived one).
+    # Request-only hint; excluded from serialization.
+    node_version: str | None = Field(default=None, exclude=True)
+
     # An ordered list of categorical partitions like ["country", "group_id"]
     # or ["region_id", "age_group"]
     categorical_partitions: list[str] | None = Field(default_factory=list)

--- a/datajunction-server/tests/api/data_availability_scoping_test.py
+++ b/datajunction-server/tests/api/data_availability_scoping_test.py
@@ -1,0 +1,468 @@
+"""
+Tests that availability posting is scoped to the node revision it was produced
+for (via the optional ``node_version`` on POST /data/{node}/availability).
+
+Kept in its own module: it needs a function-scoped, mutable client + session to
+build a two-revision node, and interleaving those with the module-scoped
+availability suite in ``data_test.py`` perturbs that suite's shared DB state.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from datajunction_server.database.node import NodeRevision
+from datajunction_server.models.cube_materialization import materialized_table_name
+from datajunction_server.utils import get_settings
+
+
+@pytest.mark.asyncio
+async def test_availability_scoped_to_named_revision(
+    session: AsyncSession,
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    Availability tagged with an older node_version is attached to THAT revision,
+    not the current one — so a workflow still running against a superseded
+    revision cannot pollute the current revision's availability.
+    """
+    node_name = "default.avail_scope_test"
+    create = await client_with_roads.post(
+        "/nodes/transform/",
+        json={
+            "name": node_name,
+            "description": "availability scoping repro",
+            "query": "SELECT repair_order_id FROM default.repair_orders",
+            "mode": "published",
+        },
+    )
+    assert create.status_code in (200, 201), create.json()
+    v1 = create.json()["version"]
+
+    # Change the query to cut a new revision.
+    patch = await client_with_roads.patch(
+        f"/nodes/{node_name}/",
+        json={
+            "query": (
+                "SELECT repair_order_id, municipality_id FROM default.repair_orders"
+            ),
+        },
+    )
+    assert patch.status_code == 200, patch.json()
+    v2 = patch.json()["version"]
+    assert v2 != v1
+
+    # Post availability tagged for the OLD version.
+    response = await client_with_roads.post(
+        f"/data/{node_name}/availability/",
+        json={
+            "catalog": "default",
+            "schema_": "roads",
+            "table": "old_repair_orders",
+            "valid_through_ts": 20230101,
+            "node_version": v1,
+        },
+    )
+    assert response.status_code == 200, response.json()
+
+    # It landed on the old revision; the current revision is untouched.
+    session.expire_all()
+    revisions = (
+        (
+            await session.execute(
+                select(NodeRevision)
+                .where(NodeRevision.name == node_name)
+                .options(selectinload(NodeRevision.availability)),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_version = {r.version: r for r in revisions}
+    assert by_version[v1].availability is not None
+    assert by_version[v1].availability.table == "old_repair_orders"
+    assert by_version[v2].availability is None
+
+
+@pytest.mark.asyncio
+async def test_availability_unknown_version_rejected(
+    client_with_roads: AsyncClient,
+) -> None:
+    """A node_version the node has never had is rejected."""
+    node_name = "default.avail_scope_unknown"
+    create = await client_with_roads.post(
+        "/nodes/transform/",
+        json={
+            "name": node_name,
+            "description": "availability scoping repro",
+            "query": "SELECT repair_order_id FROM default.repair_orders",
+            "mode": "published",
+        },
+    )
+    assert create.status_code in (200, 201), create.json()
+
+    response = await client_with_roads.post(
+        f"/data/{node_name}/availability/",
+        json={
+            "catalog": "default",
+            "schema_": "roads",
+            "table": "t",
+            "valid_through_ts": 20230101,
+            "node_version": "v9.9",
+        },
+    )
+    assert response.status_code == 422
+    assert "has no version v9.9" in response.json()["message"]
+
+
+@pytest.mark.asyncio
+async def test_availability_version_derived_from_table_name(
+    session: AsyncSession,
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    With no explicit node_version, the target revision is derived from the
+    materialized table name (which encodes <node>_<version>_<hash>), so a
+    workflow that only reports its Druid datasource is still scoped correctly.
+    """
+    node_name = "default.avail_derive_test"
+    create = await client_with_roads.post(
+        "/nodes/transform/",
+        json={
+            "name": node_name,
+            "description": "availability derivation repro",
+            "query": "SELECT repair_order_id FROM default.repair_orders",
+            "mode": "published",
+        },
+    )
+    assert create.status_code in (200, 201), create.json()
+    v1 = create.json()["version"]
+
+    patch = await client_with_roads.patch(
+        f"/nodes/{node_name}/",
+        json={
+            "query": (
+                "SELECT repair_order_id, municipality_id FROM default.repair_orders"
+            ),
+        },
+    )
+    assert patch.status_code == 200, patch.json()
+    v2 = patch.json()["version"]
+    assert v2 != v1
+
+    # No node_version; the v1 version is embedded in the reported table name.
+    table = get_settings().druid_datasource_prefix + materialized_table_name(
+        node_name,
+        v1,
+        "deadbeefdeadbeef",
+    )
+    response = await client_with_roads.post(
+        f"/data/{node_name}/availability/",
+        json={
+            "catalog": "default",
+            "schema_": "roads",
+            "table": table,
+            "valid_through_ts": 20230101,
+        },
+    )
+    assert response.status_code == 200, response.json()
+
+    session.expire_all()
+    revisions = (
+        (
+            await session.execute(
+                select(NodeRevision)
+                .where(NodeRevision.name == node_name)
+                .options(selectinload(NodeRevision.availability)),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_version = {r.version: r for r in revisions}
+    assert by_version[v1].availability is not None
+    assert by_version[v2].availability is None
+
+
+@pytest.mark.asyncio
+async def test_availability_derived_unknown_version_falls_back_to_current(
+    session: AsyncSession,
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    A version derived from the table name that matches no revision is a
+    best-effort miss (unlike an explicit node_version): it falls back to the
+    current revision rather than being rejected.
+    """
+    node_name = "default.avail_derive_fallback"
+    create = await client_with_roads.post(
+        "/nodes/transform/",
+        json={
+            "name": node_name,
+            "description": "availability derivation fallback repro",
+            "query": "SELECT repair_order_id FROM default.repair_orders",
+            "mode": "published",
+        },
+    )
+    assert create.status_code in (200, 201), create.json()
+    current_version = create.json()["version"]
+
+    # Table encodes a version the node never had; no explicit node_version.
+    table = get_settings().druid_datasource_prefix + materialized_table_name(
+        node_name,
+        "v9.0",
+        "deadbeefdeadbeef",
+    )
+    response = await client_with_roads.post(
+        f"/data/{node_name}/availability/",
+        json={
+            "catalog": "default",
+            "schema_": "roads",
+            "table": table,
+            "valid_through_ts": 20230101,
+        },
+    )
+    assert response.status_code == 200, response.json()
+
+    # Fell back to the current revision.
+    session.expire_all()
+    revision = (
+        await session.execute(
+            select(NodeRevision)
+            .where(
+                NodeRevision.name == node_name,
+                NodeRevision.version == current_version,
+            )
+            .options(selectinload(NodeRevision.availability)),
+        )
+    ).scalar_one()
+    assert revision.availability is not None
+    assert revision.availability.table == table
+
+
+async def _make_two_revision_node(client: AsyncClient, node_name: str) -> tuple:
+    """Create a transform node, then change its query to cut a second revision.
+
+    Returns (old_version, current_version).
+    """
+    create = await client.post(
+        "/nodes/transform/",
+        json={
+            "name": node_name,
+            "description": "availability scoping repro",
+            "query": "SELECT repair_order_id FROM default.repair_orders",
+            "mode": "published",
+        },
+    )
+    assert create.status_code in (200, 201), create.json()
+    v1 = create.json()["version"]
+    patch = await client.patch(
+        f"/nodes/{node_name}/",
+        json={
+            "query": (
+                "SELECT repair_order_id, municipality_id FROM default.repair_orders"
+            ),
+        },
+    )
+    assert patch.status_code == 200, patch.json()
+    v2 = patch.json()["version"]
+    assert v2 != v1
+    return v1, v2
+
+
+async def _availability_by_version(session: AsyncSession, node_name: str) -> dict:
+    session.expire_all()
+    revisions = (
+        (
+            await session.execute(
+                select(NodeRevision)
+                .where(NodeRevision.name == node_name)
+                .options(selectinload(NodeRevision.availability)),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return {r.version: r for r in revisions}
+
+
+@pytest.mark.asyncio
+async def test_two_revisions_hold_availability_independently(
+    session: AsyncSession,
+    client_with_roads: AsyncClient,
+) -> None:
+    """Posting for the current and an older revision leaves each with its own
+    availability — the current revision is not clobbered by the stale post, and
+    the old revision is not clobbered by the current one."""
+    node_name = "default.avail_two_rev"
+    v1, v2 = await _make_two_revision_node(client_with_roads, node_name)
+    prefix = get_settings().druid_datasource_prefix
+    table_v2 = prefix + materialized_table_name(node_name, v2, "cafecafecafecafe")
+    table_v1 = prefix + materialized_table_name(node_name, v1, "deadbeefdeadbeef")
+
+    for table in (table_v2, table_v1):
+        resp = await client_with_roads.post(
+            f"/data/{node_name}/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "roads",
+                "table": table,
+                "valid_through_ts": 20230101,
+            },
+        )
+        assert resp.status_code == 200, resp.json()
+
+    by_version = await _availability_by_version(session, node_name)
+    assert by_version[v1].availability is not None
+    assert by_version[v1].availability.table == table_v1
+    assert by_version[v2].availability is not None
+    assert by_version[v2].availability.table == table_v2
+
+
+@pytest.mark.asyncio
+async def test_merge_applied_to_scoped_revision(
+    session: AsyncSession,
+    client_with_roads: AsyncClient,
+) -> None:
+    """A second post for the same older revision merges into THAT revision's
+    availability (widest temporal range wins), never the current revision."""
+    node_name = "default.avail_merge_scope"
+    v1, v2 = await _make_two_revision_node(client_with_roads, node_name)
+    table_v1 = get_settings().druid_datasource_prefix + materialized_table_name(
+        node_name,
+        v1,
+        "deadbeefdeadbeef",
+    )
+
+    first = await client_with_roads.post(
+        f"/data/{node_name}/availability/",
+        json={
+            "catalog": "default",
+            "schema_": "roads",
+            "table": table_v1,
+            "valid_through_ts": 20230201,
+            "min_temporal_partition": ["20230101"],
+            "max_temporal_partition": ["20230201"],
+        },
+    )
+    assert first.status_code == 200, first.json()
+    # Second post carries a narrower range; merge must keep the wider one.
+    second = await client_with_roads.post(
+        f"/data/{node_name}/availability/",
+        json={
+            "catalog": "default",
+            "schema_": "roads",
+            "table": table_v1,
+            "valid_through_ts": 20230101,
+            "min_temporal_partition": ["20230101"],
+            "max_temporal_partition": ["20230115"],
+        },
+    )
+    assert second.status_code == 200, second.json()
+
+    by_version = await _availability_by_version(session, node_name)
+    assert by_version[v1].availability is not None
+    assert by_version[v1].availability.valid_through_ts == 20230201
+    assert by_version[v1].availability.max_temporal_partition == ["20230201"]
+    assert by_version[v2].availability is None
+
+
+@pytest.mark.asyncio
+async def test_derived_version_equal_to_current_attaches_to_current(
+    session: AsyncSession,
+    client_with_roads: AsyncClient,
+) -> None:
+    """When the derived version equals the current one, availability attaches to
+    the current revision (no scoping detour)."""
+    node_name = "default.avail_current_noop"
+    create = await client_with_roads.post(
+        "/nodes/transform/",
+        json={
+            "name": node_name,
+            "description": "availability current no-op repro",
+            "query": "SELECT repair_order_id FROM default.repair_orders",
+            "mode": "published",
+        },
+    )
+    assert create.status_code in (200, 201), create.json()
+    current_version = create.json()["version"]
+    table = get_settings().druid_datasource_prefix + materialized_table_name(
+        node_name,
+        current_version,
+        "deadbeefdeadbeef",
+    )
+    resp = await client_with_roads.post(
+        f"/data/{node_name}/availability/",
+        json={
+            "catalog": "default",
+            "schema_": "roads",
+            "table": table,
+            "valid_through_ts": 20230101,
+        },
+    )
+    assert resp.status_code == 200, resp.json()
+
+    by_version = await _availability_by_version(session, node_name)
+    assert by_version[current_version].availability is not None
+    assert by_version[current_version].availability.table == table
+
+
+@pytest.mark.asyncio
+async def test_source_node_availability_unaffected(
+    client_with_roads: AsyncClient,
+) -> None:
+    """Source-node availability is untouched by revision scoping: derivation does
+    not apply, and the existing source table-match guard still governs."""
+    node_name = "default.repair_orders"  # roads source: default.roads.repair_orders
+    # A mismatched table is still rejected by the source guard.
+    mismatch = await client_with_roads.post(
+        f"/data/{node_name}/availability/",
+        json={
+            "catalog": "default",
+            "schema_": "roads",
+            "table": "not_repair_orders",
+            "valid_through_ts": 20230101,
+        },
+    )
+    assert mismatch.status_code == 422
+    assert "source nodes require" in mismatch.json()["message"]
+
+    # The matching source table is accepted.
+    match = await client_with_roads.post(
+        f"/data/{node_name}/availability/",
+        json={
+            "catalog": "default",
+            "schema_": "roads",
+            "table": "repair_orders",
+            "valid_through_ts": 20230101,
+        },
+    )
+    assert match.status_code == 200, match.json()
+
+
+@pytest.mark.asyncio
+async def test_unprefixed_table_derivation(
+    session: AsyncSession,
+    client_with_roads: AsyncClient,
+) -> None:
+    """Version derivation also works for an unprefixed <node>_<version>_<hash>
+    table (engines that report the bare table rather than the Druid datasource)."""
+    node_name = "default.avail_unprefixed"
+    v1, v2 = await _make_two_revision_node(client_with_roads, node_name)
+    table = materialized_table_name(node_name, v1, "deadbeefdeadbeef")  # no prefix
+    resp = await client_with_roads.post(
+        f"/data/{node_name}/availability/",
+        json={
+            "catalog": "default",
+            "schema_": "roads",
+            "table": table,
+            "valid_through_ts": 20230101,
+        },
+    )
+    assert resp.status_code == 200, resp.json()
+
+    by_version = await _availability_by_version(session, node_name)
+    assert by_version[v1].availability is not None
+    assert by_version[v2].availability is None

--- a/datajunction-server/tests/api/data_test.py
+++ b/datajunction-server/tests/api/data_test.py
@@ -802,6 +802,57 @@ class TestAvailabilityState:
         assert data["message"] == "Availability state successfully posted"
 
     @pytest.mark.asyncio
+    async def test_availability_matching_node_version_is_accepted(
+        self,
+        module__client_with_account_revenue: AsyncClient,
+    ) -> None:
+        """
+        Availability tagged with the node's current version is accepted.
+        """
+        node_name = "default.large_revenue_payments_and_business_only"
+        node = (
+            await module__client_with_account_revenue.get(f"/nodes/{node_name}/")
+        ).json()
+        response = await module__client_with_account_revenue.post(
+            f"/data/{node_name}/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "accounting",
+                "table": "pmts",
+                "valid_through_ts": 20230125,
+                "max_temporal_partition": ["2023", "01", "25"],
+                "min_temporal_partition": ["2022", "01", "01"],
+                "node_version": node["version"],
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["message"] == "Availability state successfully posted"
+
+    @pytest.mark.asyncio
+    async def test_availability_unknown_node_version_is_rejected(
+        self,
+        module__client_with_account_revenue: AsyncClient,
+    ) -> None:
+        """
+        Availability tagged with a version the node has never had is rejected.
+        """
+        node_name = "default.large_revenue_payments_and_business_only"
+        response = await module__client_with_account_revenue.post(
+            f"/data/{node_name}/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "accounting",
+                "table": "pmts",
+                "valid_through_ts": 20230125,
+                "max_temporal_partition": ["2023", "01", "25"],
+                "min_temporal_partition": ["2022", "01", "01"],
+                "node_version": "v99.0",
+            },
+        )
+        assert response.status_code == 422
+        assert "has no version v99.0" in response.json()["message"]
+
+    @pytest.mark.asyncio
     async def test_setting_availability_state_multiple_times(
         self,
         module__session: AsyncSession,

--- a/datajunction-server/tests/models/cube_materialization_test.py
+++ b/datajunction-server/tests/models/cube_materialization_test.py
@@ -15,8 +15,11 @@ from datajunction_server.models.cube_materialization import (
     DruidCubeV3Config,
     MeasuresMaterialization,
     PreAggTableInfo,
+    materialized_table_name,
+    version_from_materialized_table,
 )
 from datajunction_server.models.materialization import MaterializationStrategy
+from datajunction_server.utils import get_settings
 from datajunction_server.models.node_type import NodeNameVersion
 from datajunction_server.models.partition import Granularity
 from datajunction_server.models.decompose import (
@@ -343,3 +346,68 @@ class TestFromMeasuresQueryRoleResolution:
                 measures_query,
                 temporal_partition,
             )
+
+
+class TestMaterializedTableNameRoundTrip:
+    """`materialized_table_name` and `version_from_materialized_table` must stay
+    inverses — the availability endpoint derives the node version from the table
+    name, so a drift between the two would silently misroute availability."""
+
+    def test_round_trip_unprefixed(self):
+        table = materialized_table_name("foo.bar.baz", "v2.1", "abc123def4560000")
+        assert table == "foo_bar_baz_v2_1_abc123def4560000"
+        assert version_from_materialized_table(table, "foo.bar.baz") == "v2.1"
+
+    def test_round_trip_with_druid_prefix(self):
+        prefix = get_settings().druid_datasource_prefix
+        table = prefix + materialized_table_name(
+            "cs.main.perf",
+            "v1.0",
+            "deadbeefdeadbeef",
+        )
+        assert version_from_materialized_table(table, "cs.main.perf") == "v1.0"
+
+    def test_non_materialized_names_return_none(self):
+        # A bare source table.
+        assert version_from_materialized_table("pmts", "default.revenue") is None
+        # A datasource for a different node.
+        assert (
+            version_from_materialized_table(
+                "dj__other_v1_0_abcd1234",
+                "default.revenue",
+            )
+            is None
+        )
+        # Matches the node stem but has no <version>_<hash> suffix.
+        assert (
+            version_from_materialized_table("dj__default_revenue_v1", "default.revenue")
+            is None
+        )
+
+    def test_round_trip_multi_digit_versions(self):
+        # Only the trailing hash token is peeled off, never a version digit.
+        for version in ("v1.10", "v10.2", "v10.10"):
+            table = materialized_table_name("a.b", version, "0011223344556677")
+            assert version_from_materialized_table(table, "a.b") == version
+            prefixed = get_settings().druid_datasource_prefix + table
+            assert version_from_materialized_table(prefixed, "a.b") == version
+
+    def test_round_trip_node_name_with_version_like_suffix(self):
+        # Anchoring on the full node stem handles node names that themselves
+        # look version-ish or contain underscores.
+        node_name = "default.foo_v2"
+        table = get_settings().druid_datasource_prefix + materialized_table_name(
+            node_name,
+            "v1.0",
+            "abcd1234abcd1234",
+        )
+        assert version_from_materialized_table(table, node_name) == "v1.0"
+
+    def test_boundary_inputs_return_none(self):
+        prefix = get_settings().druid_datasource_prefix
+        # Just the prefix, nothing else.
+        assert version_from_materialized_table(prefix, "default.x") is None
+        # Node stem present but nothing after it.
+        assert (
+            version_from_materialized_table(f"{prefix}default_x_", "default.x") is None
+        )


### PR DESCRIPTION
### Summary

Calling `POST /data/{node}/availability` always attaches the reported availability to the node's current revision. When a node is redefined in a non-trivial way (e.g. a cube whose dimensions or metrics change), a materialization workflow that was running against the previous revision keeps posting availability and that post lands on the new current revision, which is wrong. The reported table was built from the old definition, so its physical columns don't match what the new revision generates, and queries against the current revision resolve to a stale, schema-mismatched table and fail at execution.

Availability is already revision-scoped in the db schema (`nodeavailabilitystate.node_id` to `noderevision.id`), so the bug is that the write path ignores which revision produced the data.

The fix is to attach availability to the revision it was actually produced for. The target version is resolved in order:

1. an explicit `node_version` on the request, if the producer sends one
2. otherwise derived from the materialized table name, which already encodes `<node>_<version>_<hash>` (e.g. `dj__foo_bar_v1_0_ab12…`)
3. otherwise the current revision (unchanged prior behavior)

The availability then attaches to that revision. An older revision keeps its own availability (still valid for version-pinned queries) while the current revision is left untouched, so its queries fall back correctly instead of hitting a mismatched table.

Because the version is derived from the table name producers already send, this fixes the case for existing materialization workflows with no client-side change. `node_version` is an optional, forward-looking override.

### Test Plan

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
