### PR TITLE
Preserve role qualifying cube column identity

### DIFF
--- a/datajunction-clients/python/datajunction/cli.py
+++ b/datajunction-clients/python/datajunction/cli.py
@@ -143,7 +143,16 @@ class DJCLI:
                     "display_name": getattr(node, "display_name", None),
                     "query": getattr(node, "query", None),
                     "columns": [
-                        {"name": col.name, "type": col.type} for col in node.columns
+                        {
+                            "name": col.name
+                            + (
+                                (col.dimension_column or "")
+                                if node.type == "cube"
+                                else ""
+                            ),
+                            "type": col.type,
+                        }
+                        for col in node.columns
                     ]
                     if hasattr(node, "columns") and node.columns
                     else [],

--- a/datajunction-clients/python/tests/test_cli.py
+++ b/datajunction-clients/python/tests/test_cli.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 from io import StringIO
+from types import SimpleNamespace
 from typing import Callable
 from unittest import mock
 from unittest.mock import patch
@@ -292,6 +293,43 @@ def test_json_output_commands(
     )
     data = json.loads(output)
     assert isinstance(data, (dict, list))
+
+
+def test_describe_cube_json_preserves_column_roles():
+    """Role-played cube columns must remain distinct in CLI JSON output."""
+    builder_client = mock.MagicMock()
+    builder_client.node.return_value = SimpleNamespace(
+        name="v3.role_cube",
+        type="cube",
+        description="Role-playing cube",
+        display_name="Role Cube",
+        query=None,
+        columns=[
+            SimpleNamespace(
+                name="v3.date.date_id",
+                dimension_column="[order]",
+                type="int",
+            ),
+            SimpleNamespace(
+                name="v3.date.date_id",
+                dimension_column="[ship]",
+                type="int",
+            ),
+        ],
+        status="valid",
+        mode="published",
+        version="v1.0",
+    )
+
+    output = run_cli_command(
+        builder_client,
+        ["dj", "describe", "v3.role_cube", "--format", "json"],
+    )
+
+    assert [column["name"] for column in json.loads(output)["columns"]] == [
+        "v3.date.date_id[order]",
+        "v3.date.date_id[ship]",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -542,14 +542,18 @@ async def materialize_cube(
     # value when the cube hasn't declared one.
     if cube_tps:
         cube_tp = cube_tps[0]
-        cube_partition_ref = cube_tp.name
+        cube_partition_ref = cube_tp.cube_element_name
         # Look up the actual output column name by semantic identity
         output_col = next(
             (
                 c
                 for c in combined_result.columns
                 if c.semantic_name
-                and strip_role_suffix(c.semantic_name) == cube_partition_ref
+                and (
+                    c.semantic_name == cube_partition_ref
+                    if cube_tp.dimension_column
+                    else strip_role_suffix(c.semantic_name) == cube_partition_ref
+                )
             ),
             None,
         )

--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -85,6 +85,58 @@ settings = get_settings()
 router = SecureAPIRouter(tags=["cubes"])
 
 
+def _resolve_cube_partition_output_column(
+    columns: list,
+    cube_partition_ref: str,
+    allow_role_fallback: bool,
+):
+    """Resolve a cube partition to one combined-query output column.
+
+    Exact semantic identity always wins. Unqualified cube partitions may fall
+    back to a role-qualified output for compatibility, but only when that
+    fallback is unique.
+    """
+    exact_matches = [
+        column for column in columns if column.semantic_name == cube_partition_ref
+    ]
+    if len(exact_matches) == 1:
+        return exact_matches[0]
+    if len(exact_matches) > 1:
+        output_names = sorted(column.name for column in exact_matches)
+        raise DJInvalidInputException(
+            message=(
+                f"Cube partition column '{cube_partition_ref}' matches multiple "
+                f"combined query output columns: {output_names}"
+            ),
+            http_status_code=HTTPStatus.BAD_REQUEST,
+        )
+
+    if not allow_role_fallback:
+        return None
+
+    fallback_matches = [
+        column
+        for column in columns
+        if column.semantic_name
+        and strip_role_suffix(column.semantic_name) == cube_partition_ref
+    ]
+    if len(fallback_matches) == 1:
+        return fallback_matches[0]
+    if len(fallback_matches) > 1:
+        choices = sorted(
+            f"{column.semantic_name} ({column.name})" for column in fallback_matches
+        )
+        raise DJInvalidInputException(
+            message=(
+                f"Cube partition column '{cube_partition_ref}' is ambiguous across "
+                f"role-qualified combined query outputs. Use a role-qualified cube "
+                f"partition. Matches: {choices}"
+            ),
+            http_status_code=HTTPStatus.BAD_REQUEST,
+        )
+    return None
+
+
 def _build_metrics_spec(
     measure_columns,
     measure_components,
@@ -543,19 +595,13 @@ async def materialize_cube(
     if cube_tps:
         cube_tp = cube_tps[0]
         cube_partition_ref = cube_tp.cube_element_name
-        # Look up the actual output column name by semantic identity
-        output_col = next(
-            (
-                c
-                for c in combined_result.columns
-                if c.semantic_name
-                and (
-                    c.semantic_name == cube_partition_ref
-                    if cube_tp.dimension_column
-                    else strip_role_suffix(c.semantic_name) == cube_partition_ref
-                )
-            ),
-            None,
+        # Look up the actual output column name by semantic identity. A bare
+        # partition may use a role-qualified output only when that fallback is
+        # unique; otherwise selecting the first match would be order-dependent.
+        output_col = _resolve_cube_partition_output_column(
+            combined_result.columns,
+            cube_partition_ref,
+            allow_role_fallback=not bool(cube_tp.dimension_column),
         )
         if output_col is None:
             output_names = sorted(c.name for c in combined_result.columns)

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -46,6 +46,11 @@ class _RawColumn:
         self.type = col_type
         self.order = order
 
+    @property
+    def cube_element_name(self) -> str:
+        """Role-qualified identity matching the ORM Column contract."""
+        return self.name + (self.dimension_column or "")
+
 
 async def _attach_raw_columns(session, nodes):
     """

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -105,7 +105,9 @@ def _raw_columns_ordering(raw_columns: list) -> dict:
     ``_attach_raw_columns`` attaches on ``_cube_raw_columns``.
     """
     return {
-        col.name.replace("_DOT_", "."): (col.order if col.order is not None else idx)
+        col.cube_element_name.replace("_DOT_", "."): (
+            col.order if col.order is not None else idx
+        )
         for idx, col in enumerate(raw_columns)
     }
 
@@ -606,7 +608,7 @@ class NodeRevision:
             return sorted(
                 [
                     DimensionAttribute(  # type: ignore
-                        name=col.name + (col.dimension_column or ""),
+                        name=col.cube_element_name,
                         attribute=None,
                         role=col.dimension_column or "",
                         properties=[],
@@ -622,18 +624,19 @@ class NodeRevision:
                 ),
             )
 
-        # Full path: node_revision loaded on each cube element. Cube columns
-        # store the full dotted name (e.g. "ns.dim.col") and the role suffix
-        # (e.g. "[event_date]") separately, so build the role lookup keyed by
-        # the same full name we reconstruct from each cube element below.
-        dimension_to_roles = {
-            col.name: col.dimension_column or "" for col in root.columns
-        }
-        ordering = root.ordering()
+        # Full path: cube_elements contains each referenced DB column once,
+        # while root.columns contains one ordered entry per role. Join the two
+        # views by bare element name, then expand in root.columns order.
+        dimensions_by_name = {}
+        for element, node_revision in root.cube_elements_with_nodes():
+            if node_revision and node_revision.type != NodeType.METRIC:
+                dimensions_by_name[f"{node_revision.name}.{element.name}"] = (
+                    element,
+                    node_revision,
+                )
 
-        def make_attr(element, node_revision):
+        def make_attr(element, node_revision, role):
             full_name = f"{node_revision.name}.{element.name}"
-            role = dimension_to_roles.get(full_name, "")
             return DimensionAttribute(  # type: ignore
                 name=full_name + role,
                 attribute=element.name,
@@ -643,19 +646,11 @@ class NodeRevision:
                 properties=element.attribute_names(),
             )
 
-        return sorted(
-            [
-                make_attr(element, node_revision)
-                for element, node_revision in root.cube_elements_with_nodes()
-                if node_revision and node_revision.type != NodeType.METRIC
-            ],
-            # Strip the role suffix when ordering — `ordering` is keyed by the
-            # role-less column name.
-            key=lambda x: ordering.get(
-                x.name,
-                ordering.get(x.name.split("[", 1)[0], 0),
-            ),
-        )
+        return [
+            make_attr(*dimensions_by_name[col.name], col.dimension_column or "")
+            for col in root.columns
+            if col.name in dimensions_by_name
+        ]
 
 
 @strawberry.type

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -206,19 +206,53 @@ async def get_column(
     """
     Get a column from a node revision
     """
-    requested_column = None
     await session.refresh(node, ["columns"])
-    for node_column in node.columns:
-        if node_column.name == column_name:
-            requested_column = node_column
-            break
+    return resolve_column(
+        node.columns,
+        column_name,
+        node.name,
+        node.type,
+        missing_message=f"Column {column_name} does not exist on node {node.name}",
+    )
 
-    if not requested_column:
-        raise DJDoesNotExistException(
-            message=f"Column {column_name} does not exist on node {node.name}",
-            http_status_code=404,
+
+def resolve_column(
+    columns: List[Column],
+    column_name: str,
+    node_name: str,
+    node_type: NodeType,
+    missing_message: Optional[str] = None,
+) -> Column:
+    """Resolve a node column, including role-qualified cube identities."""
+    if node_type == NodeType.CUBE:
+        role_qualified = {column.cube_element_name: column for column in columns}
+        if column_name in role_qualified:
+            return role_qualified[column_name]
+
+        same_name = [column for column in columns if column.name == column_name]
+        if len(same_name) > 1:
+            options = sorted(column.cube_element_name for column in same_name)
+            raise DJInvalidInputException(
+                message=(
+                    f"Column `{column_name}` on node `{node_name}` is ambiguous across "
+                    f"roles. Use one of: {', '.join(options)}"
+                ),
+            )
+        if same_name:
+            return same_name[0]
+    else:
+        requested_column = next(
+            (column for column in columns if column.name == column_name),
+            None,
         )
-    return requested_column
+        if requested_column:
+            return requested_column
+
+    raise DJDoesNotExistException(
+        message=missing_message
+        or f"Column `{column_name}` does not exist on node `{node_name}`!",
+        http_status_code=404,
+    )
 
 
 async def get_attribute_type(
@@ -704,6 +738,7 @@ async def find_existing_cube(
     session: AsyncSession,
     metric_columns: List[Column],
     dimension_columns: List[Column],
+    dimension_roles: Optional[List[Optional[str]]] = None,
     materialized: bool = True,
 ) -> Optional[NodeRevision]:
     """
@@ -711,27 +746,44 @@ async def find_existing_cube(
     If `materialized` is set, it will only look for materialized cubes.
     """
     element_names = [col.name for col in (metric_columns + dimension_columns)]
-    statement = select(Node).join(
-        NodeRevision,
-        onclause=(
-            and_(
-                (Node.id == NodeRevision.node_id),
-                (Node.current_version == NodeRevision.version),
-            )
-        ),
+    required_dimension_refs = (
+        {
+            col.full_name() + (role or "")
+            for col, role in zip(dimension_columns, dimension_roles)
+        }
+        if dimension_roles is not None
+        else set()
+    )
+    statement = (
+        select(Node)
+        .join(
+            NodeRevision,
+            onclause=(
+                and_(
+                    (Node.id == NodeRevision.node_id),
+                    (Node.current_version == NodeRevision.version),
+                )
+            ),
+        )
+        .options(
+            joinedload(Node.current).options(
+                joinedload(NodeRevision.materializations),
+                joinedload(NodeRevision.availability),
+                selectinload(NodeRevision.columns),
+            ),
+        )
     )
     for name in element_names:
         statement = statement.filter(
             NodeRevision.cube_elements.any(Column.name == name),  # type: ignore
-        ).options(
-            joinedload(Node.current).options(
-                joinedload(NodeRevision.materializations),
-                joinedload(NodeRevision.availability),
-            ),
         )
 
     existing_cubes = (await session.execute(statement)).unique().scalars().all()
     for cube in existing_cubes:
+        if required_dimension_refs:
+            cube_element_refs = {col.cube_element_name for col in cube.current.columns}
+            if not required_dimension_refs.issubset(cube_element_refs):
+                continue
         if not materialized or (  # pragma: no cover
             materialized and cube.current.materializations and cube.current.availability
         ):

--- a/datajunction-server/datajunction_server/api/materializations.py
+++ b/datajunction-server/datajunction_server/api/materializations.py
@@ -14,7 +14,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
-from datajunction_server.api.helpers import get_save_history, get_materialization_info
+from datajunction_server.api.helpers import (
+    get_materialization_info,
+    get_save_history,
+    resolve_column,
+)
 from datajunction_server.database import Node, NodeRevision
 from datajunction_server.database.backfill import Backfill
 from datajunction_server.database.column import Column, ColumnAttribute
@@ -473,20 +477,23 @@ async def run_materialization_backfill(
         )
 
     materialization = materializations[0]
-    temporal_partitions = {
-        col.name: col for col in node_revision.temporal_partition_columns()
-    }
-    categorical_partitions = {
-        col.name: col for col in node_revision.categorical_partition_columns()
-    }
+    partition_columns = (
+        node_revision.temporal_partition_columns()
+        + node_revision.categorical_partition_columns()
+    )
     for backfill_spec in backfill_partitions:
-        if backfill_spec.column_name not in set(temporal_partitions).union(
-            set(categorical_partitions),
-        ):
-            raise DJDoesNotExistException(  # pragma: no cover
-                f"Partition with name {backfill_spec.column_name} does not exist on node",
-            )
-        backfill_spec.column_name = amenable_name(backfill_spec.column_name)
+        partition_column = resolve_column(
+            partition_columns,
+            backfill_spec.column_name,
+            node_revision.name,
+            node_revision.type,
+        )
+        partition_name = (
+            partition_column.cube_element_name
+            if node_revision.type == NodeType.CUBE
+            else partition_column.name
+        )
+        backfill_spec.column_name = amenable_name(partition_name)
     materialization_jobs = {
         cls.__name__: cls for cls in MaterializationJob.__subclasses__()
     }

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1565,7 +1565,11 @@ async def set_column_display_name(
             node=node.name,  # type: ignore
             activity_type=ActivityType.UPDATE,
             details={
-                "column": column.name,
+                "column": (
+                    column.cube_element_name
+                    if node.type == NodeType.CUBE
+                    else column.name
+                ),
                 "display_name": display_name,
             },
             user=current_user.username,
@@ -1611,7 +1615,11 @@ async def set_column_description(
             node=node.name,  # type: ignore
             activity_type=ActivityType.UPDATE,
             details={
-                "column": column.name,
+                "column": (
+                    column.cube_element_name
+                    if node.type == NodeType.CUBE
+                    else column.name
+                ),
                 "description": description,
             },
             user=current_user.username,
@@ -1654,12 +1662,15 @@ async def set_column_partition(
         ],
     )
     column = get_node_column(node, column_name)  # type: ignore
+    column_identifier = (
+        column.cube_element_name if node.type == NodeType.CUBE else column.name
+    )
     upsert_partition_event = History(
         entity_type=EntityType.PARTITION,
         node=node_name,
         activity_type=ActivityType.CREATE,
         details={
-            "column": column_name,
+            "column": column_identifier,
             "partition": input_partition.model_dump(),
         },
         user=current_user.username,
@@ -1728,6 +1739,9 @@ async def remove_column_partition(
         ],
     )
     column = get_node_column(node, column_name)  # type: ignore
+    column_identifier = (
+        column.cube_element_name if node.type == NodeType.CUBE else column.name
+    )
     if column.partition:
         await session.delete(column.partition)
         column.partition = None
@@ -1737,7 +1751,7 @@ async def remove_column_partition(
                 entity_type=EntityType.PARTITION,
                 node=node_name,
                 activity_type=ActivityType.DELETE,
-                details={"column": column_name},
+                details={"column": column_identifier},
                 user=current_user.username,
             ),
             session=session,

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1554,7 +1554,9 @@ async def set_column_display_name(
         session,
         node_name,
         options=[joinedload(Node.current)],
+        raise_if_not_exists=True,
     )
+    assert node is not None  # raise_if_not_exists=True ensures this
     column = await get_column(session, node.current, column_name)  # type: ignore
     column.display_name = display_name
     session.add(column)
@@ -1604,7 +1606,9 @@ async def set_column_description(
         session,
         node_name,
         options=[joinedload(Node.current)],
+        raise_if_not_exists=True,
     )
+    assert node is not None  # raise_if_not_exists=True ensures this
     column = await get_column(session, node.current, column_name)  # type: ignore
     column.description = description
     session.add(column)
@@ -1660,7 +1664,9 @@ async def set_column_partition(
                 joinedload(NodeRevision.cube_elements),
             ),
         ],
+        raise_if_not_exists=True,
     )
+    assert node is not None  # raise_if_not_exists=True ensures this
     column = get_node_column(node, column_name)  # type: ignore
     column_identifier = (
         column.cube_element_name if node.type == NodeType.CUBE else column.name
@@ -1737,7 +1743,9 @@ async def remove_column_partition(
                 joinedload(NodeRevision.cube_elements),
             ),
         ],
+        raise_if_not_exists=True,
     )
+    assert node is not None  # raise_if_not_exists=True ensures this
     column = get_node_column(node, column_name)  # type: ignore
     column_identifier = (
         column.cube_element_name if node.type == NodeType.CUBE else column.name

--- a/datajunction-server/datajunction_server/construction/build_v3/builder.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/builder.py
@@ -146,7 +146,7 @@ async def extract_temporal_partition_columns(
     temporal_partition_columns = {}
     for column in matching_cube.columns:
         if column.partition and column.partition.type_ == PartitionType.TEMPORAL:
-            temporal_partition_columns[column.name] = column.partition
+            temporal_partition_columns[column.cube_element_name] = column.partition
 
     return temporal_partition_columns if temporal_partition_columns else None
 

--- a/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
@@ -547,8 +547,8 @@ async def build_sql_from_cube(
 
 def _build_mat_col_lookup(cube: NodeRevision) -> dict[str, str]:
     """
-    Build a mapping from short column name -> physical column name by reading
-    the cube's materialization config columns.
+    Build a mapping from semantic column reference -> physical column name by
+    reading the cube's materialization config columns.
 
     Example entry in config["columns"]:
       {
@@ -559,9 +559,9 @@ def _build_mat_col_lookup(cube: NodeRevision) -> dict[str, str]:
         ...
       }
 
-    We key on ``column`` (the short name) because that is what
-    parse_dimension_ref().column_name returns, and it is stable across
-    different namespace / path representations.
+    New configs key ``column`` by the full semantic reference, including a
+    role suffix when present. Older configs used a short column name; callers
+    retain a short-name fallback for compatibility.
 
     Returns {} when no materialization config is available (e.g. in tests that
     set availability directly without going through the materialization pipeline),
@@ -578,6 +578,19 @@ def _build_mat_col_lookup(cube: NodeRevision) -> dict[str, str]:
     return lookup
 
 
+def _materialized_dimension_column(
+    lookup: dict[str, str],
+    dimension_ref: str,
+    default: str,
+) -> str:
+    """Resolve a materialized dimension by role first, then legacy short name."""
+    parsed = parse_dimension_ref(dimension_ref)
+    return lookup.get(
+        dimension_ref,
+        lookup.get(parsed.column_name, default),
+    )
+
+
 def build_synthetic_grain_group(
     ctx: BuildContext,
     decomposed_metrics: dict[str, DecomposedMetricInfo],
@@ -586,14 +599,10 @@ def build_synthetic_grain_group(
     """
     Build a synthetic GrainGroupSQL that reads from the cube's materialized Druid table.
 
-    Physical column names are resolved from the cube's materialization config
-    (``materialization.config["columns"]``).  Each entry there carries a
-    ``column`` key (the short column name, e.g. ``dateint``) and a ``name`` key
-    (the physical column name as it exists in the Druid table, e.g.
-    ``common_DOT_dimensions_DOT_time_DOT_date_DOT_dateint``).  We key on the
-    short column name because that is what parse_dimension_ref().column_name
-    returns.  When a match is found the physical name is used; otherwise we fall
-    back to the short name (which is correct for new-style materializations).
+    Physical column names are resolved from the cube's materialization config.
+    New configs use the full semantic reference (including any role) as the
+    ``column`` key; legacy configs used a short bare name. When neither exists,
+    the generated role-aware alias is already the correct fallback.
     """
     all_components = []
     component_aliases: dict[str, str] = {}
@@ -610,7 +619,7 @@ def build_synthetic_grain_group(
             p for p in [avail.catalog, avail.schema_, avail.table] if p
         )
 
-    # short_col_name -> physical column name from the materialization config.
+    # Semantic reference (or legacy short name) -> physical column name.
     # Empty when no materialization config is present (tests / direct calls).
     mat_col_lookup = _build_mat_col_lookup(cube)
 
@@ -646,7 +655,11 @@ def build_synthetic_grain_group(
         short_name = parsed_dim.column_name
         if parsed_dim.role:
             short_name = f"{short_name}_{parsed_dim.role}"
-        physical_name = mat_col_lookup.get(parsed_dim.column_name, short_name)
+        physical_name = _materialized_dimension_column(
+            mat_col_lookup,
+            dim_ref,
+            short_name,
+        )
         dim_short_names.append(short_name)
         dim_physical_names.append(physical_name)
         # Use the physical column name for WHERE clause resolution:

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -454,10 +454,14 @@ def collect_cte_nodes_and_needed_columns(
         for partition_col_ref in ctx.temporal_partition_columns:
             dimension_ref = parse_dimension_ref(partition_col_ref)
 
-            # Check if this parent has a dimension link to the partition column's node
+            # Match the exact dimension link. The same parent can reach one
+            # dimension node through multiple roles.
             if parent_node.current.dimension_links:  # pragma: no branch
                 for link in parent_node.current.dimension_links:  # pragma: no branch
-                    if link.dimension.name == dimension_ref.node_name:
+                    if (
+                        link.dimension.name == dimension_ref.node_name
+                        and (link.role or None) == dimension_ref.role
+                    ):
                         parent_needed_cols.add(dimension_ref.column_name)
                         break
 
@@ -1636,12 +1640,17 @@ def build_temporal_filter(
         # Parse "v3.date.date_id" -> dimension node and column
         parsed = parse_dimension_ref(partition_col_ref)
 
-        # Check if this parent has a dimension link to the partition column's node
+        # Check if this parent has the exact dimension link named by the
+        # partition reference. A bare ref matches only a bare link; a
+        # role-qualified ref matches only that role.
         if not parent_node.current.dimension_links:
             continue  # pragma: no cover
 
         for link in parent_node.current.dimension_links:  # pragma: no branch
-            if link.dimension.name == parsed.node_name:
+            if (
+                link.dimension.name == parsed.node_name
+                and (link.role or None) == parsed.role
+            ):
                 # Found a dimension link to the temporal partition dimension
                 # Find the column on the dimension (cube already declared this as temporal)
                 temporal_col = None

--- a/datajunction-server/datajunction_server/construction/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/dimensions.py
@@ -19,7 +19,6 @@ from datajunction_server.naming import amenable_name, from_amenable_name
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.sql.parsing.types import IntegerType
-from datajunction_server.utils import SEPARATOR
 
 
 async def build_dimensions_from_cube_query(
@@ -109,9 +108,11 @@ async def build_dimensions_from_cube_query(
         query_ast.select.from_.relations.append(  # type: ignore
             ast.Relation(primary=measures_query_ast),
         )
+    # Cube columns, unlike the deduplicated cube_elements relationship, retain
+    # one entry per role. Keying types from cube_elements makes a projection
+    # such as ``date.date_id[ship]`` miss its type entirely.
     types_lookup = {
-        amenable_name(elem.node_revision.name + SEPARATOR + elem.name): elem.type  # type: ignore
-        for elem in cube.cube_elements
+        amenable_name(column.cube_element_name): column.type for column in cube.columns
     }
     return TranslatedSQL.create(
         sql=str(query_ast),

--- a/datajunction-server/datajunction_server/database/column.py
+++ b/datajunction-server/datajunction_server/database/column.py
@@ -107,11 +107,25 @@ class Column(Base):  # type: ignore
         cascade="all,delete",
     )
 
-    def to_spec(self):
+    @property
+    def cube_element_name(self) -> str:
+        """Role-qualified identity for a column on a cube revision.
+
+        Cube columns store the dimension attribute FQN in ``name`` and the
+        role suffix (for example, ``[order_date]``) separately in
+        ``dimension_column``.  Both parts are required to distinguish two
+        role-played uses of the same dimension attribute.
+
+        ``dimension_column`` has different semantics on non-cube columns, so
+        callers should only use this property for columns owned by cubes.
+        """
+        return self.name + (self.dimension_column or "")
+
+    def to_spec(self, *, include_cube_role: bool = False):
         from datajunction_server.models.deployment import ColumnSpec
 
         return ColumnSpec(
-            name=self.name,
+            name=self.cube_element_name if include_cube_role else self.name,
             type=str(self.type),
             display_name=self.display_name,
             description=self.description,

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -561,7 +561,10 @@ class Node(Base):
             NodeType.METRIC,
             NodeType.CUBE,
         ):
-            cols = [col.to_spec() for col in sorted_columns]
+            cols = [
+                col.to_spec(include_cube_role=self.type == NodeType.CUBE)
+                for col in sorted_columns
+            ]
             extra_kwargs.update(
                 columns=cols,
             )
@@ -1927,7 +1930,11 @@ class NodeRevision(
         Column ordering
         """
         return {
-            col.name.replace("_DOT_", SEPARATOR): (col.order or idx)
+            (
+                col.cube_element_name
+                if self.type == NodeType.CUBE
+                else col.name.replace("_DOT_", SEPARATOR)
+            ): (col.order or idx)
             for idx, col in enumerate(self.columns)
         }
 
@@ -1951,7 +1958,7 @@ class NodeRevision(
         if self.type != NodeType.CUBE:
             return []  # pragma: no cover
         ordering = {
-            col.name.replace("_DOT_", SEPARATOR): (col.order or idx)
+            col.cube_element_name: (col.order or idx)
             for idx, col in enumerate(self.columns)
         }
         return sorted(
@@ -1979,7 +1986,7 @@ class NodeRevision(
             if node and node.type == NodeType.METRIC  # type: ignore
         }
         res = [
-            element.name + (element.dimension_column or "")
+            element.cube_element_name
             for element in self.columns
             if not cube_metrics.get(element.name)
         ]

--- a/datajunction-server/datajunction_server/database/partition.py
+++ b/datajunction-server/datajunction_server/database/partition.py
@@ -108,7 +108,7 @@ class Partition(Base):  # type: ignore
             )
         return None  # pragma: no cover
 
-    def categorical_expression(self):
+    def categorical_expression(self, column_name: Optional[str] = None):
         """
         Expression for the categorical partition
         """
@@ -117,7 +117,7 @@ class Partition(Base):  # type: ignore
         # Register a DJ function (inherits the `datajunction_server.sql.functions.Function` class)
         # that has the partition column name as the function name. This will be substituted at
         # runtime with the partition column name
-        amenable_partition_name = amenable_name(self.column.name)
+        amenable_partition_name = amenable_name(column_name or self.column.name)
         clazz = type(
             amenable_partition_name,
             (Function,),

--- a/datajunction-server/datajunction_server/internal/client.py
+++ b/datajunction-server/datajunction_server/internal/client.py
@@ -108,7 +108,9 @@ async def python_client_code_for_setting_column_attributes(
     snippets = [
         template.render(
             node_short_name=node_short_name,
-            column_name=col.name,
+            column_name=(
+                col.cube_element_name if node.type == NodeType.CUBE else col.name
+            ),
             attributes=[
                 attr.attribute_type
                 for attr in col.attributes

--- a/datajunction-server/datajunction_server/internal/client.py
+++ b/datajunction-server/datajunction_server/internal/client.py
@@ -102,7 +102,9 @@ async def python_client_code_for_setting_column_attributes(
                 ),
             ),
         ],
+        raise_if_not_exists=True,
     )
+    assert node is not None  # raise_if_not_exists=True ensures this
 
     template = jinja_env.get_template("set_column_attributes.j2")
     snippets = [

--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -50,7 +50,7 @@ def generate_partition_filter_sql(
     if temporal_partition.partition.granularity == Granularity.DAY and (
         lookback_window == "1 DAY" or not lookback_window
     ):
-        return f"{temporal_partition.name} = {partition_sql}"
+        return f"{temporal_partition.cube_element_name} = {partition_sql}"
     lookback_timestamp = (
         f"{logical_ts} - INTERVAL {lookback_window}"  # pragma: no cover
     )
@@ -59,7 +59,8 @@ def generate_partition_filter_sql(
         str(temporal_partition.type),
     )
     return (  # pragma: no cover
-        f"{temporal_partition.name} BETWEEN {partition_start} AND {partition_sql}"
+        f"{temporal_partition.cube_element_name} "
+        f"BETWEEN {partition_start} AND {partition_sql}"
     )
 
 

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2923,7 +2923,7 @@ class DeploymentOrchestrator:
             # identity DJ uses for cube elements — so a partition declared on a
             # role-played column (e.g. "...dateint[epoch_date]") lands on the right
             # role instead of being silently dropped.
-            element_key = full_element_name + (node_column.dimension_column or "")
+            element_key = node_column.cube_element_name
             if element_key in column_spec_map:
                 col_spec = column_spec_map[element_key]
                 if col_spec.partition:  # pragma: no branch
@@ -3788,7 +3788,12 @@ class DeploymentOrchestrator:
         # Track changes to node columns
         old_revision = existing.current if existing else None
         existing_columns_map = {
-            col.name: col for col in (old_revision.columns if old_revision else [])
+            (
+                col.cube_element_name
+                if old_revision and old_revision.type == NodeType.CUBE
+                else col.name
+            ): col
+            for col in (old_revision.columns if old_revision else [])
         }
         changed_count = [
             column_changed(new_col, existing_columns_map.get(new_col.name))

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -287,11 +287,11 @@ async def create_new_materialization(
                 access_checker,
                 current_user=current_user,
             )
-    materialization_name = (
-        f"{upsert.job.name.lower()}__{upsert.strategy.name.lower()}"  # type: ignore
-        + (f"__{temporal_partition[0].name}" if temporal_partition else "")
-        + ("__" if categorical_partitions else "")
-        + ("__".join([partition.name for partition in categorical_partitions]))
+    materialization_name = _materialization_name(
+        upsert,
+        current_revision,
+        temporal_partition,
+        categorical_partitions,
     )
     return Materialization(
         name=materialization_name,
@@ -300,6 +300,27 @@ async def create_new_materialization(
         schedule=upsert.schedule or "@daily",
         strategy=upsert.strategy,
         job=upsert.job.value.job_class,  # type: ignore
+    )
+
+
+def _materialization_name(
+    upsert: UpsertCubeMaterialization | UpsertMaterialization,
+    current_revision: NodeRevision,
+    temporal_partitions: list,
+    categorical_partitions: list,
+) -> str:
+    """Build a materialization identity that preserves cube partition roles."""
+    partition_names = [
+        partition.cube_element_name
+        if current_revision.type == NodeType.CUBE
+        else partition.name
+        for partition in temporal_partitions + categorical_partitions
+    ]
+    return (
+        f"{upsert.job.name.lower()}__{upsert.strategy.name.lower()}"  # type: ignore
+        + (f"__{partition_names[0]}" if temporal_partitions else "")
+        + ("__" if categorical_partitions else "")
+        + ("__".join(partition_names[len(temporal_partitions) :]))
     )
 
 

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -824,7 +824,7 @@ async def _cube_project_config(
         "dimensions": cube_revision.cube_node_dimensions,
         "columns": [
             {
-                "name": column.name,
+                "name": column.cube_element_name,
                 **_partition_config(column),
             }
             for column in cube_revision.columns

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -28,6 +28,7 @@ from datajunction_server.api.helpers import (
     get_node_by_name,
     get_node_namespace,
     raise_if_node_exists,
+    resolve_column,
     resolve_downstream_references,
     validate_cube,
 )
@@ -380,31 +381,12 @@ def get_node_column(node: Node, column_name: str) -> Column:
       3. Bare name that maps to multiple role-played columns -> raise, listing the
          role-qualified options, instead of silently binding the last one.
     """
-    columns = node.current.columns
-
-    # 1. exact role-qualified match: name + dimension_column (e.g. "...dateint[epoch_date]")
-    by_role_qualified = {
-        col.name + (col.dimension_column or ""): col for col in columns
-    }
-    if column_name in by_role_qualified:
-        return by_role_qualified[column_name]
-
-    # 2/3. bare-name resolution
-    same_name = [col for col in columns if col.name == column_name]
-    if not same_name:
-        raise DJDoesNotExistException(
-            message=f"Column `{column_name}` does not exist on node `{node.name}`!",
-        )
-    if len(same_name) > 1:
-        options = sorted(col.name + (col.dimension_column or "") for col in same_name)
-        raise DJInvalidInputException(
-            message=(
-                f"Column `{column_name}` on node `{node.name}` is ambiguous across "
-                f"multiple role-played dimensions. Specify the role-qualified column, "
-                f"one of: {options}"
-            ),
-        )
-    return same_name[0]
+    return resolve_column(
+        node.current.columns,
+        column_name,
+        node.name,
+        node.type,
+    )
 
 
 async def validate_and_build_attribute(
@@ -454,8 +436,6 @@ async def set_node_column_attributes(
     Sets the column attributes on the node if allowed.
     """
     column = get_node_column(node, column_name)
-    all_columns_map = {column.name: column for column in node.current.columns}
-
     existing_attributes = column.attributes
     existing_attributes_map = {
         attr.attribute_type.name: attr for attr in existing_attributes
@@ -473,7 +453,7 @@ async def set_node_column_attributes(
     # Validate column attributes by building mapping between
     # attribute scope and columns
     attributes_columns_map = defaultdict(set)
-    all_columns = all_columns_map.values()
+    all_columns = node.current.columns
 
     for _col in all_columns:
         for attribute in _col.attributes:
@@ -489,7 +469,9 @@ async def set_node_column_attributes(
                         for item in attribute.attribute_type.uniqueness_scope
                     ),
                 )
-            ].add(_col.name)
+            ].add(
+                _col.cube_element_name if node.type == NodeType.CUBE else _col.name,
+            )
 
     for (attribute, _), columns in attributes_columns_map.items():
         if len(columns) > 1 and attribute.uniqueness_scope:
@@ -508,7 +490,11 @@ async def set_node_column_attributes(
             node=node.name,
             activity_type=ActivityType.SET_ATTRIBUTE,
             details={
-                "column": column.name,
+                "column": (
+                    column.cube_element_name
+                    if node.type == NodeType.CUBE
+                    else column.name
+                ),
                 "attributes": [attr.model_dump() for attr in attributes],
             },
             user=current_user.username,
@@ -1630,9 +1616,11 @@ async def update_cube_node(
         )
 
         # Bring over existing partition columns, if any
-        new_columns_mapping = {col.name: col for col in new_cube_revision.columns}
+        new_columns_mapping = {
+            col.cube_element_name: col for col in new_cube_revision.columns
+        }
         for col in node_revision.columns:
-            new_col = new_columns_mapping.get(col.name)
+            new_col = new_columns_mapping.get(col.cube_element_name)
             if col.partition and new_col:
                 new_col.partition = Partition(
                     column=new_col,

--- a/datajunction-server/datajunction_server/internal/sql.py
+++ b/datajunction-server/datajunction_server/internal/sql.py
@@ -319,7 +319,14 @@ async def build_sql_for_multiple_metrics(
     if not orderby:
         orderby = []
 
-    metric_columns, metric_nodes, _, dimension_columns, _, _ = await validate_cube(
+    (
+        metric_columns,
+        metric_nodes,
+        _,
+        dimension_columns,
+        dimension_roles,
+        _,
+    ) = await validate_cube(
         session,
         metrics,
         dimensions,
@@ -349,6 +356,7 @@ async def build_sql_for_multiple_metrics(
         session,
         metric_columns,
         dimension_columns,
+        dimension_roles,
         materialized=True,
     )
     materialized_cube_catalog = None

--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -190,7 +190,8 @@ def build_materialization_query(
         temporal_partition_col = [
             col
             for col in cube_materialization_query_ast.select.projection
-            if col.alias_or_name.name == amenable_name(temporal_partitions[0].name)  # type: ignore
+            if col.alias_or_name.name  # type: ignore
+            == amenable_name(temporal_partitions[0].cube_element_name)
         ]
         temporal_op = (
             ast.BinaryOp(
@@ -220,13 +221,15 @@ def build_materialization_query(
                 col
                 for col in cube_materialization_query_ast.select.projection
                 if col.alias_or_name.name  # type: ignore
-                == amenable_name(categorical_partitions[0].name)  # type: ignore
+                == amenable_name(categorical_partitions[0].cube_element_name)
             ]
             categorical_op = ast.BinaryOp(
                 left=ast.Column(
                     name=ast.Name(categorical_partition_col[0].alias_or_name.name),  # type: ignore
                 ),
-                right=categorical_partitions[0].partition.categorical_expression(),
+                right=categorical_partitions[0].partition.categorical_expression(
+                    categorical_partitions[0].cube_element_name,
+                ),
                 op=ast.BinaryOpKind.Eq,
             )
             final_query.select.where = ast.BinaryOp(

--- a/datajunction-server/datajunction_server/materialization/jobs/materialization_job.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/materialization_job.py
@@ -16,6 +16,7 @@ from datajunction_server.models.materialization import (
     MaterializationInfo,
     MaterializationStrategy,
 )
+from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.partition import PartitionBackfill
 from datajunction_server.naming import amenable_name
 from datajunction_server.service_clients import QueryServiceClient
@@ -99,10 +100,17 @@ class SparkSqlMaterializationJob(  # pragma: no cover
             temporal_partitions
             and materialization.strategy == MaterializationStrategy.INCREMENTAL_TIME
         ):
+            partition_name = (
+                temporal_partitions[0].cube_element_name
+                if materialization.node_revision.type == NodeType.CUBE
+                else temporal_partitions[0].name
+            )
             temporal_partition_col = [
                 col
                 for col in query_ast.select.projection
-                if col.alias_or_name.name.endswith(temporal_partitions[0].name)  # type: ignore
+                if col.alias_or_name.name  # type: ignore
+                in {partition_name, amenable_name(partition_name)}
+                or col.alias_or_name.name.endswith(partition_name)  # type: ignore
             ]
             temporal_op = (
                 ast.BinaryOp(
@@ -143,11 +151,16 @@ class SparkSqlMaterializationJob(  # pragma: no cover
                 materialization.node_revision.categorical_partition_columns()
             )
             if categorical_partitions:
+                categorical_partition_name = (
+                    categorical_partitions[0].cube_element_name
+                    if materialization.node_revision.type == NodeType.CUBE
+                    else categorical_partitions[0].name
+                )
                 categorical_partition_col = [
                     col
                     for col in final_query.select.projection
                     if col.alias_or_name.name  # type: ignore
-                    == amenable_name(categorical_partitions[0].name)  # type: ignore
+                    == amenable_name(categorical_partition_name)
                 ]
                 categorical_op = ast.BinaryOp(
                     left=ast.Column(
@@ -155,7 +168,9 @@ class SparkSqlMaterializationJob(  # pragma: no cover
                             categorical_partition_col[0].alias_or_name.name,  # type: ignore
                         ),
                     ),
-                    right=categorical_partitions[0].partition.categorical_expression(),
+                    right=categorical_partitions[0].partition.categorical_expression(
+                        categorical_partition_name,
+                    ),
                     op=ast.BinaryOpKind.Eq,
                 )
                 final_query.select.where = ast.BinaryOp(

--- a/datajunction-server/datajunction_server/mcp/tools.py
+++ b/datajunction-server/datajunction_server/mcp/tools.py
@@ -208,7 +208,11 @@ async def get_node_details(name: str) -> str:
     if node.current:
         node_dict["current"]["query"] = node.current.query
         node_dict["current"]["columns"] = [
-            {"name": c.name, "type": str(c.type)} for c in (node.current.columns or [])
+            {
+                "name": (c.cube_element_name if node.type == NodeType.CUBE else c.name),
+                "type": str(c.type),
+            }
+            for c in (node.current.columns or [])
         ]
         node_dict["current"]["parents"] = [
             {

--- a/datajunction-server/datajunction_server/models/cube.py
+++ b/datajunction-server/datajunction_server/models/cube.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from pydantic import Field, model_validator, ConfigDict
 from pydantic.main import BaseModel
 
-from datajunction_server.naming import SEPARATOR, from_amenable_name, amenable_name
+from datajunction_server.naming import SEPARATOR, amenable_name
 from datajunction_server.models.materialization import MaterializationConfigOutput
 from datajunction_server.models.measure import (
     FrozenMeasureKey,
@@ -125,38 +125,32 @@ class CubeRevisionMetadata(BaseModel):
         """
         Converts a cube node revision into a cube revision metadata object
         """
-        # Preserve the ordering of elements
-        element_ordering = {col.name: col.order for col in cube.columns}
-        cube.cube_elements = sorted(
-            cube.cube_elements,
-            key=lambda elem: element_ordering.get(from_amenable_name(elem.name), 0),
-        )
-
         # Parse the database object into a pydantic object
         cube_metadata = cls.model_validate(cube)
 
-        # node_columns are the role-aware source of truth (one per role); the
-        # cube_elements many-to-many holds each referenced column only once. Expand
-        # each dimension element into one entry per role so both survive on load.
-        metric_names = {metric.name for metric in cube.cube_metrics()}
-        roles_by_full_name: dict[str, List[Optional[str]]] = {}
-        for col in sorted(cube.columns, key=lambda c: c.order):
-            if col.name in metric_names:
-                continue
-            role = col.dimension_column.strip("[]") if col.dimension_column else None
-            roles_by_full_name.setdefault(col.name, []).append(role)
-
+        # Cube columns are the ordered, role-aware source of truth. The
+        # cube_elements many-to-many intentionally stores each referenced DB
+        # column once, so reconstruct one metadata entry per cube column.
+        elements_by_column_name = {
+            (
+                element.node_name
+                if element.type == "metric"
+                else f"{element.node_name}{SEPARATOR}{element.name}"
+            ): element
+            for element in cube_metadata.cube_elements
+        }
         expanded_elements: List[CubeElementMetadata] = []
-        for elem_meta in cube_metadata.cube_elements:
-            if elem_meta.type == "metric":
-                expanded_elements.append(elem_meta)
+        for column in cube.columns:
+            element = elements_by_column_name.get(column.name)
+            if element is None:  # pragma: no cover - database invariant
                 continue
-            full_name = f"{elem_meta.node_name}{SEPARATOR}{elem_meta.name}"
-            roles = roles_by_full_name.get(full_name, [None])
-            for position, role in enumerate(roles):
-                element = elem_meta if position == 0 else elem_meta.model_copy()
-                element.role = role
+            if element.type == "metric":
                 expanded_elements.append(element)
+                continue
+            role = (
+                column.dimension_column.strip("[]") if column.dimension_column else None
+            )
+            expanded_elements.append(element.model_copy(update={"role": role}))
         cube_metadata.cube_elements = expanded_elements
 
         # Populate metric measures

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -143,9 +143,7 @@ class MeasuresMaterialization(BaseModel):
         # The cube column stores the role separately in ``dimension_column``
         # as ``[role]``. Reconstruct the role-qualified form to match the v3
         # measures-query ``semantic_entity`` (e.g. ``node.col[role]``).
-        partition_ref = (
-            f"{temporal_partition.name}{temporal_partition.dimension_column or ''}"
-        )
+        partition_ref = temporal_partition.cube_element_name
         partition_matches = [
             col.name
             for col in measures_query.columns

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -200,6 +200,11 @@ class GenericMaterializationConfig(GenericMaterializationConfigInput):
         if not user_defined_temporal_columns:
             return []
         user_defined_temporal_column = user_defined_temporal_columns[0]
+        partition_ref = (
+            user_defined_temporal_column.cube_element_name
+            if node_revision.type == NodeType.CUBE
+            else user_defined_temporal_column.name
+        )
         return [
             PartitionColumnOutput(
                 name=col.name,
@@ -210,7 +215,7 @@ class GenericMaterializationConfig(GenericMaterializationConfigInput):
                 ),
             )
             for col in self.columns  # type: ignore
-            if user_defined_temporal_column.name in (col.semantic_entity, col.name)
+            if partition_ref in (col.semantic_entity, col.name)
         ]
 
     def categorical_partitions(
@@ -221,7 +226,8 @@ class GenericMaterializationConfig(GenericMaterializationConfigInput):
         The categorical partition column names on the intermediate measures table
         """
         user_defined_categorical_columns = {
-            col.name for col in node_revision.categorical_partition_columns()
+            col.cube_element_name if node_revision.type == NodeType.CUBE else col.name
+            for col in node_revision.categorical_partition_columns()
         }
         return [
             PartitionColumnOutput(
@@ -348,9 +354,7 @@ class DruidMeasuresCubeConfig(DruidCubeConfigInput, GenericCubeConfig):
         # The cube column stores the role separately in ``dimension_column`` as
         # ``[role]``. Reconstruct the role-qualified form to match the v3
         # measures-query ``semantic_entity`` (e.g. ``node.col[role]``).
-        partition_ref = user_defined_temporal_partition.name + (
-            user_defined_temporal_partition.dimension_column or ""
-        )
+        partition_ref = user_defined_temporal_partition.cube_element_name
         timestamp_column = [
             col.name
             for col in self.columns  # type: ignore

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -794,6 +794,11 @@ class ColumnOutput(BaseModel):
 
     model_config = ConfigDict(from_attributes=True, validate_assignment=True)
 
+    @property
+    def cube_element_name(self) -> str:
+        """Role-qualified identity for this column when it belongs to a cube."""
+        return self.name + (self.dimension_column or "")
+
     @field_validator("type", mode="before")
     def extract_type(cls, raw):
         return str(raw)

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -374,62 +374,6 @@ def repairs_cube_elements():
             "type": "metric",
         },
         {
-            "display_name": "Company Name",
-            "name": "company_name",
-            "node_name": "default.dispatcher",
-            "partition": None,
-            "role": None,
-            "type": "dimension",
-        },
-        {
-            "display_name": "Local Region",
-            "name": "local_region",
-            "node_name": "default.municipality_dim",
-            "partition": None,
-            "role": None,
-            "type": "dimension",
-        },
-        {
-            "display_name": "Hire Date",
-            "name": "hire_date",
-            "node_name": "default.hard_hat",
-            "partition": None,
-            "role": None,
-            "type": "dimension",
-        },
-        {
-            "display_name": "City",
-            "name": "city",
-            "node_name": "default.hard_hat",
-            "partition": None,
-            "role": None,
-            "type": "dimension",
-        },
-        {
-            "display_name": "State",
-            "name": "state",
-            "node_name": "default.hard_hat",
-            "partition": None,
-            "role": None,
-            "type": "dimension",
-        },
-        {
-            "display_name": "Postal Code",
-            "name": "postal_code",
-            "node_name": "default.hard_hat",
-            "partition": None,
-            "role": None,
-            "type": "dimension",
-        },
-        {
-            "display_name": "Country",
-            "name": "country",
-            "node_name": "default.hard_hat",
-            "partition": None,
-            "role": None,
-            "type": "dimension",
-        },
-        {
             "display_name": "Num Repair Orders",
             "name": "default_DOT_num_repair_orders",
             "node_name": "default.num_repair_orders",
@@ -468,6 +412,62 @@ def repairs_cube_elements():
             "partition": None,
             "role": None,
             "type": "metric",
+        },
+        {
+            "display_name": "Country",
+            "name": "country",
+            "node_name": "default.hard_hat",
+            "partition": None,
+            "role": None,
+            "type": "dimension",
+        },
+        {
+            "display_name": "Postal Code",
+            "name": "postal_code",
+            "node_name": "default.hard_hat",
+            "partition": None,
+            "role": None,
+            "type": "dimension",
+        },
+        {
+            "display_name": "City",
+            "name": "city",
+            "node_name": "default.hard_hat",
+            "partition": None,
+            "role": None,
+            "type": "dimension",
+        },
+        {
+            "display_name": "Hire Date",
+            "name": "hire_date",
+            "node_name": "default.hard_hat",
+            "partition": None,
+            "role": None,
+            "type": "dimension",
+        },
+        {
+            "display_name": "State",
+            "name": "state",
+            "node_name": "default.hard_hat",
+            "partition": None,
+            "role": None,
+            "type": "dimension",
+        },
+        {
+            "display_name": "Company Name",
+            "name": "company_name",
+            "node_name": "default.dispatcher",
+            "partition": None,
+            "role": None,
+            "type": "dimension",
+        },
+        {
+            "display_name": "Local Region",
+            "name": "local_region",
+            "node_name": "default.municipality_dim",
+            "partition": None,
+            "role": None,
+            "type": "dimension",
         },
     ]
 
@@ -2171,16 +2171,16 @@ async def test_changing_node_upstream_from_cube(
             "role": None,
         },
         {
-            "name": "municipality_id",
-            "display_name": "Municipality Id",
+            "name": "hard_hat_id",
+            "display_name": "Hard Hat Id",
             "node_name": "default.repair_order_dim__one",
             "type": "dimension",
             "partition": None,
             "role": None,
         },
         {
-            "name": "hard_hat_id",
-            "display_name": "Hard Hat Id",
+            "name": "municipality_id",
+            "display_name": "Municipality Id",
             "node_name": "default.repair_order_dim__one",
             "type": "dimension",
             "partition": None,
@@ -4130,6 +4130,214 @@ class TestCubeRoleQualifiedDimensions:
         country_cols = await country_columns_by_role()
         assert country_cols["[from]"]["partition"] is None
         assert country_cols["[to]"]["partition"] is None
+
+    @pytest.mark.asyncio
+    async def test_partition_history_uses_resolved_cube_column_identity(
+        self,
+        module__client_with_build_v3: AsyncClient,
+    ):
+        """Legacy bare lookups must not erase the resolved role from history."""
+        cube_name = "v3.single_role_partition_history_cube"
+        response = await module__client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": cube_name,
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.location.country[from]"],
+                "mode": "published",
+                "description": "Role-aware partition history regression",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        # A unique bare name remains supported for compatibility, but the
+        # resulting audit record must retain the resolved role.
+        response = await module__client_with_build_v3.post(
+            f"/nodes/{cube_name}/columns/v3.location.country/partition",
+            json={"type_": "categorical"},
+        )
+        assert response.status_code == 201, response.json()
+        response = await module__client_with_build_v3.delete(
+            f"/nodes/{cube_name}/columns/v3.location.country/partition",
+        )
+        assert response.status_code == 200, response.json()
+
+        response = await module__client_with_build_v3.get(
+            f"/history?node={cube_name}",
+        )
+        assert response.status_code == 200, response.json()
+        partition_events = [
+            event for event in response.json() if event["entity_type"] == "partition"
+        ]
+        assert [event["details"]["column"] for event in partition_events] == [
+            "v3.location.country[from]",
+            "v3.location.country[from]",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_update_and_exports_keep_role_played_partitions_distinct(
+        self,
+        module__client_with_build_v3: AsyncClient,
+    ):
+        """A cube update must preserve metadata by role-qualified identity.
+
+        The reordered dimensions deliberately put another dimension between two
+        roles of the same column. This catches both last-wins partition copying
+        and read/export paths that reconstruct roles from a bare-name map.
+        """
+        cube_name = "v3.role_partition_update_cube"
+        response = await module__client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": cube_name,
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.location.country[from]",
+                    "v3.location.country[to]",
+                    "v3.product.category",
+                ],
+                "mode": "published",
+                "description": "Role-aware cube update regression",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        for role in ("from", "to"):
+            response = await module__client_with_build_v3.post(
+                f"/nodes/{cube_name}/columns/v3.location.country[{role}]/partition",
+                json={"type_": "categorical"},
+            )
+            assert response.status_code == 201, response.json()
+
+        response = await module__client_with_build_v3.patch(
+            f"/nodes/{cube_name}",
+            json={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.location.country[from]",
+                    "v3.product.category",
+                    "v3.location.country[to]",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        for role, description in (
+            ("from", "Country of origin"),
+            ("to", "Destination country"),
+        ):
+            response = await module__client_with_build_v3.patch(
+                f"/nodes/{cube_name}/columns/v3.location.country[{role}]/description",
+                params={"description": description},
+            )
+            assert response.status_code == 201, response.json()
+
+        response = await module__client_with_build_v3.get(f"/cubes/{cube_name}/")
+        assert response.status_code == 200, response.json()
+        cube = response.json()
+        assert cube["cube_node_dimensions"] == [
+            "v3.location.country[from]",
+            "v3.product.category",
+            "v3.location.country[to]",
+        ]
+        dimension_elements = [
+            (element["node_name"], element["name"], element["role"])
+            for element in cube["cube_elements"]
+            if element["type"] == "dimension"
+        ]
+        assert dimension_elements == [
+            ("v3.location", "country", "from"),
+            ("v3.product", "category", None),
+            ("v3.location", "country", "to"),
+        ]
+        by_role = {
+            col["dimension_column"]: col
+            for col in cube["columns"]
+            if col["name"] == "v3.location.country"
+        }
+        assert by_role["[from]"]["partition"]["type_"] == "categorical"
+        assert by_role["[to]"]["partition"]["type_"] == "categorical"
+        assert by_role["[from]"]["description"] == "Country of origin"
+        assert by_role["[to]"]["description"] == "Destination country"
+
+        response = await module__client_with_build_v3.post(
+            f"/data/{cube_name}/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "roads",
+                "table": "role_partition_update_cube",
+                "valid_through_ts": 1010129120,
+            },
+        )
+        assert response.status_code == 200, response.json()
+        response = await module__client_with_build_v3.get(
+            f"/cubes/{cube_name}/dimensions/sql",
+            params=[
+                ("dimensions", "v3.location.country[from]"),
+                ("dimensions", "v3.location.country[to]"),
+            ],
+        )
+        assert response.status_code == 200, response.json()
+        assert [
+            (column["semantic_entity"], column["type"])
+            for column in response.json()["columns"]
+        ] == [
+            ("v3.location.country[from]", "string"),
+            ("v3.location.country[to]", "string"),
+        ]
+
+        # Requesting `attribute` forces the full ORM cube-elements GraphQL path.
+        response = await module__client_with_build_v3.post(
+            "/graphql",
+            json={
+                "query": """
+                {
+                  findNodes(names: ["v3.role_partition_update_cube"]) {
+                    current {
+                      cubeDimensions { name role attribute }
+                    }
+                  }
+                }
+                """,
+            },
+        )
+        assert response.status_code == 200, response.json()
+        graphql_data = response.json()
+        assert "errors" not in graphql_data, graphql_data
+        graphql_dims = graphql_data["data"]["findNodes"][0]["current"]["cubeDimensions"]
+        assert [(dim["name"], dim["role"]) for dim in graphql_dims] == [
+            ("v3.location.country[from]", "[from]"),
+            ("v3.product.category", ""),
+            ("v3.location.country[to]", "[to]"),
+        ]
+
+        response = await module__client_with_build_v3.get(
+            "/namespaces/v3/export/spec",
+        )
+        assert response.status_code == 200, response.json()
+        exported_cube = next(
+            node
+            for node in response.json()["nodes"]
+            if node["name"] == "${prefix}role_partition_update_cube"
+        )
+        assert {
+            col["name"] for col in exported_cube["columns"] if col.get("partition")
+        } == {
+            "${prefix}location.country[from]",
+            "${prefix}location.country[to]",
+        }
+
+        response = await module__client_with_build_v3.get("/namespaces/v3/export/")
+        assert response.status_code == 200, response.json()
+        project_cube = next(
+            node
+            for node in response.json()
+            if node["build_name"] == "role_partition_update_cube"
+        )
+        assert {col["name"] for col in project_cube["columns"]} == {
+            "v3.location.country[from]",
+            "v3.location.country[to]",
+        }
 
 
 class TestCubeDeactivateEndpoint:

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -9,7 +9,11 @@ import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 
-from datajunction_server.errors import DJQueryServiceClientException
+from datajunction_server.api.cubes import _resolve_cube_partition_output_column
+from datajunction_server.errors import (
+    DJInvalidInputException,
+    DJQueryServiceClientException,
+)
 from datajunction_server.construction.build_v3.combiners import (
     PreAggSourceInfo,
     TemporalPartitionInfo,
@@ -22,6 +26,73 @@ from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.utils import get_query_service_client
 from tests.sql.utils import compare_query_strings
 from tests.construction.build_v3 import assert_sql_equal
+
+
+def test_cube_partition_output_prefers_exact_unqualified_match():
+    """An exact bare semantic match wins even when a role appears first."""
+    role_column = V3ColumnMetadata(
+        name="date_id_ship",
+        type="int",
+        semantic_name="common.date.date_id[ship_date]",
+        semantic_type="dimension",
+    )
+    exact_column = V3ColumnMetadata(
+        name="date_id",
+        type="int",
+        semantic_name="common.date.date_id",
+        semantic_type="dimension",
+    )
+
+    result = _resolve_cube_partition_output_column(
+        [role_column, exact_column],
+        "common.date.date_id",
+        allow_role_fallback=True,
+    )
+
+    assert result is exact_column
+
+
+def test_cube_partition_output_allows_unique_role_fallback():
+    """A single role match remains valid for legacy bare partitions."""
+    role_column = V3ColumnMetadata(
+        name="date_id_order",
+        type="int",
+        semantic_name="common.date.date_id[order_date]",
+        semantic_type="dimension",
+    )
+
+    result = _resolve_cube_partition_output_column(
+        [role_column],
+        "common.date.date_id",
+        allow_role_fallback=True,
+    )
+
+    assert result is role_column
+
+
+def test_cube_partition_output_rejects_ambiguous_role_fallback():
+    """A bare partition cannot silently choose between multiple roles."""
+    columns = [
+        V3ColumnMetadata(
+            name="date_id_ship",
+            type="int",
+            semantic_name="common.date.date_id[ship_date]",
+            semantic_type="dimension",
+        ),
+        V3ColumnMetadata(
+            name="date_id_order",
+            type="int",
+            semantic_name="common.date.date_id[order_date]",
+            semantic_type="dimension",
+        ),
+    ]
+
+    with pytest.raises(DJInvalidInputException, match="ambiguous"):
+        _resolve_cube_partition_output_column(
+            columns,
+            "common.date.date_id",
+            allow_role_fallback=True,
+        )
 
 
 async def make_a_test_cube(

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -52,6 +52,55 @@ def test_cube_partition_output_prefers_exact_unqualified_match():
     assert result is exact_column
 
 
+def test_cube_partition_output_rejects_duplicate_exact_matches():
+    """Multiple exact semantic matches cannot be resolved deterministically."""
+    columns = [
+        V3ColumnMetadata(
+            name="date_id_two",
+            type="int",
+            semantic_name="common.date.date_id",
+            semantic_type="dimension",
+        ),
+        V3ColumnMetadata(
+            name="date_id_one",
+            type="int",
+            semantic_name="common.date.date_id",
+            semantic_type="dimension",
+        ),
+    ]
+
+    with pytest.raises(
+        DJInvalidInputException,
+        match=(
+            "matches multiple combined query output columns: "
+            r"\['date_id_one', 'date_id_two'\]"
+        ),
+    ):
+        _resolve_cube_partition_output_column(
+            columns,
+            "common.date.date_id",
+            allow_role_fallback=True,
+        )
+
+
+def test_cube_partition_output_disallows_fallback_for_role_qualified_partition():
+    """A role-qualified partition cannot fall back to a different role."""
+    order_date_column = V3ColumnMetadata(
+        name="date_id_order",
+        type="int",
+        semantic_name="common.date.date_id[order_date]",
+        semantic_type="dimension",
+    )
+
+    result = _resolve_cube_partition_output_column(
+        [order_date_column],
+        "common.date.date_id[ship_date]",
+        allow_role_fallback=False,
+    )
+
+    assert result is None
+
+
 def test_cube_partition_output_allows_unique_role_fallback():
     """A single role match remains valid for legacy bare partitions."""
     role_column = V3ColumnMetadata(

--- a/datajunction-server/tests/api/helpers_test.py
+++ b/datajunction-server/tests/api/helpers_test.py
@@ -149,6 +149,47 @@ async def test_find_existing_cube():
 
 
 @pytest.mark.asyncio
+async def test_find_existing_cube_matches_dimension_role():
+    """Legacy cube matching must not satisfy one role with another."""
+    dimension = MagicMock(spec=Column)
+    dimension.name = "date_id"
+    dimension.full_name.return_value = "v3.date.date_id"
+
+    wrong_revision = MagicMock(
+        columns=[Column(name="v3.date.date_id", dimension_column="[ship]")],
+    )
+    right_revision = MagicMock(
+        columns=[Column(name="v3.date.date_id", dimension_column="[order]")],
+    )
+    candidates = [
+        MagicMock(current=wrong_revision),
+        MagicMock(current=right_revision),
+    ]
+    mock_execute = AsyncMock(
+        unique=MagicMock(
+            return_value=MagicMock(
+                scalars=MagicMock(
+                    return_value=MagicMock(
+                        all=MagicMock(return_value=candidates),
+                    ),
+                ),
+            ),
+        ),
+    )
+    mock_session = AsyncMock(execute=AsyncMock(return_value=mock_execute))
+
+    result = await helpers.find_existing_cube(
+        session=mock_session,
+        metric_columns=[],
+        dimension_columns=[dimension],
+        dimension_roles=["[order]"],
+        materialized=False,
+    )
+
+    assert result is right_revision
+
+
+@pytest.mark.asyncio
 @patch("datajunction_server.internal.sql.ColumnMetadata", MagicMock)
 @patch("datajunction_server.internal.sql.validate_cube")
 @patch("datajunction_server.internal.sql.Node.get_by_name")

--- a/datajunction-server/tests/construction/build_v3/cube_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/cube_matcher_test.py
@@ -8,11 +8,14 @@ Uses function-scoped sessions for test isolation.
 """
 
 import time
+from types import SimpleNamespace
 
 import pytest
 
 from datajunction_server.construction.build_v3.builder import build_metrics_sql
 from datajunction_server.construction.build_v3.cube_matcher import (
+    _build_mat_col_lookup,
+    _materialized_dimension_column,
     build_sql_from_cube,
     build_synthetic_grain_group,
     find_matching_cube,
@@ -31,6 +34,50 @@ from datajunction_server.models.decompose import Aggregability
 from datajunction_server.models.dialect import Dialect
 
 from tests.construction.build_v3 import assert_sql_equal
+
+
+def test_materialized_dimension_lookup_preserves_roles():
+    """Two roles with one short name resolve to distinct physical columns."""
+    cube = SimpleNamespace(
+        materializations=[
+            SimpleNamespace(
+                config={
+                    "combiners": [
+                        {
+                            "columns": [
+                                {
+                                    "column": "v3.date.date_id[order]",
+                                    "name": "date_id_order",
+                                },
+                                {
+                                    "column": "v3.date.date_id[ship]",
+                                    "name": "date_id_ship",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ),
+        ],
+    )
+    lookup = _build_mat_col_lookup(cube)
+
+    assert (
+        _materialized_dimension_column(
+            lookup,
+            "v3.date.date_id[order]",
+            "date_id_order_default",
+        )
+        == "date_id_order"
+    )
+    assert (
+        _materialized_dimension_column(
+            lookup,
+            "v3.date.date_id[ship]",
+            "date_id_ship_default",
+        )
+        == "date_id_ship"
+    )
 
 
 class TestExtractFilterDimensionRefs:

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -3044,6 +3044,62 @@ class TestTemporalFilters:
         )
 
     @pytest.mark.asyncio
+    async def test_temporal_filter_uses_partitioned_dimension_role(
+        self,
+        session,
+        client_with_build_v3,
+    ):
+        """A role-qualified cube partition filters through that exact link."""
+        response = await client_with_build_v3.post(
+            "/nodes/v3.order_details/link",
+            json={
+                "dimension_node": "v3.date",
+                "join_type": "left",
+                "join_on": "v3.order_details.customer_id = v3.date.date_id",
+                "role": "ship",
+            },
+        )
+        assert response.status_code in (200, 201), response.json()
+
+        cube_name = "v3.test_role_temporal_cube"
+        response = await client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": cube_name,
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.date.date_id[order]",
+                    "v3.date.date_id[ship]",
+                ],
+                "mode": "published",
+                "description": "Role-aware temporal filter regression",
+            },
+        )
+        assert response.status_code == 201, response.json()
+        response = await client_with_build_v3.post(
+            f"/nodes/{cube_name}/columns/v3.date.date_id[ship]/partition",
+            json={
+                "type_": "temporal",
+                "format": "yyyyMMdd",
+                "granularity": "day",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+        result = await build_measures_sql(
+            session=session,
+            metrics=["v3.total_revenue"],
+            dimensions=[
+                "v3.date.date_id[order]",
+                "v3.date.date_id[ship]",
+            ],
+            include_temporal_filters=True,
+        )
+        sql = result.grain_groups[0].sql
+        assert "customer_id = CAST(DATE_FORMAT" in sql
+        assert "order_date = CAST(DATE_FORMAT" not in sql
+
+    @pytest.mark.asyncio
     async def test_no_temporal_filter_when_disabled(
         self,
         session,

--- a/datajunction-server/tests/dj_mcp/test_tools.py
+++ b/datajunction-server/tests/dj_mcp/test_tools.py
@@ -15,6 +15,7 @@ import pytest
 import pytest_asyncio
 
 from datajunction_server.construction.build_v3.types import GeneratedSQL
+from datajunction_server.database.column import Column
 from datajunction_server.mcp import context, tools
 from datajunction_server.models.dialect import Dialect
 from datajunction_server.models.node_type import NodeType as NodeTypeEnum
@@ -591,7 +592,18 @@ async def test_get_node_details_cube_skips_dimension_lookup(
     current.status = MagicMock(value="valid")
     current.mode = MagicMock(value="published")
     current.query = ""
-    current.columns = []
+    current.columns = [
+        Column(
+            name="n.date.date_id",
+            dimension_column="[order]",
+            type="int",
+        ),
+        Column(
+            name="n.date.date_id",
+            dimension_column="[ship]",
+            type="int",
+        ),
+    ]
     current.parents = []
     current.metric_metadata = None
 
@@ -619,8 +631,10 @@ async def test_get_node_details_cube_skips_dimension_lookup(
     monkeypatch.setattr(tools, "get_dimensions", fake_get_dims)
     monkeypatch.setattr(tools, "get_git_info_for_namespace", fake_get_git)
 
-    await tools.get_node_details("n.cube")
+    output = await tools.get_node_details("n.cube")
     assert get_dims_called == []  # cube branch must not call get_dimensions
+    assert "n.date.date_id[order]" in output
+    assert "n.date.date_id[ship]" in output
 
 
 # ---------------------------------------------------------------------------

--- a/datajunction-server/tests/internal/cube_materializations_test.py
+++ b/datajunction-server/tests/internal/cube_materializations_test.py
@@ -9,8 +9,64 @@ from datajunction_server.construction.build_v3.types import BuildContext, GrainG
 from datajunction_server.internal.cube_materializations import (
     _v3_col_to_model_column,
     _v3_grain_group_to_measures_query,
+    generate_partition_filter_sql,
+)
+from datajunction_server.database.column import Column
+from datajunction_server.database.partition import Partition
+from datajunction_server.internal.materializations import _materialization_name
+from datajunction_server.models.materialization import (
+    MaterializationJobTypeEnum,
+    MaterializationStrategy,
 )
 from datajunction_server.models.node_type import NodeType
+from datajunction_server.models.partition import Granularity
+from datajunction_server.sql.parsing.types import StringType
+
+
+def test_generate_partition_filter_sql_preserves_cube_role():
+    """Incremental cube filters must target the partitioned role."""
+    temporal_partition = SimpleNamespace(
+        cube_element_name="v3.date.date_id[ship]",
+        type="int",
+        partition=SimpleNamespace(granularity=Granularity.DAY),
+    )
+
+    result = generate_partition_filter_sql(temporal_partition, "1 DAY")
+
+    assert result.startswith("v3.date.date_id[ship] = ")
+
+
+def test_materialization_name_preserves_cube_partition_role():
+    """Materializations on two roles must not receive the same name."""
+    temporal_partition = Column(
+        name="v3.date.date_id",
+        dimension_column="[ship]",
+        type="int",
+    )
+    revision = MagicMock(
+        type=NodeType.CUBE,
+    )
+    upsert = SimpleNamespace(
+        job=MaterializationJobTypeEnum.DRUID_CUBE,
+        strategy=MaterializationStrategy.FULL,
+        schedule="@daily",
+    )
+
+    result = _materialization_name(upsert, revision, [temporal_partition], [])
+
+    assert result.endswith("__v3.date.date_id[ship]")
+
+
+def test_categorical_partition_expression_preserves_cube_role():
+    """The runtime partition variable must use the role-qualified identity."""
+    partition = Partition()
+    partition.column = Column(name="v3.date.date_id", type=StringType())
+
+    expression = partition.categorical_expression("v3.date.date_id[ship]")
+
+    assert str(expression) == (
+        "CAST(${v3_DOT_date_DOT_date_id_LBRACK_ship_RBRACK} AS STRING)"
+    )
 
 
 def _make_col(semantic_name, semantic_type="dimension", name="col", type_="str"):

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -48,6 +48,7 @@ from datajunction_server.models.deployment import (
     DimensionReferenceLinkSpec,
 )
 from datajunction_server.models.node import MetricUnit, NodeStatus
+from datajunction_server.models.node_type import NodeType
 from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.user import OAuthProvider, User
 from datajunction_server.database.tag import Tag
@@ -2635,6 +2636,58 @@ class TestGenerateChangelog:
 
         assert changed_fields == []
         assert changelog == ["└─ Updated dimension_links"]
+
+    @pytest.mark.asyncio
+    async def test_cube_column_change_uses_role_qualified_identity(
+        self,
+        session,
+        mock_deployment_context,
+    ):
+        """A property change on one role must compare with that same role."""
+        cube_spec = CubeSpec(
+            name="role_cube",
+            namespace="default",
+            metrics=["default.metric"],
+            dimensions=["default.date.date_id[ship]"],
+            columns=[
+                ColumnSpec(
+                    name="default.date.date_id[ship]",
+                    description="new description",
+                ),
+            ],
+        )
+        existing_column = Column(
+            name="default.date.date_id",
+            dimension_column="[ship]",
+            description="old description",
+        )
+        existing_revision = MagicMock(
+            type=NodeType.CUBE,
+            columns=[existing_column],
+        )
+        existing = MagicMock(current=existing_revision)
+        existing.to_spec = AsyncMock(return_value=cube_spec)
+
+        orchestrator = DeploymentOrchestrator(
+            deployment_spec=DeploymentSpec(namespace="default", nodes=[]),
+            deployment_id="role-changelog-test",
+            session=session,
+            context=mock_deployment_context,
+            dry_run=True,
+        )
+        orchestrator.registry.nodes["default.role_cube"] = existing
+        result = NodeValidationResult(
+            spec=cube_spec,
+            status=NodeStatus.VALID,
+            inferred_columns=cube_spec.rendered_columns,
+            errors=[],
+            dependencies=[],
+        )
+
+        changelog, changed_fields = await orchestrator._generate_changelog(result)
+
+        assert changed_fields == []
+        assert changelog == ["└─ Set properties for 1 columns"]
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/internal/nodes/get_node_column_test.py
+++ b/datajunction-server/tests/internal/nodes/get_node_column_test.py
@@ -14,11 +14,16 @@ from datajunction_server.errors import (
     DJInvalidInputException,
 )
 from datajunction_server.internal.nodes import get_node_column
+from datajunction_server.models.node_type import NodeType
 
 
 def _make_node(name: str, columns):
     """Lightweight stand-in exposing the attributes ``get_node_column`` reads."""
-    return SimpleNamespace(name=name, current=SimpleNamespace(columns=columns))
+    return SimpleNamespace(
+        name=name,
+        type=NodeType.CUBE,
+        current=SimpleNamespace(columns=columns),
+    )
 
 
 def _role_playing_node():

--- a/datajunction-server/tests/models/cube_materialization_test.py
+++ b/datajunction-server/tests/models/cube_materialization_test.py
@@ -5,6 +5,8 @@ from unittest.mock import Mock
 
 import pytest
 
+from datajunction_server.database.column import Column
+from datajunction_server.database.partition import Partition
 from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.materialization.jobs.cube_materialization import (
     DruidCubeMaterializationJob,
@@ -18,13 +20,23 @@ from datajunction_server.models.cube_materialization import (
 )
 from datajunction_server.models.materialization import MaterializationStrategy
 from datajunction_server.models.node_type import NodeNameVersion
-from datajunction_server.models.partition import Granularity
+from datajunction_server.models.partition import Granularity, PartitionType
 from datajunction_server.models.decompose import (
     AggregationRule,
     Aggregability,
     MetricComponent,
 )
 from datajunction_server.models.query import ColumnMetadata
+
+
+def _temporal_partition(name: str, dimension_column: str | None) -> Column:
+    column = Column(name=name, dimension_column=dimension_column)
+    column.partition = Partition(
+        type_=PartitionType.TEMPORAL,
+        format="yyyyMMdd",
+        granularity=Granularity.DAY,
+    )
+    return column
 
 
 def test_druid_cube_materialization_job_passes_lookback_window():
@@ -296,12 +308,9 @@ class TestFromMeasuresQueryRoleResolution:
     def test_role_qualified_partition_resolves(self, measures_query):
         """Cube column with ``dimension_column='[reporting_date]'`` must
         match the role-qualified ``semantic_entity`` in the measures query."""
-        # Mimics a database Column for a role-qualified temporal partition.
-        # Cube columns store the role separately in ``dimension_column``.
-        temporal_partition = SimpleNamespace(
-            name="default.date.dateint",
-            dimension_column="[reporting_date]",
-            partition=SimpleNamespace(format="yyyyMMdd", granularity=Granularity.DAY),
+        temporal_partition = _temporal_partition(
+            "default.date.dateint",
+            "[reporting_date]",
         )
 
         result = MeasuresMaterialization.from_measures_query(
@@ -316,11 +325,7 @@ class TestFromMeasuresQueryRoleResolution:
     def test_unqualified_partition_still_resolves(self, measures_query):
         """A cube without a role on its temporal partition must still match."""
         measures_query.columns[0].semantic_entity = "default.date.dateint"
-        temporal_partition = SimpleNamespace(
-            name="default.date.dateint",
-            dimension_column=None,
-            partition=SimpleNamespace(format="yyyyMMdd", granularity=Granularity.DAY),
-        )
+        temporal_partition = _temporal_partition("default.date.dateint", None)
 
         result = MeasuresMaterialization.from_measures_query(
             measures_query,
@@ -332,11 +337,7 @@ class TestFromMeasuresQueryRoleResolution:
     def test_missing_partition_raises_clear_error(self, measures_query):
         """If no measures column matches the partition, raise a clear error
         instead of an opaque ``IndexError``."""
-        temporal_partition = SimpleNamespace(
-            name="default.unrelated.column",
-            dimension_column=None,
-            partition=SimpleNamespace(format="yyyyMMdd", granularity=Granularity.DAY),
-        )
+        temporal_partition = _temporal_partition("default.unrelated.column", None)
 
         with pytest.raises(DJInvalidInputException, match="Could not find timestamp"):
             MeasuresMaterialization.from_measures_query(

--- a/datajunction-ui/src/app/pages/NodePage/AddBackfillPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/AddBackfillPopover.jsx
@@ -5,6 +5,7 @@ import { Field, Form, Formik } from 'formik';
 import { displayMessageAfterSubmit } from '../../../utils/form';
 import PartitionValueForm from './PartitionValueForm';
 import LoadingIcon from '../../icons/LoadingIcon';
+import { getColumnIdentifier } from '../../utils/column';
 
 export default function AddBackfillPopover({
   node,
@@ -35,13 +36,14 @@ export default function AddBackfillPopover({
   };
 
   for (const partitionCol of partitionColumns) {
+    const columnIdentifier = getColumnIdentifier(node, partitionCol);
     if (partitionCol.partition.type_ === 'temporal') {
-      initialValues.partitionValues[partitionCol.name] = {
+      initialValues.partitionValues[columnIdentifier] = {
         from: '',
         to: '',
       };
     } else {
-      initialValues.partitionValues[partitionCol.name] = '';
+      initialValues.partitionValues[columnIdentifier] = '';
     }
   }
 
@@ -144,11 +146,12 @@ export default function AddBackfillPopover({
                 {node.columns
                   .filter(col => col.partition !== null)
                   .map(col => {
+                    const columnIdentifier = getColumnIdentifier(node, col);
                     return (
                       <PartitionValueForm
                         col={col}
-                        materialization={materialization}
-                        key={col.name}
+                        columnIdentifier={columnIdentifier}
+                        key={columnIdentifier}
                       />
                     );
                   })}

--- a/datajunction-ui/src/app/pages/NodePage/EditColumnDescriptionPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/EditColumnDescriptionPopover.jsx
@@ -4,6 +4,7 @@ import DJClientContext from '../../providers/djclient';
 import { Form, Formik } from 'formik';
 import EditIcon from '../../icons/EditIcon';
 import { displayMessageAfterSubmit } from '../../../utils/form';
+import { getColumnIdentifier } from '../../utils/column';
 
 export default function EditColumnDescriptionPopover({
   column,
@@ -11,6 +12,7 @@ export default function EditColumnDescriptionPopover({
   onSubmit,
 }) {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
+  const columnIdentifier = getColumnIdentifier(node, column);
   const [popoverAnchor, setPopoverAnchor] = useState(false);
   const ref = useRef(null);
 
@@ -67,7 +69,7 @@ export default function EditColumnDescriptionPopover({
       >
         <Formik
           initialValues={{
-            column: column.name,
+            column: columnIdentifier,
             node: node.name,
             description: column.description || '',
           }}
@@ -90,7 +92,7 @@ export default function EditColumnDescriptionPopover({
                 <input
                   hidden={true}
                   name="column"
-                  value={column.name}
+                  value={columnIdentifier}
                   readOnly={true}
                 />
                 <input

--- a/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
@@ -8,6 +8,7 @@ import { labelize } from '../../../utils/form';
 import PartitionColumnPopover from './PartitionColumnPopover';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import foundation from 'react-syntax-highlighter/dist/esm/styles/hljs/foundation';
+import { getColumnIdentifier } from '../../utils/column';
 
 export default function NodeColumnTab({ node, djClient, readOnly = false }) {
   const [attributes, setAttributes] = useState([]);
@@ -50,10 +51,11 @@ export default function NodeColumnTab({ node, djClient, readOnly = false }) {
   }, [djClient]);
 
   const showColumnAttributes = col => {
+    const columnIdentifier = getColumnIdentifier(node, col);
     return col.attributes.map((attr, idx) => (
       <span
         className="node_type__dimension badge node_type"
-        key={`col-attr-${col.name}-${idx}`}
+        key={`col-attr-${columnIdentifier}-${idx}`}
       >
         {attr.attribute_type.name.replace(/_/, ' ')}
       </span>
@@ -133,6 +135,7 @@ export default function NodeColumnTab({ node, djClient, readOnly = false }) {
 
   const columnList = columns => {
     return columns?.map(col => {
+      const columnIdentifier = getColumnIdentifier(node, col);
       // FK Links: Only show links that specifically reference THIS column's foreign keys
       // Filter out complex dimension links that may join on multiple columns
       const fkLinksForColumn = (
@@ -155,14 +158,14 @@ export default function NodeColumnTab({ node, djClient, readOnly = false }) {
           }
         : null;
       return (
-        <tr key={col.name} className="column-row">
+        <tr key={columnIdentifier} className="column-row">
           <td
             className="text-start"
             role="columnheader"
             aria-label="ColumnName"
             aria-hidden="false"
           >
-            {col.name}
+            {columnIdentifier}
           </td>
           <td>
             <span

--- a/datajunction-ui/src/app/pages/NodePage/NodeGraphTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeGraphTab.jsx
@@ -5,6 +5,7 @@ import '../../../styles/dag.css';
 import 'reactflow/dist/style.css';
 import DJClientContext from '../../providers/djclient';
 import LayoutFlow from '../../components/djgraph/LayoutFlow';
+import { getColumnIdentifier } from '../../utils/column';
 
 const NodeGraphTab = djNode => {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
@@ -23,7 +24,7 @@ const NodeGraphTab = djNode => {
     const column_names = node.columns
       .map(col => {
         return {
-          name: col.name,
+          name: getColumnIdentifier(node, col),
           type: col.type,
           dimension: col.dimension !== null ? col.dimension.name : null,
           order: primary_key.includes(col.name)

--- a/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
@@ -9,6 +9,10 @@ import Tab from '../../components/Tab';
 import NodeRevisionMaterializationTab from './NodeRevisionMaterializationTab';
 import AvailabilityStateBlock from './AvailabilityStateBlock';
 import cronstrue from 'cronstrue';
+import {
+  decodeColumnIdentifier,
+  getColumnIdentifier,
+} from '../../utils/column';
 
 /**
  * Cube materialization tab - shows cube-specific materializations.
@@ -109,7 +113,7 @@ export default function NodeMaterializationTab({
     ? Object.fromEntries(
         node?.columns
           .filter(col => col.partition !== null)
-          .map(col => [col.name, col.display_name]),
+          .map(col => [getColumnIdentifier(node, col), col.display_name]),
       )
     : {};
   const cron = materialization => {
@@ -440,9 +444,8 @@ export default function NodeMaterializationTab({
                                     <div>
                                       {
                                         partitionColumnsMap[
-                                          partition.column_name.replaceAll(
-                                            '_DOT_',
-                                            '.',
+                                          decodeColumnIdentifier(
+                                            partition.column_name,
                                           )
                                         ]
                                       }{' '}
@@ -474,7 +477,7 @@ export default function NodeMaterializationTab({
                     .filter(col => col.partition !== null)
                     .map(column => {
                       return (
-                        <li key={column.name}>
+                        <li key={getColumnIdentifier(node, column)}>
                           <div className="partitionLink">
                             {column.display_name}
                             <span className="badge partition_value">

--- a/datajunction-ui/src/app/pages/NodePage/PartitionColumnPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/PartitionColumnPopover.jsx
@@ -4,9 +4,11 @@ import DJClientContext from '../../providers/djclient';
 import { Field, Form, Formik } from 'formik';
 import EditIcon from '../../icons/EditIcon';
 import { displayMessageAfterSubmit } from '../../../utils/form';
+import { getColumnIdentifier } from '../../utils/column';
 
 export default function PartitionColumnPopover({ column, node, onSubmit }) {
   const djClient = useContext(DJClientContext).DataJunctionAPI;
+  const columnIdentifier = getColumnIdentifier(node, column);
   const [popoverAnchor, setPopoverAnchor] = useState(false);
   const ref = useRef(null);
 
@@ -45,7 +47,10 @@ export default function PartitionColumnPopover({ column, node, onSubmit }) {
   };
 
   const removePartition = async setStatus => {
-    const response = await djClient.removePartition(node.name, column.name);
+    const response = await djClient.removePartition(
+      node.name,
+      columnIdentifier,
+    );
     if (response.status === 200 || response.status === 201) {
       setStatus({ success: 'Partition removed' });
       onSubmit();
@@ -76,7 +81,7 @@ export default function PartitionColumnPopover({ column, node, onSubmit }) {
       >
         <Formik
           initialValues={{
-            column: column.name,
+            column: columnIdentifier,
             node: node.name,
             partition_type: column.partition?.type_ ?? '',
             format: column.partition?.format ?? 'yyyyMMdd',
@@ -90,7 +95,7 @@ export default function PartitionColumnPopover({ column, node, onSubmit }) {
                 <div className="popover-header">
                   <div className="popover-title">Partition column</div>
                   <div className="popover-subtitle">
-                    {popoverAnchor ? column.name : null}
+                    {popoverAnchor ? columnIdentifier : null}
                   </div>
                 </div>
                 {displayMessageAfterSubmit(status)}
@@ -110,7 +115,7 @@ export default function PartitionColumnPopover({ column, node, onSubmit }) {
                 <input
                   hidden={true}
                   name="column"
-                  value={column.name}
+                  value={columnIdentifier}
                   readOnly={true}
                 />
                 <input

--- a/datajunction-ui/src/app/pages/NodePage/PartitionValueForm.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/PartitionValueForm.jsx
@@ -1,22 +1,18 @@
 import * as React from 'react';
 import { Field } from 'formik';
 
-export default function PartitionValueForm({ col, materialization }) {
+export default function PartitionValueForm({ col, columnIdentifier }) {
   if (col.partition.type_ === 'temporal') {
     return (
       <>
-        <div
-          className="partition__full"
-          key={col.name}
-          style={{ width: '50%' }}
-        >
+        <div className="partition__full" style={{ width: '50%' }}>
           <div className="partition__header">{col.display_name}</div>
           <div className="partition__body">
             <span style={{ padding: '0.5rem' }}>From</span>{' '}
             <Field
               type="text"
-              name={`partitionValues.['${col.name}'].from`}
-              id={`${col.name}.from`}
+              name={`partitionValues.['${columnIdentifier}'].from`}
+              id={`${columnIdentifier}.from`}
               placeholder="20230101"
               default="20230101"
               style={{ width: '7rem', paddingRight: '1rem' }}
@@ -24,8 +20,8 @@ export default function PartitionValueForm({ col, materialization }) {
             <span style={{ padding: '0.5rem' }}>To</span>
             <Field
               type="text"
-              name={`partitionValues.['${col.name}'].to`}
-              id={`${col.name}.to`}
+              name={`partitionValues.['${columnIdentifier}'].to`}
+              id={`${columnIdentifier}.to`}
               placeholder="20230102"
               default="20230102"
               style={{ width: '7rem' }}
@@ -37,17 +33,13 @@ export default function PartitionValueForm({ col, materialization }) {
   } else {
     return (
       <>
-        <div
-          className="partition__full"
-          key={col.name}
-          style={{ width: '50%' }}
-        >
+        <div className="partition__full" style={{ width: '50%' }}>
           <div className="partition__header">{col.display_name}</div>
           <div className="partition__body">
             <Field
               type="text"
-              name={`partitionValues.['${col.name}']`}
-              id={col.name}
+              name={`partitionValues.['${columnIdentifier}']`}
+              id={columnIdentifier}
               placeholder=""
               default=""
               style={{ width: '7rem', paddingRight: '1rem' }}

--- a/datajunction-ui/src/app/pages/NodePage/RevisionDiff.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/RevisionDiff.jsx
@@ -11,6 +11,7 @@ import DiffIcon from '../../icons/DiffIcon';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import foundation from 'react-syntax-highlighter/dist/esm/styles/hljs/foundation';
 import sql from 'react-syntax-highlighter/dist/cjs/languages/hljs/sql';
+import { getColumnIdentifier } from '../../utils/column';
 
 SyntaxHighlighter.registerLanguage('sql', sql);
 foundation.hljs['padding'] = '2rem';
@@ -63,12 +64,16 @@ export default function RevisionDiff() {
             diffLines(
               older
                 ? key === 'columns'
-                  ? older[key].map(col => col.name).join('\n')
+                  ? older[key]
+                      .map(col => getColumnIdentifier(older, col))
+                      .join('\n')
                   : older[key].toString()
                 : '',
               newer
                 ? key === 'columns'
-                  ? newer[key].map(col => col.name).join('\n')
+                  ? newer[key]
+                      .map(col => getColumnIdentifier(newer, col))
+                      .join('\n')
                   : newer[key].toString()
                 : '',
             ),
@@ -185,10 +190,12 @@ export default function RevisionDiff() {
                       ) : field === 'columns' ? (
                         <div>
                           {prevRevision[0][field].map(col => (
-                            <>
-                              {col.name}
+                            <React.Fragment
+                              key={getColumnIdentifier(prevRevision[0], col)}
+                            >
+                              {getColumnIdentifier(prevRevision[0], col)}
                               <br />
-                            </>
+                            </React.Fragment>
                           ))}
                         </div>
                       ) : (

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/AddBackfillPopover.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/AddBackfillPopover.test.jsx
@@ -53,4 +53,51 @@ describe('<AddBackfillPopover />', () => {
       expect(getByText('Saved!')).toBeInTheDocument();
     });
   });
+
+  it('keeps role-played cube partitions distinct', async () => {
+    mockDjClient.DataJunctionAPI.runBackfill.mockReturnValue({
+      status: 201,
+      json: { message: '' },
+    });
+    const node = {
+      name: 'v3.role_cube',
+      type: 'cube',
+      columns: ['order', 'ship'].map(role => ({
+        name: 'v3.date.date_id',
+        dimension_column: `[${role}]`,
+        display_name: `${role} date`,
+        partition: {
+          type_: 'temporal',
+        },
+      })),
+    };
+
+    const { getByLabelText, getByText } = render(
+      <DJClientContext.Provider value={mockDjClient}>
+        <AddBackfillPopover
+          node={node}
+          materialization={{ name: 'role_cube_mat' }}
+          onSubmit={vi.fn()}
+        />
+      </DJClientContext.Provider>,
+    );
+
+    fireEvent.click(getByLabelText('AddBackfill'));
+    fireEvent.click(getByText('Save'));
+
+    await waitFor(() => {
+      expect(mockDjClient.DataJunctionAPI.runBackfill).toHaveBeenCalledWith(
+        'v3.role_cube',
+        'role_cube_mat',
+        expect.arrayContaining([
+          expect.objectContaining({
+            columnName: 'v3.date.date_id[order]',
+          }),
+          expect.objectContaining({
+            columnName: 'v3.date.date_id[ship]',
+          }),
+        ]),
+      );
+    });
+  });
 });

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/EditColumnDescriptionPopover.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/EditColumnDescriptionPopover.test.jsx
@@ -146,4 +146,47 @@ describe('<EditColumnDescriptionPopover />', () => {
     const descriptionTextarea = within(dialog).getByRole('textbox');
     expect(descriptionTextarea.value).toBe('');
   });
+
+  it('submits a role-qualified cube column', async () => {
+    const column = {
+      name: 'v3.date.date_id',
+      dimension_column: '[ship]',
+      description: '',
+    };
+    const node = {
+      name: 'v3.role_cube',
+      type: 'cube',
+    };
+    mockDjClient.DataJunctionAPI.setColumnDescription.mockReturnValue({
+      status: 200,
+      json: { message: 'Description updated successfully' },
+    });
+
+    render(
+      <DJClientContext.Provider value={mockDjClient}>
+        <EditColumnDescriptionPopover
+          column={column}
+          node={node}
+          onSubmit={vi.fn()}
+        />
+      </DJClientContext.Provider>,
+    );
+
+    fireEvent.click(screen.getByLabelText('EditColumnDescription'));
+    const dialog = screen.getByRole('dialog', { name: /edit-description/i });
+    fireEvent.change(within(dialog).getByRole('textbox'), {
+      target: { value: 'Ship date' },
+    });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(
+        mockDjClient.DataJunctionAPI.setColumnDescription,
+      ).toHaveBeenCalledWith(
+        'v3.role_cube',
+        'v3.date.date_id[ship]',
+        'Ship date',
+      );
+    });
+  });
 });

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/PartitionColumnPopover.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/PartitionColumnPopover.test.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import DJClientContext from '../../../providers/djclient';
+import PartitionColumnPopover from '../PartitionColumnPopover';
+
+describe('<PartitionColumnPopover />', () => {
+  it('submits a role-qualified cube column', async () => {
+    const setPartition = vi.fn().mockReturnValue({ status: 201, json: {} });
+    const context = {
+      DataJunctionAPI: {
+        setPartition,
+        removePartition: vi.fn(),
+      },
+    };
+    const column = {
+      name: 'v3.date.date_id',
+      dimension_column: '[ship]',
+      partition: null,
+    };
+    const node = { name: 'v3.role_cube', type: 'cube' };
+
+    render(
+      <DJClientContext.Provider value={context}>
+        <PartitionColumnPopover
+          column={column}
+          node={node}
+          onSubmit={vi.fn()}
+        />
+      </DJClientContext.Provider>,
+    );
+
+    fireEvent.click(screen.getByLabelText('PartitionColumn'));
+    fireEvent.change(screen.getByLabelText('Partition Type'), {
+      target: { value: 'temporal' },
+    });
+    fireEvent.click(screen.getByLabelText('SaveEditColumn'));
+
+    await waitFor(() => {
+      expect(setPartition).toHaveBeenCalledWith(
+        'v3.role_cube',
+        'v3.date.date_id[ship]',
+        'temporal',
+        'yyyyMMdd',
+        'day',
+      );
+    });
+  });
+});

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -1,3 +1,5 @@
+import { getColumnIdentifier } from '../utils/column';
+
 // Note: MarkerType.Arrow is just the string "arrow" - we use the literal
 // to avoid importing reactflow in this service (which would bloat the main bundle)
 const MARKER_TYPE_ARROW = 'arrow';
@@ -1709,7 +1711,7 @@ export const DataJunctionAPI = {
         )
         .map(col => col.name);
       const column_names = node.columns.map(col => {
-        return { name: col.name, type: col.type };
+        return { name: getColumnIdentifier(node, col), type: col.type };
       });
       return {
         id: String(node.name),

--- a/datajunction-ui/src/app/utils/__tests__/column.test.js
+++ b/datajunction-ui/src/app/utils/__tests__/column.test.js
@@ -1,0 +1,27 @@
+import { decodeColumnIdentifier, getColumnIdentifier } from '../column';
+
+describe('getColumnIdentifier', () => {
+  it('includes the role for cube columns', () => {
+    expect(
+      getColumnIdentifier(
+        { type: 'cube' },
+        { name: 'v3.date.date_id', dimension_column: '[ship]' },
+      ),
+    ).toBe('v3.date.date_id[ship]');
+  });
+
+  it('does not treat a non-cube reference link as a role', () => {
+    expect(
+      getColumnIdentifier(
+        { type: 'transform' },
+        { name: 'ship_date_id', dimension_column: 'date_id' },
+      ),
+    ).toBe('ship_date_id');
+  });
+
+  it('decodes a role-qualified backfill column', () => {
+    expect(
+      decodeColumnIdentifier('v3_DOT_date_DOT_date_id_LBRACK_ship_RBRACK'),
+    ).toBe('v3.date.date_id[ship]');
+  });
+});

--- a/datajunction-ui/src/app/utils/column.js
+++ b/datajunction-ui/src/app/utils/column.js
@@ -1,0 +1,15 @@
+export const getColumnIdentifier = (node, column) => {
+  if (node?.type === 'cube') {
+    return `${column.name}${column.dimension_column || ''}`;
+  }
+  return column.name;
+};
+
+export const decodeColumnIdentifier = identifier =>
+  identifier
+    .replaceAll('_DOT_', '.')
+    .replaceAll('_DOT', '.')
+    .replaceAll('_LBRACK_', '[')
+    .replaceAll('_LBRACK', '[')
+    .replaceAll('_RBRACK_', ']')
+    .replaceAll('_RBRACK', ']');


### PR DESCRIPTION
### Summary
Cubes can use the same business dimension in multiple roles. For example, one cube may contain both an order date and a ship date, even though both come from the same underlying date table.

Some DataJunction code paths currently identify these columns only as “date,” losing the role that distinguishes them. This can cause settings intended for one role to be applied to another, columns to disappear from output, or materializations to use the wrong partition. Because these failures can occur silently, they create a data-correctness and operational risk.

This pr hardens the full cube lifecycle so each role remains distinct across:
- Cube creation and updates
- Declarative deployment and export
- API and GraphQL responses
- SQL generation and cube matching
- Materialization, partitioning, and backfills
- Python clients, CLI, MCP, and the DataJunction UI

#### Expected outcome
An order-date column and a ship-date column will remain independently identifiable and configurable throughout DJ. Ambiguous requests will fail with a clear error instead of silently selecting a column.

#### Success criteria
- Role-specific column settings are applied to the intended column
- Cube updates and deployments preserve roles and partitions
- Materializations use the correct role-specific partition
- APIs, clients, and UI display all roles without collapsing them

Automated tests cover creation, updates, deployment, materialization, and user-facing workflows.