### PR TITLE
Deploy tag_metadata declared on tags in a deployment spec

### DIFF
--- a/datajunction-server/datajunction_server/api/git_sync.py
+++ b/datajunction-server/datajunction_server/api/git_sync.py
@@ -230,11 +230,28 @@ async def _fetch_deployment_spec_from_git(
                 message=f"Path '{git_path}' not found in repository at ref '{ref}'",
             )
 
-        # Parse all YAML files, routing by type: hierarchy vs nodes
+        # Parse all YAML files, routing by type: project config vs hierarchy vs nodes
         nodes: List[dict] = []
         hierarchies: List[dict] = []
+        # Tags are declared in the project config file, keyed by name so a
+        # later dj.yaml wins over an earlier one.
+        tags: dict[str, dict] = {}
         for yaml_file in files_dir.rglob("*.yaml"):
             if yaml_file.name == "dj.yaml":
+                try:
+                    with open(yaml_file, "r", encoding="utf-8") as f:
+                        project_config = yaml.safe_load(f)
+                except Exception as exc:  # pragma: no cover
+                    _logger.warning(
+                        "Skipping invalid project config %s: %s",
+                        yaml_file,
+                        exc,
+                    )
+                    continue
+                if isinstance(project_config, dict):
+                    for tag in project_config.get("tags") or []:
+                        if isinstance(tag, dict) and tag.get("name"):
+                            tags[tag["name"]] = tag
                 continue
             try:
                 with open(yaml_file, "r", encoding="utf-8") as f:
@@ -252,9 +269,10 @@ async def _fetch_deployment_spec_from_git(
                 continue
 
     _logger.info(
-        "Fetched %d node specs and %d hierarchy specs from git: %s @ %s",
+        "Fetched %d node specs, %d hierarchy specs and %d tag specs from git: %s @ %s",
         len(nodes),
         len(hierarchies),
+        len(tags),
         repo_path,
         ref[:12] if len(ref) > 12 else ref,
     )
@@ -262,7 +280,7 @@ async def _fetch_deployment_spec_from_git(
     return {
         "namespace": namespace,
         "nodes": nodes,
-        "tags": [],
+        "tags": list(tags.values()),
         "hierarchies": hierarchies,
     }
 

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -80,6 +80,7 @@ from datajunction_server.models.deployment import (
     NodeSpec,
     SourceSpec,
     TagSpec,
+    eq_or_fallback,
     render_prefixes,
 )
 from datajunction_server.models.dimensionlink import (
@@ -895,6 +896,7 @@ class DeploymentOrchestrator:
                             Tag.tag_type,
                             Tag.description,
                             Tag.display_name,
+                            Tag.tag_metadata,
                             Tag.created_by_id,
                         ),
                         noload(Tag.created_by),
@@ -929,6 +931,7 @@ class DeploymentOrchestrator:
                     tag.tag_type = tag_spec.tag_type
                     tag.description = tag_spec.description
                     tag.display_name = tag_spec.display_name or labelize(tag_name)
+                    tag.tag_metadata = tag_spec.tag_metadata or {}
                     self.session.add(tag)
                     tags_modified = True
             else:
@@ -937,6 +940,7 @@ class DeploymentOrchestrator:
                     tag_type=tag_spec.tag_type,
                     description=tag_spec.description,
                     display_name=tag_spec.display_name or labelize(tag_name),
+                    tag_metadata=tag_spec.tag_metadata or {},
                     created_by_id=self.context.current_user.id,
                 )
                 self.session.add(tag)
@@ -4381,6 +4385,10 @@ def tag_needs_update(existing_tag: Tag, tag_spec: TagSpec) -> bool:
         or existing_tag.description != tag_spec.description
         or existing_tag.display_name
         != (tag_spec.display_name or labelize(tag_spec.name))
+        # A deployment is declarative, so the spec's metadata bag replaces the
+        # stored one; an omitted bag is equivalent to an empty one, matching how
+        # node-level custom_metadata is compared.
+        or not eq_or_fallback(tag_spec.tag_metadata, existing_tag.tag_metadata, {})
     )
 
 

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from pydantic import (
+    AliasChoices,
     BaseModel,
     Field,
     PrivateAttr,
@@ -56,10 +57,19 @@ class TagSpec(BaseModel):
     """
 
     name: str
-    display_name: str
+    # Optional: the deployment falls back to a labelized version of the name.
+    display_name: str | None = None
     description: str = ""
     tag_type: str = ""
-    tag_metadata: dict | None = None
+    # The metadata bag on a tag. Node specs call their bag `custom_metadata`, so
+    # both that and a bare `metadata:` are accepted as aliases to avoid forcing
+    # users to rewrite existing YAML.
+    tag_metadata: dict | None = Field(
+        default=None,
+        validation_alias=AliasChoices("tag_metadata", "metadata", "custom_metadata"),
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class HierarchyLevelSpec(BaseModel):

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -20,6 +20,7 @@ from datajunction_server.models.deployment import (
     GitDeploymentSource,
     LocalDeploymentSource,
     PreAggSpec,
+    TagSpec,
 )
 from datajunction_server.utils import get_query_service_client
 from datajunction_server.internal.git.github_service import GitHubServiceError
@@ -2999,6 +3000,95 @@ class TestDeployments:
         }
         node = await Node.get_by_name(session, f"{namespace}.default.us_state")
         assert [tag.name for tag in node.tags] == ["tag1"]
+
+    @pytest.mark.asyncio
+    async def test_deploy_tag_metadata(
+        self,
+        client,
+        default_us_states,
+        default_us_state,
+    ):
+        """
+        Test that tag_metadata declared on a tag in the deployment spec is
+        persisted, both when the tag is created and when it is later updated.
+
+        The deployment spec is the source of truth: the declared bag replaces
+        the stored one, so keys added out-of-band or dropped from the spec do
+        not linger on the server.
+        """
+        namespace = "tag_metadata_deploy"
+        default_us_state.tags = ["inventory"]
+
+        def spec(tag_metadata):
+            return DeploymentSpec(
+                namespace=namespace,
+                nodes=[default_us_states, default_us_state],
+                tags=[
+                    TagSpec(
+                        name="inventory",
+                        display_name="Inventory",
+                        description="Inventory tag",
+                        tag_type="group",
+                        tag_metadata=tag_metadata,
+                    ),
+                ],
+            )
+
+        # Create path
+        data = await deploy_and_wait(
+            client,
+            spec({"order": 1, "display": {"color": "blue"}}),
+        )
+        assert data["status"] == "success"
+        response = await client.get("/tags/inventory/")
+        assert response.json() == {
+            "name": "inventory",
+            "display_name": "Inventory",
+            "description": "Inventory tag",
+            "tag_type": "group",
+            "tag_metadata": {"order": 1, "display": {"color": "blue"}},
+        }
+
+        # A key is added out-of-band, outside the deployment
+        response = await client.patch(
+            "/tags/inventory/",
+            json={
+                "tag_metadata": {
+                    "order": 1,
+                    "display": {"color": "blue"},
+                    "added_out_of_band": {"foo": "bar"},
+                },
+            },
+        )
+        assert response.status_code == 200
+
+        # Update path: the spec replaces the stored bag, dropping the
+        # out-of-band key and replacing nested contents rather than merging
+        data = await deploy_and_wait(
+            client,
+            spec({"order": 2, "display": {"icon": "box"}}),
+        )
+        assert data["status"] == "success"
+        response = await client.get("/tags/inventory/")
+        assert response.json() == {
+            "name": "inventory",
+            "display_name": "Inventory",
+            "description": "Inventory tag",
+            "tag_type": "group",
+            "tag_metadata": {"order": 2, "display": {"icon": "box"}},
+        }
+
+        # Removing tag_metadata from the spec clears it on the server
+        data = await deploy_and_wait(client, spec(None))
+        assert data["status"] == "success"
+        response = await client.get("/tags/inventory/")
+        assert response.json() == {
+            "name": "inventory",
+            "display_name": "Inventory",
+            "description": "Inventory tag",
+            "tag_type": "group",
+            "tag_metadata": {},
+        }
 
     @pytest.mark.asyncio
     async def test_deploy_column_properties(

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -5528,6 +5528,236 @@ columns:
             assert data["source"]["commit_author_email"] == "alice@example.com"
 
     @pytest.mark.asyncio
+    async def test_sync_from_git_deploys_tags_from_project_config(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """
+        Tags declared in dj.yaml must be deployed by sync-from-git, with their
+        tag_metadata intact.
+        """
+        await client_with_service_setup.post("/namespaces/sync_tags")
+        await client_with_service_setup.patch(
+            "/namespaces/sync_tags/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "git_branch": "main",
+                "git_path": "nodes",
+            },
+        )
+
+        project_yaml = """
+namespace: sync_tags
+tags:
+  - name: inventory
+    display_name: Inventory
+    description: Inventory tag
+    tag_type: group
+    tag_metadata:
+      order: 1
+      display:
+        color: blue
+"""
+        node_yaml = """
+name: ${prefix}tagged_source
+node_type: source
+description: Test source node
+catalog: default
+schema_: test
+table: test_table
+tags:
+  - inventory
+columns:
+  - name: id
+    type: int
+"""
+        tarball = create_mock_tarball(
+            {
+                "nodes/dj.yaml": project_yaml,
+                "nodes/tagged_source.yaml": node_yaml,
+            },
+        )
+
+        with patch(
+            "datajunction_server.api.git_sync.GitHubService",
+        ) as mock_github_class:
+            mock_github = MagicMock()
+            mock_github.resolve_ref_to_sha = AsyncMock(return_value="abc123def456")
+            mock_github.get_commit_author = AsyncMock(
+                return_value=("Alice Smith", "alice@example.com"),
+            )
+            mock_github.download_archive = AsyncMock(return_value=tarball)
+            mock_github_class.return_value = mock_github
+
+            response = await client_with_service_setup.post(
+                "/namespaces/sync_tags/sync-from-git",
+            )
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["status"] == "success"
+
+        response = await client_with_service_setup.get("/tags/inventory/")
+        assert response.json() == {
+            "name": "inventory",
+            "display_name": "Inventory",
+            "description": "Inventory tag",
+            "tag_type": "group",
+            "tag_metadata": {"order": 1, "display": {"color": "blue"}},
+        }
+
+    @pytest.mark.asyncio
+    async def test_sync_from_git_skips_malformed_tag_entries(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """
+        Malformed entries in the dj.yaml `tags:` list (a bare string, or a
+        mapping with no name) are skipped, while well-formed tags in the same
+        file are still deployed.
+        """
+        await client_with_service_setup.post("/namespaces/sync_bad_tags")
+        await client_with_service_setup.patch(
+            "/namespaces/sync_bad_tags/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "git_branch": "main",
+                "git_path": "nodes",
+            },
+        )
+
+        project_yaml = """
+namespace: sync_bad_tags
+tags:
+  - just_a_string
+  - description: a mapping with no name
+    tag_type: group
+  - name: well_formed
+    display_name: Well Formed
+    description: Well formed tag
+    tag_type: group
+    tag_metadata:
+      order: 1
+"""
+        node_yaml = """
+name: ${prefix}tagged_source
+node_type: source
+description: Test source node
+catalog: default
+schema_: test
+table: test_table
+tags:
+  - well_formed
+columns:
+  - name: id
+    type: int
+"""
+        tarball = create_mock_tarball(
+            {
+                "nodes/dj.yaml": project_yaml,
+                "nodes/tagged_source.yaml": node_yaml,
+            },
+        )
+
+        with patch(
+            "datajunction_server.api.git_sync.GitHubService",
+        ) as mock_github_class:
+            mock_github = MagicMock()
+            mock_github.resolve_ref_to_sha = AsyncMock(return_value="abc123def456")
+            mock_github.get_commit_author = AsyncMock(
+                return_value=("Alice Smith", "alice@example.com"),
+            )
+            mock_github.download_archive = AsyncMock(return_value=tarball)
+            mock_github_class.return_value = mock_github
+
+            response = await client_with_service_setup.post(
+                "/namespaces/sync_bad_tags/sync-from-git",
+            )
+
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["status"] == "success"
+
+        # The well-formed tag was deployed
+        response = await client_with_service_setup.get("/tags/well_formed/")
+        assert response.json() == {
+            "name": "well_formed",
+            "display_name": "Well Formed",
+            "description": "Well formed tag",
+            "tag_type": "group",
+            "tag_metadata": {"order": 1},
+        }
+
+        # The bare string was not turned into a tag
+        response = await client_with_service_setup.get("/tags/just_a_string/")
+        assert response.status_code == HTTPStatus.NOT_FOUND
+
+        # ...and neither was the mapping without a name
+        response = await client_with_service_setup.get("/tags/")
+        assert [
+            tag
+            for tag in response.json()
+            if tag["description"] == "a mapping with no name"
+        ] == []
+
+    @pytest.mark.asyncio
+    async def test_sync_from_git_ignores_non_mapping_project_config(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """
+        A dj.yaml that does not parse to a mapping (e.g. an empty file, which
+        yields None) is ignored instead of failing the deployment.
+        """
+        await client_with_service_setup.post("/namespaces/sync_empty_config")
+        await client_with_service_setup.patch(
+            "/namespaces/sync_empty_config/git",
+            json={
+                "github_repo_path": "myorg/myrepo",
+                "git_branch": "main",
+                "git_path": "nodes",
+            },
+        )
+
+        node_yaml = """
+name: ${prefix}untagged_source
+node_type: source
+description: Test source node
+catalog: default
+schema_: test
+table: test_table
+columns:
+  - name: id
+    type: int
+"""
+        tarball = create_mock_tarball(
+            {
+                "nodes/dj.yaml": "",
+                "nodes/tagged_source.yaml": node_yaml,
+            },
+        )
+
+        with patch(
+            "datajunction_server.api.git_sync.GitHubService",
+        ) as mock_github_class:
+            mock_github = MagicMock()
+            mock_github.resolve_ref_to_sha = AsyncMock(return_value="abc123def456")
+            mock_github.get_commit_author = AsyncMock(
+                return_value=("Alice Smith", "alice@example.com"),
+            )
+            mock_github.download_archive = AsyncMock(return_value=tarball)
+            mock_github_class.return_value = mock_github
+
+            response = await client_with_service_setup.post(
+                "/namespaces/sync_empty_config/sync-from-git",
+            )
+
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()
+        assert data["status"] == "success"
+        assert [result["name"] for result in data["results"]] == [
+            "sync_empty_config.untagged_source",
+        ]
+
+    @pytest.mark.asyncio
     async def test_sync_from_git_no_git_config(
         self,
         client_with_service_setup: AsyncClient,

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -25,6 +25,7 @@ from datajunction_server.internal.deployment.orchestrator import (
     DeploymentPlan,
     ResourceRegistry,
     column_changed,
+    tag_needs_update,
 )
 from datajunction_server.internal.deployment.validation import (
     NodeValidationResult,
@@ -490,6 +491,114 @@ class TestDeploymentPlanning:
         result_tags = await orchestrator._setup_tags()
         assert result_tags.keys() == {"new_tag"}
         assert len(orchestrator.errors) == 0
+
+    @pytest.mark.asyncio
+    async def test_setup_tags_metadata_is_declarative(
+        self,
+        session,
+        current_user,
+    ):
+        """
+        tag_metadata declared in the deployment spec must be written on the
+        create path and on the update path. A deployment is declarative: the
+        spec is the source of truth, so the declared bag replaces whatever is
+        stored — keys dropped from the spec (or written out-of-band by someone
+        else) are removed, and an omitted bag clears the metadata entirely.
+        """
+        context = MagicMock(autospec=DeploymentContext)
+        context.current_user = current_user
+        context.save_history = AsyncMock()
+
+        def make_orchestrator(tag_metadata):
+            return DeploymentOrchestrator(
+                deployment_spec=DeploymentSpec(
+                    namespace="some.namespace",
+                    nodes=[],
+                    tags=[
+                        TagSpec(
+                            name="inventory",
+                            display_name="Inventory",
+                            description="Inventory tag",
+                            tag_type="group",
+                            tag_metadata=tag_metadata,
+                        ),
+                    ],
+                ),
+                deployment_id="test-deployment",
+                session=session,
+                context=context,
+            )
+
+        # Create path
+        result_tags = await make_orchestrator(
+            {"order": 1, "display": {"color": "blue"}},
+        )._setup_tags()
+        assert result_tags["inventory"].tag_metadata == {
+            "order": 1,
+            "display": {"color": "blue"},
+        }
+
+        # A key is added out-of-band (e.g. via PATCH /tags), so the stored bag
+        # no longer matches the spec
+        result_tags["inventory"].tag_metadata = {
+            "order": 1,
+            "display": {"color": "blue"},
+            "added_out_of_band": {"foo": "bar"},
+        }
+        session.add(result_tags["inventory"])
+        await session.commit()
+
+        # Update path: the spec replaces the stored bag wholesale, so the
+        # out-of-band key is dropped and nested contents are replaced, not merged
+        orchestrator = make_orchestrator({"order": 2, "display": {"icon": "box"}})
+        assert (
+            tag_needs_update(
+                result_tags["inventory"],
+                orchestrator.deployment_spec.tags[0],
+            )
+            is True
+        )
+        result_tags = await orchestrator._setup_tags()
+        assert result_tags["inventory"].tag_metadata == {
+            "order": 2,
+            "display": {"icon": "box"},
+        }
+
+        # Redeploying the same metadata is not a change
+        assert (
+            tag_needs_update(
+                result_tags["inventory"],
+                make_orchestrator(
+                    {"order": 2, "display": {"icon": "box"}},
+                ).deployment_spec.tags[0],
+            )
+            is False
+        )
+
+        # Dropping a key from the spec removes it from the server
+        result_tags = await make_orchestrator({"order": 3})._setup_tags()
+        assert result_tags["inventory"].tag_metadata == {"order": 3}
+
+        # A spec without tag_metadata clears the bag
+        orchestrator = make_orchestrator(None)
+        assert (
+            tag_needs_update(
+                result_tags["inventory"],
+                orchestrator.deployment_spec.tags[0],
+            )
+            is True
+        )
+        result_tags = await orchestrator._setup_tags()
+        assert result_tags["inventory"].tag_metadata == {}
+
+        # ...and an already-empty bag with an omitted spec value is not a change
+        assert (
+            tag_needs_update(
+                result_tags["inventory"],
+                make_orchestrator(None).deployment_spec.tags[0],
+            )
+            is False
+        )
 
     @pytest.mark.asyncio
     async def test_setup_owners_missing(self, session, current_user):

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -16,6 +16,7 @@ from datajunction_server.models.deployment import (
     PreAggSpec,
     Granularity,
     PartitionType,
+    TagSpec,
     eq_columns,
     eq_or_fallback,
 )
@@ -646,3 +647,39 @@ def test_preagg_spec_renders_dimension_columns():
     )
     assert spec.rendered_dimension_columns == {"ns.d.attr": "phys_attr"}
     assert spec.rendered_measure_columns == {"ns.count": "cnt"}
+
+
+def test_tag_spec_metadata_aliases():
+    """
+    A tag's metadata bag may be authored as `tag_metadata`, `metadata` or
+    `custom_metadata`; all three land on `tag_metadata`. `display_name` is
+    optional (the deployment labelizes the name when it is absent).
+    """
+    metadata = {"order": 1, "display": {"color": "blue"}}
+    for key in ("tag_metadata", "metadata", "custom_metadata"):
+        tag_spec = TagSpec.model_validate(
+            {
+                "name": "inventory",
+                "description": "Inventory tag",
+                "tag_type": "group",
+                key: metadata,
+            },
+        )
+        assert tag_spec.model_dump() == {
+            "name": "inventory",
+            "display_name": None,
+            "description": "Inventory tag",
+            "tag_type": "group",
+            "tag_metadata": metadata,
+        }
+
+    # Legacy tag entries with neither display_name nor metadata still validate
+    assert TagSpec.model_validate(
+        {"name": "deprecated", "description": "d", "tag_type": "Maintenance"},
+    ).model_dump() == {
+        "name": "deprecated",
+        "display_name": None,
+        "description": "d",
+        "tag_type": "Maintenance",
+        "tag_metadata": None,
+    }

--- a/docs/content/0.1.0/docs/data-modeling/yaml.md
+++ b/docs/content/0.1.0/docs/data-modeling/yaml.md
@@ -62,7 +62,30 @@ primary_key:
 | Field | Required? | Description |
 | ---- | ---- | ---- |
 | `namespace` | Yes | The DJ namespace for this YAML project |
-| `tags` | No | Used to define any tags that are used by nodes in the project |
+| `tags` | No | Used to define any tags that are used by nodes in the project. See [details](#tag-yaml). |
+
+##### Tag YAML
+| Field | Required? | Description |
+| ---- | ---- | ---- |
+| `name` | Yes | The tag name |
+| `display_name` | No | The display name of the tag, derived from the name if not provided |
+| `description` | No | Description of the tag |
+| `tag_type` | No | The type of the tag (e.g. `Maintenance`, `group`) |
+| `tag_metadata` | No | A free-form object for any extra information you want to attach to the tag. DJ does not interpret its contents. Also accepted as `metadata` or `custom_metadata`. Deployments are declarative, so this replaces the stored metadata: removing a key from the YAML removes it on the server, and omitting the field clears the metadata |
+
+Example:
+```
+namespace: projects.roads
+tags:
+  - name: deprecated
+    display_name: Deprecated
+    description: This node is deprecated
+    tag_type: Maintenance
+    tag_metadata:
+      order: 1
+      display:
+        color: red
+```
 
 
 #### Node YAML Fields Overview


### PR DESCRIPTION
### Summary

A tag's `tag_metadata` was accepted by `TagSpec` but never written to the database by the deployment path: `_setup_tags` set only tag_type, description and display_name on both the create and the update branch, and `tag_needs_update` did not consider metadata at all. Tags authored declaratively (including domains modelled as tags) therefore always landed with an empty metadata bag.

Changes:
- `_setup_tags` writes `tag_metadata` on create and on update, and `tag_needs_update` detects metadata drift. `Tag.tag_metadata` is added to the `load_only` list so the stored value is available for comparison.
- The semantics are declarative, matching node-level `custom_metadata`: the declared bag replaces the stored one, an omitted bag clears it, and a missing value is compared as equivalent to `{}` via `eq_or_fallback`.
- `sync-from-git` now reads `tags` out of `dj.yaml` instead of hardcoding an empty list, so the DJ-pull deployment path deploys tags too.
- `TagSpec.display_name` is optional (the deployment already labelizes the name when absent), and `metadata` / `custom_metadata` are accepted as aliases for `tag_metadata` so existing YAML does not have to change.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
