### PR TITLE
Fix preagg registration identity

### DIFF
--- a/datajunction-server/datajunction_server/api/preaggregations.py
+++ b/datajunction-server/datajunction_server/api/preaggregations.py
@@ -38,6 +38,7 @@ from datajunction_server.database.preaggregation import (
     compute_grain_group_hash,
     compute_expression_hash,
     compute_preagg_hash,
+    get_measure_identities,
 )
 from datajunction_server.errors import (
     DJConfigurationException,
@@ -617,7 +618,7 @@ async def plan_preaggregations(
             session=session,
             node_revision_id=node_revision_id,
             grain_columns=grain_columns,
-            measure_expr_hashes={m.expr_hash for m in measures if m.expr_hash},
+            measure_identities=get_measure_identities(measures),
         )
 
         if existing:

--- a/datajunction-server/datajunction_server/construction/build_v3/combiners.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/combiners.py
@@ -594,11 +594,9 @@ async def build_combiner_sql_from_preaggs(
             grain_group_hash,
         )
 
-        # Find a pre-agg that covers the required measures. Measures are compared
-        # by identity token (expression hash + Phase-1 aggregation), not by
-        # expression hash alone, so a SUM-backed pre-agg is not mistaken for a
-        # MAX-backed one over the same expression.
-        # MetricComponent doesn't have expr_hash, so compute it from expression.
+        # Find a pre-agg covering the required measures, compared by identity
+        # token so a SUM-backed pre-agg isn't mistaken for a MAX-backed one.
+        # MetricComponent has no expr_hash, so compute it from the expression.
         required_measure_identities = [
             measure_identity_token(
                 compute_expression_hash(m.expression),

--- a/datajunction-server/datajunction_server/construction/build_v3/combiners.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/combiners.py
@@ -29,6 +29,8 @@ from datajunction_server.database.preaggregation import (
     compute_expression_hash,
     compute_grain_group_hash,
     compute_preagg_hash_from_hashes,
+    get_measure_identities,
+    measure_identity_token,
 )
 
 from datajunction_server.construction.build_v3.cte import (
@@ -592,15 +594,24 @@ async def build_combiner_sql_from_preaggs(
             grain_group_hash,
         )
 
-        # Find a pre-agg that covers the required measures
-        # MetricComponent doesn't have expr_hash, so compute it from expression
-        required_measure_hashes = [
-            compute_expression_hash(m.expression) for m in gg.components if m.expression
+        # Find a pre-agg that covers the required measures. Measures are compared
+        # by identity token (expression hash + Phase-1 aggregation), not by
+        # expression hash alone, so a SUM-backed pre-agg is not mistaken for a
+        # MAX-backed one over the same expression.
+        # MetricComponent doesn't have expr_hash, so compute it from expression.
+        required_measure_identities = [
+            measure_identity_token(
+                compute_expression_hash(m.expression),
+                m.aggregation,
+            )
+            for m in gg.components
+            if m.expression
         ]
         matching_preagg = None
         for preagg in preaggs:
-            existing_hashes = {m.expr_hash for m in preagg.measures if m.expr_hash}
-            if set(required_measure_hashes) <= existing_hashes:
+            if set(required_measure_identities) <= get_measure_identities(
+                preagg.measures,
+            ):
                 matching_preagg = preagg
                 break
 
@@ -622,7 +633,7 @@ async def build_combiner_sql_from_preaggs(
             preagg_hash = compute_preagg_hash_from_hashes(
                 node_revision_id,
                 grain_columns_for_hash,
-                required_measure_hashes,
+                required_measure_identities,
             )
 
         # Use the preagg_hash for the table name (includes measures)

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -147,6 +147,37 @@ def strip_role_suffix(ref: str) -> str:
     return ref
 
 
+def references_filter_only_dimension(
+    filter_ast: ast.Expression,
+    filter_dimensions: set[str],
+) -> bool:
+    """
+    Whether a filter references a "filter-only" dimension -- one that is part of a
+    grain group but not projected into the final output.
+
+    This encodes one half of a contract shared by two layers: the metrics builder
+    skips these filters at the outer query precisely because each grain group is
+    expected to have applied them at its own CTE. Both sides must agree on which
+    filters those are, so both call this.
+
+    Role-qualified refs (``dim.col[role]``) parse as
+    ``Subscript(Column("dim.col"), Column("role"))``, so ``find_all(ast.Column)``
+    sees only the base column; they are matched separately against role-stripped
+    dimension names.
+    """
+    base_refs = {strip_role_suffix(ref) for ref in filter_dimensions}
+    if any(
+        isinstance(subscript.expr, ast.Column)
+        and get_column_full_name(subscript.expr) in base_refs
+        for subscript in filter_ast.find_all(ast.Subscript)
+    ):
+        return True
+    return any(
+        get_column_full_name(col) in filter_dimensions
+        for col in filter_ast.find_all(ast.Column)
+    )
+
+
 def extract_dim_info_from_grain_groups(
     grain_groups: list[GrainGroupSQL],
 ) -> list[tuple[str, str]]:

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -152,18 +152,16 @@ def references_filter_only_dimension(
     filter_dimensions: set[str],
 ) -> bool:
     """
-    Whether a filter references a "filter-only" dimension -- one that is part of a
-    grain group but not projected into the final output.
+    Whether a filter references a "filter-only" dimension -- in a grain group but
+    not projected into the output.
 
-    This encodes one half of a contract shared by two layers: the metrics builder
-    skips these filters at the outer query precisely because each grain group is
-    expected to have applied them at its own CTE. Both sides must agree on which
-    filters those are, so both call this.
+    Shared by the metrics builder (which skips these at the outer query) and the
+    grain-group builders (which must apply them at their CTE); both sides have to
+    agree, so both call this.
 
-    Role-qualified refs (``dim.col[role]``) parse as
-    ``Subscript(Column("dim.col"), Column("role"))``, so ``find_all(ast.Column)``
-    sees only the base column; they are matched separately against role-stripped
-    dimension names.
+    Role-qualified refs parse as ``Subscript(Column("dim.col"), Column("role"))``,
+    so ``find_all(ast.Column)`` sees only the base column -- hence the separate
+    pass against role-stripped names.
     """
     base_refs = {strip_role_suffix(ref) for ref in filter_dimensions}
     if any(

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -19,8 +19,8 @@ from datajunction_server.construction.build_v3.cte import (
     _fk_key_column_names,
     collect_node_ctes,
     extract_dimension_node,
-    get_column_full_name,
     inject_filter_into_select,
+    references_filter_only_dimension,
     strip_role_suffix,
 )
 from datajunction_server.construction.build_v3.decomposition import (
@@ -1744,32 +1744,6 @@ def find_upstream_temporal_source_node(
     return None
 
 
-def _references_filter_only_dimension(
-    filter_ast: ast.Expression,
-    filter_dimensions: set[str],
-) -> bool:
-    """
-    True if a filter references a "filter-only" dimension -- one the outer metrics
-    query skips (expecting the grain group CTE to have applied it). Mirrors the
-    skip logic in the metrics builder, including role-suffixed refs which parse as
-    ``Subscript(Column("dim.col"), Column("role"))``.
-    """
-    for subscript in filter_ast.find_all(ast.Subscript):
-        if not isinstance(subscript.expr, ast.Column):
-            continue  # pragma: no cover
-        base_ref = get_column_full_name(subscript.expr)
-        if base_ref and any(
-            (fd.split("[")[0] if "[" in fd else fd) == base_ref
-            for fd in filter_dimensions
-        ):
-            return True
-    for col in filter_ast.find_all(ast.Column):
-        full_name = get_column_full_name(col)
-        if full_name and full_name in filter_dimensions:
-            return True
-    return False
-
-
 def build_grain_group_from_preagg(
     ctx: BuildContext,
     grain_group: GrainGroup,
@@ -1936,19 +1910,25 @@ def build_grain_group_from_preagg(
         group_by=group_by,
     )
 
-    # Push filter-only dimension filters into the pre-agg scan. The metrics layer
-    # applies filters on projected (output) dimensions at the outer query, but
-    # deliberately skips "filter-only" dimensions -- ones in the pre-agg grain
-    # that are rolled away -- expecting each grain group to have applied them.
-    # For a pre-agg-backed grain group we must do that here, mapping each filtered
-    # dimension to its physical column and filtering before the roll-up; otherwise
-    # the predicate lands nowhere and the result silently over-counts.
-    for filter_str in ctx.dimension_filters or []:
-        filter_ast = parse_filter(filter_str)
-        if not _references_filter_only_dimension(filter_ast, ctx.filter_dimensions):
-            continue  # a projected-dimension filter -> the outer query applies it
-        resolve_filter_references(filter_ast, ref_to_physical, cte_alias=None)
-        inject_filter_into_select(select, filter_ast)
+    # Push filter-only dimension filters into the pre-agg scan, on the physical
+    # column and before the roll-up. The outer metrics query skips these filters
+    # (see references_filter_only_dimension) because each grain group is expected
+    # to apply them itself; without this the predicate lands nowhere and the
+    # result silently over-counts. Filters on projected dimensions are left to the
+    # outer query, matching the pre-agg read the non-filtered case produces.
+    #
+    # Guarded on ctx.filter_dimensions: when there are none -- the common case --
+    # no filter can qualify, and parsing here would be wasted (ANTLR).
+    if ctx.filter_dimensions:
+        for filter_str in ctx.dimension_filters or []:
+            filter_ast = parse_filter(filter_str)
+            if not references_filter_only_dimension(
+                filter_ast,
+                ctx.filter_dimensions,
+            ):
+                continue
+            resolve_filter_references(filter_ast, ref_to_physical, cte_alias=None)
+            inject_filter_into_select(select, filter_ast)
 
     # Build the query
     query = ast.Query(select=select)

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -19,6 +19,7 @@ from datajunction_server.construction.build_v3.cte import (
     _fk_key_column_names,
     collect_node_ctes,
     extract_dimension_node,
+    get_column_full_name,
     inject_filter_into_select,
     strip_role_suffix,
 )
@@ -30,6 +31,8 @@ from datajunction_server.construction.build_v3.dimensions import (
 )
 from datajunction_server.construction.build_v3.filters import (
     parse_and_resolve_filters,
+    parse_filter,
+    resolve_filter_references,
 )
 from datajunction_server.construction.build_v3.utils import (
     extract_columns_from_expression,
@@ -1741,6 +1744,32 @@ def find_upstream_temporal_source_node(
     return None
 
 
+def _references_filter_only_dimension(
+    filter_ast: ast.Expression,
+    filter_dimensions: set[str],
+) -> bool:
+    """
+    True if a filter references a "filter-only" dimension -- one the outer metrics
+    query skips (expecting the grain group CTE to have applied it). Mirrors the
+    skip logic in the metrics builder, including role-suffixed refs which parse as
+    ``Subscript(Column("dim.col"), Column("role"))``.
+    """
+    for subscript in filter_ast.find_all(ast.Subscript):
+        if not isinstance(subscript.expr, ast.Column):
+            continue  # pragma: no cover
+        base_ref = get_column_full_name(subscript.expr)
+        if base_ref and any(
+            (fd.split("[")[0] if "[" in fd else fd) == base_ref
+            for fd in filter_dimensions
+        ):
+            return True
+    for col in filter_ast.find_all(ast.Column):
+        full_name = get_column_full_name(col)
+        if full_name and full_name in filter_dimensions:
+            return True
+    return False
+
+
 def build_grain_group_from_preagg(
     ctx: BuildContext,
     grain_group: GrainGroup,
@@ -1791,6 +1820,9 @@ def build_grain_group_from_preagg(
     # pre-agg remaps a dimension's column).
     grain_col_names: list[str] = []
     group_by_cols: list[str] = []
+    # Dimension ref -> physical column in the pre-agg table, used to push
+    # filter-only dimension filters into the CTE below.
+    ref_to_physical: dict[str, str] = {}
     for dim in resolved_dimensions:
         # Output name the rest of the query references this grain column by. It
         # must match the alias the source-built path would emit (role-qualified,
@@ -1812,6 +1844,7 @@ def build_grain_group_from_preagg(
             dim.column_name,
         )
         group_by_cols.append(physical_col)
+        ref_to_physical[dim.original_ref] = physical_col
 
         if physical_col == output_alias:
             select_items.append(ast.Column(name=ast.Name(output_alias)))
@@ -1902,6 +1935,20 @@ def build_grain_group_from_preagg(
         from_=from_clause,
         group_by=group_by,
     )
+
+    # Push filter-only dimension filters into the pre-agg scan. The metrics layer
+    # applies filters on projected (output) dimensions at the outer query, but
+    # deliberately skips "filter-only" dimensions -- ones in the pre-agg grain
+    # that are rolled away -- expecting each grain group to have applied them.
+    # For a pre-agg-backed grain group we must do that here, mapping each filtered
+    # dimension to its physical column and filtering before the roll-up; otherwise
+    # the predicate lands nowhere and the result silently over-counts.
+    for filter_str in ctx.dimension_filters or []:
+        filter_ast = parse_filter(filter_str)
+        if not _references_filter_only_dimension(filter_ast, ctx.filter_dimensions):
+            continue  # a projected-dimension filter -> the outer query applies it
+        resolve_filter_references(filter_ast, ref_to_physical, cte_alias=None)
+        inject_filter_into_select(select, filter_ast)
 
     # Build the query
     query = ast.Query(select=select)

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -1794,24 +1794,20 @@ def build_grain_group_from_preagg(
     # pre-agg remaps a dimension's column).
     grain_col_names: list[str] = []
     group_by_cols: list[str] = []
-    # Dimension ref -> physical column in the pre-agg table, used to push
-    # filter-only dimension filters into the CTE below.
+    # Dimension ref -> physical column, for the filter pushdown below.
     ref_to_physical: dict[str, str] = {}
     for dim in resolved_dimensions:
-        # Output name the rest of the query references this grain column by. It
-        # must match the alias the source-built path would emit (role-qualified,
-        # via the alias registry) -- the combiner/metrics layer references grain
-        # columns by that alias, not by the parent's physical column name. Using
-        # dim.column_name here breaks whenever it differs from the alias, e.g. a
-        # joined dimension's key satisfied by a differently-named parent FK
-        # column (order_details.order_date = date.date_id[order]): the CTE would
-        # expose ``order_date`` while the outer query selects ``date_id_order``.
+        # Output name, via the alias registry so it matches what the source-built
+        # path emits -- the metrics layer references grain columns by that alias.
+        # dim.column_name is wrong whenever the two differ, e.g. a joined key
+        # satisfied by a differently-named FK (order_details.order_date =
+        # date.date_id[order]): the CTE would expose order_date while the outer
+        # query selects date_id_order.
         output_alias = ctx.alias_registry.register(dim.original_ref)
         grain_col_names.append(output_alias)
 
-        # Physical column actually read from the pre-agg table. It may be remapped
-        # via dimension_columns; otherwise it defaults to the parent's grain
-        # column name. This is independent of the output alias above.
+        # Physical column read from the table, remapped via dimension_columns if
+        # present. Independent of the output alias above.
         physical_col = get_preagg_dimension_column(
             preagg,
             dim.original_ref,
@@ -1910,15 +1906,12 @@ def build_grain_group_from_preagg(
         group_by=group_by,
     )
 
-    # Push filter-only dimension filters into the pre-agg scan, on the physical
-    # column and before the roll-up. The outer metrics query skips these filters
-    # (see references_filter_only_dimension) because each grain group is expected
-    # to apply them itself; without this the predicate lands nowhere and the
-    # result silently over-counts. Filters on projected dimensions are left to the
-    # outer query, matching the pre-agg read the non-filtered case produces.
-    #
-    # Guarded on ctx.filter_dimensions: when there are none -- the common case --
-    # no filter can qualify, and parsing here would be wasted (ANTLR).
+    # Push filter-only dimension filters into the scan, on the physical column and
+    # before the roll-up. The outer query skips these (the grain group is expected
+    # to apply them), so without this the predicate lands nowhere and the result
+    # over-counts. Projected-dimension filters are left to the outer query.
+    # Guarded on filter_dimensions: when empty -- the common case -- nothing can
+    # qualify and the ANTLR parse below would be wasted.
     if ctx.filter_dimensions:
         for filter_str in ctx.dimension_filters or []:
             filter_ast = parse_filter(filter_str)

--- a/datajunction-server/datajunction_server/construction/build_v3/metrics.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/metrics.py
@@ -19,6 +19,7 @@ from datajunction_server.construction.build_v3.cte import (
     has_window_function,
     inject_partition_by_into_windows,
     process_metric_combiner_expression,
+    references_filter_only_dimension,
     replace_component_refs_in_ast,
     replace_dimension_refs_in_ast,
     replace_metric_refs_in_ast,
@@ -2112,34 +2113,14 @@ def generate_metrics_sql(
 
         # Filter out filters that reference filter-only dimensions
         # Those filters are already applied in the grain group CTEs
-        applicable_dimension_filters = []
-        for f in dimension_filters_raw:
-            filter_ast = parse_filter(f)
-            # Check if any column ref in this filter is a filter-only dimension.
-            # Must handle both plain column refs and role-qualified subscript refs
-            # (e.g., "v3.location.country[customer->home]"), because find_all(ast.Column)
-            # returns only the base Column inside the Subscript, not the full role string.
-            refs_filter_only = False
-            for subscript in filter_ast.find_all(ast.Subscript):
-                if not isinstance(subscript.expr, ast.Column):
-                    continue  # pragma: no cover
-                base_ref = get_column_full_name(subscript.expr)
-                if base_ref:  # pragma: no branch
-                    for fd in ctx.filter_dimensions:
-                        fd_base = fd.split("[")[0] if "[" in fd else fd
-                        if fd_base == base_ref:  # pragma: no branch
-                            refs_filter_only = True
-                            break
-                if refs_filter_only:
-                    break
-            if not refs_filter_only:
-                for col in filter_ast.find_all(ast.Column):
-                    full_name = get_column_full_name(col)
-                    if full_name and full_name in ctx.filter_dimensions:
-                        refs_filter_only = True
-                        break
-            if not refs_filter_only:
-                applicable_dimension_filters.append(f)
+        applicable_dimension_filters = [
+            f
+            for f in dimension_filters_raw
+            if not references_filter_only_dimension(
+                parse_filter(f),
+                ctx.filter_dimensions,
+            )
+        ]
 
         if applicable_dimension_filters:
             where_clause = parse_and_resolve_filters(

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -32,26 +32,16 @@ def get_required_measure_identities(
 ) -> set[tuple[str, str]]:
     """
     Identity of each measure a grain group needs: (expression hash, Phase-1
-    aggregation function).
+    aggregation).
 
-    Measure matching is intentionally name-independent -- a pre-agg should be
-    reusable even when its component names differ -- so ``expr_hash`` stands in
-    for the measure's identity. But ``expr_hash`` covers the inner expression
-    alone: ``SUM(x)`` and ``MAX(x)`` are distinct measures (distinct components,
-    distinct ``aggregation``) that hash identically. Keying on the hash alone is
-    therefore coarser than the real identity, and lets a MAX metric match a
-    SUM-built pre-agg and compute MAX(sum) rather than MAX(row).
+    Matching is name-independent, so ``expr_hash`` stands in for identity -- but
+    it covers the expression alone, making ``SUM(x)`` and ``MAX(x)`` hash alike
+    and letting a MAX metric read a SUM column. Pairing it with the aggregation
+    restores the distinction: a partial is reusable only by a metric that
+    accumulates the same way.
 
-    Pairing the hash with the aggregation restores the distinction while keeping
-    matching name-independent. It is sound because a stored partial is only
-    reusable by a metric that accumulates the same way: SUM->SUM, MAX->MAX,
-    MIN->MIN and COUNT->COUNT are valid, while a SUM partial can serve neither
-    MAX nor MIN.
-
-    The discriminator is the Phase-1 ``aggregation``, not ``merge``, because
-    merge is not unique: COUNT accumulates with COUNT but merges with SUM, so
-    ``SUM(x)`` and ``COUNT(x)`` share both an expression hash and a merge
-    function.
+    Phase-1 ``aggregation`` rather than ``merge``, because merge is not unique --
+    COUNT accumulates with COUNT but merges with SUM.
     """
     return {
         (
@@ -181,11 +171,10 @@ def get_preagg_measure_column(
     """
     Find the column name in the pre-agg that corresponds to a metric component.
 
-    Matches on the full measure identity -- expression hash AND Phase-1
-    aggregation -- so we get the right column even if names differ. The
-    aggregation matters because one pre-agg can hold several measures over the
-    same expression (e.g. SUM(x) and MAX(x)); matching on the hash alone would
-    return whichever came first and could read the wrong column.
+    Matches on the full identity -- expression hash and Phase-1 aggregation -- so
+    the right column is found even when names differ. One pre-agg can hold several
+    measures over the same expression (SUM(x) and MAX(x)), where matching on the
+    hash alone would return whichever came first.
 
     Args:
         preagg: The pre-aggregation to search

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -34,13 +34,24 @@ def get_required_measure_identities(
     Identity of each measure a grain group needs: (expression hash, Phase-1
     aggregation function).
 
-    The aggregation is part of the identity because a pre-aggregation stores
-    partials produced by a specific Phase-1 function, and the expression hash
-    covers only the inner expression -- not the function. Two metrics that share
-    an inner expression but aggregate it differently (e.g. SUM(x) vs MAX(x))
-    would otherwise collide, letting a MAX metric bind to a SUM pre-agg column
-    and compute MAX(sum) instead of MAX(row). A SUM partial cannot serve a MAX
-    (or MIN) metric, so the aggregation must match for the pre-agg to be usable.
+    Measure matching is intentionally name-independent -- a pre-agg should be
+    reusable even when its component names differ -- so ``expr_hash`` stands in
+    for the measure's identity. But ``expr_hash`` covers the inner expression
+    alone: ``SUM(x)`` and ``MAX(x)`` are distinct measures (distinct components,
+    distinct ``aggregation``) that hash identically. Keying on the hash alone is
+    therefore coarser than the real identity, and lets a MAX metric match a
+    SUM-built pre-agg and compute MAX(sum) rather than MAX(row).
+
+    Pairing the hash with the aggregation restores the distinction while keeping
+    matching name-independent. It is sound because a stored partial is only
+    reusable by a metric that accumulates the same way: SUM->SUM, MAX->MAX,
+    MIN->MIN and COUNT->COUNT are valid, while a SUM partial can serve neither
+    MAX nor MIN.
+
+    The discriminator is the Phase-1 ``aggregation``, not ``merge``, because
+    merge is not unique: COUNT accumulates with COUNT but merges with SUM, so
+    ``SUM(x)`` and ``COUNT(x)`` share both an expression hash and a merge
+    function.
     """
     return {
         (

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -27,11 +27,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _normalize_aggregation(aggregation: str | None) -> str:
-    """Normalize a Phase-1 aggregation function name for identity comparison."""
-    return (aggregation or "").strip().upper()
-
-
 def get_required_measure_identities(
     grain_group: "GrainGroup",
 ) -> set[tuple[str, str]]:
@@ -50,7 +45,7 @@ def get_required_measure_identities(
     return {
         (
             compute_expression_hash(component.expression),
-            _normalize_aggregation(component.aggregation),
+            component.normalized_aggregation,
         )
         for _, component in grain_group.components
     }
@@ -138,7 +133,7 @@ def find_matching_preagg(
         # Coverage check on (expression hash, Phase-1 aggregation) -- see
         # get_required_measure_identities for why the aggregation is part of it.
         preagg_measures = {
-            (measure.expr_hash, _normalize_aggregation(measure.aggregation))
+            (measure.expr_hash, measure.normalized_aggregation)
             for measure in preagg.measures
             if measure.expr_hash
         }
@@ -175,8 +170,11 @@ def get_preagg_measure_column(
     """
     Find the column name in the pre-agg that corresponds to a metric component.
 
-    Matches by expression hash to ensure we're getting the right column
-    even if names differ.
+    Matches on the full measure identity -- expression hash AND Phase-1
+    aggregation -- so we get the right column even if names differ. The
+    aggregation matters because one pre-agg can hold several measures over the
+    same expression (e.g. SUM(x) and MAX(x)); matching on the hash alone would
+    return whichever came first and could read the wrong column.
 
     Args:
         preagg: The pre-aggregation to search
@@ -185,10 +183,13 @@ def get_preagg_measure_column(
     Returns:
         Column name in the pre-agg, or None if not found
     """
-    target_hash = compute_expression_hash(component.expression)
+    target = (
+        compute_expression_hash(component.expression),
+        component.normalized_aggregation,
+    )
 
     for measure in preagg.measures:
-        if measure.expr_hash == target_hash:
+        if (measure.expr_hash, measure.normalized_aggregation) == target:
             # Externally-registered pre-aggs bind the measure to a physical
             # column name that may differ from the DJ component name.
             return measure.source_column or measure.name

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -27,22 +27,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def get_required_measure_hashes(grain_group: "GrainGroup") -> set[str]:
-    """
-    Get the set of expression hashes for all measures required by a grain group.
-
-    Args:
-        grain_group: The grain group to analyze
-
-    Returns:
-        Set of expression hashes (MD5 hashes of normalized expressions)
-    """
-    return {
-        compute_expression_hash(component.expression)
-        for _, component in grain_group.components
-    }
-
-
 def _normalize_aggregation(aggregation: str | None) -> str:
     """Normalize a Phase-1 aggregation function name for identity comparison."""
     return (aggregation or "").strip().upper()
@@ -109,7 +93,6 @@ def find_matching_preagg(
     if not available:
         return None
 
-    # Get required measure identities (expression hash + Phase-1 aggregation)
     required_measures = get_required_measure_identities(grain_group)
     if not required_measures:
         return None
@@ -152,10 +135,8 @@ def find_matching_preagg(
             )
             continue
 
-        # Check measure coverage: every required measure identity (expression hash
-        # + Phase-1 aggregation) must be present in the pre-agg. Matching on the
-        # aggregation too prevents a MAX/MIN metric from binding to a SUM-built
-        # column (or vice versa) just because they share an inner expression.
+        # Coverage check on (expression hash, Phase-1 aggregation) -- see
+        # get_required_measure_identities for why the aggregation is part of it.
         preagg_measures = {
             (measure.expr_hash, _normalize_aggregation(measure.aggregation))
             for measure in preagg.measures

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING
 
 from datajunction_server.database.preaggregation import (
     PreAggregation,
-    get_measure_expr_hashes,
     compute_expression_hash,
 )
 from datajunction_server.models.decompose import Aggregability, MetricComponent
@@ -38,11 +37,39 @@ def get_required_measure_hashes(grain_group: "GrainGroup") -> set[str]:
     Returns:
         Set of expression hashes (MD5 hashes of normalized expressions)
     """
-    hashes = set()
-    for _, component in grain_group.components:
-        expr_hash = compute_expression_hash(component.expression)
-        hashes.add(expr_hash)
-    return hashes
+    return {
+        compute_expression_hash(component.expression)
+        for _, component in grain_group.components
+    }
+
+
+def _normalize_aggregation(aggregation: str | None) -> str:
+    """Normalize a Phase-1 aggregation function name for identity comparison."""
+    return (aggregation or "").strip().upper()
+
+
+def get_required_measure_identities(
+    grain_group: "GrainGroup",
+) -> set[tuple[str, str]]:
+    """
+    Identity of each measure a grain group needs: (expression hash, Phase-1
+    aggregation function).
+
+    The aggregation is part of the identity because a pre-aggregation stores
+    partials produced by a specific Phase-1 function, and the expression hash
+    covers only the inner expression -- not the function. Two metrics that share
+    an inner expression but aggregate it differently (e.g. SUM(x) vs MAX(x))
+    would otherwise collide, letting a MAX metric bind to a SUM pre-agg column
+    and compute MAX(sum) instead of MAX(row). A SUM partial cannot serve a MAX
+    (or MIN) metric, so the aggregation must match for the pre-agg to be usable.
+    """
+    return {
+        (
+            compute_expression_hash(component.expression),
+            _normalize_aggregation(component.aggregation),
+        )
+        for _, component in grain_group.components
+    }
 
 
 def find_matching_preagg(
@@ -82,8 +109,8 @@ def find_matching_preagg(
     if not available:
         return None
 
-    # Get required measure hashes
-    required_measures = get_required_measure_hashes(grain_group)
+    # Get required measure identities (expression hash + Phase-1 aggregation)
+    required_measures = get_required_measure_identities(grain_group)
     if not required_measures:
         return None
 
@@ -125,11 +152,18 @@ def find_matching_preagg(
             )
             continue
 
-        # Check measure coverage: required measures must be subset of pre-agg measures
-        preagg_measure_hashes = get_measure_expr_hashes(preagg.measures)
-        if not required_measures.issubset(preagg_measure_hashes):
+        # Check measure coverage: every required measure identity (expression hash
+        # + Phase-1 aggregation) must be present in the pre-agg. Matching on the
+        # aggregation too prevents a MAX/MIN metric from binding to a SUM-built
+        # column (or vice versa) just because they share an inner expression.
+        preagg_measures = {
+            (measure.expr_hash, _normalize_aggregation(measure.aggregation))
+            for measure in preagg.measures
+            if measure.expr_hash
+        }
+        if not required_measures.issubset(preagg_measures):
             logger.debug(
-                f"[BuildV3] Pre-agg {preagg.id} measures {preagg_measure_hashes} "
+                f"[BuildV3] Pre-agg {preagg.id} measures {preagg_measures} "
                 f"don't cover required measures {required_measures}",
             )
             continue
@@ -141,7 +175,7 @@ def find_matching_preagg(
             best_grain_size = len(preagg_grain_set)
             logger.debug(
                 f"[BuildV3] Found matching pre-agg {preagg.id} "
-                f"(grain={preagg_grain_set}, measures={len(preagg_measure_hashes)})",
+                f"(grain={preagg_grain_set}, measures={len(preagg_measures)})",
             )
 
     if best_match:

--- a/datajunction-server/datajunction_server/database/preaggregation.py
+++ b/datajunction-server/datajunction_server/database/preaggregation.py
@@ -80,36 +80,61 @@ def compute_grain_group_hash(
     return hashlib.md5(content.encode()).hexdigest()
 
 
-def get_measure_expr_hashes(measures: List[PreAggMeasure]) -> Set[str]:
+def measure_identity_token(expr_hash: str, aggregation: str | None) -> str:
     """
-    Extract expression hashes from a list of measures.
+    Canonical token identifying one measure: its expression hash plus the Phase-1
+    aggregation that produced it.
+
+    The expression hash alone is not a measure's identity -- ``SUM(x)`` and
+    ``MAX(x)`` hash identically -- and a stored partial is only reusable by a
+    metric that accumulates the same way. Everything that compares or hashes
+    measures uses this token so the distinction cannot be lost at one site.
+    """
+    return f"{expr_hash}:{(aggregation or '').strip().upper()}"
+
+
+def get_measure_identities(measures: List[PreAggMeasure]) -> Set[str]:
+    """
+    Identity tokens for a list of measures (see ``measure_identity_token``).
 
     Args:
         measures: List of PreAggMeasure objects
 
     Returns:
-        Set of expression hashes
+        Set of identity tokens
     """
-    return {m.expr_hash for m in measures if m.expr_hash}
+    return {
+        measure_identity_token(m.expr_hash, m.aggregation)
+        for m in measures
+        if m.expr_hash
+    }
 
 
 def compute_preagg_hash_from_hashes(
     node_revision_id: int,
     grain_columns: List[str],
-    measure_hashes: List[str],
+    measure_identities: List[str],
 ) -> str:
     """
-    Compute a unique hash for a pre-aggregation from expression hashes.
+    Compute a unique hash for a pre-aggregation from measure identity tokens.
 
     This hash uniquely identifies a pre-aggregation by combining:
     - node_revision_id: Which node version
     - grain_columns: What dimensions we're grouping by
-    - measure_hashes: Expression hashes for the measures
+    - measure_identities: Identity tokens for the measures (expression hash plus
+      Phase-1 aggregation -- see ``measure_identity_token``)
+
+    The aggregation belongs here because the hash carries a UNIQUE constraint:
+    without it, a SUM-backed and a MAX-backed pre-agg over the same expression at
+    the same grain collide, and the second cannot be stored alongside the first.
+
+    Only computed when a row is created; existing rows keep the value they were
+    stored with (and so keep their materialization table names).
 
     Args:
         node_revision_id: The ID of the node revision
         grain_columns: Fully qualified dimension/column references
-        measure_hashes: List of expression hashes
+        measure_identities: List of measure identity tokens
 
     Returns:
         MD5 hash string (8 chars) uniquely identifying this pre-agg
@@ -117,7 +142,7 @@ def compute_preagg_hash_from_hashes(
     content = (
         f"{node_revision_id}:"
         f"{json.dumps(sorted(grain_columns))}:"
-        f"{json.dumps(sorted(measure_hashes))}"
+        f"{json.dumps(sorted(measure_identities))}"
     )
     return hashlib.md5(content.encode()).hexdigest()[:8]
 
@@ -133,7 +158,7 @@ def compute_preagg_hash(
     This hash uniquely identifies a pre-aggregation by combining:
     - node_revision_id: Which node version
     - grain_columns: What dimensions we're grouping by
-    - measure expr_hashes: What aggregations we're computing
+    - measure identities: What we're computing, and how we aggregate it
 
     Args:
         node_revision_id: The ID of the node revision
@@ -143,11 +168,10 @@ def compute_preagg_hash(
     Returns:
         MD5 hash string (8 chars) uniquely identifying this pre-agg
     """
-    measure_hashes = [m.expr_hash for m in measures if m.expr_hash]
     return compute_preagg_hash_from_hashes(
         node_revision_id,
         grain_columns,
-        measure_hashes,
+        sorted(get_measure_identities(measures)),
     )
 
 
@@ -418,13 +442,16 @@ class PreAggregation(Base):
         session: AsyncSession,
         node_revision_id: int,
         grain_columns: List[str],
-        measure_expr_hashes: Set[str],
+        measure_identities: Set[str],
     ) -> Optional["PreAggregation"]:
         """
         Find an existing pre-agg that covers the requested measures.
 
-        Looks up by grain_group_hash, then checks if any candidate
-        has a superset of the required measures (by expr_hash).
+        Looks up by grain_group_hash, then checks if any candidate has a superset
+        of the required measures, compared by identity token (expression hash plus
+        Phase-1 aggregation) rather than expression hash alone. Comparing hashes
+        alone made a SUM-backed and a MAX-backed pre-agg over the same expression
+        look like the same row, so registering one silently overwrote the other.
 
         Returns:
             Matching PreAggregation if found, None otherwise
@@ -433,8 +460,7 @@ class PreAggregation(Base):
         candidates = await cls.get_by_grain_group_hash(session, grain_group_hash)
 
         for candidate in candidates:
-            existing_hashes = get_measure_expr_hashes(candidate.measures)
-            if measure_expr_hashes <= existing_hashes:
+            if measure_identities <= get_measure_identities(candidate.measures):
                 return candidate
 
         return None

--- a/datajunction-server/datajunction_server/database/preaggregation.py
+++ b/datajunction-server/datajunction_server/database/preaggregation.py
@@ -82,13 +82,12 @@ def compute_grain_group_hash(
 
 def measure_identity_token(expr_hash: str, aggregation: str | None) -> str:
     """
-    Canonical token identifying one measure: its expression hash plus the Phase-1
-    aggregation that produced it.
+    Canonical token identifying one measure: expression hash plus Phase-1
+    aggregation.
 
-    The expression hash alone is not a measure's identity -- ``SUM(x)`` and
-    ``MAX(x)`` hash identically -- and a stored partial is only reusable by a
-    metric that accumulates the same way. Everything that compares or hashes
-    measures uses this token so the distinction cannot be lost at one site.
+    The hash alone is not an identity -- ``SUM(x)`` and ``MAX(x)`` hash alike --
+    and a partial is reusable only by a metric that accumulates the same way.
+    Everything comparing or hashing measures goes through this.
     """
     return f"{expr_hash}:{(aggregation or '').strip().upper()}"
 
@@ -124,12 +123,10 @@ def compute_preagg_hash_from_hashes(
     - measure_identities: Identity tokens for the measures (expression hash plus
       Phase-1 aggregation -- see ``measure_identity_token``)
 
-    The aggregation belongs here because the hash carries a UNIQUE constraint:
-    without it, a SUM-backed and a MAX-backed pre-agg over the same expression at
-    the same grain collide, and the second cannot be stored alongside the first.
-
-    Only computed when a row is created; existing rows keep the value they were
-    stored with (and so keep their materialization table names).
+    The aggregation matters here because this hash is UNIQUE-constrained: without
+    it, SUM- and MAX-backed pre-aggs over the same expression and grain collide.
+    Computed only at insert -- existing rows keep their stored value, and so keep
+    their materialization table names.
 
     Args:
         node_revision_id: The ID of the node revision
@@ -447,11 +444,10 @@ class PreAggregation(Base):
         """
         Find an existing pre-agg that covers the requested measures.
 
-        Looks up by grain_group_hash, then checks if any candidate has a superset
-        of the required measures, compared by identity token (expression hash plus
-        Phase-1 aggregation) rather than expression hash alone. Comparing hashes
-        alone made a SUM-backed and a MAX-backed pre-agg over the same expression
-        look like the same row, so registering one silently overwrote the other.
+        Looks up by grain_group_hash, then finds a candidate whose measures are a
+        superset of those required, compared by identity token. Comparing bare
+        expression hashes made SUM- and MAX-backed pre-aggs look like one row, so
+        registering either silently overwrote the other.
 
         Returns:
             Matching PreAggregation if found, None otherwise

--- a/datajunction-server/datajunction_server/internal/preaggregations.py
+++ b/datajunction-server/datajunction_server/internal/preaggregations.py
@@ -95,10 +95,9 @@ async def register_external_preaggregations(
     commits its whole plan). Callers must ensure ``query_service_client`` is
     configured. Returns the created/updated pre-aggregations.
     """
-    # 1. Validate each mapped metric is a measure, and map its single component's
+    # 1. Validate each mapped metric is a measure, and map its component's
     #    identity -- (expression hash, Phase-1 aggregation) -- to the declared
-    #    physical column. Keying on the hash alone would collapse measures that
-    #    share an inner expression but aggregate it differently (SUM(x) vs MAX(x)),
+    #    column. Keying on the hash alone would collapse SUM(x) and MAX(x),
     #    silently discarding one metric's declared column.
     measure_identity_to_column: dict[tuple[str, str], str] = {}
     for metric_name, physical_column in measure_columns.items():

--- a/datajunction-server/datajunction_server/internal/preaggregations.py
+++ b/datajunction-server/datajunction_server/internal/preaggregations.py
@@ -95,8 +95,11 @@ async def register_external_preaggregations(
     configured. Returns the created/updated pre-aggregations.
     """
     # 1. Validate each mapped metric is a measure, and map its single component's
-    #    expression hash to the declared physical column.
-    measure_hash_to_column: dict[str, str] = {}
+    #    identity -- (expression hash, Phase-1 aggregation) -- to the declared
+    #    physical column. Keying on the hash alone would collapse measures that
+    #    share an inner expression but aggregate it differently (SUM(x) vs MAX(x)),
+    #    silently discarding one metric's declared column.
+    measure_identity_to_column: dict[tuple[str, str], str] = {}
     for metric_name, physical_column in measure_columns.items():
         node = await Node.get_by_name(
             session,
@@ -123,9 +126,13 @@ async def register_external_preaggregations(
             )
         components, _ = await MetricComponentExtractor(node.current.id).extract(session)
         # is_measure guarantees exactly one component.
-        measure_hash_to_column[compute_expression_hash(components[0].expression)] = (
-            physical_column
-        )
+        component = components[0]
+        measure_identity_to_column[
+            (
+                compute_expression_hash(component.expression),
+                component.normalized_aggregation,
+            )
+        ] = physical_column
 
     # 2. Decompose the requested metrics into grain groups (no SQL is executed).
     measures_result = await build_measures_sql(
@@ -190,15 +197,18 @@ async def register_external_preaggregations(
         grain_measures: list[PreAggMeasure] = []
         for component in grain_group.components:
             expr_hash = compute_expression_hash(component.expression)
-            if expr_hash not in measure_hash_to_column:
+            identity = (expr_hash, component.normalized_aggregation)
+            if identity not in measure_identity_to_column:
                 raise DJInvalidInputException(
                     message=(
-                        f"Measure '{component.name}' required by the requested "
+                        f"Measure '{component.name}' "
+                        f"({component.normalized_aggregation} over "
+                        f"'{component.expression}') required by the requested "
                         f"metrics is not covered by measure_columns. Add the "
                         f"is_measure metric it corresponds to."
                     ),
                 )
-            physical_column = measure_hash_to_column[expr_hash]
+            physical_column = measure_identity_to_column[identity]
             measure_name = grain_group.component_aliases.get(
                 component.name,
                 component.name,

--- a/datajunction-server/datajunction_server/internal/preaggregations.py
+++ b/datajunction-server/datajunction_server/internal/preaggregations.py
@@ -22,6 +22,7 @@ from datajunction_server.database.preaggregation import (
     compute_expression_hash,
     compute_grain_group_hash,
     compute_preagg_hash,
+    get_measure_identities,
 )
 from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models.decompose import PreAggMeasure
@@ -261,7 +262,7 @@ async def register_external_preaggregations(
             session=session,
             node_revision_id=node_revision_id,
             grain_columns=grain_columns,
-            measure_expr_hashes={m.expr_hash for m in grain_measures if m.expr_hash},
+            measure_identities=get_measure_identities(grain_measures),
         )
         if existing:
             existing.measures = grain_measures

--- a/datajunction-server/datajunction_server/models/decompose.py
+++ b/datajunction-server/datajunction_server/models/decompose.py
@@ -104,11 +104,11 @@ class MetricComponent(BaseModel):
         """
         Phase-1 aggregation function, normalized for identity comparison.
 
-        A measure's identity is (expression, aggregation), not expression alone:
-        pre-aggregated partials are only reusable by a metric that aggregates the
-        same way -- a SUM partial cannot serve MAX or MIN. Everything that matches
-        or binds measures compares this, so normalization lives here rather than
-        being re-derived per call site.
+        A measure is identified by (expression, aggregation), not by expression
+        alone -- a stored partial is only reusable by a metric that accumulates
+        the same way. Pre-agg matching, column binding and registration all
+        compare this, so the normalization lives with the model rather than being
+        re-derived at each call site.
         """
         return (self.aggregation or "").strip().upper()
 

--- a/datajunction-server/datajunction_server/models/decompose.py
+++ b/datajunction-server/datajunction_server/models/decompose.py
@@ -104,11 +104,9 @@ class MetricComponent(BaseModel):
         """
         Phase-1 aggregation function, normalized for identity comparison.
 
-        A measure is identified by (expression, aggregation), not by expression
-        alone -- a stored partial is only reusable by a metric that accumulates
-        the same way. Pre-agg matching, column binding and registration all
-        compare this, so the normalization lives with the model rather than being
-        re-derived at each call site.
+        A measure is identified by (expression, aggregation), not expression
+        alone. Matching, column binding and registration all compare this, so
+        normalization lives with the model rather than at each call site.
         """
         return (self.aggregation or "").strip().upper()
 

--- a/datajunction-server/datajunction_server/models/decompose.py
+++ b/datajunction-server/datajunction_server/models/decompose.py
@@ -99,6 +99,19 @@ class MetricComponent(BaseModel):
     # valid and consistent with what decompose.py computed.
     grain_alias: str | None = None
 
+    @property
+    def normalized_aggregation(self) -> str:
+        """
+        Phase-1 aggregation function, normalized for identity comparison.
+
+        A measure's identity is (expression, aggregation), not expression alone:
+        pre-aggregated partials are only reusable by a metric that aggregates the
+        same way -- a SUM partial cannot serve MAX or MIN. Everything that matches
+        or binds measures compares this, so normalization lives here rather than
+        being re-derived per call site.
+        """
+        return (self.aggregation or "").strip().upper()
+
 
 class PreAggMeasure(MetricComponent):
     """

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -4160,7 +4160,7 @@ class TestCombinedMeasuresSQLEndpoint:
         # Source tables should be pre-agg table references
         assert len(data["source_tables"]) >= 1
         assert data["source_tables"] == [
-            "default.dj_preaggs.v3_order_details_preagg_d344b4e3",
+            "default.dj_preaggs.v3_order_details_preagg_0bad539a",
         ]
 
         # Extract the preagg table name for SQL comparison
@@ -4169,7 +4169,7 @@ class TestCombinedMeasuresSQLEndpoint:
             data["sql"],
             """
             SELECT status, SUM(line_total_sum_e1f61696) line_total_sum_e1f61696
-            FROM default.dj_preaggs.v3_order_details_preagg_d344b4e3
+            FROM default.dj_preaggs.v3_order_details_preagg_0bad539a
             GROUP BY status
             """,
         )
@@ -4200,7 +4200,7 @@ class TestCombinedMeasuresSQLEndpoint:
 
         expected_table = (
             f"{settings.preagg_catalog}.{settings.preagg_schema}"
-            f".v3_order_details_preagg_d344b4e3"
+            f".v3_order_details_preagg_0bad539a"
         )
 
         # Source tables should include the configured catalog.schema prefix

--- a/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
@@ -10,7 +10,7 @@ from datajunction_server.construction.build_v3.preagg_matcher import (
     find_matching_preagg,
     get_preagg_dimension_column,
     get_preagg_measure_column,
-    get_required_measure_hashes,
+    get_required_measure_identities,
     get_temporal_partitions,
 )
 from datajunction_server.models.query import V3ColumnMetadata
@@ -183,28 +183,29 @@ def make_grain_group(
     )
 
 
-class TestGetRequiredMeasureHashes:
-    """Tests for get_required_measure_hashes function."""
+class TestGetRequiredMeasureIdentities:
+    """Tests for get_required_measure_identities function."""
 
     @pytest.mark.asyncio
-    async def test_returns_hashes_for_all_components(
+    async def test_returns_identities_for_all_components(
         self,
         session: AsyncSession,
         parent_node: Node,
         metric_node: Node,
     ):
-        """Should return a hash for each component in the grain group."""
+        """Should return an (expression hash, aggregation) pair per component."""
         components = [
             (metric_node, make_component("sum_revenue", "price * quantity")),
             (metric_node, make_component("sum_quantity", "quantity")),
         ]
         grain_group = make_grain_group(parent_node, components)
 
-        hashes = get_required_measure_hashes(grain_group)
+        identities = get_required_measure_identities(grain_group)
 
-        assert len(hashes) == 2
-        assert compute_expression_hash("price * quantity") in hashes
-        assert compute_expression_hash("quantity") in hashes
+        assert identities == {
+            (compute_expression_hash("price * quantity"), "SUM"),
+            (compute_expression_hash("quantity"), "SUM"),
+        }
 
     @pytest.mark.asyncio
     async def test_empty_components_returns_empty_set(
@@ -215,18 +216,18 @@ class TestGetRequiredMeasureHashes:
         """Should return empty set when grain group has no components."""
         grain_group = make_grain_group(parent_node, [])
 
-        hashes = get_required_measure_hashes(grain_group)
+        identities = get_required_measure_identities(grain_group)
 
-        assert hashes == set()
+        assert identities == set()
 
     @pytest.mark.asyncio
-    async def test_deduplicates_same_expression(
+    async def test_deduplicates_same_expression_and_aggregation(
         self,
         session: AsyncSession,
         parent_node: Node,
         metric_node: Node,
     ):
-        """Components with same expression should result in single hash."""
+        """Components with same expression AND aggregation collapse to one."""
         # Same expression, different component names
         components = [
             (metric_node, make_component("sum_rev_1", "price * quantity")),
@@ -234,9 +235,41 @@ class TestGetRequiredMeasureHashes:
         ]
         grain_group = make_grain_group(parent_node, components)
 
-        hashes = get_required_measure_hashes(grain_group)
+        identities = get_required_measure_identities(grain_group)
 
-        assert len(hashes) == 1
+        assert identities == {(compute_expression_hash("price * quantity"), "SUM")}
+
+    @pytest.mark.asyncio
+    async def test_same_expression_different_aggregation_are_distinct(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+        metric_node: Node,
+    ):
+        """The aggregation is part of the identity: SUM(x) and MAX(x) differ.
+
+        This is what stops a MAX metric from binding a SUM-built pre-agg column.
+        """
+        components = [
+            (metric_node, make_component("sum_price", "unit_price")),
+            (
+                metric_node,
+                make_component(
+                    "max_price",
+                    "unit_price",
+                    aggregation="MAX",
+                    merge="MAX",
+                ),
+            ),
+        ]
+        grain_group = make_grain_group(parent_node, components)
+
+        identities = get_required_measure_identities(grain_group)
+
+        assert identities == {
+            (compute_expression_hash("unit_price"), "SUM"),
+            (compute_expression_hash("unit_price"), "MAX"),
+        }
 
 
 class TestFindMatchingPreagg:

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -660,6 +660,75 @@ class TestExternalPreAggRouting:
         )
 
     @pytest.mark.asyncio
+    async def test_external_preagg_filter_on_rolled_up_dimension(
+        self,
+        client_with_build_v3,
+    ):
+        """A filter on a dimension that is in the pre-agg grain but rolled away
+        from the requested output must be pushed into the pre-agg scan, on the
+        physical (mapped) column, before the roll-up. Previously the predicate was
+        silently dropped and the result over-counted. Here ``category`` is mapped
+        to physical ``cat`` and is in the agg grain, but the query groups by
+        ``status`` only, so ``category`` is filter-only."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status", "v3.product.category"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "rev_by_status_cat",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.product.category": "cat"},
+            table_columns={"status": "string", "cat": "string", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_details.status"],
+            "filters": ["v3.product.category = 'Electronics'"],
+        }
+        # Measures SQL: the filter is injected on the physical column `cat`,
+        # inside the CTE, before the GROUP BY roll-up.
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params=params,
+        )
+        assert measures_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(measures_response.json())["sql"],
+            """
+            SELECT status, cat category, SUM(rev_sum) rev_sum
+            FROM default.analytics.rev_by_status_cat
+            WHERE cat = 'Electronics'
+            GROUP BY status, cat
+            """,
+        )
+        # Metrics SQL: the outer query does not re-apply the (filter-only) cat
+        # predicate; it is applied once, inside the CTE.
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params=params,
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT status, cat category, SUM(rev_sum) rev_sum
+                FROM default.analytics.rev_by_status_cat
+                WHERE cat = 'Electronics'
+                GROUP BY status, cat
+            )
+            SELECT order_details_0.status AS status,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.status
+            """,
+        )
+
+    @pytest.mark.asyncio
     async def test_external_preagg_cross_fact_partial_substitution(
         self,
         client_with_build_v3,

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -358,6 +358,76 @@ class TestExternalPreAggRouting:
         )
 
     @pytest.mark.asyncio
+    async def test_separate_preaggs_same_grain_different_aggregation_coexist(
+        self,
+        client_with_build_v3,
+    ):
+        """Two independently-registered pre-aggs over the same expression and grain,
+        differing only in aggregation, are distinct rows -- and each metric routes
+        to its own table.
+
+        Registration deduped by expression hash alone, so the SUM-backed and
+        MAX-backed pre-aggs looked like one row: registering the second silently
+        overwrote the first (its measures, columns and table pointer), and the
+        first metric lost its pre-agg. Row identity is the measure identity token,
+        which includes the aggregation -- and so is the unique preagg_hash, so the
+        second row can be stored alongside the first.
+        """
+        for metric, table, column in (
+            ("v3.total_unit_price", "unit_price_sum_tbl", "up_sum"),
+            ("v3.max_unit_price", "unit_price_max_tbl", "up_max"),
+        ):
+            await _register_external_preagg(
+                client_with_build_v3,
+                metrics=[metric],
+                dimensions=["v3.order_details.status"],
+                table_ref={
+                    "catalog": "default",
+                    "schema": "analytics",
+                    "table": table,
+                    "valid_through_ts": 20250101,
+                },
+                measure_columns={metric: column},
+                table_columns={"status": "string", column: "double"},
+            )
+
+        listing = await client_with_build_v3.get(
+            "/preaggs/",
+            params={"node_name": "v3.order_details"},
+        )
+        assert listing.status_code == 200
+        rows = listing.json()["items"]
+        assert {
+            (measure["aggregation"], measure["source_column"])
+            for row in rows
+            for measure in row["measures"]
+        } == {("SUM", "up_sum"), ("MAX", "up_max")}
+        # Distinct rows, and distinct preagg_hash (the column is UNIQUE).
+        assert len({row["preagg_hash"] for row in rows}) == len(rows) == 2
+
+        # Each metric reads its own table.
+        for metric, table, column, agg in (
+            ("v3.total_unit_price", "unit_price_sum_tbl", "up_sum", "SUM"),
+            ("v3.max_unit_price", "unit_price_max_tbl", "up_max", "MAX"),
+        ):
+            response = await client_with_build_v3.get(
+                "/sql/measures/v3/",
+                params={
+                    "metrics": [metric],
+                    "dimensions": ["v3.order_details.status"],
+                },
+            )
+            assert response.status_code == 200
+            assert_sql_equal(
+                get_first_grain_group(response.json())["sql"],
+                f"""
+                SELECT status, {agg}({column}) {column}
+                FROM default.analytics.{table}
+                GROUP BY status
+                """,
+            )
+
+    @pytest.mark.asyncio
     async def test_external_preagg_pending_not_used(self, client_with_build_v3):
         """A registered pre-agg with no availability (no valid_through_ts) is not
         used to answer queries."""

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -290,6 +290,74 @@ class TestExternalPreAggRouting:
         )
 
     @pytest.mark.asyncio
+    async def test_external_preagg_same_expression_two_aggregations(
+        self,
+        client_with_build_v3,
+    ):
+        """One pre-agg can carry several aggregations over the same expression,
+        each bound to its own physical column, and each metric reads its own.
+
+        ``total_unit_price`` (SUM) and ``max_unit_price`` (MAX) both decompose to
+        the expression ``unit_price``, so a measure identity of expression-hash
+        alone collapses them: registration kept only the last-declared column and
+        both metrics read it -- the SUM metric summing the MAX column. Identity is
+        (expression hash, Phase-1 aggregation) at registration and at lookup, so
+        both mappings survive and each metric binds the right column.
+        """
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_unit_price", "v3.max_unit_price"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "unit_price_both",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={
+                "v3.total_unit_price": "unit_price_sum",
+                "v3.max_unit_price": "unit_price_max",
+            },
+            table_columns={
+                "status": "string",
+                "unit_price_sum": "double",
+                "unit_price_max": "double",
+            },
+        )
+        sum_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_unit_price"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert sum_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(sum_response.json())["sql"],
+            """
+            SELECT status, SUM(unit_price_sum) unit_price_sum
+            FROM default.analytics.unit_price_both
+            GROUP BY status
+            """,
+        )
+        max_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.max_unit_price"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert max_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(max_response.json())["sql"],
+            """
+            SELECT status, MAX(unit_price_max) unit_price_max
+            FROM default.analytics.unit_price_both
+            GROUP BY status
+            """,
+        )
+
+    @pytest.mark.asyncio
     async def test_external_preagg_pending_not_used(self, client_with_build_v3):
         """A registered pre-agg with no availability (no valid_through_ts) is not
         used to answer queries."""

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -223,6 +223,73 @@ class TestExternalPreAggRouting:
         assert "default.analytics.orders_by_status" not in sql
 
     @pytest.mark.asyncio
+    async def test_external_preagg_not_used_for_incompatible_aggregation(
+        self,
+        client_with_build_v3,
+    ):
+        """A pre-agg built with SUM must not satisfy a metric that needs MAX of
+        the same column. ``total_unit_price = SUM(unit_price)`` and
+        ``max_unit_price = MAX(unit_price)`` share the inner expression
+        ``unit_price``; matching on the expression hash alone routed the MAX
+        metric to the SUM pre-agg and computed MAX(sum) instead of MAX(row). The
+        matcher must also require the Phase-1 aggregation to match: the SUM metric
+        keeps using the agg, the MAX metric falls back to the base fact.
+        """
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_unit_price"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "unit_price_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_unit_price": "unit_price_sum"},
+            table_columns=["status", "unit_price_sum"],
+        )
+        # SUM metric routes to the agg (control).
+        sum_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_unit_price"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert sum_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(sum_response.json())["sql"],
+            """
+            SELECT status, SUM(unit_price_sum) unit_price_sum
+            FROM default.analytics.unit_price_by_status
+            GROUP BY status
+            """,
+        )
+        # MAX metric shares the inner expression but not the aggregation -> it must
+        # NOT bind the SUM column; it builds MAX from the base fact instead.
+        max_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.max_unit_price"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert max_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(max_response.json())["sql"],
+            """
+            WITH v3_order_details AS (
+                SELECT o.status, oi.unit_price
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT t1.status, MAX(t1.unit_price) unit_price_max_55cff00f
+            FROM v3_order_details t1
+            GROUP BY t1.status
+            """,
+        )
+
+    @pytest.mark.asyncio
     async def test_external_preagg_pending_not_used(self, client_with_build_v3):
         """A registered pre-agg with no availability (no valid_through_ts) is not
         used to answer queries."""

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -925,6 +925,230 @@ class TestExternalPreAggRouting:
         )
 
     @pytest.mark.asyncio
+    async def test_external_preagg_coarsest_covering_agg_wins(
+        self,
+        client_with_build_v3,
+    ):
+        """With two pre-aggs registered on one node at different grains, a query
+        covered by both reads the coarser one, and a query needing a dimension
+        only the finer one carries reads the finer one -- each through its own
+        column mapping.
+        """
+        for table, dimensions, dimension_columns, table_columns in (
+            (
+                "rev_by_status_cat",
+                ["v3.order_details.status", "v3.product.category"],
+                {"v3.product.category": "cat"},
+                {"status": "string", "cat": "string", "rev_sum": "double"},
+            ),
+            (
+                "rev_by_status_cat_day",
+                [
+                    "v3.order_details.status",
+                    "v3.product.category",
+                    "v3.date.date_id[order]",
+                ],
+                {
+                    "v3.product.category": "cat",
+                    "v3.date.date_id[order]": "day_key",
+                },
+                {
+                    "status": "string",
+                    "cat": "string",
+                    "day_key": "int",
+                    "rev_sum": "double",
+                },
+            ),
+        ):
+            await _register_external_preagg(
+                client_with_build_v3,
+                metrics=["v3.total_revenue"],
+                dimensions=dimensions,
+                table_ref={
+                    "catalog": "default",
+                    "schema": "analytics",
+                    "table": table,
+                    "valid_through_ts": 20250101,
+                },
+                measure_columns={"v3.total_revenue": "rev_sum"},
+                dimension_columns=dimension_columns,
+                table_columns=table_columns,
+            )
+
+        # Both cover {status}; the 2-column grain is chosen over the 3-column one.
+        both_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert both_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(both_response.json())["sql"],
+            """
+            SELECT status, SUM(rev_sum) rev_sum
+            FROM default.analytics.rev_by_status_cat
+            GROUP BY status
+            """,
+        )
+
+        # Only the finer grain carries the order date, so it wins despite being
+        # the larger grain -- and reads its own mapped column.
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_details.status", "v3.date.date_id[order]"],
+        }
+        finer_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params=params,
+        )
+        assert finer_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(finer_response.json())["sql"],
+            """
+            SELECT status, day_key date_id_order, SUM(rev_sum) rev_sum
+            FROM default.analytics.rev_by_status_cat_day
+            GROUP BY status, day_key
+            """,
+        )
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params=params,
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT status, day_key date_id_order, SUM(rev_sum) rev_sum
+                FROM default.analytics.rev_by_status_cat_day
+                GROUP BY status, day_key
+            )
+            SELECT order_details_0.status AS status,
+                   order_details_0.date_id_order AS date_id_order,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.status, order_details_0.date_id_order
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_two_roles_of_one_dimension(
+        self,
+        client_with_build_v3,
+    ):
+        """Two roles of the same dimension in one pre-agg grain get distinct
+        aliases and bind their own physical columns.
+
+        ``country[from]`` and ``country[to]`` both resolve to the column
+        ``country``, so they must be disambiguated to ``country_from`` /
+        ``country_to``; mapping only the ``to`` role checks the two are bound
+        independently rather than sharing one column.
+        """
+        dimensions = ["v3.location.country[from]", "v3.location.country[to]"]
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=dimensions,
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "rev_by_route",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.location.country[to]": "dest_country"},
+            table_columns={
+                "country_from": "string",
+                "dest_country": "string",
+                "rev_sum": "double",
+            },
+        )
+        params = {"metrics": ["v3.total_revenue"], "dimensions": dimensions}
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params=params,
+        )
+        assert measures_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(measures_response.json())["sql"],
+            """
+            SELECT country_from, dest_country country_to, SUM(rev_sum) rev_sum
+            FROM default.analytics.rev_by_route
+            GROUP BY country_from, dest_country
+            """,
+        )
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params=params,
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT country_from, dest_country country_to, SUM(rev_sum) rev_sum
+                FROM default.analytics.rev_by_route
+                GROUP BY country_from, dest_country
+            )
+            SELECT order_details_0.country_from AS country_from,
+                   order_details_0.country_to AS country_to,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.country_from, order_details_0.country_to
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_order_by_mapped_dimension(
+        self,
+        client_with_build_v3,
+    ):
+        """ORDER BY on a column-mapped dimension sorts on the DJ alias the outer
+        query projects, not the pre-agg's physical column (which is out of scope
+        there).
+        """
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.date.date_id[order]"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "rev_by_day",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.date.date_id[order]": "day_key"},
+            table_columns={"day_key": "int", "rev_sum": "double"},
+        )
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.date.date_id[order]"],
+                "orderby": ["v3.date.date_id[order] DESC"],
+            },
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT day_key date_id_order, SUM(rev_sum) rev_sum
+                FROM default.analytics.rev_by_day
+                GROUP BY day_key
+            )
+            SELECT order_details_0.date_id_order AS date_id_order,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.date_id_order
+            ORDER BY date_id_order DESC
+            """,
+        )
+
+    @pytest.mark.asyncio
     async def test_external_preagg_cross_fact_partial_substitution(
         self,
         client_with_build_v3,

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -227,13 +227,11 @@ class TestExternalPreAggRouting:
         self,
         client_with_build_v3,
     ):
-        """A pre-agg built with SUM must not satisfy a metric that needs MAX of
-        the same column. ``total_unit_price = SUM(unit_price)`` and
-        ``max_unit_price = MAX(unit_price)`` share the inner expression
-        ``unit_price``; matching on the expression hash alone routed the MAX
-        metric to the SUM pre-agg and computed MAX(sum) instead of MAX(row). The
-        matcher must also require the Phase-1 aggregation to match: the SUM metric
-        keeps using the agg, the MAX metric falls back to the base fact.
+        """A SUM-built pre-agg must not satisfy a metric that needs MAX.
+
+        Both metrics decompose to the expression ``unit_price``, so matching on
+        the hash alone routed MAX to the SUM pre-agg and computed MAX(sum) rather
+        than MAX(row). SUM keeps the agg; MAX falls back to the base fact.
         """
         await _register_external_preagg(
             client_with_build_v3,
@@ -295,14 +293,11 @@ class TestExternalPreAggRouting:
         client_with_build_v3,
     ):
         """One pre-agg can carry several aggregations over the same expression,
-        each bound to its own physical column, and each metric reads its own.
+        each bound to its own column.
 
-        ``total_unit_price`` (SUM) and ``max_unit_price`` (MAX) both decompose to
-        the expression ``unit_price``, so a measure identity of expression-hash
-        alone collapses them: registration kept only the last-declared column and
-        both metrics read it -- the SUM metric summing the MAX column. Identity is
-        (expression hash, Phase-1 aggregation) at registration and at lookup, so
-        both mappings survive and each metric binds the right column.
+        Hash-only identity collapsed them: registration kept only the
+        last-declared column and both metrics read it, so the SUM metric summed
+        the MAX column.
         """
         await _register_external_preagg(
             client_with_build_v3,
@@ -362,16 +357,12 @@ class TestExternalPreAggRouting:
         self,
         client_with_build_v3,
     ):
-        """Two independently-registered pre-aggs over the same expression and grain,
-        differing only in aggregation, are distinct rows -- and each metric routes
-        to its own table.
+        """Two pre-aggs over the same expression and grain, differing only in
+        aggregation, are distinct rows and each metric routes to its own table.
 
-        Registration deduped by expression hash alone, so the SUM-backed and
-        MAX-backed pre-aggs looked like one row: registering the second silently
-        overwrote the first (its measures, columns and table pointer), and the
-        first metric lost its pre-agg. Row identity is the measure identity token,
-        which includes the aggregation -- and so is the unique preagg_hash, so the
-        second row can be stored alongside the first.
+        Hash-only dedup made them look like one row, so registering the second
+        silently overwrote the first. Both row identity and the UNIQUE
+        preagg_hash now include the aggregation.
         """
         for metric, table, column in (
             ("v3.total_unit_price", "unit_price_sum_tbl", "up_sum"),
@@ -802,12 +793,9 @@ class TestExternalPreAggRouting:
         self,
         client_with_build_v3,
     ):
-        """A filter on a dimension that is in the pre-agg grain but rolled away
-        from the requested output must be pushed into the pre-agg scan, on the
-        physical (mapped) column, before the roll-up. Previously the predicate was
-        silently dropped and the result over-counted. Here ``category`` is mapped
-        to physical ``cat`` and is in the agg grain, but the query groups by
-        ``status`` only, so ``category`` is filter-only."""
+        """A filter on a dimension in the pre-agg grain but rolled away from the
+        output is pushed into the scan, on the mapped column, before the roll-up.
+        Previously the predicate was dropped and the result over-counted."""
         await _register_external_preagg(
             client_with_build_v3,
             metrics=["v3.total_revenue"],
@@ -1043,20 +1031,12 @@ class TestExternalPreAggRouting:
         self,
         client_with_build_v3,
     ):
-        """A joined dimension's *key* requested through a differently-named parent
-        foreign-key column reads the mapped physical column and aliases it to the
-        dimension's DJ alias -- the name the outer metrics query references -- not
-        the parent FK column name.
+        """A joined dimension's key, requested through a differently-named parent
+        FK column, is aliased to the DJ alias the outer query references.
 
-        Regression: the pre-agg grain group aliased the grain column to
-        ``dim.column_name`` (the parent FK column, e.g. ``order_date``) instead of
-        the alias-registry alias (``date_id_order``) used by the source-built
-        path. The metrics query then selected ``date_id_order`` from a CTE that
-        only exposed ``order_date``, producing SQL that could not execute.
-        ``order_details.order_date = date.date_id[order]`` exercises this: the
-        requested key ``date.date_id[order]`` is satisfied by the FK
-        ``order_date``, whose name differs from both the DJ alias and the mapped
-        physical column.
+        The grain group used ``dim.column_name`` (the FK, ``order_date``) instead
+        of the alias-registry alias (``date_id_order``), so the metrics query
+        selected a column the CTE never exposed -- SQL that could not execute.
         """
         await _register_external_preagg(
             client_with_build_v3,

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -867,6 +867,76 @@ class TestExternalPreAggRouting:
         )
 
     @pytest.mark.asyncio
+    async def test_external_preagg_projected_and_rolled_up_filters(
+        self,
+        client_with_build_v3,
+    ):
+        """Filters of both kinds in one query land in different places: the
+        rolled-up (filter-only) dimension is pushed into the pre-agg scan, while
+        the projected dimension's filter stays at the outer query -- applied once
+        each, and not swapped.
+        """
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status", "v3.product.category"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "rev_status_cat_both",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.product.category": "cat"},
+            table_columns={"status": "string", "cat": "string", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_details.status"],
+            "filters": [
+                "v3.order_details.status = 'completed'",
+                "v3.product.category = 'Electronics'",
+            ],
+        }
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params=params,
+        )
+        assert measures_response.status_code == 200
+        # Only the rolled-up `category` predicate is inlined into the scan.
+        assert_sql_equal(
+            get_first_grain_group(measures_response.json())["sql"],
+            """
+            SELECT status, cat category, SUM(rev_sum) rev_sum
+            FROM default.analytics.rev_status_cat_both
+            WHERE cat = 'Electronics'
+            GROUP BY status, cat
+            """,
+        )
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params=params,
+        )
+        assert metrics_response.status_code == 200
+        # `status` is projected, so its filter is applied over the CTE instead.
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT status, cat category, SUM(rev_sum) rev_sum
+                FROM default.analytics.rev_status_cat_both
+                WHERE cat = 'Electronics'
+                GROUP BY status, cat
+            )
+            SELECT order_details_0.status AS status,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            WHERE order_details_0.status = 'completed'
+            GROUP BY order_details_0.status
+            """,
+        )
+
+    @pytest.mark.asyncio
     async def test_external_preagg_cross_fact_partial_substitution(
         self,
         client_with_build_v3,

--- a/datajunction-server/tests/database/preaggregation_test.py
+++ b/datajunction-server/tests/database/preaggregation_test.py
@@ -10,7 +10,8 @@ from datajunction_server.database.preaggregation import (
     VALID_PREAGG_STRATEGIES,
     compute_grain_group_hash,
     compute_expression_hash,
-    get_measure_expr_hashes,
+    get_measure_identities,
+    measure_identity_token,
     compute_preagg_hash,
 )
 from datajunction_server.database.user import OAuthProvider, User
@@ -65,11 +66,11 @@ class TestComputeExpressionHash:
         assert hash1 == hash2 == hash3
 
 
-class TestGetMeasureExprHashes:
-    """Tests for get_measure_expr_hashes function."""
+class TestGetMeasureIdentities:
+    """Tests for get_measure_identities function."""
 
-    def test_extracts_hashes(self):
-        """Test extracting expr_hashes from measures."""
+    def test_extracts_identities(self):
+        """Identity pairs the expr_hash with the Phase-1 aggregation."""
         measures = [
             PreAggMeasure(
                 name="sum_revenue",
@@ -86,8 +87,8 @@ class TestGetMeasureExprHashes:
                 expr_hash="def456",
             ),
         ]
-        hashes = get_measure_expr_hashes(measures)
-        assert hashes == {"abc123", "def456"}
+        identities = get_measure_identities(measures)
+        assert identities == {"abc123:SUM", "def456:COUNT"}
 
     def test_handles_missing_hash(self):
         """Test that missing expr_hash is handled."""
@@ -107,13 +108,13 @@ class TestGetMeasureExprHashes:
                 expr_hash=None,  # No expr_hash
             ),
         ]
-        hashes = get_measure_expr_hashes(measures)
-        assert hashes == {"abc123"}
+        identities = get_measure_identities(measures)
+        assert identities == {"abc123:SUM"}
 
     def test_empty_list(self):
         """Test with empty measures list."""
-        hashes = get_measure_expr_hashes([])
-        assert hashes == set()
+        identities = get_measure_identities([])
+        assert identities == set()
 
 
 class TestComputeGrainGroupHash:
@@ -589,10 +590,63 @@ class TestPreAggregationDBMethods:
             session,
             node_revision_id=minimal_node_revision.id,
             grain_columns=grain_columns,
-            measure_expr_hashes={compute_expression_hash("price")},
+            measure_identities={
+                measure_identity_token(compute_expression_hash("price"), "SUM"),
+            },
         )
         assert result is not None
         assert result.id == preagg.id
+
+    async def test_find_matching_row_predating_identity_change(
+        self,
+        session,
+        minimal_node_revision,
+    ):
+        """A pre-agg stored before measure identity included the aggregation is
+        still matched, and keeps its original preagg_hash.
+
+        Rows written by an older server hold a hash computed from expression
+        hashes alone, and that hash names their materialization table. Matching
+        does not consult preagg_hash -- it compares measure identities derived
+        from the stored measures -- so such rows keep matching, keep being updated
+        in place, and keep their table name. No backfill is required.
+        """
+        grain_columns = ["test.dim.col"]
+        measures = [make_measure("sum_price", "price")]
+        legacy_hash = "deadbeef"  # what an older server would have stored
+        preagg = PreAggregation(
+            node_revision_id=minimal_node_revision.id,
+            grain_columns=grain_columns,
+            measures=measures,
+            columns=[],
+            sql="SELECT price FROM t GROUP BY col",
+            grain_group_hash=compute_grain_group_hash(
+                minimal_node_revision.id,
+                grain_columns,
+            ),
+            preagg_hash=legacy_hash,
+        )
+        session.add(preagg)
+        await session.flush()
+
+        # The hash this server would compute today differs from the stored one...
+        assert (
+            compute_preagg_hash(minimal_node_revision.id, grain_columns, measures)
+            != legacy_hash
+        )
+        # ...yet the row is still found, because matching compares identities.
+        result = await PreAggregation.find_matching(
+            session,
+            node_revision_id=minimal_node_revision.id,
+            grain_columns=grain_columns,
+            measure_identities={
+                measure_identity_token(compute_expression_hash("price"), "SUM"),
+            },
+        )
+        assert result is not None
+        assert result.id == preagg.id
+        # Untouched, so its materialization table name is preserved.
+        assert result.preagg_hash == legacy_hash
 
     async def test_find_matching_no_match(self, session, minimal_node_revision):
         """Test find_matching returns None when no candidate has superset."""
@@ -623,7 +677,9 @@ class TestPreAggregationDBMethods:
             session,
             node_revision_id=minimal_node_revision.id,
             grain_columns=grain_columns,
-            measure_expr_hashes={compute_expression_hash("nonexistent")},
+            measure_identities={
+                measure_identity_token(compute_expression_hash("nonexistent"), "SUM"),
+            },
         )
         assert result is None
 
@@ -637,6 +693,8 @@ class TestPreAggregationDBMethods:
             session,
             node_revision_id=minimal_node_revision.id,
             grain_columns=["completely.different.grain"],
-            measure_expr_hashes={compute_expression_hash("anything")},
+            measure_identities={
+                measure_identity_token(compute_expression_hash("anything"), "SUM"),
+            },
         )
         assert result is None

--- a/datajunction-server/tests/database/preaggregation_test.py
+++ b/datajunction-server/tests/database/preaggregation_test.py
@@ -602,14 +602,12 @@ class TestPreAggregationDBMethods:
         session,
         minimal_node_revision,
     ):
-        """A pre-agg stored before measure identity included the aggregation is
-        still matched, and keeps its original preagg_hash.
+        """A pre-agg stored before the identity change is still matched, and
+        keeps its original preagg_hash.
 
-        Rows written by an older server hold a hash computed from expression
-        hashes alone, and that hash names their materialization table. Matching
-        does not consult preagg_hash -- it compares measure identities derived
-        from the stored measures -- so such rows keep matching, keep being updated
-        in place, and keep their table name. No backfill is required.
+        Older rows hold a hash built from expression hashes alone, and that hash
+        names their materialization table. Matching compares identities, not the
+        hash, so such rows keep matching and keep their table name -- no backfill.
         """
         grain_columns = ["test.dim.col"]
         measures = [make_measure("sum_price", "price")]

--- a/datajunction-server/uv.lock
+++ b/datajunction-server/uv.lock
@@ -596,6 +596,7 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "sqlalchemy" },
     { name = "sqlalchemy-utils" },
+    { name = "sqlglot" },
     { name = "sse-starlette" },
     { name = "strawberry-graphql" },
     { name = "types-cachetools" },
@@ -610,13 +611,9 @@ all = [
 ]
 bigquery = [
     { name = "google-cloud-bigquery" },
-    { name = "sqlglot" },
 ]
 snowflake = [
     { name = "snowflake-connector-python" },
-]
-transpilation = [
-    { name = "sqlglot" },
 ]
 uvicorn = [
     { name = "uvicorn", extra = ["standard"] },
@@ -685,8 +682,7 @@ requires-dist = [
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.0.0" },
     { name = "sqlalchemy", specifier = ">=2" },
     { name = "sqlalchemy-utils", specifier = ">=0.40.0,<1.0.0" },
-    { name = "sqlglot", marker = "extra == 'bigquery'", specifier = ">=18.0.1" },
-    { name = "sqlglot", marker = "extra == 'transpilation'", specifier = ">=18.0.1" },
+    { name = "sqlglot", specifier = ">=18.0.1" },
     { name = "sse-starlette", specifier = ">=1.6.0,<=2.0.0" },
     { name = "strawberry-graphql", specifier = ">=0.235.0" },
     { name = "types-cachetools", specifier = ">=5.3.0.6" },
@@ -694,7 +690,7 @@ requires-dist = [
     { name = "yamlfix", specifier = ">=1.16.0" },
     { name = "yarl", specifier = ">=1.8.2,<2.0.0" },
 ]
-provides-extras = ["all", "bigquery", "snowflake", "transpilation", "uvicorn"]
+provides-extras = ["all", "bigquery", "snowflake", "uvicorn"]
 
 [package.metadata.requires-dev]
 test = [


### PR DESCRIPTION
### Summary

This fixes two bugs in external pre-aggregation substitution. Both cause wrong numbers with no error when a query routes to an externally-registered pre-agg.

#### 1. Measure identity ignored the aggregation function

A measure was identified by `compute_expression_hash(expression)`, basically the inner expression only. The result is that `SUM(x)` and `MAX(x)` are distinct measures that hash identically. This means:
- Routing errors where a MAX metric matched a SUM-built pre-agg and computed MAX(sum) instead of MAX(row).
- Registration errors, where `measure_hash_to_column` was keyed by hash, so registering {total_unit_price: unit_price_sum, max_unit_price: unit_price_max} silently discarded one declared column.
- Column binding: `get_preagg_measure_column` returned the first hash match, so even a correct match could resolve to the wrong column.

The fix is for `MetricComponent.normalized_aggregation` to give the identity one home so that routing, binding and registration all key on (expr_hash, aggregation). The aggregation was already persisted, so there is no migration needed.

#### 2. Filters on rolled-up dimensions were dropped

The metrics layer skips filters on "filter-only" dimensions at the outer query, on the contract that each grain group's CTE applied them. The source path honors that but the pre-agg path didn't, so filtering on a dimension in the pre-agg grain but absent from the output emitted no `WHERE` at all.

The fix is to inject those predicates into the pre-agg scan on the physical (possibly `dimension_columns`-remapped) column, before the roll-up.

### Test Plan

Added some regression tests.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
