### PR TITLE
Add deploy-path test coverage for external pre-agg dimension_columns

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -1792,28 +1792,42 @@ def build_grain_group_from_preagg(
     grain_col_names: list[str] = []
     group_by_cols: list[str] = []
     for dim in resolved_dimensions:
-        col_name = dim.column_name
-        grain_col_names.append(col_name)
+        # Output name the rest of the query references this grain column by. It
+        # must match the alias the source-built path would emit (role-qualified,
+        # via the alias registry) -- the combiner/metrics layer references grain
+        # columns by that alias, not by the parent's physical column name. Using
+        # dim.column_name here breaks whenever it differs from the alias, e.g. a
+        # joined dimension's key satisfied by a differently-named parent FK
+        # column (order_details.order_date = date.date_id[order]): the CTE would
+        # expose ``order_date`` while the outer query selects ``date_id_order``.
+        output_alias = ctx.alias_registry.register(dim.original_ref)
+        grain_col_names.append(output_alias)
 
-        # Read the physical column (may be remapped) and alias to the DJ name.
-        physical_col = get_preagg_dimension_column(preagg, dim.original_ref, col_name)
+        # Physical column actually read from the pre-agg table. It may be remapped
+        # via dimension_columns; otherwise it defaults to the parent's grain
+        # column name. This is independent of the output alias above.
+        physical_col = get_preagg_dimension_column(
+            preagg,
+            dim.original_ref,
+            dim.column_name,
+        )
         group_by_cols.append(physical_col)
 
-        if physical_col == col_name:
-            select_items.append(ast.Column(name=ast.Name(col_name)))
+        if physical_col == output_alias:
+            select_items.append(ast.Column(name=ast.Name(output_alias)))
         else:
             select_items.append(
                 ast.Alias(
                     child=ast.Column(name=ast.Name(physical_col)),
-                    alias=ast.Name(col_name),
+                    alias=ast.Name(output_alias),
                 ),
             )
 
-        # Type metadata is keyed by the DJ name, not the physical column.
-        col_type = preagg.get_column_type(col_name, default="string")
+        # Type metadata is keyed by the output (DJ) name, not the physical column.
+        col_type = preagg.get_column_type(output_alias, default="string")
         columns.append(
             ColumnMetadata(
-                name=col_name,
+                name=output_alias,
                 semantic_name=dim.original_ref,
                 type=col_type,
                 semantic_type="dimension",

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1804,6 +1804,130 @@ class TestDeployments:
             del client.app.dependency_overrides[get_query_service_client]
 
     @pytest.mark.asyncio
+    async def test_deploy_preagg_applies_dimension_columns(
+        self,
+        client,
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+    ):
+        """
+        A pre-agg declared in a deployment spec with ``dimension_columns`` binds
+        each grain dimension to its physical column, and the generated measures
+        SQL reads that physical column (aliased back to the DJ name) instead of
+        the DJ dimension name.
+
+        Regression: the ``dimension_columns`` feature was only covered through the
+        POST /preaggs/register API path; the deployment/orchestrator path (what
+        ``dj push`` uses) had no coverage. This exercises the two shapes that path
+        must get right: a joined dimension's *key* satisfied by a differently
+        named parent foreign-key column (``dim.state_short`` via ``fact.state``),
+        and a *local* fact column (``fact.hard_hat_id``).
+        """
+        fact = TransformSpec(
+            name="default.dimcol_facts",
+            node_type=NodeType.TRANSFORM,
+            query="SELECT hard_hat_id, state FROM ${prefix}default.hard_hats",
+            dimension_links=[
+                DimensionJoinLinkSpec(
+                    dimension_node="${prefix}default.us_state",
+                    join_type="inner",
+                    join_on=(
+                        "${prefix}default.dimcol_facts.state = "
+                        "${prefix}default.us_state.state_short"
+                    ),
+                ),
+            ],
+            primary_key=["hard_hat_id"],
+            owners=["dj"],
+        )
+        metric = MetricSpec(
+            name="default.dimcol_count",
+            node_type=NodeType.METRIC,
+            query="SELECT COUNT(*) FROM ${prefix}default.dimcol_facts",
+            owners=["dj"],
+        )
+
+        async def _fake_columns(*args, **kwargs):
+            return [
+                SimpleNamespace(name="cnt", type="bigint"),
+                SimpleNamespace(name="st_code", type="string"),
+                SimpleNamespace(name="hh_id_col", type="int"),
+            ]
+
+        mock_qs = MagicMock()
+        mock_qs.get_columns_for_table = _fake_columns
+        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+        try:
+            preagg = PreAggSpec(
+                name="dimcol_agg",
+                metrics=["${prefix}default.dimcol_count"],
+                dimensions=[
+                    "${prefix}default.us_state.state_short",
+                    "${prefix}default.dimcol_facts.hard_hat_id",
+                ],
+                catalog="default",
+                schema="analytics",
+                table="dimcol_agg_tbl",
+                valid_through_ts=1700000000,
+                measure_columns={"${prefix}default.dimcol_count": "cnt"},
+                dimension_columns={
+                    "${prefix}default.us_state.state_short": "st_code",
+                    "${prefix}default.dimcol_facts.hard_hat_id": "hh_id_col",
+                },
+            )
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace="preagg_dimcol",
+                    nodes=[
+                        default_hard_hats,
+                        default_us_states,
+                        default_us_state,
+                        fact,
+                        metric,
+                    ],
+                    preaggregations=[preagg],
+                ),
+            )
+            assert data["status"] == "success", data["results"]
+
+            # The registered dimensions carry their physical source_column binding.
+            listing = await client.get(
+                "/preaggs/",
+                params={"node_name": "preagg_dimcol.default.dimcol_facts"},
+            )
+            preagg_row = listing.json()["items"][0]
+            source_cols = {
+                col["source_column"]
+                for col in preagg_row["columns"]
+                if col.get("semantic_type") == "dimension"
+            }
+            assert source_cols == {"st_code", "hh_id_col"}, preagg_row["columns"]
+
+            # The measures SQL reads the physical columns from the agg table and
+            # re-aggregates over them -- no join back to the dimension node.
+            response = await client.get(
+                "/sql/measures/v3/",
+                params={
+                    "metrics": ["preagg_dimcol.default.dimcol_count"],
+                    "dimensions": [
+                        "preagg_dimcol.default.us_state.state_short",
+                        "preagg_dimcol.default.dimcol_facts.hard_hat_id",
+                    ],
+                },
+            )
+            assert response.status_code == 200, response.text
+            grain_sql = response.json()["grain_groups"][0]["sql"]
+            lowered = grain_sql.lower()
+            assert "default.analytics.dimcol_agg_tbl" in grain_sql
+            assert "st_code" in grain_sql
+            assert "hh_id_col" in grain_sql
+            assert "join" not in lowered
+        finally:
+            del client.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
     async def test_deploy_dimension_with_update(
         self,
         client,

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -36,6 +36,7 @@ from datajunction_server.models.node import (
     NodeMode,
     NodeType,
 )
+from tests.construction.build_v3 import assert_sql_equal
 import pytest
 
 
@@ -1919,11 +1920,51 @@ class TestDeployments:
             )
             assert response.status_code == 200, response.text
             grain_sql = response.json()["grain_groups"][0]["sql"]
-            lowered = grain_sql.lower()
-            assert "default.analytics.dimcol_agg_tbl" in grain_sql
-            assert "st_code" in grain_sql
-            assert "hh_id_col" in grain_sql
-            assert "join" not in lowered
+            # Reads the mapped physical columns (st_code, hh_id_col) from the agg
+            # table, aliased to the DJ dimension aliases (state_short,
+            # hard_hat_id) the metrics layer references; groups by the physical
+            # columns; no join back to the dimension node.
+            assert_sql_equal(
+                grain_sql,
+                """
+                SELECT st_code state_short,
+                       hh_id_col hard_hat_id,
+                       SUM(cnt) cnt
+                FROM default.analytics.dimcol_agg_tbl
+                GROUP BY st_code, hh_id_col
+                """,
+            )
+
+            # The outer metrics query references the SAME aliases the CTE exposes
+            # (state_short, hard_hat_id), so inner/outer aliasing is consistent.
+            metrics_response = await client.get(
+                "/sql/metrics/v3/",
+                params={
+                    "metrics": ["preagg_dimcol.default.dimcol_count"],
+                    "dimensions": [
+                        "preagg_dimcol.default.us_state.state_short",
+                        "preagg_dimcol.default.dimcol_facts.hard_hat_id",
+                    ],
+                },
+            )
+            assert metrics_response.status_code == 200, metrics_response.text
+            assert_sql_equal(
+                metrics_response.json()["sql"],
+                """
+                WITH dimcol_facts_0 AS (
+                    SELECT st_code state_short,
+                           hh_id_col hard_hat_id,
+                           SUM(cnt) cnt
+                    FROM default.analytics.dimcol_agg_tbl
+                    GROUP BY st_code, hh_id_col
+                )
+                SELECT dimcol_facts_0.state_short AS state_short,
+                       dimcol_facts_0.hard_hat_id AS hard_hat_id,
+                       SUM(dimcol_facts_0.cnt) AS dimcol_count
+                FROM dimcol_facts_0
+                GROUP BY dimcol_facts_0.state_short, dimcol_facts_0.hard_hat_id
+                """,
+            )
         finally:
             del client.app.dependency_overrides[get_query_service_client]
 

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -695,6 +695,84 @@ class TestExternalPreAggRouting:
         )
 
     @pytest.mark.asyncio
+    async def test_external_preagg_joined_key_via_foreign_key_column(
+        self,
+        client_with_build_v3,
+    ):
+        """A joined dimension's *key* requested through a differently-named parent
+        foreign-key column reads the mapped physical column and aliases it to the
+        dimension's DJ alias -- the name the outer metrics query references -- not
+        the parent FK column name.
+
+        Regression: the pre-agg grain group aliased the grain column to
+        ``dim.column_name`` (the parent FK column, e.g. ``order_date``) instead of
+        the alias-registry alias (``date_id_order``) used by the source-built
+        path. The metrics query then selected ``date_id_order`` from a CTE that
+        only exposed ``order_date``, producing SQL that could not execute.
+        ``order_details.order_date = date.date_id[order]`` exercises this: the
+        requested key ``date.date_id[order]`` is satisfied by the FK
+        ``order_date``, whose name differs from both the DJ alias and the mapped
+        physical column.
+        """
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.date.date_id[order]"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_day",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.date.date_id[order]": "day_key"},
+            table_columns={"day_key": "int", "rev_sum": "double"},
+        )
+        # Measures SQL: reads the mapped physical column (day_key) and aliases it
+        # to the dimension alias (date_id_order); no join back to the date dim.
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.date.date_id[order]"],
+            },
+        )
+        assert measures_response.status_code == 200
+        measures_sql = get_first_grain_group(measures_response.json())["sql"]
+        assert_sql_equal(
+            measures_sql,
+            """
+            SELECT day_key date_id_order, SUM(rev_sum) rev_sum
+            FROM default.analytics.revenue_by_day
+            GROUP BY day_key
+            """,
+        )
+        # Metrics SQL: the outer query references the same alias the CTE exposes
+        # (date_id_order), so the query is internally consistent.
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.date.date_id[order]"],
+            },
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT day_key date_id_order, SUM(rev_sum) rev_sum
+                FROM default.analytics.revenue_by_day
+                GROUP BY day_key
+            )
+            SELECT order_details_0.date_id_order AS date_id_order,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.date_id_order
+            """,
+        )
+
+    @pytest.mark.asyncio
     async def test_external_preagg_dimension_column_must_exist(
         self,
         client_with_build_v3,


### PR DESCRIPTION
### Summary

The `dimension_columns` mapping for externally-registered pre-aggregations (#2360) was only exercised through the POST /preaggs/register API path. The deployment/orchestrator path (used by `dj push`) had no coverage.

This adds a deployment-path test asserting that a pre-agg declared with dimension_columns binds each grain dimension to its physical column and that the generated measures SQL reads the mapped physical column (aliased back to the DJ name) instead of the DJ dimension name. It covers the two shapes a real external agg hits: a joined dimension's key satisfied by a differently-named parent foreign-key column, and a local fact column.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
