### PR TITLE
Handle roles consistently when matching external pre-aggregations

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/dimensions.py
@@ -151,6 +151,22 @@ def find_join_path(
     return None  # pragma: no cover
 
 
+def roles_reaching_dimension(
+    ctx: "BuildContext",
+    node_rev_id: int,
+    dim_node_name: str,
+) -> set[str]:
+    """
+    Role paths from a node revision to a dimension node, ``""`` for a role-free
+    link. Read from the join paths preloaded for this build.
+    """
+    return {
+        stored_role
+        for (src_id, dim_name, stored_role) in ctx.join_paths
+        if src_id == node_rev_id and dim_name == dim_node_name
+    }
+
+
 def can_skip_join_for_dimension(
     dim_ref: DimensionRef,
     join_path: Optional[JoinPath],

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -1345,8 +1345,18 @@ def build_select_ast(
     #
     # Skip adding to projection if the column was already projected as a dimension
     # (e.g., order_id requested as both a dimension and a COUNT DISTINCT level).
+    # Two dedup sets: the projection emits a grain column bare, so it collides on
+    # output aliases, while GROUP BY groups dimensions by their source column.
+    # Using source names for the projection drops the grain column whenever its
+    # dimension is aliased differently (e.g. a role-qualified ref to the same
+    # column), leaving a LIMITED wrapper referencing a column the CTE never emitted.
     projected_dim_col_names = {
         rd.column_name
+        for rd in resolved_dimensions
+        if rd.original_ref not in ctx.filter_dimensions
+    }
+    projected_dim_aliases = {
+        ctx.alias_registry.register(rd.original_ref)
         for rd in resolved_dimensions
         if rd.original_ref not in ctx.filter_dimensions
     }
@@ -1356,7 +1366,7 @@ def build_select_ast(
             col_name = gc_expr.name.name
             col_ref = make_column_ref(col_name, main_alias)
             grain_col_refs.append(col_ref)
-            if col_name not in projected_dim_col_names:
+            if col_name not in projected_dim_aliases:
                 projection.append(col_ref)
         else:
             _rewrite_col_refs(gc_expr, main_alias)
@@ -2232,8 +2242,9 @@ def build_grain_group_sql(
     # Skip plain grain columns that are already represented as a requested dimension
     # to avoid duplicate entries (e.g., order_id requested as both a dimension and
     # the COUNT DISTINCT level column).
-    projected_dim_col_names_meta = {
-        rd.column_name
+    # Compare output names, matching the projection's dedup.
+    projected_dim_aliases_meta = {
+        ctx.alias_registry.register(rd.original_ref)
         for rd in resolved_dimensions
         if rd.original_ref not in ctx.filter_dimensions
     }
@@ -2243,7 +2254,7 @@ def build_grain_group_sql(
     ]
 
     for gc, gc_alias in zip(effective_grain_columns, effective_grain_aliases):
-        if gc in projected_dim_col_names_meta:
+        if gc_alias in projected_dim_aliases_meta:
             continue
         col_type = get_column_type(parent_node, gc_alias)
         columns_metadata.append(

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -75,6 +75,7 @@ from datajunction_server.construction.build_v3.dimensions import (
 )
 from datajunction_server.construction.build_v3.preagg_matcher import (
     find_matching_preagg,
+    canonical_dimension_ref,
     get_preagg_dimension_column,
     get_preagg_measure_column,
 )
@@ -1831,6 +1832,7 @@ def build_grain_group_from_preagg(
             preagg,
             dim.original_ref,
             dim.column_name,
+            canonicalize=lambda ref: canonical_dimension_ref(ctx, parent_node, ref),
         )
         group_by_cols.append(physical_col)
         ref_to_physical[dim.original_ref] = physical_col

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -75,7 +75,6 @@ from datajunction_server.construction.build_v3.dimensions import (
 )
 from datajunction_server.construction.build_v3.preagg_matcher import (
     find_matching_preagg,
-    canonical_dimension_ref,
     get_preagg_dimension_column,
     get_preagg_measure_column,
 )
@@ -1351,16 +1350,12 @@ def build_select_ast(
     # Using source names for the projection drops the grain column whenever its
     # dimension is aliased differently (e.g. a role-qualified ref to the same
     # column), leaving a LIMITED wrapper referencing a column the CTE never emitted.
-    projected_dim_col_names = {
-        rd.column_name
-        for rd in resolved_dimensions
-        if rd.original_ref not in ctx.filter_dimensions
-    }
-    projected_dim_aliases = {
-        ctx.alias_registry.register(rd.original_ref)
-        for rd in resolved_dimensions
-        if rd.original_ref not in ctx.filter_dimensions
-    }
+    projected_dim_col_names: set[str] = set()
+    projected_dim_aliases: set[str] = set()
+    for rd in resolved_dimensions:
+        if rd.original_ref not in ctx.filter_dimensions:
+            projected_dim_col_names.add(rd.column_name)
+            projected_dim_aliases.add(ctx.alias_registry.register(rd.original_ref))
     grain_col_refs: list[ast.Column] = []
     for gc_expr, gc_alias in grain_col_specs:
         if isinstance(gc_expr, ast.Column):
@@ -1832,7 +1827,8 @@ def build_grain_group_from_preagg(
             preagg,
             dim.original_ref,
             dim.column_name,
-            canonicalize=lambda ref: canonical_dimension_ref(ctx, parent_node, ref),
+            ctx=ctx,
+            node_rev_id=preagg.node_revision_id,
         )
         group_by_cols.append(physical_col)
         ref_to_physical[dim.original_ref] = physical_col

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -9,7 +9,7 @@ tables are available.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from datajunction_server.database.preaggregation import (
     PreAggregation,
@@ -18,7 +18,10 @@ from datajunction_server.database.preaggregation import (
 from datajunction_server.models.decompose import Aggregability, MetricComponent
 from datajunction_server.models.preaggregation import TemporalPartitionColumn
 from datajunction_server.naming import SEPARATOR
-from datajunction_server.construction.build_v3.dimensions import parse_dimension_ref
+from datajunction_server.construction.build_v3.dimensions import (
+    parse_dimension_ref,
+    roles_reaching_dimension,
+)
 
 if TYPE_CHECKING:
     from datajunction_server.construction.build_v3.types import BuildContext, GrainGroup
@@ -54,31 +57,23 @@ def get_required_measure_identities(
 
 def canonical_dimension_ref(
     ctx: "BuildContext",
-    parent_node: "Node",
+    node_rev_id: int,
     ref: str,
 ) -> str:
     """
-    Canonical form of a dimension reference for grain comparison.
+    Canonical form of a dimension reference, so that a pre-agg registered with one
+    spelling still matches a query written with the other.
 
-    A bare reference to a dimension reached by exactly one role means that role,
-    so it is qualified here -- otherwise a pre-agg registered with one spelling
-    would not match a query using the other, and the query would silently fall
-    back to the source. Ambiguous bare refs (several roles) and already-qualified
-    refs are returned unchanged.
+    A bare reference is qualified only when exactly one named role reaches the
+    dimension and no role-free link does -- mirroring how the reference resolves,
+    which prefers the role-free link. Anything else is returned unchanged.
     """
-    if "[" in ref or not parent_node.current:
+    if "[" in ref:
         return ref
-    try:
-        dim_ref = parse_dimension_ref(ref)
-    except Exception:  # pragma: no cover - defensive
+    roles = roles_reaching_dimension(ctx, node_rev_id, ref.rsplit(SEPARATOR, 1)[0])
+    if "" in roles or len(roles) != 1:
         return ref
-    node_rev_id = parent_node.current.id
-    roles = {
-        stored_role
-        for (src_id, dim_name, stored_role) in ctx.join_paths
-        if src_id == node_rev_id and dim_name == dim_ref.node_name and stored_role
-    }
-    return f"{ref}[{roles.pop()}]" if len(roles) == 1 else ref
+    return f"{ref}[{roles.pop()}]"
 
 
 def find_matching_preagg(
@@ -122,10 +117,8 @@ def find_matching_preagg(
     if not required_measures:
         return None
 
-    # Compare canonical refs so a bare and a role-qualified spelling of the same
-    # single-role dimension match each other.
     requested_grain_set = {
-        canonical_dimension_ref(ctx, parent_node, ref) for ref in requested_grain
+        canonical_dimension_ref(ctx, node_rev_id, ref) for ref in requested_grain
     }
 
     # Non-additive measures (e.g. COUNT(DISTINCT ...), raw AVG components) cannot
@@ -144,7 +137,7 @@ def find_matching_preagg(
 
     for preagg in available:
         preagg_grain_set = {
-            canonical_dimension_ref(ctx, parent_node, ref)
+            canonical_dimension_ref(ctx, node_rev_id, ref)
             for ref in (preagg.grain_columns or [])
         }
 
@@ -236,16 +229,23 @@ def get_preagg_dimension_column(
     preagg: PreAggregation,
     dimension_ref: str,
     default_column: str,
-    canonicalize: Callable[[str], str] | None = None,
+    ctx: BuildContext | None = None,
+    node_rev_id: int | None = None,
 ) -> str:
     """
     Physical column in the pre-agg backing a resolved grain dimension.
 
     External pre-aggs may store a dimension under a different column name (kept as
-    source_column). Matched by dimension reference (semantic_name == original_ref,
-    so role-safe), falling back to the DJ column name.
+    source_column). Matched by dimension reference, canonicalized so a bare and a
+    role-qualified spelling of the same dimension still match, falling back to the
+    DJ column name.
     """
-    canon = canonicalize or (lambda ref: ref)
+
+    def canon(ref: str) -> str:
+        if ctx is None or node_rev_id is None:
+            return ref
+        return canonical_dimension_ref(ctx, node_rev_id, ref)
+
     target = canon(dimension_ref)
     for col in preagg.columns or []:
         if col.semantic_type == "dimension" and canon(col.semantic_name) == target:

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -9,7 +9,7 @@ tables are available.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from datajunction_server.database.preaggregation import (
     PreAggregation,
@@ -50,6 +50,35 @@ def get_required_measure_identities(
         )
         for _, component in grain_group.components
     }
+
+
+def canonical_dimension_ref(
+    ctx: "BuildContext",
+    parent_node: "Node",
+    ref: str,
+) -> str:
+    """
+    Canonical form of a dimension reference for grain comparison.
+
+    A bare reference to a dimension reached by exactly one role means that role,
+    so it is qualified here -- otherwise a pre-agg registered with one spelling
+    would not match a query using the other, and the query would silently fall
+    back to the source. Ambiguous bare refs (several roles) and already-qualified
+    refs are returned unchanged.
+    """
+    if "[" in ref or not parent_node.current:
+        return ref
+    try:
+        dim_ref = parse_dimension_ref(ref)
+    except Exception:  # pragma: no cover - defensive
+        return ref
+    node_rev_id = parent_node.current.id
+    roles = {
+        stored_role
+        for (src_id, dim_name, stored_role) in ctx.join_paths
+        if src_id == node_rev_id and dim_name == dim_ref.node_name and stored_role
+    }
+    return f"{ref}[{roles.pop()}]" if len(roles) == 1 else ref
 
 
 def find_matching_preagg(
@@ -93,8 +122,11 @@ def find_matching_preagg(
     if not required_measures:
         return None
 
-    # Normalize requested grain to a set for comparison
-    requested_grain_set = set(requested_grain)
+    # Compare canonical refs so a bare and a role-qualified spelling of the same
+    # single-role dimension match each other.
+    requested_grain_set = {
+        canonical_dimension_ref(ctx, parent_node, ref) for ref in requested_grain
+    }
 
     # Non-additive measures (e.g. COUNT(DISTINCT ...), raw AVG components) cannot
     # be rolled up to a coarser grain without producing wrong results. When any
@@ -111,7 +143,10 @@ def find_matching_preagg(
     best_grain_size = float("inf")
 
     for preagg in available:
-        preagg_grain_set = set(preagg.grain_columns or [])
+        preagg_grain_set = {
+            canonical_dimension_ref(ctx, parent_node, ref)
+            for ref in (preagg.grain_columns or [])
+        }
 
         # Check grain compatibility. For additive measures the pre-agg may be at
         # the same or a finer grain (roll-up allowed → subset match). For
@@ -201,6 +236,7 @@ def get_preagg_dimension_column(
     preagg: PreAggregation,
     dimension_ref: str,
     default_column: str,
+    canonicalize: Callable[[str], str] | None = None,
 ) -> str:
     """
     Physical column in the pre-agg backing a resolved grain dimension.
@@ -209,8 +245,10 @@ def get_preagg_dimension_column(
     source_column). Matched by dimension reference (semantic_name == original_ref,
     so role-safe), falling back to the DJ column name.
     """
+    canon = canonicalize or (lambda ref: ref)
+    target = canon(dimension_ref)
     for col in preagg.columns or []:
-        if col.semantic_type == "dimension" and col.semantic_name == dimension_ref:
+        if col.semantic_type == "dimension" and canon(col.semantic_name) == target:
             return col.source_column or col.name
     return default_column
 

--- a/datajunction-server/datajunction_server/internal/preaggregations.py
+++ b/datajunction-server/datajunction_server/internal/preaggregations.py
@@ -15,6 +15,10 @@ from sqlalchemy.orm import selectinload
 
 from datajunction_server.api.helpers import get_catalog_by_name
 from datajunction_server.construction.build_v3.builder import build_measures_sql
+from datajunction_server.construction.build_v3.dimensions import (
+    roles_reaching_dimension,
+)
+from datajunction_server.construction.build_v3.types import GeneratedMeasuresSQL
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.availabilitystate import AvailabilityState
 from datajunction_server.database.preaggregation import (
@@ -26,13 +30,13 @@ from datajunction_server.database.preaggregation import (
 )
 from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models.decompose import PreAggMeasure
+from datajunction_server.naming import SEPARATOR
 from datajunction_server.models.dialect import Dialect
 from datajunction_server.models.materialization import MaterializationStrategy
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.preaggregation import ExternalPreAggTable
 from datajunction_server.models.query import V3ColumnMetadata
 from datajunction_server.service_clients import QueryServiceClient
-from datajunction_server.sql.dag import get_dimensions
 from datajunction_server.sql.decompose import MetricComponentExtractor
 
 
@@ -74,44 +78,39 @@ def assert_column_type_compatible(
         )
 
 
-async def assert_dimension_refs_are_role_qualified(
-    session: AsyncSession,
-    measures_result,
+def assert_dimension_refs_are_role_qualified(
+    measures_result: GeneratedMeasuresSQL,
     dimensions: list[str],
 ) -> None:
     """
     Reject a bare dimension reference that reaches its dimension by more than one
-    role, since it does not identify which one is meant.
+    role, since it names none of them.
 
-    Mirrors the resolution order used elsewhere for role-played columns: a bare
-    name is fine when unambiguous, but when several roles reach the dimension it
-    must be qualified rather than resolved to whichever path happens to sort
-    first. Locally-owned columns and single-role dimensions are left alone.
+    Mirrors how such a reference resolves: a role-free link wins, a single named
+    role is unambiguous, and anything else has to be qualified rather than
+    resolved to whichever path happens to sort first.
     """
-    unqualified = [ref for ref in dimensions if "[" not in ref]
-    if not unqualified:
-        return
-
-    advertised: set[str] = set()
-    for parent_name in {gg.parent_name for gg in measures_result.grain_groups}:
-        parent_node = measures_result.ctx.nodes.get(parent_name)
-        if not parent_node:  # pragma: no cover - defensive
+    for ref in dimensions:
+        if "[" in ref:
             continue
-        advertised.update(
-            dim.name for dim in await get_dimensions(session, parent_node)
-        )
-
-    for ref in unqualified:
-        if ref in advertised:
-            continue
-        roles = sorted(
-            candidate for candidate in advertised if candidate.startswith(f"{ref}[")
-        )
-        if len(roles) > 1:
+        dim_node_name = ref.rsplit(SEPARATOR, 1)[0]
+        roles: set[str] = set()
+        for grain_group in measures_result.grain_groups:
+            parent_node = measures_result.ctx.nodes.get(grain_group.parent_name)
+            if not parent_node or not parent_node.current:  # pragma: no cover
+                continue
+            roles |= roles_reaching_dimension(
+                measures_result.ctx,
+                parent_node.current.id,
+                dim_node_name,
+            )
+        named = sorted(role for role in roles if role)
+        if "" not in roles and len(named) > 1:
+            options = ", ".join(f"`{ref}[{role}]`" for role in named)
             raise DJInvalidInputException(
                 message=(
-                    f"Dimension '{ref}' is ambiguous across roles and must be "
-                    f"role-qualified. Use one of: {', '.join(roles)}."
+                    f"Dimension `{ref}` is ambiguous across roles. "
+                    f"Use one of: {options}"
                 ),
             )
 
@@ -185,11 +184,7 @@ async def register_external_preaggregations(
         dialect=Dialect.SPARK,
         use_materialized=False,
     )
-    await assert_dimension_refs_are_role_qualified(
-        session,
-        measures_result,
-        dimensions,
-    )
+    assert_dimension_refs_are_role_qualified(measures_result, dimensions)
 
     # 3. Introspect the external table and confirm the declared columns exist.
     catalog = await get_catalog_by_name(session=session, name=table.catalog)

--- a/datajunction-server/datajunction_server/internal/preaggregations.py
+++ b/datajunction-server/datajunction_server/internal/preaggregations.py
@@ -80,17 +80,13 @@ async def assert_dimension_refs_are_role_qualified(
     dimensions: list[str],
 ) -> None:
     """
-    Reject an unqualified dimension reference whose dimension node is only
-    reachable through role-carrying links.
+    Reject a bare dimension reference that reaches its dimension by more than one
+    role, since it does not identify which one is meant.
 
-    Grain matching compares dimension reference strings, so a registration only
-    serves queries that spell each dimension the same way. Where a link declares a
-    role, the role is part of the canonical reference and the only form the catalog
-    advertises -- registering the bare name would build a grain nothing can ask
-    for, and queries would silently fall back to the source.
-
-    Only refs with a role-qualified counterpart are rejected. A locally-owned
-    column has no dimension node and no role, so it is left alone.
+    Mirrors the resolution order used elsewhere for role-played columns: a bare
+    name is fine when unambiguous, but when several roles reach the dimension it
+    must be qualified rather than resolved to whichever path happens to sort
+    first. Locally-owned columns and single-role dimensions are left alone.
     """
     unqualified = [ref for ref in dimensions if "[" not in ref]
     if not unqualified:
@@ -111,13 +107,11 @@ async def assert_dimension_refs_are_role_qualified(
         roles = sorted(
             candidate for candidate in advertised if candidate.startswith(f"{ref}[")
         )
-        if roles:
+        if len(roles) > 1:
             raise DJInvalidInputException(
                 message=(
-                    f"Dimension '{ref}' must be role-qualified. The link to this "
-                    f"dimension declares a role, so '{ref}' is not a reference "
-                    f"queries can use and a pre-aggregation registered with it "
-                    f"would never match. Use one of: {', '.join(roles)}."
+                    f"Dimension '{ref}' is ambiguous across roles and must be "
+                    f"role-qualified. Use one of: {', '.join(roles)}."
                 ),
             )
 

--- a/datajunction-server/datajunction_server/internal/preaggregations.py
+++ b/datajunction-server/datajunction_server/internal/preaggregations.py
@@ -32,6 +32,7 @@ from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.preaggregation import ExternalPreAggTable
 from datajunction_server.models.query import V3ColumnMetadata
 from datajunction_server.service_clients import QueryServiceClient
+from datajunction_server.sql.dag import get_dimensions
 from datajunction_server.sql.decompose import MetricComponentExtractor
 
 
@@ -71,6 +72,54 @@ def assert_column_type_compatible(
                 f"type-compatible with {subject} (expected {expected})."
             ),
         )
+
+
+async def assert_dimension_refs_are_role_qualified(
+    session: AsyncSession,
+    measures_result,
+    dimensions: list[str],
+) -> None:
+    """
+    Reject an unqualified dimension reference whose dimension node is only
+    reachable through role-carrying links.
+
+    Grain matching compares dimension reference strings, so a registration only
+    serves queries that spell each dimension the same way. Where a link declares a
+    role, the role is part of the canonical reference and the only form the catalog
+    advertises -- registering the bare name would build a grain nothing can ask
+    for, and queries would silently fall back to the source.
+
+    Only refs with a role-qualified counterpart are rejected. A locally-owned
+    column has no dimension node and no role, so it is left alone.
+    """
+    unqualified = [ref for ref in dimensions if "[" not in ref]
+    if not unqualified:
+        return
+
+    advertised: set[str] = set()
+    for parent_name in {gg.parent_name for gg in measures_result.grain_groups}:
+        parent_node = measures_result.ctx.nodes.get(parent_name)
+        if not parent_node:  # pragma: no cover - defensive
+            continue
+        advertised.update(
+            dim.name for dim in await get_dimensions(session, parent_node)
+        )
+
+    for ref in unqualified:
+        if ref in advertised:
+            continue
+        roles = sorted(
+            candidate for candidate in advertised if candidate.startswith(f"{ref}[")
+        )
+        if roles:
+            raise DJInvalidInputException(
+                message=(
+                    f"Dimension '{ref}' must be role-qualified. The link to this "
+                    f"dimension declares a role, so '{ref}' is not a reference "
+                    f"queries can use and a pre-aggregation registered with it "
+                    f"would never match. Use one of: {', '.join(roles)}."
+                ),
+            )
 
 
 async def register_external_preaggregations(
@@ -141,6 +190,11 @@ async def register_external_preaggregations(
         dimensions=dimensions,
         dialect=Dialect.SPARK,
         use_materialized=False,
+    )
+    await assert_dimension_refs_are_role_qualified(
+        session,
+        measures_result,
+        dimensions,
     )
 
     # 3. Introspect the external table and confirm the declared columns exist.

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -1163,7 +1163,7 @@ class TestExternalPreAggRouting:
         await _register_external_preagg(
             client_with_build_v3,
             metrics=["v3.total_revenue"],
-            dimensions=["v3.customer.customer_id"],
+            dimensions=["v3.customer.customer_id[customer]"],
             table_ref={
                 "catalog": "default",
                 "schema": "analytics",
@@ -1177,7 +1177,7 @@ class TestExternalPreAggRouting:
             "/sql/metrics/v3/",
             params={
                 "metrics": ["v3.revenue_per_visitor"],
-                "dimensions": ["v3.customer.customer_id"],
+                "dimensions": ["v3.customer.customer_id[customer]"],
             },
         )
         assert metrics_response.status_code == 200
@@ -1190,23 +1190,31 @@ class TestExternalPreAggRouting:
                 FROM default.v3.page_views
             ),
             order_details_0 AS (
-                SELECT customer_id, SUM(revenue_sum) revenue_sum
+                SELECT customer_id_customer, SUM(revenue_sum) revenue_sum
                 FROM default.analytics.revenue_by_customer
-                GROUP BY customer_id
+                GROUP BY customer_id_customer
             ),
             page_views_enriched_0 AS (
-                SELECT t1.customer_id
+                SELECT t1.customer_id customer_id_customer, t1.customer_id
                 FROM v3_page_views_enriched t1
                 GROUP BY t1.customer_id
+            ),
+            page_views_enriched_0_agg AS (
+                SELECT customer_id_customer,
+                       COUNT(DISTINCT customer_id) customer_id
+                FROM page_views_enriched_0
+                GROUP BY customer_id_customer
             )
-            SELECT COALESCE(order_details_0.customer_id,
-                            page_views_enriched_0.customer_id) AS customer_id,
+            SELECT COALESCE(order_details_0.customer_id_customer,
+                            page_views_enriched_0_agg.customer_id_customer)
+                       AS customer_id_customer,
                    SUM(order_details_0.revenue_sum)
-                   / NULLIF(COUNT(DISTINCT page_views_enriched_0.customer_id), 0)
+                   / NULLIF(MAX(page_views_enriched_0_agg.customer_id), 0)
                    AS revenue_per_visitor
             FROM order_details_0
-            FULL OUTER JOIN page_views_enriched_0
-                ON order_details_0.customer_id = page_views_enriched_0.customer_id
+            FULL OUTER JOIN page_views_enriched_0_agg
+                ON order_details_0.customer_id_customer
+                   = page_views_enriched_0_agg.customer_id_customer
             GROUP BY 1
             """,
         )
@@ -1319,6 +1327,74 @@ class TestExternalPreAggRouting:
             GROUP BY order_details_0.date_id_order
             """,
         )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_rejects_unqualified_role_dimension(
+        self,
+        client_with_build_v3,
+    ):
+        """An unqualified reference to a role-linked dimension is rejected.
+
+        Grain matching compares reference strings, so registering the bare name
+        would build a grain no query can ask for -- the catalog only advertises
+        the role-qualified form -- and queries would silently fall back to source.
+        Locally-owned columns and role-free links are unaffected.
+        """
+        rejected = await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.location.country"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_country",
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            table_columns={"country": "string", "rev_sum": "double"},
+            expected_status=422,
+        )
+        message = rejected.json()["message"]
+        assert "must be role-qualified" in message
+        assert "v3.location.country[from]" in message
+        assert "v3.location.country[to]" in message
+
+        # References that are legal stay legal: a role-qualified dimension, a
+        # locally-owned column, the FK column behind a join, and a role-free link.
+        for dimension, table, columns in (
+            (
+                "v3.location.country[from]",
+                "revenue_by_from_country",
+                {"country_from": "string", "rev_sum": "double"},
+            ),
+            (
+                "v3.order_details.status",
+                "revenue_by_status_local",
+                {"status": "string", "rev_sum": "double"},
+            ),
+            (
+                "v3.order_details.order_date",
+                "revenue_by_order_date",
+                {"order_date": "int", "rev_sum": "double"},
+            ),
+            (
+                "v3.product.category",
+                "revenue_by_category_plain",
+                {"category": "string", "rev_sum": "double"},
+            ),
+        ):
+            await _register_external_preagg(
+                client_with_build_v3,
+                metrics=["v3.total_revenue"],
+                dimensions=[dimension],
+                table_ref={
+                    "catalog": "default",
+                    "schema": "analytics",
+                    "table": table,
+                    "valid_through_ts": 20250101,
+                },
+                measure_columns={"v3.total_revenue": "rev_sum"},
+                table_columns=columns,
+            )
 
     @pytest.mark.asyncio
     async def test_external_preagg_dimension_column_must_exist(

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -1350,10 +1350,11 @@ class TestExternalPreAggRouting:
             table_columns={"country": "string", "rev_sum": "double"},
             expected_status=422,
         )
-        message = rejected.json()["message"]
-        assert "ambiguous across roles" in message
-        assert "v3.location.country[from]" in message
-        assert "v3.location.country[to]" in message
+        assert rejected.json()["message"] == (
+            "Dimension `v3.location.country` is ambiguous across roles. "
+            "Use one of: `v3.location.country[customer->home]`, "
+            "`v3.location.country[from]`, `v3.location.country[to]`"
+        )
 
         # References that are legal stay legal: a role-qualified dimension, a
         # locally-owned column, the FK column behind a join, and a role-free link.

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -1333,12 +1333,9 @@ class TestExternalPreAggRouting:
         self,
         client_with_build_v3,
     ):
-        """An unqualified reference to a role-linked dimension is rejected.
-
-        Grain matching compares reference strings, so registering the bare name
-        would build a grain no query can ask for -- the catalog only advertises
-        the role-qualified form -- and queries would silently fall back to source.
-        Locally-owned columns and role-free links are unaffected.
+        """A bare reference is rejected only when several roles reach the
+        dimension, since it then names none of them. Single-role dimensions,
+        locally-owned columns and role-free links stay legal.
         """
         rejected = await _register_external_preagg(
             client_with_build_v3,
@@ -1354,7 +1351,7 @@ class TestExternalPreAggRouting:
             expected_status=422,
         )
         message = rejected.json()["message"]
-        assert "must be role-qualified" in message
+        assert "ambiguous across roles" in message
         assert "v3.location.country[from]" in message
         assert "v3.location.country[to]" in message
 
@@ -1381,6 +1378,11 @@ class TestExternalPreAggRouting:
                 "revenue_by_category_plain",
                 {"category": "string", "rev_sum": "double"},
             ),
+            (
+                "v3.customer.customer_id",
+                "revenue_by_customer_bare",
+                {"customer_id": "int", "rev_sum": "double"},
+            ),
         ):
             await _register_external_preagg(
                 client_with_build_v3,
@@ -1394,6 +1396,49 @@ class TestExternalPreAggRouting:
                 },
                 measure_columns={"v3.total_revenue": "rev_sum"},
                 table_columns=columns,
+            )
+
+    @pytest.mark.asyncio
+    async def test_external_preagg_bare_and_role_qualified_refs_interoperate(
+        self,
+        client_with_build_v3,
+    ):
+        """When one role reaches a dimension, a bare and a role-qualified
+        reference name the same thing, so either spelling matches a pre-agg
+        registered with the other -- including its column mapping.
+        """
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.customer.customer_id"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_customer_key",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.customer.customer_id": "cust_key"},
+            table_columns={"cust_key": "int", "rev_sum": "double"},
+        )
+        # The output alias follows the spelling that was requested; only matching
+        # is canonicalized.
+        for dimension, alias in (
+            ("v3.customer.customer_id", "customer_id"),
+            ("v3.customer.customer_id[customer]", "customer_id_customer"),
+        ):
+            response = await client_with_build_v3.get(
+                "/sql/measures/v3/",
+                params={"metrics": ["v3.total_revenue"], "dimensions": [dimension]},
+            )
+            assert response.status_code == 200
+            assert_sql_equal(
+                get_first_grain_group(response.json())["sql"],
+                f"""
+                SELECT cust_key {alias}, SUM(rev_sum) rev_sum
+                FROM default.analytics.revenue_by_customer_key
+                GROUP BY cust_key
+                """,
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

Registering an external pre-aggregation against a dimension that is reachable by more than one role either silently failed to route or routed to the wrong role's column. There are a few issues around how a dimension reference's role is (or isn't) accounted for.

**A role-less reference to a multi-role dimension is now rejected at registration**

For example, `v3.location.country` names no particular role when the fact reaches `location` as both `[from]` and `[to]`. Previously this registered fine and then resolved to whichever join path sorted first. `POST /preaggs/` now rejects it:

> Dimension `v3.location.country` is ambiguous across roles. Use one of: `v3.location.country[customer->home]`, `v3.location.country[from]`, `v3.location.country[to]`

This deliberately stays compatible with the convention where a role-less dimension ref is still legal when it is unambiguous. However, if there are several roles that reach the dimension then it will be rejected due to ambiguity.

**Grain matching compares canonical references**

A pre-agg registered as `v3.date.date_id[order]` did not match a query asking for `v3.date.date_id`, or vice versa, so the query fell back to a full scan of the source. Both sides of the grain comparison (and the `dimension_columns` physical-column lookup) now go through `canonical_dimension_ref`, which qualifies a bare reference when exactly one named role reaches the dimension.

**Limited-aggregability grain columns dedup on output aliases**

`build_select_ast` skipped a COUNT(DISTINCT) level column when its name collided with an already-projected dimension, but compared *source* column names against a projection that emits *aliases*. With a role-qualified reference to the same underlying column the two differ, so the grain column was dropped and the LIMITED wrapper CTE then referenced a column its inner CTE never emitted. The projection now dedups on aliases; GROUP BY keeps deduping on source columns, since it groups by source.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
