### PR TITLE
Fix preagg matching and filters

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -147,6 +147,37 @@ def strip_role_suffix(ref: str) -> str:
     return ref
 
 
+def references_filter_only_dimension(
+    filter_ast: ast.Expression,
+    filter_dimensions: set[str],
+) -> bool:
+    """
+    Whether a filter references a "filter-only" dimension -- one that is part of a
+    grain group but not projected into the final output.
+
+    This encodes one half of a contract shared by two layers: the metrics builder
+    skips these filters at the outer query precisely because each grain group is
+    expected to have applied them at its own CTE. Both sides must agree on which
+    filters those are, so both call this.
+
+    Role-qualified refs (``dim.col[role]``) parse as
+    ``Subscript(Column("dim.col"), Column("role"))``, so ``find_all(ast.Column)``
+    sees only the base column; they are matched separately against role-stripped
+    dimension names.
+    """
+    base_refs = {strip_role_suffix(ref) for ref in filter_dimensions}
+    if any(
+        isinstance(subscript.expr, ast.Column)
+        and get_column_full_name(subscript.expr) in base_refs
+        for subscript in filter_ast.find_all(ast.Subscript)
+    ):
+        return True
+    return any(
+        get_column_full_name(col) in filter_dimensions
+        for col in filter_ast.find_all(ast.Column)
+    )
+
+
 def extract_dim_info_from_grain_groups(
     grain_groups: list[GrainGroupSQL],
 ) -> list[tuple[str, str]]:

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -19,8 +19,8 @@ from datajunction_server.construction.build_v3.cte import (
     _fk_key_column_names,
     collect_node_ctes,
     extract_dimension_node,
-    get_column_full_name,
     inject_filter_into_select,
+    references_filter_only_dimension,
     strip_role_suffix,
 )
 from datajunction_server.construction.build_v3.decomposition import (
@@ -1744,32 +1744,6 @@ def find_upstream_temporal_source_node(
     return None
 
 
-def _references_filter_only_dimension(
-    filter_ast: ast.Expression,
-    filter_dimensions: set[str],
-) -> bool:
-    """
-    True if a filter references a "filter-only" dimension -- one the outer metrics
-    query skips (expecting the grain group CTE to have applied it). Mirrors the
-    skip logic in the metrics builder, including role-suffixed refs which parse as
-    ``Subscript(Column("dim.col"), Column("role"))``.
-    """
-    for subscript in filter_ast.find_all(ast.Subscript):
-        if not isinstance(subscript.expr, ast.Column):
-            continue  # pragma: no cover
-        base_ref = get_column_full_name(subscript.expr)
-        if base_ref and any(
-            (fd.split("[")[0] if "[" in fd else fd) == base_ref
-            for fd in filter_dimensions
-        ):
-            return True
-    for col in filter_ast.find_all(ast.Column):
-        full_name = get_column_full_name(col)
-        if full_name and full_name in filter_dimensions:
-            return True
-    return False
-
-
 def build_grain_group_from_preagg(
     ctx: BuildContext,
     grain_group: GrainGroup,
@@ -1936,19 +1910,25 @@ def build_grain_group_from_preagg(
         group_by=group_by,
     )
 
-    # Push filter-only dimension filters into the pre-agg scan. The metrics layer
-    # applies filters on projected (output) dimensions at the outer query, but
-    # deliberately skips "filter-only" dimensions -- ones in the pre-agg grain
-    # that are rolled away -- expecting each grain group to have applied them.
-    # For a pre-agg-backed grain group we must do that here, mapping each filtered
-    # dimension to its physical column and filtering before the roll-up; otherwise
-    # the predicate lands nowhere and the result silently over-counts.
-    for filter_str in ctx.dimension_filters or []:
-        filter_ast = parse_filter(filter_str)
-        if not _references_filter_only_dimension(filter_ast, ctx.filter_dimensions):
-            continue  # a projected-dimension filter -> the outer query applies it
-        resolve_filter_references(filter_ast, ref_to_physical, cte_alias=None)
-        inject_filter_into_select(select, filter_ast)
+    # Push filter-only dimension filters into the pre-agg scan, on the physical
+    # column and before the roll-up. The outer metrics query skips these filters
+    # (see references_filter_only_dimension) because each grain group is expected
+    # to apply them itself; without this the predicate lands nowhere and the
+    # result silently over-counts. Filters on projected dimensions are left to the
+    # outer query, matching the pre-agg read the non-filtered case produces.
+    #
+    # Guarded on ctx.filter_dimensions: when there are none -- the common case --
+    # no filter can qualify, and parsing here would be wasted (ANTLR).
+    if ctx.filter_dimensions:
+        for filter_str in ctx.dimension_filters or []:
+            filter_ast = parse_filter(filter_str)
+            if not references_filter_only_dimension(
+                filter_ast,
+                ctx.filter_dimensions,
+            ):
+                continue
+            resolve_filter_references(filter_ast, ref_to_physical, cte_alias=None)
+            inject_filter_into_select(select, filter_ast)
 
     # Build the query
     query = ast.Query(select=select)

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -19,6 +19,7 @@ from datajunction_server.construction.build_v3.cte import (
     _fk_key_column_names,
     collect_node_ctes,
     extract_dimension_node,
+    get_column_full_name,
     inject_filter_into_select,
     strip_role_suffix,
 )
@@ -30,6 +31,8 @@ from datajunction_server.construction.build_v3.dimensions import (
 )
 from datajunction_server.construction.build_v3.filters import (
     parse_and_resolve_filters,
+    parse_filter,
+    resolve_filter_references,
 )
 from datajunction_server.construction.build_v3.utils import (
     extract_columns_from_expression,
@@ -1741,6 +1744,32 @@ def find_upstream_temporal_source_node(
     return None
 
 
+def _references_filter_only_dimension(
+    filter_ast: ast.Expression,
+    filter_dimensions: set[str],
+) -> bool:
+    """
+    True if a filter references a "filter-only" dimension -- one the outer metrics
+    query skips (expecting the grain group CTE to have applied it). Mirrors the
+    skip logic in the metrics builder, including role-suffixed refs which parse as
+    ``Subscript(Column("dim.col"), Column("role"))``.
+    """
+    for subscript in filter_ast.find_all(ast.Subscript):
+        if not isinstance(subscript.expr, ast.Column):
+            continue  # pragma: no cover
+        base_ref = get_column_full_name(subscript.expr)
+        if base_ref and any(
+            (fd.split("[")[0] if "[" in fd else fd) == base_ref
+            for fd in filter_dimensions
+        ):
+            return True
+    for col in filter_ast.find_all(ast.Column):
+        full_name = get_column_full_name(col)
+        if full_name and full_name in filter_dimensions:
+            return True
+    return False
+
+
 def build_grain_group_from_preagg(
     ctx: BuildContext,
     grain_group: GrainGroup,
@@ -1791,6 +1820,9 @@ def build_grain_group_from_preagg(
     # pre-agg remaps a dimension's column).
     grain_col_names: list[str] = []
     group_by_cols: list[str] = []
+    # Dimension ref -> physical column in the pre-agg table, used to push
+    # filter-only dimension filters into the CTE below.
+    ref_to_physical: dict[str, str] = {}
     for dim in resolved_dimensions:
         # Output name the rest of the query references this grain column by. It
         # must match the alias the source-built path would emit (role-qualified,
@@ -1812,6 +1844,7 @@ def build_grain_group_from_preagg(
             dim.column_name,
         )
         group_by_cols.append(physical_col)
+        ref_to_physical[dim.original_ref] = physical_col
 
         if physical_col == output_alias:
             select_items.append(ast.Column(name=ast.Name(output_alias)))
@@ -1902,6 +1935,20 @@ def build_grain_group_from_preagg(
         from_=from_clause,
         group_by=group_by,
     )
+
+    # Push filter-only dimension filters into the pre-agg scan. The metrics layer
+    # applies filters on projected (output) dimensions at the outer query, but
+    # deliberately skips "filter-only" dimensions -- ones in the pre-agg grain
+    # that are rolled away -- expecting each grain group to have applied them.
+    # For a pre-agg-backed grain group we must do that here, mapping each filtered
+    # dimension to its physical column and filtering before the roll-up; otherwise
+    # the predicate lands nowhere and the result silently over-counts.
+    for filter_str in ctx.dimension_filters or []:
+        filter_ast = parse_filter(filter_str)
+        if not _references_filter_only_dimension(filter_ast, ctx.filter_dimensions):
+            continue  # a projected-dimension filter -> the outer query applies it
+        resolve_filter_references(filter_ast, ref_to_physical, cte_alias=None)
+        inject_filter_into_select(select, filter_ast)
 
     # Build the query
     query = ast.Query(select=select)

--- a/datajunction-server/datajunction_server/construction/build_v3/metrics.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/metrics.py
@@ -19,6 +19,7 @@ from datajunction_server.construction.build_v3.cte import (
     has_window_function,
     inject_partition_by_into_windows,
     process_metric_combiner_expression,
+    references_filter_only_dimension,
     replace_component_refs_in_ast,
     replace_dimension_refs_in_ast,
     replace_metric_refs_in_ast,
@@ -2112,34 +2113,14 @@ def generate_metrics_sql(
 
         # Filter out filters that reference filter-only dimensions
         # Those filters are already applied in the grain group CTEs
-        applicable_dimension_filters = []
-        for f in dimension_filters_raw:
-            filter_ast = parse_filter(f)
-            # Check if any column ref in this filter is a filter-only dimension.
-            # Must handle both plain column refs and role-qualified subscript refs
-            # (e.g., "v3.location.country[customer->home]"), because find_all(ast.Column)
-            # returns only the base Column inside the Subscript, not the full role string.
-            refs_filter_only = False
-            for subscript in filter_ast.find_all(ast.Subscript):
-                if not isinstance(subscript.expr, ast.Column):
-                    continue  # pragma: no cover
-                base_ref = get_column_full_name(subscript.expr)
-                if base_ref:  # pragma: no branch
-                    for fd in ctx.filter_dimensions:
-                        fd_base = fd.split("[")[0] if "[" in fd else fd
-                        if fd_base == base_ref:  # pragma: no branch
-                            refs_filter_only = True
-                            break
-                if refs_filter_only:
-                    break
-            if not refs_filter_only:
-                for col in filter_ast.find_all(ast.Column):
-                    full_name = get_column_full_name(col)
-                    if full_name and full_name in ctx.filter_dimensions:
-                        refs_filter_only = True
-                        break
-            if not refs_filter_only:
-                applicable_dimension_filters.append(f)
+        applicable_dimension_filters = [
+            f
+            for f in dimension_filters_raw
+            if not references_filter_only_dimension(
+                parse_filter(f),
+                ctx.filter_dimensions,
+            )
+        ]
 
         if applicable_dimension_filters:
             where_clause = parse_and_resolve_filters(

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -34,13 +34,24 @@ def get_required_measure_identities(
     Identity of each measure a grain group needs: (expression hash, Phase-1
     aggregation function).
 
-    The aggregation is part of the identity because a pre-aggregation stores
-    partials produced by a specific Phase-1 function, and the expression hash
-    covers only the inner expression -- not the function. Two metrics that share
-    an inner expression but aggregate it differently (e.g. SUM(x) vs MAX(x))
-    would otherwise collide, letting a MAX metric bind to a SUM pre-agg column
-    and compute MAX(sum) instead of MAX(row). A SUM partial cannot serve a MAX
-    (or MIN) metric, so the aggregation must match for the pre-agg to be usable.
+    Measure matching is intentionally name-independent -- a pre-agg should be
+    reusable even when its component names differ -- so ``expr_hash`` stands in
+    for the measure's identity. But ``expr_hash`` covers the inner expression
+    alone: ``SUM(x)`` and ``MAX(x)`` are distinct measures (distinct components,
+    distinct ``aggregation``) that hash identically. Keying on the hash alone is
+    therefore coarser than the real identity, and lets a MAX metric match a
+    SUM-built pre-agg and compute MAX(sum) rather than MAX(row).
+
+    Pairing the hash with the aggregation restores the distinction while keeping
+    matching name-independent. It is sound because a stored partial is only
+    reusable by a metric that accumulates the same way: SUM->SUM, MAX->MAX,
+    MIN->MIN and COUNT->COUNT are valid, while a SUM partial can serve neither
+    MAX nor MIN.
+
+    The discriminator is the Phase-1 ``aggregation``, not ``merge``, because
+    merge is not unique: COUNT accumulates with COUNT but merges with SUM, so
+    ``SUM(x)`` and ``COUNT(x)`` share both an expression hash and a merge
+    function.
     """
     return {
         (

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -27,11 +27,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _normalize_aggregation(aggregation: str | None) -> str:
-    """Normalize a Phase-1 aggregation function name for identity comparison."""
-    return (aggregation or "").strip().upper()
-
-
 def get_required_measure_identities(
     grain_group: "GrainGroup",
 ) -> set[tuple[str, str]]:
@@ -50,7 +45,7 @@ def get_required_measure_identities(
     return {
         (
             compute_expression_hash(component.expression),
-            _normalize_aggregation(component.aggregation),
+            component.normalized_aggregation,
         )
         for _, component in grain_group.components
     }
@@ -138,7 +133,7 @@ def find_matching_preagg(
         # Coverage check on (expression hash, Phase-1 aggregation) -- see
         # get_required_measure_identities for why the aggregation is part of it.
         preagg_measures = {
-            (measure.expr_hash, _normalize_aggregation(measure.aggregation))
+            (measure.expr_hash, measure.normalized_aggregation)
             for measure in preagg.measures
             if measure.expr_hash
         }
@@ -175,8 +170,11 @@ def get_preagg_measure_column(
     """
     Find the column name in the pre-agg that corresponds to a metric component.
 
-    Matches by expression hash to ensure we're getting the right column
-    even if names differ.
+    Matches on the full measure identity -- expression hash AND Phase-1
+    aggregation -- so we get the right column even if names differ. The
+    aggregation matters because one pre-agg can hold several measures over the
+    same expression (e.g. SUM(x) and MAX(x)); matching on the hash alone would
+    return whichever came first and could read the wrong column.
 
     Args:
         preagg: The pre-aggregation to search
@@ -185,10 +183,13 @@ def get_preagg_measure_column(
     Returns:
         Column name in the pre-agg, or None if not found
     """
-    target_hash = compute_expression_hash(component.expression)
+    target = (
+        compute_expression_hash(component.expression),
+        component.normalized_aggregation,
+    )
 
     for measure in preagg.measures:
-        if measure.expr_hash == target_hash:
+        if (measure.expr_hash, measure.normalized_aggregation) == target:
             # Externally-registered pre-aggs bind the measure to a physical
             # column name that may differ from the DJ component name.
             return measure.source_column or measure.name

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -27,22 +27,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def get_required_measure_hashes(grain_group: "GrainGroup") -> set[str]:
-    """
-    Get the set of expression hashes for all measures required by a grain group.
-
-    Args:
-        grain_group: The grain group to analyze
-
-    Returns:
-        Set of expression hashes (MD5 hashes of normalized expressions)
-    """
-    return {
-        compute_expression_hash(component.expression)
-        for _, component in grain_group.components
-    }
-
-
 def _normalize_aggregation(aggregation: str | None) -> str:
     """Normalize a Phase-1 aggregation function name for identity comparison."""
     return (aggregation or "").strip().upper()
@@ -109,7 +93,6 @@ def find_matching_preagg(
     if not available:
         return None
 
-    # Get required measure identities (expression hash + Phase-1 aggregation)
     required_measures = get_required_measure_identities(grain_group)
     if not required_measures:
         return None
@@ -152,10 +135,8 @@ def find_matching_preagg(
             )
             continue
 
-        # Check measure coverage: every required measure identity (expression hash
-        # + Phase-1 aggregation) must be present in the pre-agg. Matching on the
-        # aggregation too prevents a MAX/MIN metric from binding to a SUM-built
-        # column (or vice versa) just because they share an inner expression.
+        # Coverage check on (expression hash, Phase-1 aggregation) -- see
+        # get_required_measure_identities for why the aggregation is part of it.
         preagg_measures = {
             (measure.expr_hash, _normalize_aggregation(measure.aggregation))
             for measure in preagg.measures

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING
 
 from datajunction_server.database.preaggregation import (
     PreAggregation,
-    get_measure_expr_hashes,
     compute_expression_hash,
 )
 from datajunction_server.models.decompose import Aggregability, MetricComponent
@@ -38,11 +37,39 @@ def get_required_measure_hashes(grain_group: "GrainGroup") -> set[str]:
     Returns:
         Set of expression hashes (MD5 hashes of normalized expressions)
     """
-    hashes = set()
-    for _, component in grain_group.components:
-        expr_hash = compute_expression_hash(component.expression)
-        hashes.add(expr_hash)
-    return hashes
+    return {
+        compute_expression_hash(component.expression)
+        for _, component in grain_group.components
+    }
+
+
+def _normalize_aggregation(aggregation: str | None) -> str:
+    """Normalize a Phase-1 aggregation function name for identity comparison."""
+    return (aggregation or "").strip().upper()
+
+
+def get_required_measure_identities(
+    grain_group: "GrainGroup",
+) -> set[tuple[str, str]]:
+    """
+    Identity of each measure a grain group needs: (expression hash, Phase-1
+    aggregation function).
+
+    The aggregation is part of the identity because a pre-aggregation stores
+    partials produced by a specific Phase-1 function, and the expression hash
+    covers only the inner expression -- not the function. Two metrics that share
+    an inner expression but aggregate it differently (e.g. SUM(x) vs MAX(x))
+    would otherwise collide, letting a MAX metric bind to a SUM pre-agg column
+    and compute MAX(sum) instead of MAX(row). A SUM partial cannot serve a MAX
+    (or MIN) metric, so the aggregation must match for the pre-agg to be usable.
+    """
+    return {
+        (
+            compute_expression_hash(component.expression),
+            _normalize_aggregation(component.aggregation),
+        )
+        for _, component in grain_group.components
+    }
 
 
 def find_matching_preagg(
@@ -82,8 +109,8 @@ def find_matching_preagg(
     if not available:
         return None
 
-    # Get required measure hashes
-    required_measures = get_required_measure_hashes(grain_group)
+    # Get required measure identities (expression hash + Phase-1 aggregation)
+    required_measures = get_required_measure_identities(grain_group)
     if not required_measures:
         return None
 
@@ -125,11 +152,18 @@ def find_matching_preagg(
             )
             continue
 
-        # Check measure coverage: required measures must be subset of pre-agg measures
-        preagg_measure_hashes = get_measure_expr_hashes(preagg.measures)
-        if not required_measures.issubset(preagg_measure_hashes):
+        # Check measure coverage: every required measure identity (expression hash
+        # + Phase-1 aggregation) must be present in the pre-agg. Matching on the
+        # aggregation too prevents a MAX/MIN metric from binding to a SUM-built
+        # column (or vice versa) just because they share an inner expression.
+        preagg_measures = {
+            (measure.expr_hash, _normalize_aggregation(measure.aggregation))
+            for measure in preagg.measures
+            if measure.expr_hash
+        }
+        if not required_measures.issubset(preagg_measures):
             logger.debug(
-                f"[BuildV3] Pre-agg {preagg.id} measures {preagg_measure_hashes} "
+                f"[BuildV3] Pre-agg {preagg.id} measures {preagg_measures} "
                 f"don't cover required measures {required_measures}",
             )
             continue
@@ -141,7 +175,7 @@ def find_matching_preagg(
             best_grain_size = len(preagg_grain_set)
             logger.debug(
                 f"[BuildV3] Found matching pre-agg {preagg.id} "
-                f"(grain={preagg_grain_set}, measures={len(preagg_measure_hashes)})",
+                f"(grain={preagg_grain_set}, measures={len(preagg_measures)})",
             )
 
     if best_match:

--- a/datajunction-server/datajunction_server/internal/preaggregations.py
+++ b/datajunction-server/datajunction_server/internal/preaggregations.py
@@ -95,8 +95,11 @@ async def register_external_preaggregations(
     configured. Returns the created/updated pre-aggregations.
     """
     # 1. Validate each mapped metric is a measure, and map its single component's
-    #    expression hash to the declared physical column.
-    measure_hash_to_column: dict[str, str] = {}
+    #    identity -- (expression hash, Phase-1 aggregation) -- to the declared
+    #    physical column. Keying on the hash alone would collapse measures that
+    #    share an inner expression but aggregate it differently (SUM(x) vs MAX(x)),
+    #    silently discarding one metric's declared column.
+    measure_identity_to_column: dict[tuple[str, str], str] = {}
     for metric_name, physical_column in measure_columns.items():
         node = await Node.get_by_name(
             session,
@@ -123,9 +126,13 @@ async def register_external_preaggregations(
             )
         components, _ = await MetricComponentExtractor(node.current.id).extract(session)
         # is_measure guarantees exactly one component.
-        measure_hash_to_column[compute_expression_hash(components[0].expression)] = (
-            physical_column
-        )
+        component = components[0]
+        measure_identity_to_column[
+            (
+                compute_expression_hash(component.expression),
+                component.normalized_aggregation,
+            )
+        ] = physical_column
 
     # 2. Decompose the requested metrics into grain groups (no SQL is executed).
     measures_result = await build_measures_sql(
@@ -190,15 +197,18 @@ async def register_external_preaggregations(
         grain_measures: list[PreAggMeasure] = []
         for component in grain_group.components:
             expr_hash = compute_expression_hash(component.expression)
-            if expr_hash not in measure_hash_to_column:
+            identity = (expr_hash, component.normalized_aggregation)
+            if identity not in measure_identity_to_column:
                 raise DJInvalidInputException(
                     message=(
-                        f"Measure '{component.name}' required by the requested "
+                        f"Measure '{component.name}' "
+                        f"({component.normalized_aggregation} over "
+                        f"'{component.expression}') required by the requested "
                         f"metrics is not covered by measure_columns. Add the "
                         f"is_measure metric it corresponds to."
                     ),
                 )
-            physical_column = measure_hash_to_column[expr_hash]
+            physical_column = measure_identity_to_column[identity]
             measure_name = grain_group.component_aliases.get(
                 component.name,
                 component.name,

--- a/datajunction-server/datajunction_server/models/decompose.py
+++ b/datajunction-server/datajunction_server/models/decompose.py
@@ -104,11 +104,11 @@ class MetricComponent(BaseModel):
         """
         Phase-1 aggregation function, normalized for identity comparison.
 
-        A measure's identity is (expression, aggregation), not expression alone:
-        pre-aggregated partials are only reusable by a metric that aggregates the
-        same way -- a SUM partial cannot serve MAX or MIN. Everything that matches
-        or binds measures compares this, so normalization lives here rather than
-        being re-derived per call site.
+        A measure is identified by (expression, aggregation), not by expression
+        alone -- a stored partial is only reusable by a metric that accumulates
+        the same way. Pre-agg matching, column binding and registration all
+        compare this, so the normalization lives with the model rather than being
+        re-derived at each call site.
         """
         return (self.aggregation or "").strip().upper()
 

--- a/datajunction-server/datajunction_server/models/decompose.py
+++ b/datajunction-server/datajunction_server/models/decompose.py
@@ -99,6 +99,19 @@ class MetricComponent(BaseModel):
     # valid and consistent with what decompose.py computed.
     grain_alias: str | None = None
 
+    @property
+    def normalized_aggregation(self) -> str:
+        """
+        Phase-1 aggregation function, normalized for identity comparison.
+
+        A measure's identity is (expression, aggregation), not expression alone:
+        pre-aggregated partials are only reusable by a metric that aggregates the
+        same way -- a SUM partial cannot serve MAX or MIN. Everything that matches
+        or binds measures compares this, so normalization lives here rather than
+        being re-derived per call site.
+        """
+        return (self.aggregation or "").strip().upper()
+
 
 class PreAggMeasure(MetricComponent):
     """

--- a/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
@@ -10,7 +10,7 @@ from datajunction_server.construction.build_v3.preagg_matcher import (
     find_matching_preagg,
     get_preagg_dimension_column,
     get_preagg_measure_column,
-    get_required_measure_hashes,
+    get_required_measure_identities,
     get_temporal_partitions,
 )
 from datajunction_server.models.query import V3ColumnMetadata
@@ -183,28 +183,29 @@ def make_grain_group(
     )
 
 
-class TestGetRequiredMeasureHashes:
-    """Tests for get_required_measure_hashes function."""
+class TestGetRequiredMeasureIdentities:
+    """Tests for get_required_measure_identities function."""
 
     @pytest.mark.asyncio
-    async def test_returns_hashes_for_all_components(
+    async def test_returns_identities_for_all_components(
         self,
         session: AsyncSession,
         parent_node: Node,
         metric_node: Node,
     ):
-        """Should return a hash for each component in the grain group."""
+        """Should return an (expression hash, aggregation) pair per component."""
         components = [
             (metric_node, make_component("sum_revenue", "price * quantity")),
             (metric_node, make_component("sum_quantity", "quantity")),
         ]
         grain_group = make_grain_group(parent_node, components)
 
-        hashes = get_required_measure_hashes(grain_group)
+        identities = get_required_measure_identities(grain_group)
 
-        assert len(hashes) == 2
-        assert compute_expression_hash("price * quantity") in hashes
-        assert compute_expression_hash("quantity") in hashes
+        assert identities == {
+            (compute_expression_hash("price * quantity"), "SUM"),
+            (compute_expression_hash("quantity"), "SUM"),
+        }
 
     @pytest.mark.asyncio
     async def test_empty_components_returns_empty_set(
@@ -215,18 +216,18 @@ class TestGetRequiredMeasureHashes:
         """Should return empty set when grain group has no components."""
         grain_group = make_grain_group(parent_node, [])
 
-        hashes = get_required_measure_hashes(grain_group)
+        identities = get_required_measure_identities(grain_group)
 
-        assert hashes == set()
+        assert identities == set()
 
     @pytest.mark.asyncio
-    async def test_deduplicates_same_expression(
+    async def test_deduplicates_same_expression_and_aggregation(
         self,
         session: AsyncSession,
         parent_node: Node,
         metric_node: Node,
     ):
-        """Components with same expression should result in single hash."""
+        """Components with same expression AND aggregation collapse to one."""
         # Same expression, different component names
         components = [
             (metric_node, make_component("sum_rev_1", "price * quantity")),
@@ -234,9 +235,41 @@ class TestGetRequiredMeasureHashes:
         ]
         grain_group = make_grain_group(parent_node, components)
 
-        hashes = get_required_measure_hashes(grain_group)
+        identities = get_required_measure_identities(grain_group)
 
-        assert len(hashes) == 1
+        assert identities == {(compute_expression_hash("price * quantity"), "SUM")}
+
+    @pytest.mark.asyncio
+    async def test_same_expression_different_aggregation_are_distinct(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+        metric_node: Node,
+    ):
+        """The aggregation is part of the identity: SUM(x) and MAX(x) differ.
+
+        This is what stops a MAX metric from binding a SUM-built pre-agg column.
+        """
+        components = [
+            (metric_node, make_component("sum_price", "unit_price")),
+            (
+                metric_node,
+                make_component(
+                    "max_price",
+                    "unit_price",
+                    aggregation="MAX",
+                    merge="MAX",
+                ),
+            ),
+        ]
+        grain_group = make_grain_group(parent_node, components)
+
+        identities = get_required_measure_identities(grain_group)
+
+        assert identities == {
+            (compute_expression_hash("unit_price"), "SUM"),
+            (compute_expression_hash("unit_price"), "MAX"),
+        }
 
 
 class TestFindMatchingPreagg:

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -660,6 +660,75 @@ class TestExternalPreAggRouting:
         )
 
     @pytest.mark.asyncio
+    async def test_external_preagg_filter_on_rolled_up_dimension(
+        self,
+        client_with_build_v3,
+    ):
+        """A filter on a dimension that is in the pre-agg grain but rolled away
+        from the requested output must be pushed into the pre-agg scan, on the
+        physical (mapped) column, before the roll-up. Previously the predicate was
+        silently dropped and the result over-counted. Here ``category`` is mapped
+        to physical ``cat`` and is in the agg grain, but the query groups by
+        ``status`` only, so ``category`` is filter-only."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status", "v3.product.category"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "rev_by_status_cat",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.product.category": "cat"},
+            table_columns={"status": "string", "cat": "string", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_details.status"],
+            "filters": ["v3.product.category = 'Electronics'"],
+        }
+        # Measures SQL: the filter is injected on the physical column `cat`,
+        # inside the CTE, before the GROUP BY roll-up.
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params=params,
+        )
+        assert measures_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(measures_response.json())["sql"],
+            """
+            SELECT status, cat category, SUM(rev_sum) rev_sum
+            FROM default.analytics.rev_by_status_cat
+            WHERE cat = 'Electronics'
+            GROUP BY status, cat
+            """,
+        )
+        # Metrics SQL: the outer query does not re-apply the (filter-only) cat
+        # predicate; it is applied once, inside the CTE.
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params=params,
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT status, cat category, SUM(rev_sum) rev_sum
+                FROM default.analytics.rev_by_status_cat
+                WHERE cat = 'Electronics'
+                GROUP BY status, cat
+            )
+            SELECT order_details_0.status AS status,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.status
+            """,
+        )
+
+    @pytest.mark.asyncio
     async def test_external_preagg_cross_fact_partial_substitution(
         self,
         client_with_build_v3,

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -290,6 +290,74 @@ class TestExternalPreAggRouting:
         )
 
     @pytest.mark.asyncio
+    async def test_external_preagg_same_expression_two_aggregations(
+        self,
+        client_with_build_v3,
+    ):
+        """One pre-agg can carry several aggregations over the same expression,
+        each bound to its own physical column, and each metric reads its own.
+
+        ``total_unit_price`` (SUM) and ``max_unit_price`` (MAX) both decompose to
+        the expression ``unit_price``, so a measure identity of expression-hash
+        alone collapses them: registration kept only the last-declared column and
+        both metrics read it -- the SUM metric summing the MAX column. Identity is
+        (expression hash, Phase-1 aggregation) at registration and at lookup, so
+        both mappings survive and each metric binds the right column.
+        """
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_unit_price", "v3.max_unit_price"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "unit_price_both",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={
+                "v3.total_unit_price": "unit_price_sum",
+                "v3.max_unit_price": "unit_price_max",
+            },
+            table_columns={
+                "status": "string",
+                "unit_price_sum": "double",
+                "unit_price_max": "double",
+            },
+        )
+        sum_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_unit_price"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert sum_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(sum_response.json())["sql"],
+            """
+            SELECT status, SUM(unit_price_sum) unit_price_sum
+            FROM default.analytics.unit_price_both
+            GROUP BY status
+            """,
+        )
+        max_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.max_unit_price"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert max_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(max_response.json())["sql"],
+            """
+            SELECT status, MAX(unit_price_max) unit_price_max
+            FROM default.analytics.unit_price_both
+            GROUP BY status
+            """,
+        )
+
+    @pytest.mark.asyncio
     async def test_external_preagg_pending_not_used(self, client_with_build_v3):
         """A registered pre-agg with no availability (no valid_through_ts) is not
         used to answer queries."""

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -223,6 +223,73 @@ class TestExternalPreAggRouting:
         assert "default.analytics.orders_by_status" not in sql
 
     @pytest.mark.asyncio
+    async def test_external_preagg_not_used_for_incompatible_aggregation(
+        self,
+        client_with_build_v3,
+    ):
+        """A pre-agg built with SUM must not satisfy a metric that needs MAX of
+        the same column. ``total_unit_price = SUM(unit_price)`` and
+        ``max_unit_price = MAX(unit_price)`` share the inner expression
+        ``unit_price``; matching on the expression hash alone routed the MAX
+        metric to the SUM pre-agg and computed MAX(sum) instead of MAX(row). The
+        matcher must also require the Phase-1 aggregation to match: the SUM metric
+        keeps using the agg, the MAX metric falls back to the base fact.
+        """
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_unit_price"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "unit_price_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_unit_price": "unit_price_sum"},
+            table_columns=["status", "unit_price_sum"],
+        )
+        # SUM metric routes to the agg (control).
+        sum_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_unit_price"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert sum_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(sum_response.json())["sql"],
+            """
+            SELECT status, SUM(unit_price_sum) unit_price_sum
+            FROM default.analytics.unit_price_by_status
+            GROUP BY status
+            """,
+        )
+        # MAX metric shares the inner expression but not the aggregation -> it must
+        # NOT bind the SUM column; it builds MAX from the base fact instead.
+        max_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.max_unit_price"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert max_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(max_response.json())["sql"],
+            """
+            WITH v3_order_details AS (
+                SELECT o.status, oi.unit_price
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT t1.status, MAX(t1.unit_price) unit_price_max_55cff00f
+            FROM v3_order_details t1
+            GROUP BY t1.status
+            """,
+        )
+
+    @pytest.mark.asyncio
     async def test_external_preagg_pending_not_used(self, client_with_build_v3):
         """A registered pre-agg with no availability (no valid_through_ts) is not
         used to answer queries."""


### PR DESCRIPTION
### Summary

This fixes two bugs in external pre-aggregation substitution. Both cause wrong numbers with no error when a query routes to an externally-registered pre-agg.

#### 1. Measure identity ignored the aggregation function

A measure was identified by `compute_expression_hash(expression)`, basically the inner expression only. The result is that `SUM(x)` and `MAX(x)` are distinct measures that hash identically. This means:
- Routing errors where a MAX metric matched a SUM-built pre-agg and computed MAX(sum) instead of MAX(row).
- Registration errors, where `measure_hash_to_column` was keyed by hash, so registering {total_unit_price: unit_price_sum, max_unit_price: unit_price_max} silently discarded one declared column.
- Column binding: `get_preagg_measure_column` returned the first hash match, so even a correct match could resolve to the wrong column.

The fix is for `MetricComponent.normalized_aggregation` to give the identity one home so that routing, binding and registration all key on (expr_hash, aggregation). The aggregation was already persisted, so there is no migration needed.

#### 2. Filters on rolled-up dimensions were dropped

The metrics layer skips filters on "filter-only" dimensions at the outer query, on the contract that each grain group's CTE applied them. The source path honors that but the pre-agg path didn't, so filtering on a dimension in the pre-agg grain but absent from the output emitted no `WHERE` at all.

The fix is to inject those predicates into the pre-agg scan on the physical (possibly `dimension_columns`-remapped) column, before the roll-up.

### Test Plan

Added some regression tests.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
