### PR TITLE
Pre-agg routing tests, plus a small refactor of the role helpers

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -1824,11 +1824,11 @@ def build_grain_group_from_preagg(
         # Physical column read from the table, remapped via dimension_columns if
         # present. Independent of the output alias above.
         physical_col = get_preagg_dimension_column(
+            ctx,
+            preagg.node_revision_id,
             preagg,
             dim.original_ref,
             dim.column_name,
-            ctx=ctx,
-            node_rev_id=preagg.node_revision_id,
         )
         group_by_cols.append(physical_col)
         ref_to_physical[dim.original_ref] = physical_col

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.database.preaggregation import (
     PreAggregation,
     compute_expression_hash,
@@ -68,9 +69,15 @@ def canonical_dimension_ref(
     dimension and no role-free link does -- mirroring how the reference resolves,
     which prefers the role-free link. Anything else is returned unchanged.
     """
-    if "[" in ref:
+    try:
+        dim_ref = parse_dimension_ref(ref)
+    except DJInvalidInputException:
+        # Not a node.column reference, so there is no dimension node to look up
+        # roles for. Compared as-is rather than failing the whole build.
         return ref
-    roles = roles_reaching_dimension(ctx, node_rev_id, ref.rsplit(SEPARATOR, 1)[0])
+    if dim_ref.role:
+        return ref
+    roles = roles_reaching_dimension(ctx, node_rev_id, dim_ref.node_name)
     if "" in roles or len(roles) != 1:
         return ref
     return f"{ref}[{roles.pop()}]"
@@ -226,29 +233,27 @@ def get_preagg_measure_column(
 
 
 def get_preagg_dimension_column(
+    ctx: "BuildContext",
+    node_rev_id: int,
     preagg: PreAggregation,
     dimension_ref: str,
     default_column: str,
-    ctx: BuildContext | None = None,
-    node_rev_id: int | None = None,
 ) -> str:
     """
     Physical column in the pre-agg backing a resolved grain dimension.
 
     External pre-aggs may store a dimension under a different column name (kept as
-    source_column). Matched by dimension reference, canonicalized so a bare and a
+    source_column). Matched by canonical dimension reference, so a bare and a
     role-qualified spelling of the same dimension still match, falling back to the
     DJ column name.
     """
-
-    def canon(ref: str) -> str:
-        if ctx is None or node_rev_id is None:
-            return ref
-        return canonical_dimension_ref(ctx, node_rev_id, ref)
-
-    target = canon(dimension_ref)
+    target = canonical_dimension_ref(ctx, node_rev_id, dimension_ref)
     for col in preagg.columns or []:
-        if col.semantic_type == "dimension" and canon(col.semantic_name) == target:
+        if col.semantic_type == "dimension" and target == canonical_dimension_ref(
+            ctx,
+            node_rev_id,
+            col.semantic_name,
+        ):
             return col.source_column or col.name
     return default_column
 

--- a/datajunction-server/datajunction_server/internal/preaggregations.py
+++ b/datajunction-server/datajunction_server/internal/preaggregations.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import selectinload
 from datajunction_server.api.helpers import get_catalog_by_name
 from datajunction_server.construction.build_v3.builder import build_measures_sql
 from datajunction_server.construction.build_v3.dimensions import (
+    parse_dimension_ref,
     roles_reaching_dimension,
 )
 from datajunction_server.construction.build_v3.types import GeneratedMeasuresSQL
@@ -30,7 +31,6 @@ from datajunction_server.database.preaggregation import (
 )
 from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models.decompose import PreAggMeasure
-from datajunction_server.naming import SEPARATOR
 from datajunction_server.models.dialect import Dialect
 from datajunction_server.models.materialization import MaterializationStrategy
 from datajunction_server.models.node_type import NodeType
@@ -91,9 +91,9 @@ def assert_dimension_refs_are_role_qualified(
     resolved to whichever path happens to sort first.
     """
     for ref in dimensions:
-        if "[" in ref:
+        dim_ref = parse_dimension_ref(ref)
+        if dim_ref.role:
             continue
-        dim_node_name = ref.rsplit(SEPARATOR, 1)[0]
         roles: set[str] = set()
         for grain_group in measures_result.grain_groups:
             parent_node = measures_result.ctx.nodes.get(grain_group.parent_name)
@@ -102,7 +102,7 @@ def assert_dimension_refs_are_role_qualified(
             roles |= roles_reaching_dimension(
                 measures_result.ctx,
                 parent_node.current.id,
-                dim_node_name,
+                dim_ref.node_name,
             )
         named = sorted(role for role in roles if role)
         if "" not in roles and len(named) > 1:

--- a/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
@@ -84,18 +84,34 @@ def test_get_preagg_dimension_column():
             ),
         ],
     )
+    ctx = BuildContext(session=None, metrics=[], dimensions=[])
     # Mapped dimension -> its physical source column.
     assert (
-        get_preagg_dimension_column(preagg, "v3.order_details.status", "status")
+        get_preagg_dimension_column(
+            ctx,
+            1,
+            preagg,
+            "v3.order_details.status",
+            "status",
+        )
         == "order_status"
     )
     # A dimension not in the pre-agg's columns falls back to the DJ column name.
     assert (
-        get_preagg_dimension_column(preagg, "v3.order_details.other", "other")
+        get_preagg_dimension_column(ctx, 1, preagg, "v3.order_details.other", "other")
         == "other"
     )
     # No columns at all also falls back.
-    assert get_preagg_dimension_column(PreAggregation(columns=None), "x", "y") == "y"
+    assert (
+        get_preagg_dimension_column(
+            ctx,
+            1,
+            PreAggregation(columns=None),
+            "v3.order_details.status",
+            "status",
+        )
+        == "status"
+    )
 
 
 @pytest_asyncio.fixture

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -1573,6 +1573,507 @@ class TestExternalPreAggRouting:
             """,
         )
 
+    @pytest.mark.asyncio
+    async def test_external_preagg_filter_only_dimension_selects_finer_agg(
+        self,
+        client_with_build_v3,
+    ):
+        """A filter-only dimension is part of the coverage requirement: with a
+        coarse and a fine pre-agg both covering the projected grain, the finer one
+        wins because only it carries the filtered dimension. Ignoring filters when
+        ranking candidates picked the coarse agg and dropped the predicate."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "rev_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            table_columns={"status": "string", "rev_sum": "double"},
+        )
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status", "v3.product.category"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "rev_by_status_cat",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            table_columns={
+                "status": "string",
+                "category": "string",
+                "rev_sum": "double",
+            },
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_details.status"],
+            "filters": ["v3.product.category = 'Electronics'"],
+        }
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params=params,
+        )
+        assert measures_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(measures_response.json())["sql"],
+            """
+            SELECT status, category, SUM(rev_sum) rev_sum
+            FROM default.analytics.rev_by_status_cat
+            WHERE category = 'Electronics'
+            GROUP BY status, category
+            """,
+        )
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params=params,
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT status, category, SUM(rev_sum) rev_sum
+                FROM default.analytics.rev_by_status_cat
+                WHERE category = 'Electronics'
+                GROUP BY status, category
+            )
+            SELECT order_details_0.status AS status,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_filter_pushdown_uses_mapped_column(
+        self,
+        client_with_build_v3,
+    ):
+        """A pushed-down predicate on a locally-owned dimension is rewritten to the
+        pre-agg's mapped physical column (``st``), not the DJ column name -- which
+        would reference a column the external table does not have."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status", "v3.product.category"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "rev_st_cat",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.order_details.status": "st"},
+            table_columns={"st": "string", "category": "string", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.product.category"],
+            "filters": ["v3.order_details.status = 'completed'"],
+        }
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params=params,
+        )
+        assert measures_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(measures_response.json())["sql"],
+            """
+            SELECT category, st status, SUM(rev_sum) rev_sum
+            FROM default.analytics.rev_st_cat
+            WHERE st = 'completed'
+            GROUP BY category, st
+            """,
+        )
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params=params,
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT category, st status, SUM(rev_sum) rev_sum
+                FROM default.analytics.rev_st_cat
+                WHERE st = 'completed'
+                GROUP BY category, st
+            )
+            SELECT order_details_0.category AS category,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.category
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_dimension_mapping_is_per_agg(
+        self,
+        client_with_build_v3,
+    ):
+        """Column mappings are scoped to the pre-agg that declares them: the same
+        dimension reads ``order_status`` from one table and ``status`` from
+        another, depending on which agg the metric routes to."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "rev_by_st",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.order_details.status": "order_status"},
+            table_columns={"order_status": "string", "rev_sum": "double"},
+        )
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_quantity"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "qty_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_quantity": "qty_sum"},
+            table_columns={"status": "string", "qty_sum": "double"},
+        )
+        revenue_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert revenue_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(revenue_response.json())["sql"],
+            """
+            SELECT order_status status, SUM(rev_sum) rev_sum
+            FROM default.analytics.rev_by_st
+            GROUP BY order_status
+            """,
+        )
+        quantity_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_quantity"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert quantity_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(quantity_response.json())["sql"],
+            """
+            SELECT status, SUM(qty_sum) qty_sum
+            FROM default.analytics.qty_by_status
+            GROUP BY status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_metric_filter_becomes_having(
+        self,
+        client_with_build_v3,
+    ):
+        """A metric-valued filter becomes a HAVING over the merge expression on the
+        pre-agg column, not over the base-fact expression (which the CTE no longer
+        exposes)."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "rev_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            table_columns={"status": "string", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_details.status"],
+            "filters": ["v3.total_revenue > 100"],
+        }
+        # The metric filter does not leak into the pre-agg scan.
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params=params,
+        )
+        assert measures_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(measures_response.json())["sql"],
+            """
+            SELECT status, SUM(rev_sum) rev_sum
+            FROM default.analytics.rev_by_status
+            GROUP BY status
+            """,
+        )
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params=params,
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT status, SUM(rev_sum) rev_sum
+                FROM default.analytics.rev_by_status
+                GROUP BY status
+            )
+            SELECT order_details_0.status AS status,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.status
+            HAVING SUM(order_details_0.rev_sum) > 100
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_order_by_metric_with_limit(
+        self,
+        client_with_build_v3,
+    ):
+        """ORDER BY on a metric plus LIMIT apply to the outer query only; neither
+        leaks into the pre-agg CTE, which would truncate rows before the roll-up."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "rev_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            table_columns={"status": "string", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_details.status"],
+            "orderby": ["v3.total_revenue DESC"],
+            "limit": 10,
+        }
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params=params,
+        )
+        assert measures_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(measures_response.json())["sql"],
+            """
+            SELECT status, SUM(rev_sum) rev_sum
+            FROM default.analytics.rev_by_status
+            GROUP BY status
+            """,
+        )
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params=params,
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT status, SUM(rev_sum) rev_sum
+                FROM default.analytics.rev_by_status
+                GROUP BY status
+            )
+            SELECT order_details_0.status AS status,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.status
+            ORDER BY total_revenue DESC
+            LIMIT 10
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_degenerate_grains(self, client_with_build_v3):
+        """Degenerate grains: an empty-grain pre-agg answers a no-dimension query
+        with a GROUP BY-less scan, and a subset grain that drops the agg's leading
+        key still rolls up (on the mapped column)."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=[],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "rev_total",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            table_columns={"rev_sum": "double"},
+        )
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status", "v3.product.category"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "rev_st_cat",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.product.category": "cat"},
+            table_columns={"status": "string", "cat": "string", "rev_sum": "double"},
+        )
+        # (a) No dimensions at all -> the empty-grain agg, scanned without GROUP BY.
+        no_dims = {"metrics": ["v3.total_revenue"]}
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params=no_dims,
+        )
+        assert measures_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(measures_response.json())["sql"],
+            """
+            SELECT SUM(rev_sum) rev_sum
+            FROM default.analytics.rev_total
+            """,
+        )
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params=no_dims,
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT SUM(rev_sum) rev_sum
+                FROM default.analytics.rev_total
+            )
+            SELECT SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            """,
+        )
+        # (b) A subset grain that omits the agg's first grain column (status).
+        subset = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.product.category"],
+        }
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params=subset,
+        )
+        assert measures_response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(measures_response.json())["sql"],
+            """
+            SELECT cat category, SUM(rev_sum) rev_sum
+            FROM default.analytics.rev_st_cat
+            GROUP BY cat
+            """,
+        )
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params=subset,
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT cat category, SUM(rev_sum) rev_sum
+                FROM default.analytics.rev_st_cat
+                GROUP BY cat
+            )
+            SELECT order_details_0.category AS category,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.category
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_uncovered_distinct_measure_falls_back(
+        self,
+        client_with_build_v3,
+    ):
+        """Rejection is about measure coverage, not grain: a COUNT DISTINCT metric
+        at exactly the pre-agg's grain still falls back to source when the table
+        carries no column for the distinct component."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "rev_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            table_columns={"status": "string", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.order_count"],
+            "dimensions": ["v3.order_details.status"],
+        }
+        measures_response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params=params,
+        )
+        assert measures_response.status_code == 200
+        measures_sql = get_first_grain_group(measures_response.json())["sql"]
+        assert "default.analytics.rev_by_status" not in measures_sql
+        assert_sql_equal(
+            measures_sql,
+            """
+            WITH v3_order_details AS (
+                SELECT o.order_id, o.status
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT t1.status, t1.order_id
+            FROM v3_order_details t1
+            GROUP BY t1.status, t1.order_id
+            """,
+        )
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params=params,
+        )
+        assert metrics_response.status_code == 200
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH v3_order_details AS (
+                SELECT o.order_id, o.status
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            order_details_0 AS (
+                SELECT t1.status, t1.order_id
+                FROM v3_order_details t1
+                GROUP BY t1.status, t1.order_id
+            )
+            SELECT order_details_0.status AS status,
+                   COUNT(DISTINCT order_details_0.order_id) AS order_count
+            FROM order_details_0
+            GROUP BY order_details_0.status
+            """,
+        )
+
 
 class TestMetricsSQLWithPreAggregation:
     """

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -419,6 +419,176 @@ class TestExternalPreAggRouting:
             )
 
     @pytest.mark.asyncio
+    async def test_external_preagg_stranded_by_node_revision(
+        self,
+        client_with_build_v3,
+    ):
+        """A pre-agg stops being used once the parent node gains a new revision.
+
+        Pre-aggs are keyed by node_revision_id (via grain_group_hash), so any edit
+        that creates a revision -- including a description-only change -- silently
+        strands them until they are re-registered. ``dj push`` re-registers in the
+        same deploy, but out-of-band registrations go stale with no warning.
+        """
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            table_columns={"status": "string", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_details.status"],
+        }
+        before = await client_with_build_v3.get("/sql/measures/v3/", params=params)
+        assert before.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(before.json())["sql"],
+            """
+            SELECT status, SUM(rev_sum) rev_sum
+            FROM default.analytics.revenue_by_status
+            GROUP BY status
+            """,
+        )
+
+        # A description-only edit still produces a new node revision.
+        patched = await client_with_build_v3.patch(
+            "/nodes/v3.order_details/",
+            json={"description": "Order line items (edited)"},
+        )
+        assert patched.status_code == 200
+
+        # The pre-agg is pinned to the previous revision, so the query now builds
+        # from source instead.
+        after = await client_with_build_v3.get("/sql/measures/v3/", params=params)
+        assert after.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(after.json())["sql"],
+            """
+            WITH v3_order_details AS (
+                SELECT o.status, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT t1.status, SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            GROUP BY t1.status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_same_grain_tie_is_first_registered(
+        self,
+        client_with_build_v3,
+    ):
+        """When two pre-aggs at the same grain both cover the requested measures,
+        the first-registered one wins.
+
+        The matcher prefers the smallest grain (``<``), so equal grain sizes never
+        displace an earlier candidate. Pinning this makes the tie-break explicit
+        rather than incidental.
+        """
+        for table, metrics, measure_columns, table_columns in (
+            (
+                "revenue_only",
+                ["v3.total_revenue"],
+                {"v3.total_revenue": "rev_sum"},
+                {"status": "string", "rev_sum": "double"},
+            ),
+            (
+                "revenue_and_quantity",
+                ["v3.total_revenue", "v3.total_quantity"],
+                {"v3.total_revenue": "rev_sum", "v3.total_quantity": "qty_sum"},
+                {"status": "string", "rev_sum": "double", "qty_sum": "double"},
+            ),
+        ):
+            await _register_external_preagg(
+                client_with_build_v3,
+                metrics=metrics,
+                dimensions=["v3.order_details.status"],
+                table_ref={
+                    "catalog": "default",
+                    "schema": "analytics",
+                    "table": table,
+                    "valid_through_ts": 20250101,
+                },
+                measure_columns=measure_columns,
+                table_columns=table_columns,
+            )
+
+        # Distinct rows: same grain, different measure sets.
+        listing = await client_with_build_v3.get(
+            "/preaggs/",
+            params={"node_name": "v3.order_details"},
+        )
+        assert len(listing.json()["items"]) == 2
+
+        # Both cover total_revenue; the earlier registration is used.
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            SELECT status, SUM(rev_sum) rev_sum
+            FROM default.analytics.revenue_only
+            GROUP BY status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_multi_hop_role_dimension(
+        self,
+        client_with_build_v3,
+    ):
+        """A multi-hop role reference resolves like any other: the mapped physical
+        column is read and aliased to the hop-qualified alias.
+
+        ``v3.location.country[customer->home]`` reaches location via customer, so
+        the alias is ``country_home``.
+        """
+        dimension = "v3.location.country[customer->home]"
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=[dimension],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_home_country",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={dimension: "home_country"},
+            table_columns={"home_country": "string", "rev_sum": "double"},
+        )
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={"metrics": ["v3.total_revenue"], "dimensions": [dimension]},
+        )
+        assert response.status_code == 200
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            SELECT home_country country_home, SUM(rev_sum) rev_sum
+            FROM default.analytics.revenue_by_home_country
+            GROUP BY home_country
+            """,
+        )
+
+    @pytest.mark.asyncio
     async def test_external_preagg_pending_not_used(self, client_with_build_v3):
         """A registered pre-agg with no availability (no valid_through_ts) is not
         used to answer queries."""


### PR DESCRIPTION
### Summary

Mostly tests. Ten new cases in `preagg_substitution_test.py` pinning external pre-aggregation behavior that #2375 left uncovered, and one refactor commit collapsing hand-rolled reference parsing onto the parser that already exists. 

The refactor was to reuse `parse_dimension_ref` instead of reimplmeneting the parsing of roles via `[`. Also removes the inline `canon()` closure in `get_preagg_dimension_column`. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
