### PR TITLE
Gate pre-aggregation routing on reported freshness (opt-in)

### DIFF
--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -244,9 +244,10 @@ class Settings(BaseSettings):  # pragma: no cover
     preagg_schema: str = "dj_preaggs"
 
     # Freshness gating for pre-aggregations. When enabled, a pre-aggregation is
-    # only allowed to answer a query if its reported `valid_through_ts` covers
-    # the time range the query asks for. Off by default: enabling it can route
-    # queries away from pre-aggs that serve them today.
+    # only allowed to answer a query if the temporal range its table covers
+    # (`min_temporal_partition`/`max_temporal_partition`, falling back to
+    # `valid_through_ts`) contains the range the query asks for. Off by default:
+    # enabling it can route queries away from pre-aggs that serve them today.
     preagg_freshness_gating: bool = False
 
     # Wall-clock staleness budget, in seconds, applied only when a query has no

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -243,6 +243,19 @@ class Settings(BaseSettings):  # pragma: no cover
     preagg_catalog: str = "default"
     preagg_schema: str = "dj_preaggs"
 
+    # Freshness gating for pre-aggregations. When enabled, a pre-aggregation is
+    # only allowed to answer a query if its reported `valid_through_ts` covers
+    # the time range the query asks for. Off by default: enabling it can route
+    # queries away from pre-aggs that serve them today.
+    preagg_freshness_gating: bool = False
+
+    # Wall-clock staleness budget, in seconds, applied only when a query has no
+    # discoverable upper bound on the pre-agg's temporal partition (such a query
+    # implicitly asks for data through the present). When None, unbounded
+    # queries are never rejected for staleness. Ignored unless
+    # `preagg_freshness_gating` is on.
+    preagg_max_staleness_seconds: Optional[int] = None
+
     # Cube view output location
     # Used when generating CREATE OR REPLACE VIEW DDL for cube views
     view_catalog: str = "default"

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from typing import Optional, cast
 
 from datajunction_server.construction.build_v3.filters import (
-    extract_subscript_role,
+    dimension_ref_of_expression,
     parse_filter,
 )
 from datajunction_server.construction.build_v3.materialization import (
@@ -298,12 +298,9 @@ def replace_dimension_refs_in_ast(
         if not base_col_name:  # pragma: no cover
             continue
 
-        role = extract_subscript_role(subscript)
-        if not role:  # pragma: no cover
+        dim_ref_with_role = dimension_ref_of_expression(subscript)
+        if dim_ref_with_role is None:  # pragma: no cover
             continue
-
-        # Build the full dimension ref with role: "v3.date.week[order]"
-        dim_ref_with_role = f"{base_col_name}[{role}]"
 
         # Look up in dimension_refs
         ref_tuple = None
@@ -1945,10 +1942,9 @@ def _rewrite_filter_for_select(
             continue  # pragma: no cover
         # Reconstruct the original role-qualified form: base = "v3.date.date_id", role = "order"
         base = get_column_full_name(subscript.expr)
-        role = extract_subscript_role(subscript)
-        if not role:
+        full_name = dimension_ref_of_expression(subscript)
+        if full_name is None:
             continue  # pragma: no cover
-        full_name = f"{base}[{role}]"
 
         # Look up in the filter alias map. Prefers the role-specific key over the fallback.
         output_col = filter_column_aliases.get(

--- a/datajunction-server/datajunction_server/construction/build_v3/filters.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/filters.py
@@ -193,8 +193,9 @@ def resolve_filter_references(
         if not base_col_ref:
             continue  # pragma: no cover
 
-        role = extract_subscript_role(subscript)
-        if not role:
+        # The base ref is kept for the fallback lookup below.
+        dim_ref_with_role = dimension_ref_of_expression(subscript)
+        if dim_ref_with_role is None:
             continue  # pragma: no cover
 
         # Mark every Column under the index as a role marker so it isn't
@@ -206,7 +207,6 @@ def resolve_filter_references(
                 role_marker_ids.add(id(inner_col))
 
         # Look up with role first, then fall back to base ref without role
-        dim_ref_with_role = f"{base_col_ref}[{role}]"
         alias_to_use = column_aliases.get(dim_ref_with_role) or column_aliases.get(
             base_col_ref,
         )

--- a/datajunction-server/datajunction_server/construction/build_v3/filters.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/filters.py
@@ -417,6 +417,10 @@ def dimension_ref_of_expression(expression: ast.Expression) -> str | None:
     ``v3.date.date_id`` and ``v3.date.date_id[order]`` both resolve; anything
     wrapped in a function or arithmetic does not.
     """
+    # Local import: ``cte`` imports from this module, so importing it at module
+    # top would cycle. ``get_column_full_name`` is the package's public helper
+    # for this and is a pure AST function -- it would sit more naturally here,
+    # but moving it means updating its callers in ``cte``/``utils``/``metrics``.
     from datajunction_server.construction.build_v3.cte import get_column_full_name
 
     if isinstance(expression, ast.Subscript):
@@ -457,6 +461,8 @@ def _bounds_by_ref(
     Computed once per build per node revision per side -- parsing every filter
     for every candidate pre-aggregation would re-parse the same strings N times.
     """
+    # Local import: ``preagg_matcher`` -> ``dimensions`` -> ``utils`` -> ``filters``
+    # is an existing chain, so importing it at module top would cycle.
     from datajunction_server.construction.build_v3.preagg_matcher import (
         canonical_dimension_ref,
     )

--- a/datajunction-server/datajunction_server/construction/build_v3/filters.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/filters.py
@@ -393,14 +393,14 @@ def get_filter_column_references(filter_str: str) -> list[str]:
     return references
 
 
-# Comparisons that put a ceiling on the column they name.
-_UPPER_BOUND_OPS = {
+# Comparisons under which the left operand is bounded above by the right.
+_CEILING_OPS = {
     ast.BinaryOpKind.Lt,
     ast.BinaryOpKind.LtEq,
     ast.BinaryOpKind.Eq,
 }
-# Mirror image, for filters written with the literal on the left.
-_REVERSED_UPPER_BOUND_OPS = {
+# Mirror image: the left operand is bounded below by the right.
+_FLOOR_OPS = {
     ast.BinaryOpKind.Gt,
     ast.BinaryOpKind.GtEq,
     ast.BinaryOpKind.Eq,
@@ -436,31 +436,43 @@ def _int_literal(expression: ast.Expression) -> int | None:
     return None
 
 
-def upper_bounds_by_ref(
+def _bounds_by_ref(
     ctx: "BuildContext",
     node_rev_id: int,
+    *,
+    upper: bool,
 ) -> dict[str, int]:
     """
-    Tightest upper bound each dimension reference carries, over all the query's
-    filters, keyed by canonical reference.
+    Tightest bound on one side that each dimension reference carries, over all
+    the query's filters, keyed by canonical reference.
 
-    Reads ``<``, ``<=``, ``=`` and ``BETWEEN`` against an integer literal, in
-    either operand order, which is the shape a partition-format temporal filter
-    takes. A strict ``<`` is lowered by one: exact for a contiguous partition
-    ordinal, merely conservative otherwise. Filters are ANDed, so the tightest
-    ceiling wins. A reference absent from the result carries no readable bound,
-    which callers must treat as an open-ended request rather than as permission.
+    Reads ``<``, ``<=``, ``>``, ``>=``, ``=`` and ``BETWEEN`` against an integer
+    literal, in either operand order, which is the shape a partition-format
+    temporal filter takes. A strict inequality moves the bound one step inward:
+    exact for a contiguous partition ordinal, merely conservative otherwise.
+    Filters are ANDed, so the tightest bound wins. A reference absent from the
+    result carries no readable bound on this side, which callers must treat as
+    an open-ended request rather than as permission.
 
-    Computed once per build per node revision -- parsing every filter for every
-    candidate pre-aggregation would re-parse the same strings N times.
+    Computed once per build per node revision per side -- parsing every filter
+    for every candidate pre-aggregation would re-parse the same strings N times.
     """
     from datajunction_server.construction.build_v3.preagg_matcher import (
         canonical_dimension_ref,
     )
 
-    cached = ctx._upper_bound_cache.get(node_rev_id)
+    cached = ctx._filter_bound_cache.get((node_rev_id, upper))
     if cached is not None:
         return cached
+
+    # The ref sits on the left of a ceiling comparison, or on the right of a
+    # floor one, to be bounded above; the two sets swap for a lower bound.
+    left_ops = _CEILING_OPS if upper else _FLOOR_OPS
+    right_ops = _FLOOR_OPS if upper else _CEILING_OPS
+    strict_left = ast.BinaryOpKind.Lt if upper else ast.BinaryOpKind.Gt
+    strict_right = ast.BinaryOpKind.Gt if upper else ast.BinaryOpKind.Lt
+    step = -1 if upper else 1
+    tighter = min if upper else max
 
     bounds: dict[str, int] = {}
 
@@ -468,7 +480,7 @@ def upper_bounds_by_ref(
         if ref is None or value is None:
             return
         canonical = canonical_dimension_ref(ctx, node_rev_id, ref)
-        bounds[canonical] = min(bounds.get(canonical, value), value)
+        bounds[canonical] = tighter(bounds.get(canonical, value), value)
 
     for filter_str in ctx.dimension_filters:
         filter_ast = parse_filter(filter_str)
@@ -476,28 +488,44 @@ def upper_bounds_by_ref(
         if any(comparison.op in _DISJUNCTION_OPS for comparison in comparisons):
             continue
         for comparison in comparisons:
-            if comparison.op in _UPPER_BOUND_OPS:
+            if comparison.op in left_ops:
                 value = _int_literal(comparison.right)
                 offer(
                     dimension_ref_of_expression(comparison.left),
                     None
                     if value is None
-                    else value - (comparison.op == ast.BinaryOpKind.Lt),
+                    else value + step * (comparison.op == strict_left),
                 )
-            if comparison.op in _REVERSED_UPPER_BOUND_OPS:
+            if comparison.op in right_ops:
                 value = _int_literal(comparison.left)
                 offer(
                     dimension_ref_of_expression(comparison.right),
                     None
                     if value is None
-                    else value - (comparison.op == ast.BinaryOpKind.Gt),
+                    else value + step * (comparison.op == strict_right),
                 )
         for between in filter_ast.find_all(ast.Between):
             if not between.negated:
                 offer(
                     dimension_ref_of_expression(between.expr),
-                    _int_literal(between.high),
+                    _int_literal(between.high if upper else between.low),
                 )
 
-    ctx._upper_bound_cache[node_rev_id] = bounds
+    ctx._filter_bound_cache[(node_rev_id, upper)] = bounds
     return bounds
+
+
+def upper_bounds_by_ref(ctx: "BuildContext", node_rev_id: int) -> dict[str, int]:
+    """
+    Tightest ceiling each dimension reference carries, over all the query's
+    filters. See :func:`_bounds_by_ref`.
+    """
+    return _bounds_by_ref(ctx, node_rev_id, upper=True)
+
+
+def lower_bounds_by_ref(ctx: "BuildContext", node_rev_id: int) -> dict[str, int]:
+    """
+    Tightest floor each dimension reference carries, over all the query's
+    filters. See :func:`_bounds_by_ref`.
+    """
+    return _bounds_by_ref(ctx, node_rev_id, upper=False)

--- a/datajunction-server/datajunction_server/construction/build_v3/filters.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/filters.py
@@ -18,6 +18,7 @@ from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.utils import SEPARATOR
 
 if TYPE_CHECKING:
+    from datajunction_server.construction.build_v3.types import BuildContext
     from datajunction_server.database.node import Node
 
 
@@ -390,3 +391,113 @@ def get_filter_column_references(filter_str: str) -> list[str]:
             references.append(full_ref)
 
     return references
+
+
+# Comparisons that put a ceiling on the column they name.
+_UPPER_BOUND_OPS = {
+    ast.BinaryOpKind.Lt,
+    ast.BinaryOpKind.LtEq,
+    ast.BinaryOpKind.Eq,
+}
+# Mirror image, for filters written with the literal on the left.
+_REVERSED_UPPER_BOUND_OPS = {
+    ast.BinaryOpKind.Gt,
+    ast.BinaryOpKind.GtEq,
+    ast.BinaryOpKind.Eq,
+}
+# A disjunction can widen the requested range beyond any bound read off one of
+# its sides, so filters containing one are skipped rather than trusted.
+_DISJUNCTION_OPS = {ast.BinaryOpKind.Or, ast.BinaryOpKind.LogicalOr}
+
+
+def dimension_ref_of_expression(expression: ast.Expression) -> str | None:
+    """
+    Dimension reference an expression names, if it names one directly.
+
+    ``v3.date.date_id`` and ``v3.date.date_id[order]`` both resolve; anything
+    wrapped in a function or arithmetic does not.
+    """
+    from datajunction_server.construction.build_v3.cte import get_column_full_name
+
+    if isinstance(expression, ast.Subscript):
+        role = extract_subscript_role(expression)
+        if not isinstance(expression.expr, ast.Column) or not role:
+            return None
+        return f"{get_column_full_name(expression.expr)}[{role}]"
+    if isinstance(expression, ast.Column):
+        return get_column_full_name(expression)
+    return None
+
+
+def _int_literal(expression: ast.Expression) -> int | None:
+    """The integer a literal expression holds, or None if it isn't one."""
+    if isinstance(expression, ast.Number) and isinstance(expression.value, int):
+        return expression.value
+    return None
+
+
+def upper_bounds_by_ref(
+    ctx: "BuildContext",
+    node_rev_id: int,
+) -> dict[str, int]:
+    """
+    Tightest upper bound each dimension reference carries, over all the query's
+    filters, keyed by canonical reference.
+
+    Reads ``<``, ``<=``, ``=`` and ``BETWEEN`` against an integer literal, in
+    either operand order, which is the shape a partition-format temporal filter
+    takes. A strict ``<`` is lowered by one: exact for a contiguous partition
+    ordinal, merely conservative otherwise. Filters are ANDed, so the tightest
+    ceiling wins. A reference absent from the result carries no readable bound,
+    which callers must treat as an open-ended request rather than as permission.
+
+    Computed once per build per node revision -- parsing every filter for every
+    candidate pre-aggregation would re-parse the same strings N times.
+    """
+    from datajunction_server.construction.build_v3.preagg_matcher import (
+        canonical_dimension_ref,
+    )
+
+    cached = ctx._upper_bound_cache.get(node_rev_id)
+    if cached is not None:
+        return cached
+
+    bounds: dict[str, int] = {}
+
+    def offer(ref: str | None, value: int | None) -> None:
+        if ref is None or value is None:
+            return
+        canonical = canonical_dimension_ref(ctx, node_rev_id, ref)
+        bounds[canonical] = min(bounds.get(canonical, value), value)
+
+    for filter_str in ctx.dimension_filters:
+        filter_ast = parse_filter(filter_str)
+        comparisons = list(filter_ast.find_all(ast.BinaryOp))
+        if any(comparison.op in _DISJUNCTION_OPS for comparison in comparisons):
+            continue
+        for comparison in comparisons:
+            if comparison.op in _UPPER_BOUND_OPS:
+                value = _int_literal(comparison.right)
+                offer(
+                    dimension_ref_of_expression(comparison.left),
+                    None
+                    if value is None
+                    else value - (comparison.op == ast.BinaryOpKind.Lt),
+                )
+            if comparison.op in _REVERSED_UPPER_BOUND_OPS:
+                value = _int_literal(comparison.left)
+                offer(
+                    dimension_ref_of_expression(comparison.right),
+                    None
+                    if value is None
+                    else value - (comparison.op == ast.BinaryOpKind.Gt),
+                )
+        for between in filter_ast.find_all(ast.Between):
+            if not between.negated:
+                offer(
+                    dimension_ref_of_expression(between.expr),
+                    _int_literal(between.high),
+                )
+
+    ctx._upper_bound_cache[node_rev_id] = bounds
+    return bounds

--- a/datajunction-server/datajunction_server/construction/build_v3/filters.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/filters.py
@@ -405,9 +405,24 @@ _FLOOR_OPS = {
     ast.BinaryOpKind.GtEq,
     ast.BinaryOpKind.Eq,
 }
-# A disjunction can widen the requested range beyond any bound read off one of
-# its sides, so filters containing one are skipped rather than trusted.
-_DISJUNCTION_OPS = {ast.BinaryOpKind.Or, ast.BinaryOpKind.LogicalOr}
+# Only these join predicates the query definitely asserts. Anything else -- a
+# disjunction, a negation, a comparison buried in a CASE -- is not asserted by
+# being present, so no bound may be read from inside it.
+_CONJUNCTION_OPS = {ast.BinaryOpKind.And, ast.BinaryOpKind.LogicalAnd}
+
+
+def _conjuncts(expression: ast.Expression) -> list[ast.Expression]:
+    """
+    The predicates a filter asserts unconditionally: its top-level AND spine.
+
+    A comparison is only a bound if the query actually asserts it. Walking every
+    ``BinaryOp`` in the tree would read one out of ``NOT (x <= 1)`` or
+    ``CASE WHEN x < 1 ...`` and invert its meaning, so descent stops at anything
+    that is not an AND.
+    """
+    if isinstance(expression, ast.BinaryOp) and expression.op in _CONJUNCTION_OPS:
+        return _conjuncts(expression.left) + _conjuncts(expression.right)
+    return [expression]
 
 
 def dimension_ref_of_expression(expression: ast.Expression) -> str | None:
@@ -489,10 +504,9 @@ def _bounds_by_ref(
         bounds[canonical] = tighter(bounds.get(canonical, value), value)
 
     for filter_str in ctx.dimension_filters:
-        filter_ast = parse_filter(filter_str)
-        comparisons = list(filter_ast.find_all(ast.BinaryOp))
-        if any(comparison.op in _DISJUNCTION_OPS for comparison in comparisons):
-            continue
+        conjuncts = _conjuncts(parse_filter(filter_str))
+        comparisons = [c for c in conjuncts if isinstance(c, ast.BinaryOp)]
+        betweens = [c for c in conjuncts if isinstance(c, ast.Between)]
         for comparison in comparisons:
             if comparison.op in left_ops:
                 value = _int_literal(comparison.right)
@@ -510,7 +524,7 @@ def _bounds_by_ref(
                     if value is None
                     else value + step * (comparison.op == strict_right),
                 )
-        for between in filter_ast.find_all(ast.Between):
+        for between in betweens:
             if not between.negated:
                 offer(
                     dimension_ref_of_expression(between.expr),

--- a/datajunction-server/datajunction_server/construction/build_v3/loaders.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/loaders.py
@@ -17,6 +17,10 @@ from datajunction_server.database.preaggregation import PreAggregation
 from datajunction_server.models.node_type import NodeType
 
 from datajunction_server.construction.build_v3.dimensions import parse_dimension_ref
+from datajunction_server.construction.build_v3.preagg_freshness import (
+    freshness_gating_enabled,
+    preagg_is_fresh,
+)
 from datajunction_server.construction.build_v3.types import BuildContext
 from datajunction_server.construction.build_v3.utils import (
     collect_required_dimensions,
@@ -642,9 +646,22 @@ async def load_available_preaggs(ctx: BuildContext) -> None:
         return
 
     # Query for available pre-aggs with their availability state
+    options = [joinedload(PreAggregation.availability)]
+    if freshness_gating_enabled():
+        # Freshness gating reads the parent's temporal partition columns and the
+        # dimension links they feed, so eager-load them — but only when the gate
+        # is on, to keep the common path's query as cheap as it is today.
+        options.append(
+            joinedload(PreAggregation.node_revision).options(
+                selectinload(NodeRevision.columns).joinedload(Column.partition),
+                selectinload(NodeRevision.dimension_links).joinedload(
+                    DimensionLink.dimension,
+                ),
+            ),
+        )
     stmt = (
         select(PreAggregation)
-        .options(joinedload(PreAggregation.availability))
+        .options(*options)
         .where(
             PreAggregation.node_revision_id.in_(parent_revision_ids),
             PreAggregation.availability_id.isnot(None),  # Has availability
@@ -655,7 +672,11 @@ async def load_available_preaggs(ctx: BuildContext) -> None:
 
     # Index by node_revision_id for fast lookup
     for preagg in preaggs:
-        if preagg.availability and preagg.availability.is_available():
+        if (
+            preagg.availability
+            and preagg.availability.is_available()
+            and preagg_is_fresh(ctx, preagg)
+        ):
             if preagg.node_revision_id not in ctx.available_preaggs:
                 ctx.available_preaggs[preagg.node_revision_id] = []
             ctx.available_preaggs[preagg.node_revision_id].append(preagg)

--- a/datajunction-server/datajunction_server/construction/build_v3/loaders.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/loaders.py
@@ -17,10 +17,7 @@ from datajunction_server.database.preaggregation import PreAggregation
 from datajunction_server.models.node_type import NodeType
 
 from datajunction_server.construction.build_v3.dimensions import parse_dimension_ref
-from datajunction_server.construction.build_v3.preagg_freshness import (
-    freshness_gating_enabled,
-    preagg_is_fresh,
-)
+from datajunction_server.construction.build_v3.preagg_freshness import preagg_is_fresh
 from datajunction_server.construction.build_v3.types import BuildContext
 from datajunction_server.construction.build_v3.utils import (
     collect_required_dimensions,
@@ -646,22 +643,9 @@ async def load_available_preaggs(ctx: BuildContext) -> None:
         return
 
     # Query for available pre-aggs with their availability state
-    options = [joinedload(PreAggregation.availability)]
-    if freshness_gating_enabled():
-        # Freshness gating reads the parent's temporal partition columns and the
-        # dimension links they feed, so eager-load them — but only when the gate
-        # is on, to keep the common path's query as cheap as it is today.
-        options.append(
-            joinedload(PreAggregation.node_revision).options(
-                selectinload(NodeRevision.columns).joinedload(Column.partition),
-                selectinload(NodeRevision.dimension_links).joinedload(
-                    DimensionLink.dimension,
-                ),
-            ),
-        )
     stmt = (
         select(PreAggregation)
-        .options(*options)
+        .options(joinedload(PreAggregation.availability))
         .where(
             PreAggregation.node_revision_id.in_(parent_revision_ids),
             PreAggregation.availability_id.isnot(None),  # Has availability

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_freshness.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_freshness.py
@@ -9,10 +9,13 @@ never been backfilled past 2026, or whose pipeline had stopped running, kept
 serving silently truncated results.
 
 The gate is a two-sided range check: a pre-agg is rejected when the query asks
-for data outside what the table holds, below the covered range as readily as
-above it. Both ends matter -- a backfill gap at the low end is at least as common
-as a dead pipeline at the high end -- and both are compared against the range the
-query's own filters describe, not against wall clock. A query bounded at last
+for data outside what the table holds, below the covered range as well as above
+it. Only a side the query actually states is checked, though -- a query with no
+lower bound formally asks for all history, and rejecting every retention-limited
+pre-agg for an unfiltered query would be worse than serving one. Both ends
+matter -- a backfill gap at the low end is at least as common as a dead pipeline
+at the high end -- and both are compared against the range the query's own
+filters describe, not against wall clock. A query bounded at last
 March is served correctly by a table that stopped updating yesterday, and
 rejecting it would be wrong.
 
@@ -132,7 +135,9 @@ def _axis_value(
     names = availability.temporal_partitions or []
     if names and len(names) != len(values):
         return None
-    if len(values) == 1:
+    # A lone value is the axis's only when nothing says otherwise -- if the names
+    # are reported and name a different column, this value isn't for our axis.
+    if len(values) == 1 and (not names or names == [axis.output_name]):
         return _as_int(values[0])
     if axis.output_name in names:
         return _as_int(values[names.index(axis.output_name)])

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_freshness.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_freshness.py
@@ -1,22 +1,27 @@
 """
 Freshness gating for pre-aggregations.
 
-A pre-aggregation reports how far its data goes with ``valid_through_ts``, an
-integer in the backing table's partition format (``20260721`` for ``yyyyMMdd``).
-Nothing consulted it when routing queries, so a pre-agg whose pipeline stopped
-running kept serving silently truncated results.
+A pre-aggregation's availability records the range its table actually covers:
+``min_temporal_partition`` and ``max_temporal_partition``, the lowest and highest
+partition values written, alongside the self-reported ``valid_through_ts``
+scalar. Nothing consulted any of it when routing queries, so a pre-agg that had
+never been backfilled past 2026, or whose pipeline had stopped running, kept
+serving silently truncated results.
 
-The gate compares that watermark against the time range the query actually asks
-for, rather than against wall clock: a query bounded at last March is served
-correctly by a table that stopped updating yesterday, and rejecting it would be
-wrong. Only when the query has no discoverable upper bound -- so it implicitly
-asks for data through the present -- does a wall-clock staleness budget apply.
+The gate is a two-sided range check: a pre-agg is rejected when the query asks
+for data outside what the table holds, below the covered range as readily as
+above it. Both ends matter -- a backfill gap at the low end is at least as common
+as a dead pipeline at the high end -- and both are compared against the range the
+query's own filters describe, not against wall clock. A query bounded at last
+March is served correctly by a table that stopped updating yesterday, and
+rejecting it would be wrong.
 
-Both comparisons stay in the partition format, which is what makes them safe:
-``valid_through_ts`` is never interpreted as a point in time, only compared
-against a filter literal written in the same encoding, or against "now" rendered
-into that encoding. Where the watermark plainly isn't in that encoding the gate
-says so and declines, rather than comparing incommensurable integers.
+Every comparison stays inside the partition format, which is what makes it safe:
+a partition value is never interpreted as a point in time, only compared against
+a filter literal written in the same encoding. ``valid_through_ts`` stands in for
+a missing ``max_temporal_partition`` -- externally registered pre-aggs report
+nothing else -- but its encoding is contradicted across the repo, so it is used
+only where its magnitude is consistent with the value it's compared against.
 
 Pre-aggregations only. Cubes and node-level materializations have their own
 availability checks and are not gated here. Off unless
@@ -27,61 +32,169 @@ from __future__ import annotations
 
 import logging
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
-from datajunction_server.construction.build_v3.filters import upper_bounds_by_ref
+from datajunction_server.construction.build_v3.filters import (
+    lower_bounds_by_ref,
+    upper_bounds_by_ref,
+)
 from datajunction_server.construction.build_v3.preagg_matcher import (
+    canonical_dimension_ref,
     match_temporal_columns_to_grain,
+    temporal_output_name,
 )
 from datajunction_server.models.partition import render_partition_value
 from datajunction_server.utils import get_settings
 
 if TYPE_CHECKING:
+    from datajunction_server.config import Settings
     from datajunction_server.construction.build_v3.types import BuildContext
+    from datajunction_server.database.availabilitystate import AvailabilityState
     from datajunction_server.database.preaggregation import PreAggregation
 
 logger = logging.getLogger(__name__)
 
 
-def freshness_gating_enabled() -> bool:
-    """Whether freshness gating is turned on for this deployment."""
-    return get_settings().preagg_freshness_gating
+class TemporalAxis(NamedTuple):
+    """The single temporal axis a pre-aggregation can be judged on."""
+
+    # Canonical grain entry, e.g. ``v3.date.date_id[order]``.
+    grain_ref: str
+    # Partition format of the underlying column, e.g. ``yyyyMMdd``.
+    partition_format: str | None
+    # Name the axis carries in the pre-agg's output table.
+    output_name: str
 
 
-def temporal_grain_axis(preagg: "PreAggregation") -> tuple[str, str | None] | None:
+def temporal_grain_axis(preagg: "PreAggregation") -> TemporalAxis | None:
     """
-    The single temporal axis ``valid_through_ts`` describes, as (grain ref, format).
+    The single temporal axis a pre-agg's availability range describes.
 
-    A pre-agg reports one watermark, so it can only be judged when exactly one of
-    its temporal partition columns is part of the grain. Zero means there is no
-    temporal axis to judge; more than one means the watermark doesn't say which it
-    belongs to, and bounds read off different axes may not even share an encoding.
-    Both decline rather than guess -- the same collapse to a single axis that
-    combiner construction already makes.
+    A pre-agg can only be judged when exactly one of its temporal partition
+    columns is part of the grain. Zero means there is no temporal axis to judge;
+    more than one means bounds read off different axes may not even share an
+    encoding. Both decline rather than guess -- the same collapse to a single
+    axis that combiner construction already makes.
     """
     axes = [
-        (grain_ref, temporal_col.partition.format)
+        TemporalAxis(
+            grain_ref,
+            temporal_col.partition.format,
+            temporal_output_name(temporal_col, grain_ref),
+        )
         for temporal_col, grain_ref in match_temporal_columns_to_grain(preagg)
         if grain_ref
     ]
     return axes[0] if len(axes) == 1 else None
 
 
-def _watermark_is_comparable(valid_through_ts: int, reference: int) -> bool:
+def _is_comparable(covered: int, requested: int) -> bool:
     """
-    Whether a watermark plausibly shares an encoding with a partition-format value.
+    Whether two values plausibly share an encoding.
 
-    ``valid_through_ts`` has no agreed encoding across DJ -- partition format,
-    epoch seconds and epoch milliseconds all appear. Comparing across encodings is
-    meaningless in a way that silently passes everything, so an order-of-magnitude
-    mismatch is treated as "cannot judge" and reported.
+    Partition formats, epoch seconds and epoch milliseconds all appear in the
+    wild as ``valid_through_ts``, while a filter literal is only ever in the
+    partition format. Comparing across encodings is meaningless in a way that
+    silently passes everything, so an order-of-magnitude mismatch is treated as
+    "cannot judge" and reported.
     """
-    return len(str(abs(valid_through_ts))) == len(str(abs(reference)))
+    return len(str(abs(covered))) == len(str(abs(requested)))
+
+
+def _as_int(value: str) -> int | None:
+    """A partition value as the integer its format renders to, if it is one."""
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _axis_value(
+    availability: "AvailabilityState",
+    values: list[str] | None,
+    axis: TemporalAxis,
+) -> int | None:
+    """
+    The bound on ``axis`` read out of a min/max temporal partition list.
+
+    The list runs parallel to ``temporal_partitions`` -- one value per temporal
+    partition column, ``["20260721", "13"]`` against ``["date", "hour"]`` -- so
+    the axis's entry is the one at its output column's position. A lone value
+    needs no placing. Anything else, including a list whose length contradicts
+    the declared columns, is declined rather than guessed at.
+
+    Values are read as integers rather than compared as strings: the filter side
+    is already an integer literal, so string comparison would mean rendering it
+    back out at a width nothing declares, whereas a partition value in an integer
+    format parses exactly.
+    """
+    values = values or []
+    names = availability.temporal_partitions or []
+    if names and len(names) != len(values):
+        return None
+    if len(values) == 1:
+        return _as_int(values[0])
+    if axis.output_name in names:
+        return _as_int(values[names.index(axis.output_name)])
+    return None
+
+
+def _report_incomparable(
+    preagg: "PreAggregation",
+    covered: int,
+    requested: int,
+) -> None:
+    """Note that a bound can't be judged, and why."""
+    logger.warning(
+        "[BuildV3] Pre-agg %s reports coverage %s, which is not in the same "
+        "encoding as the requested bound %s -- not gating on freshness. Report "
+        "temporal coverage in the table's partition format.",
+        preagg.id,
+        covered,
+        requested,
+    )
+
+
+def _within_staleness_budget(
+    ctx: "BuildContext",
+    preagg: "PreAggregation",
+    axis: TemporalAxis,
+    covered_through: int,
+    settings: "Settings",
+) -> bool:
+    """
+    Whether an open-ended query's implicit "through the present" is satisfied.
+
+    A query with no readable ceiling asks for data up to now, and no partition
+    comparison settles that on its own, so this is the one place a wall-clock
+    budget applies. It renders "now minus the budget" into the partition format
+    and requires the covered range to reach it, keeping the comparison inside the
+    one encoding even though the question is about wall clock.
+    """
+    if settings.preagg_max_staleness_seconds is None:
+        return True
+
+    cutoff = render_partition_value(
+        ctx.build_timestamp - timedelta(seconds=settings.preagg_max_staleness_seconds),
+        axis.partition_format,
+    )
+    if cutoff is None or not _is_comparable(covered_through, cutoff):
+        return True
+    if covered_through < cutoff:
+        logger.info(
+            "[BuildV3] Pre-agg %s covers through %s, past the staleness budget "
+            "cutoff of %s for an open-ended query",
+            preagg.id,
+            covered_through,
+            cutoff,
+        )
+        return False
+    return True
 
 
 def preagg_is_fresh(ctx: "BuildContext", preagg: "PreAggregation") -> bool:
     """
-    Whether a pre-agg's reported freshness covers what the query asks for.
+    Whether the range a pre-agg covers contains the range the query asks for.
 
     Always True unless ``preagg_freshness_gating`` is enabled, and True whenever
     the pre-agg offers no single temporal axis to judge it on.
@@ -93,51 +206,49 @@ def preagg_is_fresh(ctx: "BuildContext", preagg: "PreAggregation") -> bool:
     axis = temporal_grain_axis(preagg)
     if axis is None:
         return True
-    ref, partition_format = axis
 
-    valid_through_ts = preagg.availability.valid_through_ts
+    availability = preagg.availability
+    covered_from = _axis_value(availability, availability.min_temporal_partition, axis)
+    covered_through = _axis_value(
+        availability,
+        availability.max_temporal_partition,
+        axis,
+    )
+    if covered_through is None:
+        # Externally registered pre-aggs report only the scalar watermark.
+        covered_through = availability.valid_through_ts
+
+    # Filter bounds are keyed canonically, so the grain entry must be too.
+    ref = canonical_dimension_ref(ctx, preagg.node_revision_id, axis.grain_ref)
+    requested_from = lower_bounds_by_ref(ctx, preagg.node_revision_id).get(ref)
     requested_through = upper_bounds_by_ref(ctx, preagg.node_revision_id).get(ref)
 
-    if requested_through is not None:
-        if not _watermark_is_comparable(valid_through_ts, requested_through):
-            logger.warning(
-                "[BuildV3] Pre-agg %s reports valid_through_ts %s, which is not in "
-                "the same encoding as the requested bound %s -- not gating on "
-                "freshness. Report valid_through_ts in the table's partition format.",
-                preagg.id,
-                valid_through_ts,
-                requested_through,
-            )
-            return True
-        if requested_through > valid_through_ts:
+    if requested_from is not None and covered_from is not None:
+        if not _is_comparable(covered_from, requested_from):
+            _report_incomparable(preagg, covered_from, requested_from)
+        elif requested_from < covered_from:
             logger.info(
-                "[BuildV3] Pre-agg %s is valid through %s but the query asks "
-                "for data through %s",
+                "[BuildV3] Pre-agg %s covers from %s but the query asks for "
+                "data from %s",
                 preagg.id,
-                valid_through_ts,
-                requested_through,
+                covered_from,
+                requested_from,
             )
             return False
-        return True
 
-    # Open-ended request: the query implicitly asks for data through the present,
-    # so fall back to the wall-clock staleness budget if one is configured.
-    if settings.preagg_max_staleness_seconds is None:
-        return True
+    if requested_through is None:
+        return _within_staleness_budget(ctx, preagg, axis, covered_through, settings)
 
-    cutoff = render_partition_value(
-        ctx.build_timestamp - timedelta(seconds=settings.preagg_max_staleness_seconds),
-        partition_format,
-    )
-    if cutoff is None or not _watermark_is_comparable(valid_through_ts, cutoff):
+    if not _is_comparable(covered_through, requested_through):
+        _report_incomparable(preagg, covered_through, requested_through)
         return True
-    if valid_through_ts < cutoff:
+    if requested_through > covered_through:
         logger.info(
-            "[BuildV3] Pre-agg %s is valid through %s, past the staleness "
-            "budget cutoff of %s for an open-ended query",
+            "[BuildV3] Pre-agg %s covers through %s but the query asks for "
+            "data through %s",
             preagg.id,
-            valid_through_ts,
-            cutoff,
+            covered_through,
+            requested_through,
         )
         return False
     return True

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_freshness.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_freshness.py
@@ -6,37 +6,34 @@ integer in the backing table's partition format (``20260721`` for ``yyyyMMdd``).
 Nothing consulted it when routing queries, so a pre-agg whose pipeline stopped
 running kept serving silently truncated results.
 
-The gate here compares that watermark against the time range the query actually
-asks for, rather than against wall clock: a query bounded at last March is served
+The gate compares that watermark against the time range the query actually asks
+for, rather than against wall clock: a query bounded at last March is served
 correctly by a table that stopped updating yesterday, and rejecting it would be
 wrong. Only when the query has no discoverable upper bound -- so it implicitly
 asks for data through the present -- does a wall-clock staleness budget apply.
 
 Both comparisons stay in the partition format, which is what makes them safe:
-``valid_through_ts`` is never interpreted as a point in time, it is only compared
+``valid_through_ts`` is never interpreted as a point in time, only compared
 against a filter literal written in the same encoding, or against "now" rendered
-into that encoding.
+into that encoding. Where the watermark plainly isn't in that encoding the gate
+says so and declines, rather than comparing incommensurable integers.
 
-Everything here is off unless ``preagg_freshness_gating`` is set.
+Pre-aggregations only. Cubes and node-level materializations have their own
+availability checks and are not gated here. Off unless
+``preagg_freshness_gating`` is set.
 """
 
 from __future__ import annotations
 
 import logging
-import re
-from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Callable
+from datetime import timedelta
+from typing import TYPE_CHECKING
 
-from datajunction_server.construction.build_v3.filters import (
-    _extract_full_column_ref,
-    extract_subscript_role,
-    parse_filter,
-)
+from datajunction_server.construction.build_v3.filters import upper_bounds_by_ref
 from datajunction_server.construction.build_v3.preagg_matcher import (
-    canonical_dimension_ref,
+    match_temporal_columns_to_grain,
 )
-from datajunction_server.naming import SEPARATOR
-from datajunction_server.sql.parsing import ast
+from datajunction_server.models.partition import render_partition_value
 from datajunction_server.utils import get_settings
 
 if TYPE_CHECKING:
@@ -45,164 +42,41 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Comparisons that put a ceiling on a temporal column.
-UPPER_BOUND_OPS = {
-    ast.BinaryOpKind.Lt,
-    ast.BinaryOpKind.LtEq,
-    ast.BinaryOpKind.Eq,
-}
-
-# A disjunction can widen the requested range beyond any bound we read off one
-# of its sides, so filters containing one are skipped rather than trusted.
-DISJUNCTION_OPS = {ast.BinaryOpKind.Or, ast.BinaryOpKind.LogicalOr}
-
-# Java-style temporal format tokens, rendered as the zero-padded value.
-FORMAT_TOKENS: dict[str, Callable[[datetime], str]] = {
-    "yyyy": lambda dt: f"{dt.year:04d}",
-    "MM": lambda dt: f"{dt.month:02d}",
-    "dd": lambda dt: f"{dt.day:02d}",
-    "HH": lambda dt: f"{dt.hour:02d}",
-    "mm": lambda dt: f"{dt.minute:02d}",
-    "ss": lambda dt: f"{dt.second:02d}",
-}
-TOKEN_PATTERN = re.compile("|".join(FORMAT_TOKENS))
-
 
 def freshness_gating_enabled() -> bool:
     """Whether freshness gating is turned on for this deployment."""
     return get_settings().preagg_freshness_gating
 
 
-def render_partition_value(moment: datetime, format_: str | None) -> int | None:
+def temporal_grain_axis(preagg: "PreAggregation") -> tuple[str, str | None] | None:
     """
-    Render a point in time as an integer in a partition format.
+    The single temporal axis ``valid_through_ts`` describes, as (grain ref, format).
 
-    Only all-token formats render: anything with separators or unknown text
-    (``yyyy-MM-dd``) can't produce an integer comparable to ``valid_through_ts``,
-    and yields None so the caller declines to judge.
+    A pre-agg reports one watermark, so it can only be judged when exactly one of
+    its temporal partition columns is part of the grain. Zero means there is no
+    temporal axis to judge; more than one means the watermark doesn't say which it
+    belongs to, and bounds read off different axes may not even share an encoding.
+    Both decline rather than guess -- the same collapse to a single axis that
+    combiner construction already makes.
     """
-    if not format_ or TOKEN_PATTERN.sub("", format_) != "":
-        return None
-    return int(
-        TOKEN_PATTERN.sub(lambda match: FORMAT_TOKENS[match.group()](moment), format_),
-    )
+    axes = [
+        (grain_ref, temporal_col.partition.format)
+        for temporal_col, grain_ref in match_temporal_columns_to_grain(preagg)
+        if grain_ref
+    ]
+    return axes[0] if len(axes) == 1 else None
 
 
-def temporal_grain_refs(preagg: "PreAggregation") -> list[tuple[str, str | None]]:
+def _watermark_is_comparable(valid_through_ts: int, reference: int) -> bool:
     """
-    The pre-agg's temporal partition columns as (grain dimension ref, format).
+    Whether a watermark plausibly shares an encoding with a partition-format value.
 
-    A pre-agg's freshness is only meaningful along a temporal column that is part
-    of its grain, since that is the axis ``valid_through_ts`` describes. The
-    parent's temporal partition column is matched to a grain entry either
-    directly, or through the dimension link that column feeds -- the same two
-    strategies ``get_temporal_partitions`` uses to name the output column.
+    ``valid_through_ts`` has no agreed encoding across DJ -- partition format,
+    epoch seconds and epoch milliseconds all appear. Comparing across encodings is
+    meaningless in a way that silently passes everything, so an order-of-magnitude
+    mismatch is treated as "cannot judge" and reported.
     """
-    node_revision = preagg.node_revision
-    if not node_revision:
-        return []
-
-    grain_columns = preagg.grain_columns or []
-
-    # A source column can feed several dimension links, so this is multi-valued.
-    col_to_dims: dict[str, list[str]] = {}
-    for dim_attr, source_col in node_revision.dimensions_to_columns_map().items():
-        source_name = source_col.identifier().split(SEPARATOR)[-1]
-        col_to_dims.setdefault(source_name, []).append(dim_attr)
-
-    refs: list[tuple[str, str | None]] = []
-    for temporal_col in node_revision.temporal_partition_columns():
-        format_ = temporal_col.partition.format
-        direct_ref = f"{node_revision.name}{SEPARATOR}{temporal_col.name}"
-        if direct_ref in grain_columns:
-            refs.append((direct_ref, format_))
-            continue
-        for dim_attr in col_to_dims.get(temporal_col.name, []):
-            dim_node = dim_attr.rsplit(SEPARATOR, 1)[0]
-            matched = next(
-                (
-                    grain_col
-                    for grain_col in grain_columns
-                    if grain_col == dim_attr
-                    or grain_col.startswith(dim_node + SEPARATOR)
-                ),
-                None,
-            )
-            if matched:
-                refs.append((matched, format_))
-                break
-    return refs
-
-
-def _dimension_ref_of(
-    ctx: "BuildContext",
-    node_rev_id: int,
-    expression: ast.Expression,
-) -> str | None:
-    """
-    Canonical dimension reference an expression names, if it names one directly.
-    """
-    if isinstance(expression, ast.Subscript):
-        role = extract_subscript_role(expression)
-        if not isinstance(expression.expr, ast.Column) or not role:
-            return None
-        ref = f"{_extract_full_column_ref(expression.expr)}[{role}]"
-        return canonical_dimension_ref(ctx, node_rev_id, ref)
-    if isinstance(expression, ast.Column):
-        return canonical_dimension_ref(
-            ctx,
-            node_rev_id,
-            _extract_full_column_ref(expression),
-        )
-    return None
-
-
-def _int_literal(expression: ast.Expression) -> int | None:
-    """The integer a literal expression holds, or None if it isn't one."""
-    if isinstance(expression, ast.Number) and isinstance(expression.value, int):
-        return expression.value
-    return None
-
-
-def query_upper_bound(
-    ctx: "BuildContext",
-    node_rev_id: int,
-    ref: str,
-) -> int | None:
-    """
-    Tightest upper bound the query's filters place on a dimension reference.
-
-    Reads ``<``, ``<=``, ``=`` and ``BETWEEN`` against an integer literal, which
-    is the shape a partition-format temporal filter takes. A strict ``<`` is
-    lowered by one, which is exact for a contiguous partition ordinal and merely
-    conservative otherwise. Returns None when no bound can be read, which the
-    caller treats as an open-ended request rather than as permission.
-    """
-    bounds: list[int] = []
-    for filter_str in ctx.dimension_filters:
-        filter_ast = parse_filter(filter_str)
-        if any(op.op in DISJUNCTION_OPS for op in filter_ast.find_all(ast.BinaryOp)):
-            continue
-        for comparison in filter_ast.find_all(ast.BinaryOp):
-            if comparison.op not in UPPER_BOUND_OPS:
-                continue
-            if _dimension_ref_of(ctx, node_rev_id, comparison.left) != ref:
-                continue
-            value = _int_literal(comparison.right)
-            if value is None:
-                continue
-            bounds.append(
-                value - 1 if comparison.op == ast.BinaryOpKind.Lt else value,
-            )
-        for between in filter_ast.find_all(ast.Between):
-            if between.negated:
-                continue
-            if _dimension_ref_of(ctx, node_rev_id, between.expr) != ref:
-                continue
-            value = _int_literal(between.high)
-            if value is not None:
-                bounds.append(value)
-    return min(bounds) if bounds else None
+    return len(str(abs(valid_through_ts))) == len(str(abs(reference)))
 
 
 def preagg_is_fresh(ctx: "BuildContext", preagg: "PreAggregation") -> bool:
@@ -210,32 +84,31 @@ def preagg_is_fresh(ctx: "BuildContext", preagg: "PreAggregation") -> bool:
     Whether a pre-agg's reported freshness covers what the query asks for.
 
     Always True unless ``preagg_freshness_gating`` is enabled, and True whenever
-    the pre-agg carries no temporal grain to judge it on.
+    the pre-agg offers no single temporal axis to judge it on.
     """
-    if not freshness_gating_enabled():
+    settings = get_settings()
+    if not settings.preagg_freshness_gating:
         return True
 
-    refs = temporal_grain_refs(preagg)
-    if not refs:
+    axis = temporal_grain_axis(preagg)
+    if axis is None:
         return True
+    ref, partition_format = axis
 
     valid_through_ts = preagg.availability.valid_through_ts
-    node_rev_id = preagg.node_revision_id
+    requested_through = upper_bounds_by_ref(ctx, preagg.node_revision_id).get(ref)
 
-    bounds: list[int] = []
-    for ref, _ in refs:
-        bound = query_upper_bound(
-            ctx,
-            node_rev_id,
-            canonical_dimension_ref(ctx, node_rev_id, ref),
-        )
-        if bound is None:
-            bounds = []
-            break
-        bounds.append(bound)
-
-    if bounds:
-        requested_through = max(bounds)
+    if requested_through is not None:
+        if not _watermark_is_comparable(valid_through_ts, requested_through):
+            logger.warning(
+                "[BuildV3] Pre-agg %s reports valid_through_ts %s, which is not in "
+                "the same encoding as the requested bound %s -- not gating on "
+                "freshness. Report valid_through_ts in the table's partition format.",
+                preagg.id,
+                valid_through_ts,
+                requested_through,
+            )
+            return True
         if requested_through > valid_through_ts:
             logger.info(
                 "[BuildV3] Pre-agg %s is valid through %s but the query asks "
@@ -249,15 +122,14 @@ def preagg_is_fresh(ctx: "BuildContext", preagg: "PreAggregation") -> bool:
 
     # Open-ended request: the query implicitly asks for data through the present,
     # so fall back to the wall-clock staleness budget if one is configured.
-    max_staleness = get_settings().preagg_max_staleness_seconds
-    if max_staleness is None:
+    if settings.preagg_max_staleness_seconds is None:
         return True
 
     cutoff = render_partition_value(
-        datetime.now(timezone.utc) - timedelta(seconds=max_staleness),
-        refs[0][1],
+        ctx.build_timestamp - timedelta(seconds=settings.preagg_max_staleness_seconds),
+        partition_format,
     )
-    if cutoff is None:
+    if cutoff is None or not _watermark_is_comparable(valid_through_ts, cutoff):
         return True
     if valid_through_ts < cutoff:
         logger.info(

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_freshness.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_freshness.py
@@ -1,0 +1,271 @@
+"""
+Freshness gating for pre-aggregations.
+
+A pre-aggregation reports how far its data goes with ``valid_through_ts``, an
+integer in the backing table's partition format (``20260721`` for ``yyyyMMdd``).
+Nothing consulted it when routing queries, so a pre-agg whose pipeline stopped
+running kept serving silently truncated results.
+
+The gate here compares that watermark against the time range the query actually
+asks for, rather than against wall clock: a query bounded at last March is served
+correctly by a table that stopped updating yesterday, and rejecting it would be
+wrong. Only when the query has no discoverable upper bound -- so it implicitly
+asks for data through the present -- does a wall-clock staleness budget apply.
+
+Both comparisons stay in the partition format, which is what makes them safe:
+``valid_through_ts`` is never interpreted as a point in time, it is only compared
+against a filter literal written in the same encoding, or against "now" rendered
+into that encoding.
+
+Everything here is off unless ``preagg_freshness_gating`` is set.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Callable
+
+from datajunction_server.construction.build_v3.filters import (
+    _extract_full_column_ref,
+    extract_subscript_role,
+    parse_filter,
+)
+from datajunction_server.construction.build_v3.preagg_matcher import (
+    canonical_dimension_ref,
+)
+from datajunction_server.naming import SEPARATOR
+from datajunction_server.sql.parsing import ast
+from datajunction_server.utils import get_settings
+
+if TYPE_CHECKING:
+    from datajunction_server.construction.build_v3.types import BuildContext
+    from datajunction_server.database.preaggregation import PreAggregation
+
+logger = logging.getLogger(__name__)
+
+# Comparisons that put a ceiling on a temporal column.
+UPPER_BOUND_OPS = {
+    ast.BinaryOpKind.Lt,
+    ast.BinaryOpKind.LtEq,
+    ast.BinaryOpKind.Eq,
+}
+
+# A disjunction can widen the requested range beyond any bound we read off one
+# of its sides, so filters containing one are skipped rather than trusted.
+DISJUNCTION_OPS = {ast.BinaryOpKind.Or, ast.BinaryOpKind.LogicalOr}
+
+# Java-style temporal format tokens, rendered as the zero-padded value.
+FORMAT_TOKENS: dict[str, Callable[[datetime], str]] = {
+    "yyyy": lambda dt: f"{dt.year:04d}",
+    "MM": lambda dt: f"{dt.month:02d}",
+    "dd": lambda dt: f"{dt.day:02d}",
+    "HH": lambda dt: f"{dt.hour:02d}",
+    "mm": lambda dt: f"{dt.minute:02d}",
+    "ss": lambda dt: f"{dt.second:02d}",
+}
+TOKEN_PATTERN = re.compile("|".join(FORMAT_TOKENS))
+
+
+def freshness_gating_enabled() -> bool:
+    """Whether freshness gating is turned on for this deployment."""
+    return get_settings().preagg_freshness_gating
+
+
+def render_partition_value(moment: datetime, format_: str | None) -> int | None:
+    """
+    Render a point in time as an integer in a partition format.
+
+    Only all-token formats render: anything with separators or unknown text
+    (``yyyy-MM-dd``) can't produce an integer comparable to ``valid_through_ts``,
+    and yields None so the caller declines to judge.
+    """
+    if not format_ or TOKEN_PATTERN.sub("", format_) != "":
+        return None
+    return int(
+        TOKEN_PATTERN.sub(lambda match: FORMAT_TOKENS[match.group()](moment), format_),
+    )
+
+
+def temporal_grain_refs(preagg: "PreAggregation") -> list[tuple[str, str | None]]:
+    """
+    The pre-agg's temporal partition columns as (grain dimension ref, format).
+
+    A pre-agg's freshness is only meaningful along a temporal column that is part
+    of its grain, since that is the axis ``valid_through_ts`` describes. The
+    parent's temporal partition column is matched to a grain entry either
+    directly, or through the dimension link that column feeds -- the same two
+    strategies ``get_temporal_partitions`` uses to name the output column.
+    """
+    node_revision = preagg.node_revision
+    if not node_revision:
+        return []
+
+    grain_columns = preagg.grain_columns or []
+
+    # A source column can feed several dimension links, so this is multi-valued.
+    col_to_dims: dict[str, list[str]] = {}
+    for dim_attr, source_col in node_revision.dimensions_to_columns_map().items():
+        source_name = source_col.identifier().split(SEPARATOR)[-1]
+        col_to_dims.setdefault(source_name, []).append(dim_attr)
+
+    refs: list[tuple[str, str | None]] = []
+    for temporal_col in node_revision.temporal_partition_columns():
+        format_ = temporal_col.partition.format
+        direct_ref = f"{node_revision.name}{SEPARATOR}{temporal_col.name}"
+        if direct_ref in grain_columns:
+            refs.append((direct_ref, format_))
+            continue
+        for dim_attr in col_to_dims.get(temporal_col.name, []):
+            dim_node = dim_attr.rsplit(SEPARATOR, 1)[0]
+            matched = next(
+                (
+                    grain_col
+                    for grain_col in grain_columns
+                    if grain_col == dim_attr
+                    or grain_col.startswith(dim_node + SEPARATOR)
+                ),
+                None,
+            )
+            if matched:
+                refs.append((matched, format_))
+                break
+    return refs
+
+
+def _dimension_ref_of(
+    ctx: "BuildContext",
+    node_rev_id: int,
+    expression: ast.Expression,
+) -> str | None:
+    """
+    Canonical dimension reference an expression names, if it names one directly.
+    """
+    if isinstance(expression, ast.Subscript):
+        role = extract_subscript_role(expression)
+        if not isinstance(expression.expr, ast.Column) or not role:
+            return None
+        ref = f"{_extract_full_column_ref(expression.expr)}[{role}]"
+        return canonical_dimension_ref(ctx, node_rev_id, ref)
+    if isinstance(expression, ast.Column):
+        return canonical_dimension_ref(
+            ctx,
+            node_rev_id,
+            _extract_full_column_ref(expression),
+        )
+    return None
+
+
+def _int_literal(expression: ast.Expression) -> int | None:
+    """The integer a literal expression holds, or None if it isn't one."""
+    if isinstance(expression, ast.Number) and isinstance(expression.value, int):
+        return expression.value
+    return None
+
+
+def query_upper_bound(
+    ctx: "BuildContext",
+    node_rev_id: int,
+    ref: str,
+) -> int | None:
+    """
+    Tightest upper bound the query's filters place on a dimension reference.
+
+    Reads ``<``, ``<=``, ``=`` and ``BETWEEN`` against an integer literal, which
+    is the shape a partition-format temporal filter takes. A strict ``<`` is
+    lowered by one, which is exact for a contiguous partition ordinal and merely
+    conservative otherwise. Returns None when no bound can be read, which the
+    caller treats as an open-ended request rather than as permission.
+    """
+    bounds: list[int] = []
+    for filter_str in ctx.dimension_filters:
+        filter_ast = parse_filter(filter_str)
+        if any(op.op in DISJUNCTION_OPS for op in filter_ast.find_all(ast.BinaryOp)):
+            continue
+        for comparison in filter_ast.find_all(ast.BinaryOp):
+            if comparison.op not in UPPER_BOUND_OPS:
+                continue
+            if _dimension_ref_of(ctx, node_rev_id, comparison.left) != ref:
+                continue
+            value = _int_literal(comparison.right)
+            if value is None:
+                continue
+            bounds.append(
+                value - 1 if comparison.op == ast.BinaryOpKind.Lt else value,
+            )
+        for between in filter_ast.find_all(ast.Between):
+            if between.negated:
+                continue
+            if _dimension_ref_of(ctx, node_rev_id, between.expr) != ref:
+                continue
+            value = _int_literal(between.high)
+            if value is not None:
+                bounds.append(value)
+    return min(bounds) if bounds else None
+
+
+def preagg_is_fresh(ctx: "BuildContext", preagg: "PreAggregation") -> bool:
+    """
+    Whether a pre-agg's reported freshness covers what the query asks for.
+
+    Always True unless ``preagg_freshness_gating`` is enabled, and True whenever
+    the pre-agg carries no temporal grain to judge it on.
+    """
+    if not freshness_gating_enabled():
+        return True
+
+    refs = temporal_grain_refs(preagg)
+    if not refs:
+        return True
+
+    valid_through_ts = preagg.availability.valid_through_ts
+    node_rev_id = preagg.node_revision_id
+
+    bounds: list[int] = []
+    for ref, _ in refs:
+        bound = query_upper_bound(
+            ctx,
+            node_rev_id,
+            canonical_dimension_ref(ctx, node_rev_id, ref),
+        )
+        if bound is None:
+            bounds = []
+            break
+        bounds.append(bound)
+
+    if bounds:
+        requested_through = max(bounds)
+        if requested_through > valid_through_ts:
+            logger.info(
+                "[BuildV3] Pre-agg %s is valid through %s but the query asks "
+                "for data through %s",
+                preagg.id,
+                valid_through_ts,
+                requested_through,
+            )
+            return False
+        return True
+
+    # Open-ended request: the query implicitly asks for data through the present,
+    # so fall back to the wall-clock staleness budget if one is configured.
+    max_staleness = get_settings().preagg_max_staleness_seconds
+    if max_staleness is None:
+        return True
+
+    cutoff = render_partition_value(
+        datetime.now(timezone.utc) - timedelta(seconds=max_staleness),
+        refs[0][1],
+    )
+    if cutoff is None:
+        return True
+    if valid_through_ts < cutoff:
+        logger.info(
+            "[BuildV3] Pre-agg %s is valid through %s, past the staleness "
+            "budget cutoff of %s for an open-ended query",
+            preagg.id,
+            valid_through_ts,
+            cutoff,
+        )
+        return False
+    return True

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -26,6 +26,7 @@ from datajunction_server.construction.build_v3.dimensions import (
 
 if TYPE_CHECKING:
     from datajunction_server.construction.build_v3.types import BuildContext, GrainGroup
+    from datajunction_server.database.column import Column
     from datajunction_server.database.node import Node
 
 logger = logging.getLogger(__name__)
@@ -258,106 +259,119 @@ def get_preagg_dimension_column(
     return default_column
 
 
+def match_temporal_columns_to_grain(
+    preagg: PreAggregation,
+) -> list[tuple["Column", str | None]]:
+    """
+    Each temporal partition column of a pre-agg's parent, paired with the grain
+    entry it corresponds to (``None`` when the column isn't part of the grain).
+
+    A temporal column reaches the grain three ways: named directly by the parent,
+    reached through a dimension link the column feeds, or through the column's own
+    dimension reference. Callers derive what they need from the matched ref --
+    ``get_temporal_partitions`` an output column name, freshness gating the axis
+    ``valid_through_ts`` describes.
+    """
+    node_revision = preagg.node_revision
+    if not node_revision:  # pragma: no cover - defensive
+        return []
+
+    grain_columns = preagg.grain_columns or []
+    temporal_columns = node_revision.temporal_partition_columns()
+    if not temporal_columns:
+        return []
+
+    def grain_ref_under(dim_node: str, dim_attr: str | None = None) -> str | None:
+        """First grain entry belonging to a dimension node."""
+        return next(
+            (
+                grain_col
+                for grain_col in grain_columns
+                if grain_col == dim_attr or grain_col.startswith(dim_node + SEPARATOR)
+            ),
+            None,
+        )
+
+    # A source column can feed several dimension links, so this is multi-valued:
+    # keeping only one would miss the attribute actually named in the grain. Built
+    # lazily -- it parses each link's join SQL, which is wasted whenever the grain
+    # names the parent's own column.
+    col_to_dims: dict[str, list[str]] | None = None
+
+    matches: list[tuple["Column", str | None]] = []
+    for temporal_col in temporal_columns:
+        direct_ref = f"{node_revision.name}{SEPARATOR}{temporal_col.name}"
+        if direct_ref in grain_columns:
+            matches.append((temporal_col, direct_ref))
+            continue
+
+        if col_to_dims is None:
+            col_to_dims = {}
+            for (
+                dim_attr,
+                source_col,
+            ) in node_revision.dimensions_to_columns_map().items():
+                source_name = source_col.identifier().split(SEPARATOR)[-1]
+                col_to_dims.setdefault(source_name, []).append(dim_attr)
+
+        matched_ref = next(
+            (
+                ref
+                for dim_attr in col_to_dims.get(temporal_col.name, [])
+                if (ref := grain_ref_under(dim_attr.rsplit(SEPARATOR, 1)[0], dim_attr))
+            ),
+            None,
+        )
+        if matched_ref is None and temporal_col.dimension:
+            matched_ref = grain_ref_under(temporal_col.dimension.name)
+        matches.append((temporal_col, matched_ref))
+    return matches
+
+
+def temporal_output_name(temporal_col: "Column", grain_ref: str | None) -> str:
+    """
+    Output column name for a temporal partition column.
+
+    Named from the grain entry it matched -- ``v3.date.week[order]`` becomes
+    ``week_order`` -- falling back to the source column name when the column
+    isn't in the grain.
+    """
+    if grain_ref is None:
+        return temporal_col.name
+    parsed = parse_dimension_ref(grain_ref)
+    if parsed.role:
+        return f"{parsed.column_name}_{parsed.role}"
+    return parsed.column_name
+
+
 def get_temporal_partitions(preagg: PreAggregation) -> list[TemporalPartitionColumn]:
     """
     Get temporal partition columns for a pre-aggregation.
     """
-    col_type_map: dict[str, str] = {}
-    if preagg.node_revision and preagg.node_revision.columns:  # pragma: no branch
-        for col in preagg.node_revision.columns:
-            col_type_map[col.name] = str(col.type)
-
     temporal_partitions: list[TemporalPartitionColumn] = []
-    if preagg.node_revision:  # pragma: no branch
-        # Build reverse mapping: source column name -> list of dimension attributes.
-        # dimensions_to_columns_map returns {dim_attr (AST Column): source_col (AST Column)}.
-        # A single source column may appear in multiple dimension links (e.g., one
-        # simple link plus one multi-column link), so this must be multi-valued —
-        # otherwise only one mapping survives and we may miss the dim_attr that
-        # the user actually selected in the cube grain.
-        col_to_dims: dict[str, list[str]] = {}
-        dim_to_col = preagg.node_revision.dimensions_to_columns_map()
-        for dim_attr, source_col in dim_to_col.items():
-            source_col_name = source_col.identifier().split(SEPARATOR)[-1]
-            col_to_dims.setdefault(source_col_name, []).append(dim_attr)
-
-        for temporal_col in preagg.node_revision.temporal_partition_columns():
-            source_name = temporal_col.name
-            source_type = str(temporal_col.type) if temporal_col.type else "int"
-            output_name = source_name  # default
-
-            # Strategy 1: Source name directly in grain
-            full_source_col = f"{preagg.node_revision.name}{SEPARATOR}{source_name}"
-            if full_source_col in preagg.grain_columns:
-                output_name = source_name  # pragma: no cover
-
-            # Strategy 2: Check dimension links via dimensions_to_columns_map.
-            # Try every dim_attr that maps back to this source column — the first
-            # one whose attribute (or parent node) appears in grain_columns wins.
-            elif source_name in col_to_dims:
-                for dim_attr in col_to_dims[source_name]:
-                    dim_node = dim_attr.rsplit(SEPARATOR, 1)[0]
-                    matched = False
-                    for gc in preagg.grain_columns:
-                        if gc == dim_attr or gc.startswith(dim_node + SEPARATOR):
-                            # Parse the dimension ref to handle role syntax properly
-                            # e.g., "v3.date.week[order]" -> column_name="week", role="order"
-                            # -> output_name="week_order"
-                            parsed = parse_dimension_ref(gc)
-                            output_name = parsed.column_name
-                            if parsed.role:  # pragma: no branch
-                                output_name = f"{output_name}_{parsed.role}"
-                            logger.info(
-                                "Temporal column %s links to dimension %s -> output %s",
-                                source_name,
-                                dim_attr,
-                                output_name,
-                            )
-                            matched = True
-                            break
-                    if matched:
-                        break
-
-            # Strategy 3: Check column.dimension reference link
-            elif temporal_col.dimension:  # pragma: no cover
-                dim_name = temporal_col.dimension.name
-                for gc in preagg.grain_columns:
-                    if gc.startswith(dim_name + SEPARATOR):
-                        # Parse the dimension ref to handle role syntax properly
-                        parsed = parse_dimension_ref(gc)
-                        output_name = parsed.column_name
-                        if parsed.role:
-                            output_name = f"{output_name}_{parsed.role}"
-                        break
-
-            # Map output column to source type (for DDL generation)
-            if output_name != source_name:
-                col_type_map[output_name] = source_type  # pragma: no cover
-
-            logger.info(
-                "Temporal partition: source=%s -> output=%s (type=%s)",
-                source_name,
-                output_name,
-                source_type,
-            )
-
-            temporal_partitions.append(
-                TemporalPartitionColumn(
-                    column_name=output_name,
-                    column_type=source_type,
-                    format=temporal_col.partition.format
-                    if temporal_col.partition
-                    else None,
-                    granularity=(
-                        str(temporal_col.partition.granularity.value)
-                        if temporal_col.partition and temporal_col.partition.granularity
-                        else None
-                    ),
-                    expression=(
-                        str(temporal_col.partition.temporal_expression())
-                        if temporal_col.partition
-                        else None
-                    ),
+    for temporal_col, grain_ref in match_temporal_columns_to_grain(preagg):
+        source_type = str(temporal_col.type) if temporal_col.type else "int"
+        output_name = temporal_output_name(temporal_col, grain_ref)
+        logger.info(
+            "Temporal partition: source=%s -> output=%s (type=%s)",
+            temporal_col.name,
+            output_name,
+            source_type,
+        )
+        partition = temporal_col.partition
+        temporal_partitions.append(
+            TemporalPartitionColumn(
+                column_name=output_name,
+                column_type=source_type,
+                format=partition.format if partition else None,
+                granularity=(
+                    str(partition.granularity.value)
+                    if partition and partition.granularity
+                    else None
                 ),
-            )
+                expression=(
+                    str(partition.temporal_expression()) if partition else None
+                ),
+            ),
+        )
     return temporal_partitions

--- a/datajunction-server/datajunction_server/construction/build_v3/types.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -87,6 +88,16 @@ class BuildContext:
 
     # AST cache: node_name -> parsed query AST (avoids re-parsing same query)
     _parsed_query_cache: dict[str, ast.Query] = field(default_factory=dict)
+
+    # Tightest upper bound per dimension ref, per node revision. Derived from the
+    # filters once per build rather than per candidate pre-aggregation.
+    _upper_bound_cache: dict[int, dict[str, int]] = field(default_factory=dict)
+
+    # One instant for the whole build, so every staleness judgement in a request
+    # is made against the same "now".
+    build_timestamp: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc),
+    )
 
     # Pre-aggregation cache: maps node_revision_id to list of available PreAggregation records
     # Populated by load_available_preaggs() when use_materialized=True

--- a/datajunction-server/datajunction_server/construction/build_v3/types.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/types.py
@@ -89,9 +89,11 @@ class BuildContext:
     # AST cache: node_name -> parsed query AST (avoids re-parsing same query)
     _parsed_query_cache: dict[str, ast.Query] = field(default_factory=dict)
 
-    # Tightest upper bound per dimension ref, per node revision. Derived from the
-    # filters once per build rather than per candidate pre-aggregation.
-    _upper_bound_cache: dict[int, dict[str, int]] = field(default_factory=dict)
+    # Tightest bound per dimension ref, keyed by (node revision, is-upper-bound).
+    # Derived from the filters once per build rather than per candidate pre-agg.
+    _filter_bound_cache: dict[tuple[int, bool], dict[str, int]] = field(
+        default_factory=dict,
+    )
 
     # One instant for the whole build, so every staleness judgement in a request
     # is made against the same "now".

--- a/datajunction-server/datajunction_server/construction/build_v3/utils.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/utils.py
@@ -4,7 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Iterator, NamedTuple
 
 from datajunction_server.construction.build_v3.filters import (
-    extract_subscript_role,
+    dimension_ref_of_expression,
     parse_filter,
 )
 from datajunction_server.database.node import Node
@@ -384,11 +384,8 @@ def extract_filter_dimension_refs(
             if not base_col_ref or SEPARATOR not in base_col_ref:
                 continue  # pragma: no cover
 
-            role = extract_subscript_role(subscript)
-            if role:
-                full_name = f"{base_col_ref}[{role}]"
-            else:  # pragma: no cover
-                full_name = base_col_ref
+            # The base ref is still needed below to mark this subscript handled.
+            full_name = dimension_ref_of_expression(subscript) or base_col_ref
 
             # Mark this base ref as handled so the Column pass skips it
             subscript_handled_refs.add(base_col_ref)

--- a/datajunction-server/datajunction_server/models/partition.py
+++ b/datajunction-server/datajunction_server/models/partition.py
@@ -1,5 +1,7 @@
 """Partition-related models."""
 
+import re
+from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional
 
 from pydantic.main import BaseModel
@@ -103,3 +105,43 @@ class BackfillOutput(BaseModel):
     urls: Optional[List[str]] = None
 
     model_config = ConfigDict(from_attributes=True)
+
+
+# Java-style temporal format tokens, most to least significant. A format built
+# only from these, in this order, renders to an integer whose ordering is
+# chronological -- which is what makes comparing two such values meaningful.
+PARTITION_FORMAT_TOKENS = {
+    "yyyy": "%Y",
+    "MM": "%m",
+    "dd": "%d",
+    "HH": "%H",
+    "mm": "%M",
+    "ss": "%S",
+}
+_TOKEN_PATTERN = re.compile("|".join(PARTITION_FORMAT_TOKENS))
+
+
+def render_partition_value(moment: datetime, format_: str | None) -> Optional[int]:
+    """
+    Render a point in time as an integer in a partition format.
+
+    Only a format built purely from tokens in descending order of significance
+    renders: anything with separators (``yyyy-MM-dd``) can't produce an integer,
+    and anything out of order (``ddMMyyyy``) produces one whose ordering isn't
+    chronological. Both yield None so the caller declines to judge.
+    """
+    if not format_:
+        return None
+    tokens = _TOKEN_PATTERN.findall(format_)
+    if _TOKEN_PATTERN.sub("", format_) != "":
+        return None
+    order = list(PARTITION_FORMAT_TOKENS)
+    if [order.index(token) for token in tokens] != sorted(
+        order.index(token) for token in tokens
+    ):
+        return None
+    return int(
+        moment.strftime(
+            _TOKEN_PATTERN.sub(lambda m: PARTITION_FORMAT_TOKENS[m.group()], format_),
+        ),
+    )

--- a/datajunction-server/tests/construction/build_v3/preagg_freshness_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_freshness_test.py
@@ -7,10 +7,11 @@ import pytest
 from datajunction_server.config import Settings
 from datajunction_server.construction.build_v3.filters import (
     dimension_ref_of_expression,
+    lower_bounds_by_ref,
     upper_bounds_by_ref,
 )
 from datajunction_server.construction.build_v3.preagg_freshness import (
-    freshness_gating_enabled,
+    TemporalAxis,
     preagg_is_fresh,
     temporal_grain_axis,
 )
@@ -66,15 +67,24 @@ def make_context(
     )
 
 
-def bound_for(filters: list[str], ref: str = "v3.date.date_id") -> int | None:
+def upper_bound_for(filters: list[str], ref: str = "v3.date.date_id") -> int | None:
     """Tightest upper bound the filters place on a dimension reference."""
     return upper_bounds_by_ref(make_context(filters), 1).get(ref)
+
+
+def lower_bound_for(filters: list[str], ref: str = "v3.date.date_id") -> int | None:
+    """Tightest lower bound the filters place on a dimension reference."""
+    return lower_bounds_by_ref(make_context(filters), 1).get(ref)
 
 
 def make_preagg(
     grain_columns: list[str],
     valid_through_ts: int,
     node_revision: NodeRevision | None = None,
+    *,
+    temporal_partitions: list[str] | None = None,
+    min_temporal_partition: list[str] | None = None,
+    max_temporal_partition: list[str] | None = None,
 ) -> PreAggregation:
     """A pre-agg with availability, detached from any session."""
     preagg = PreAggregation(
@@ -100,6 +110,9 @@ def make_preagg(
         schema_="analytics",
         table="preagg",
         valid_through_ts=valid_through_ts,
+        temporal_partitions=temporal_partitions or [],
+        min_temporal_partition=min_temporal_partition or [],
+        max_temporal_partition=max_temporal_partition or [],
     )
     if node_revision is not None:
         preagg.node_revision = node_revision
@@ -123,6 +136,22 @@ def make_partitioned_revision(
         version="v1.0",
         columns=[column],
     )
+
+
+def make_two_axis_revision() -> NodeRevision:
+    """A revision partitioned on both a date and an hour column."""
+    revision = make_partitioned_revision()
+    hour_col = Column(name="order_hour", type=IntegerType(), order=1)
+    hour_col.partition = Partition(
+        type_=PartitionType.TEMPORAL,
+        granularity=Granularity.HOUR,
+        format="HH",
+    )
+    revision.columns = list(revision.columns) + [hour_col]
+    return revision
+
+
+DATE_GRAIN = ["v3.order_details.order_date"]
 
 
 class TestRenderPartitionValue:
@@ -177,11 +206,14 @@ class TestUpperBounds:
         ],
     )
     def test_upper_bound(self, filters, expected):
-        assert bound_for(filters) == expected
+        assert upper_bound_for(filters) == expected
 
     def test_role_qualified_reference(self):
         assert (
-            bound_for(["v3.date.date_id[order] <= 20250101"], "v3.date.date_id[order]")
+            upper_bound_for(
+                ["v3.date.date_id[order] <= 20250101"],
+                "v3.date.date_id[order]",
+            )
             == 20250101
         )
 
@@ -201,21 +233,63 @@ class TestUpperBounds:
         assert dimension_ref_of_expression(ast.Number(value=1)) is None
 
 
+class TestLowerBounds:
+    """The mirror image: reading the query's floor on a dimension."""
+
+    @pytest.mark.parametrize(
+        "filters, expected",
+        [
+            ([], None),
+            (["v3.date.date_id >= 20250101"], 20250101),
+            # A strict > is raised by one.
+            (["v3.date.date_id > 20250100"], 20250101),
+            (["v3.date.date_id = 20250101"], 20250101),
+            (["v3.date.date_id BETWEEN 20250101 AND 20260101"], 20250101),
+            # Either operand order reads the same.
+            (["20250101 <= v3.date.date_id"], 20250101),
+            (["20250100 < v3.date.date_id"], 20250101),
+            # Filters are ANDed, so the tightest floor wins.
+            (["v3.date.date_id >= 20240101", "v3.date.date_id >= 20250101"], 20250101),
+            # No floor to read.
+            (["v3.date.date_id <= 20250101"], None),
+            (["v3.order_details.status = 'shipped'"], None),
+            (["v3.date.date_id NOT BETWEEN 20240101 AND 20250101"], None),
+            (["v3.date.date_id >= '2025-01-01'"], None),
+            (["v3.date.date_id BETWEEN '2025-01-01' AND 20260101"], None),
+            (["DATE_TRUNC('day', v3.date.date_id) >= 20250101"], None),
+            (["v3.date.date_id >= 20250101 OR v3.date.date_id >= 20200101"], None),
+        ],
+    )
+    def test_lower_bound(self, filters, expected):
+        assert lower_bound_for(filters) == expected
+
+    def test_bounds_are_computed_once_per_node_revision(self):
+        ctx = make_context(["v3.date.date_id >= 20250101"])
+        first = lower_bounds_by_ref(ctx, 1)
+        assert lower_bounds_by_ref(ctx, 1) is first
+
+    def test_both_sides_are_cached_separately(self):
+        ctx = make_context(["v3.date.date_id BETWEEN 20240101 AND 20250101"])
+        assert lower_bounds_by_ref(ctx, 1) == {"v3.date.date_id": 20240101}
+        assert upper_bounds_by_ref(ctx, 1) == {"v3.date.date_id": 20250101}
+
+
 class TestTemporalGrainAxis:
-    """Finding the single temporal axis valid_through_ts describes."""
+    """Finding the single temporal axis the availability range describes."""
 
     def test_no_node_revision(self):
         assert temporal_grain_axis(make_preagg(["v3.order_details.status"], 1)) is None
 
     def test_source_column_directly_in_grain(self):
         preagg = make_preagg(
-            ["v3.order_details.order_date"],
+            DATE_GRAIN,
             20250101,
             node_revision=make_partitioned_revision(),
         )
-        assert temporal_grain_axis(preagg) == (
+        assert temporal_grain_axis(preagg) == TemporalAxis(
             "v3.order_details.order_date",
             "yyyyMMdd",
+            "order_date",
         )
 
     def test_temporal_column_absent_from_grain(self):
@@ -233,27 +307,15 @@ class TestTemporalGrainAxis:
             version="v1.0",
             columns=[Column(name="order_date", type=IntegerType(), order=0)],
         )
-        preagg = make_preagg(
-            ["v3.order_details.order_date"],
-            20250101,
-            node_revision=revision,
-        )
+        preagg = make_preagg(DATE_GRAIN, 20250101, node_revision=revision)
         assert temporal_grain_axis(preagg) is None
 
     def test_two_temporal_axes_are_not_judged(self):
-        """One watermark can't say which of two axes it belongs to."""
-        revision = make_partitioned_revision()
-        hour_col = Column(name="order_hour", type=IntegerType(), order=1)
-        hour_col.partition = Partition(
-            type_=PartitionType.TEMPORAL,
-            granularity=Granularity.HOUR,
-            format="yyyyMMddHH",
-        )
-        revision.columns = list(revision.columns) + [hour_col]
+        """A single covered range can't say which of two axes it belongs to."""
         preagg = make_preagg(
             ["v3.order_details.order_date", "v3.order_details.order_hour"],
             20250101,
-            node_revision=revision,
+            node_revision=make_two_axis_revision(),
         )
         assert temporal_grain_axis(preagg) is None
 
@@ -264,9 +326,10 @@ class TestPreaggIsFresh:
     def test_gating_off_allows_anything(self, mocker):
         configure(mocker, gating=False)
         preagg = make_preagg(
-            ["v3.order_details.order_date"],
+            DATE_GRAIN,
             20200101,
             node_revision=make_partitioned_revision(),
+            max_temporal_partition=["20200101"],
         )
         ctx = make_context(["v3.order_details.order_date <= 20250101"])
         assert preagg_is_fresh(ctx, preagg) is True
@@ -276,20 +339,85 @@ class TestPreaggIsFresh:
         preagg = make_preagg(["v3.order_details.status"], 20200101)
         assert preagg_is_fresh(make_context([]), preagg) is True
 
-    def test_query_bounded_within_the_watermark(self, mocker):
+    def test_query_inside_the_covered_range(self, mocker):
         configure(mocker, gating=True)
         preagg = make_preagg(
-            ["v3.order_details.order_date"],
+            DATE_GRAIN,
             20250601,
             node_revision=make_partitioned_revision(),
+            min_temporal_partition=["20240101"],
+            max_temporal_partition=["20250601"],
         )
-        ctx = make_context(["v3.order_details.order_date <= 20250101"])
+        ctx = make_context(
+            ["v3.order_details.order_date BETWEEN 20250101 AND 20250201"],
+        )
         assert preagg_is_fresh(ctx, preagg) is True
 
-    def test_query_bounded_past_the_watermark(self, mocker):
+    def test_query_reaching_above_the_covered_range(self, mocker):
         configure(mocker, gating=True)
         preagg = make_preagg(
-            ["v3.order_details.order_date"],
+            DATE_GRAIN,
+            20250601,
+            node_revision=make_partitioned_revision(),
+            min_temporal_partition=["20240101"],
+            max_temporal_partition=["20250601"],
+        )
+        ctx = make_context(["v3.order_details.order_date <= 20251231"])
+        assert preagg_is_fresh(ctx, preagg) is False
+
+    def test_query_reaching_below_the_covered_range(self, mocker):
+        """A table backfilled only to 2024 can't answer a query about 2020."""
+        configure(mocker, gating=True)
+        preagg = make_preagg(
+            DATE_GRAIN,
+            20250601,
+            node_revision=make_partitioned_revision(),
+            min_temporal_partition=["20240101"],
+            max_temporal_partition=["20250601"],
+        )
+        ctx = make_context(["v3.order_details.order_date >= 20200101"])
+        assert preagg_is_fresh(ctx, preagg) is False
+
+    def test_lower_bound_in_another_encoding_is_not_judged(self, mocker):
+        configure(mocker, gating=True)
+        preagg = make_preagg(
+            DATE_GRAIN,
+            20250601,
+            node_revision=make_partitioned_revision(),
+            min_temporal_partition=["1704067200"],
+            max_temporal_partition=["20250601"],
+        )
+        ctx = make_context(["v3.order_details.order_date >= 20240101"])
+        assert preagg_is_fresh(ctx, preagg) is True
+
+    def test_no_recorded_lower_bound_is_not_judged(self, mocker):
+        """Without a min there is nothing to reject a historical query against."""
+        configure(mocker, gating=True)
+        preagg = make_preagg(
+            DATE_GRAIN,
+            20250601,
+            node_revision=make_partitioned_revision(),
+            max_temporal_partition=["20250601"],
+        )
+        ctx = make_context(["v3.order_details.order_date >= 20200101"])
+        assert preagg_is_fresh(ctx, preagg) is True
+
+    def test_unparseable_partition_value_falls_back_to_the_watermark(self, mocker):
+        configure(mocker, gating=True)
+        preagg = make_preagg(
+            DATE_GRAIN,
+            20250601,
+            node_revision=make_partitioned_revision(),
+            max_temporal_partition=["2025-06-01"],
+        )
+        ctx = make_context(["v3.order_details.order_date <= 20251231"])
+        assert preagg_is_fresh(ctx, preagg) is False
+
+    def test_watermark_stands_in_for_a_missing_max(self, mocker):
+        """Externally registered pre-aggs report only the scalar."""
+        configure(mocker, gating=True)
+        preagg = make_preagg(
+            DATE_GRAIN,
             20250101,
             node_revision=make_partitioned_revision(),
         )
@@ -300,7 +428,7 @@ class TestPreaggIsFresh:
         """An epoch watermark can't be compared to a partition-format bound."""
         configure(mocker, gating=True)
         preagg = make_preagg(
-            ["v3.order_details.order_date"],
+            DATE_GRAIN,
             1767225600000,
             node_revision=make_partitioned_revision(),
         )
@@ -310,9 +438,10 @@ class TestPreaggIsFresh:
     def test_open_ended_query_without_a_budget(self, mocker):
         configure(mocker, gating=True)
         preagg = make_preagg(
-            ["v3.order_details.order_date"],
+            DATE_GRAIN,
             20200101,
             node_revision=make_partitioned_revision(),
+            max_temporal_partition=["20200101"],
         )
         assert preagg_is_fresh(make_context([]), preagg) is True
 
@@ -320,9 +449,10 @@ class TestPreaggIsFresh:
         configure(mocker, gating=True, max_staleness=86400 * 7)
         now = datetime(2025, 1, 10, tzinfo=timezone.utc)
         preagg = make_preagg(
-            ["v3.order_details.order_date"],
+            DATE_GRAIN,
             20250108,
             node_revision=make_partitioned_revision(),
+            max_temporal_partition=["20250108"],
         )
         assert preagg_is_fresh(make_context([], build_timestamp=now), preagg) is True
 
@@ -330,18 +460,20 @@ class TestPreaggIsFresh:
         configure(mocker, gating=True, max_staleness=86400)
         now = datetime(2025, 1, 10, tzinfo=timezone.utc)
         preagg = make_preagg(
-            ["v3.order_details.order_date"],
+            DATE_GRAIN,
             20240101,
             node_revision=make_partitioned_revision(),
+            max_temporal_partition=["20240101"],
         )
         assert preagg_is_fresh(make_context([], build_timestamp=now), preagg) is False
 
     def test_open_ended_query_with_an_unrenderable_format(self, mocker):
         configure(mocker, gating=True, max_staleness=86400)
         preagg = make_preagg(
-            ["v3.order_details.order_date"],
+            DATE_GRAIN,
             20200101,
             node_revision=make_partitioned_revision(format_="yyyy-MM-dd"),
+            max_temporal_partition=["20200101"],
         )
         assert preagg_is_fresh(make_context([]), preagg) is True
 
@@ -349,7 +481,7 @@ class TestPreaggIsFresh:
         configure(mocker, gating=True, max_staleness=86400)
         now = datetime(2025, 1, 10, tzinfo=timezone.utc)
         preagg = make_preagg(
-            ["v3.order_details.order_date"],
+            DATE_GRAIN,
             1767225600000,
             node_revision=make_partitioned_revision(),
         )
@@ -362,6 +494,58 @@ class TestPreaggIsFresh:
         assert ctx.build_timestamp is ctx.build_timestamp
 
 
-def test_freshness_gating_enabled_reads_settings(mocker):
-    configure(mocker, gating=True)
-    assert freshness_gating_enabled() is True
+class TestMultiColumnTemporalPartitions:
+    """
+    Placing the axis's entry in a multi-column min/max list.
+
+    ``min_temporal_partition`` runs parallel to ``temporal_partitions``, so a
+    table partitioned by date and hour reports ``["20250101", "00"]``.
+    """
+
+    def _preagg(self, mocker, **availability):
+        configure(mocker, gating=True)
+        # Only order_date is in the grain, so it is the single axis; order_hour
+        # is a partition column of the parent that the grain doesn't carry.
+        return make_preagg(
+            DATE_GRAIN,
+            20250601,
+            node_revision=make_two_axis_revision(),
+            **availability,
+        )
+
+    def test_aligned_by_column_name(self, mocker):
+        preagg = self._preagg(
+            mocker,
+            temporal_partitions=["order_date", "order_hour"],
+            max_temporal_partition=["20250601", "23"],
+        )
+        ctx = make_context(["v3.order_details.order_date <= 20251231"])
+        assert preagg_is_fresh(ctx, preagg) is False
+
+    def test_axis_absent_from_the_declared_columns(self, mocker):
+        """Nothing places the values, so the max is declined and the scalar used."""
+        preagg = self._preagg(
+            mocker,
+            temporal_partitions=["dt", "hr"],
+            max_temporal_partition=["20991231", "23"],
+        )
+        ctx = make_context(["v3.order_details.order_date <= 20251231"])
+        assert preagg_is_fresh(ctx, preagg) is False
+
+    def test_list_length_contradicts_the_declared_columns(self, mocker):
+        preagg = self._preagg(
+            mocker,
+            temporal_partitions=["order_date", "order_hour"],
+            max_temporal_partition=["20991231"],
+        )
+        ctx = make_context(["v3.order_details.order_date <= 20251231"])
+        assert preagg_is_fresh(ctx, preagg) is False
+
+    def test_a_lone_value_needs_no_placing(self, mocker):
+        preagg = self._preagg(
+            mocker,
+            temporal_partitions=["order_date"],
+            max_temporal_partition=["20991231"],
+        )
+        ctx = make_context(["v3.order_details.order_date <= 20251231"])
+        assert preagg_is_fresh(ctx, preagg) is True

--- a/datajunction-server/tests/construction/build_v3/preagg_freshness_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_freshness_test.py
@@ -1,39 +1,34 @@
 """Tests for preagg_freshness.py - freshness gating for pre-aggregations."""
 
-from datetime import datetime, timedelta, timezone
-from types import SimpleNamespace
+from datetime import datetime, timezone
 
 import pytest
-import pytest_asyncio
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload
 
+from datajunction_server.config import Settings
+from datajunction_server.construction.build_v3.filters import (
+    dimension_ref_of_expression,
+    upper_bounds_by_ref,
+)
 from datajunction_server.construction.build_v3.preagg_freshness import (
-    _dimension_ref_of,
     freshness_gating_enabled,
     preagg_is_fresh,
-    query_upper_bound,
-    render_partition_value,
-    temporal_grain_refs,
+    temporal_grain_axis,
 )
+from datajunction_server.models.partition import render_partition_value
 from datajunction_server.construction.build_v3.types import BuildContext
 from datajunction_server.database.availabilitystate import AvailabilityState
 from datajunction_server.database.column import Column
-from datajunction_server.database.dimensionlink import DimensionLink
-from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.node import NodeRevision
 from datajunction_server.database.partition import Partition
 from datajunction_server.database.preaggregation import (
     PreAggregation,
     compute_expression_hash,
 )
-from datajunction_server.database.user import User
 from datajunction_server.models.decompose import (
     Aggregability,
     AggregationRule,
     PreAggMeasure,
 )
-from datajunction_server.models.dimensionlink import JoinType
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.partition import Granularity, PartitionType
 from datajunction_server.sql.parsing import ast
@@ -46,23 +41,34 @@ SETTINGS_PATH = (
 
 def configure(mocker, *, gating: bool, max_staleness: int | None = None) -> None:
     """Point the module's settings lookup at an explicit gating configuration."""
+    # A real Settings instance, so renaming a setting fails here loudly rather
+    # than leaving these tests green while the feature stops working.
     mocker.patch(
         SETTINGS_PATH,
-        return_value=SimpleNamespace(
+        return_value=Settings(
             preagg_freshness_gating=gating,
             preagg_max_staleness_seconds=max_staleness,
         ),
     )
 
 
-def make_context(filters: list[str]) -> BuildContext:
+def make_context(
+    filters: list[str],
+    build_timestamp: datetime | None = None,
+) -> BuildContext:
     """A build context carrying nothing but the query's dimension filters."""
     return BuildContext(
         session=None,
         metrics=[],
         dimensions=[],
         dimension_filters=filters,
+        build_timestamp=build_timestamp or datetime.now(timezone.utc),
     )
+
+
+def bound_for(filters: list[str], ref: str = "v3.date.date_id") -> int | None:
+    """Tightest upper bound the filters place on a dimension reference."""
+    return upper_bounds_by_ref(make_context(filters), 1).get(ref)
 
 
 def make_preagg(
@@ -120,128 +126,105 @@ def make_partitioned_revision(
 
 
 class TestRenderPartitionValue:
-    """Rendering a moment into a partition format's integer encoding."""
+    """Rendering a moment into an integer partition format."""
 
-    def test_day_granularity(self):
-        moment = datetime(2026, 7, 21, 5, 4, 3, tzinfo=timezone.utc)
-        assert render_partition_value(moment, "yyyyMMdd") == 20260721
+    @pytest.mark.parametrize(
+        "format_, expected",
+        [
+            ("yyyyMMdd", 20260731),
+            ("yyyyMMddHH", 2026073114),
+            ("yyyyMM", 202607),
+            ("yyyy", 2026),
+            # Separators can't produce an integer.
+            ("yyyy-MM-dd", None),
+            # Out of order, so the integer's ordering isn't chronological.
+            ("ddMMyyyy", None),
+            ("", None),
+            (None, None),
+        ],
+    )
+    def test_render(self, format_, expected):
+        moment = datetime(2026, 7, 31, 14, 5, 9, tzinfo=timezone.utc)
+        assert render_partition_value(moment, format_) == expected
 
-    def test_sub_day_granularity(self):
-        moment = datetime(2026, 7, 21, 5, 4, 3, tzinfo=timezone.utc)
-        assert render_partition_value(moment, "yyyyMMddHHmmss") == 20260721050403
 
-    def test_coarse_granularity(self):
-        moment = datetime(2026, 7, 21, tzinfo=timezone.utc)
-        assert render_partition_value(moment, "yyyyMM") == 202607
+class TestUpperBounds:
+    """Reading the query's ceiling on a dimension out of its filters."""
 
-    def test_no_format(self):
-        assert render_partition_value(datetime(2026, 7, 21), None) is None
-
-    def test_non_numeric_format(self):
-        assert render_partition_value(datetime(2026, 7, 21), "yyyy-MM-dd") is None
-
-
-class TestQueryUpperBound:
-    """Reading the query's ceiling on a temporal dimension out of its filters."""
-
-    def test_no_filters(self):
-        assert query_upper_bound(make_context([]), 1, "v3.date.date_id") is None
-
-    def test_less_than_or_equal(self):
-        ctx = make_context(["v3.date.date_id <= 20250101"])
-        assert query_upper_bound(ctx, 1, "v3.date.date_id") == 20250101
-
-    def test_strict_less_than_lowers_the_bound(self):
-        ctx = make_context(["v3.date.date_id < 20250102"])
-        assert query_upper_bound(ctx, 1, "v3.date.date_id") == 20250101
-
-    def test_equality(self):
-        ctx = make_context(["v3.date.date_id = 20250101"])
-        assert query_upper_bound(ctx, 1, "v3.date.date_id") == 20250101
-
-    def test_between(self):
-        ctx = make_context(["v3.date.date_id BETWEEN 20240101 AND 20250101"])
-        assert query_upper_bound(ctx, 1, "v3.date.date_id") == 20250101
-
-    def test_between_on_another_dimension(self):
-        ctx = make_context(["v3.product.price BETWEEN 1 AND 20250101"])
-        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
-
-    def test_between_non_integer_literal(self):
-        ctx = make_context(["v3.date.date_id BETWEEN '2024-01-01' AND '2025-01-01'"])
-        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
-
-    def test_negated_between_is_not_a_bound(self):
-        ctx = make_context(["v3.date.date_id NOT BETWEEN 20240101 AND 20250101"])
-        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
-
-    def test_tightest_of_several_filters_wins(self):
-        ctx = make_context(
-            [
-                "v3.date.date_id <= 20250601",
-                "v3.date.date_id <= 20250101",
-                "v3.order_details.status = 'shipped'",
-            ],
-        )
-        assert query_upper_bound(ctx, 1, "v3.date.date_id") == 20250101
-
-    def test_lower_bound_only(self):
-        ctx = make_context(["v3.date.date_id >= 20250101"])
-        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
-
-    def test_other_dimension(self):
-        ctx = make_context(["v3.product.category <= 20250101"])
-        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
-
-    def test_non_integer_literal(self):
-        ctx = make_context(["v3.date.date_id <= '2025-01-01'"])
-        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
-
-    def test_disjunction_is_skipped(self):
-        ctx = make_context(
-            ["v3.date.date_id <= 20250101 OR v3.order_details.status = 'shipped'"],
-        )
-        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
-
-    def test_expression_over_the_column_is_not_a_bound(self):
-        ctx = make_context(["DATE_TRUNC('day', v3.date.date_id) <= 20250101"])
-        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
+    @pytest.mark.parametrize(
+        "filters, expected",
+        [
+            ([], None),
+            (["v3.date.date_id <= 20250101"], 20250101),
+            # A strict < is lowered by one.
+            (["v3.date.date_id < 20250102"], 20250101),
+            (["v3.date.date_id = 20250101"], 20250101),
+            (["v3.date.date_id BETWEEN 20240101 AND 20250101"], 20250101),
+            # Either operand order reads the same.
+            (["20250101 >= v3.date.date_id"], 20250101),
+            (["20250102 > v3.date.date_id"], 20250101),
+            # Filters are ANDed, so the tightest ceiling wins.
+            (["v3.date.date_id <= 20250601", "v3.date.date_id <= 20250101"], 20250101),
+            # No ceiling to read.
+            (["v3.date.date_id >= 20250101"], None),
+            (["v3.order_details.status = 'shipped'"], None),
+            (["v3.date.date_id NOT BETWEEN 20240101 AND 20250101"], None),
+            (["v3.date.date_id <= '2025-01-01'"], None),
+            (["v3.date.date_id BETWEEN 20240101 AND '2025-01-01'"], None),
+            (["DATE_TRUNC('day', v3.date.date_id) <= 20250101"], None),
+            # A disjunction can widen the range past either side's bound.
+            (["v3.date.date_id <= 20250101 OR v3.date.date_id <= 20990101"], None),
+        ],
+    )
+    def test_upper_bound(self, filters, expected):
+        assert bound_for(filters) == expected
 
     def test_role_qualified_reference(self):
-        ctx = make_context(["v3.date.date_id[order] <= 20250101"])
-        assert query_upper_bound(ctx, 1, "v3.date.date_id[order]") == 20250101
+        assert (
+            bound_for(["v3.date.date_id[order] <= 20250101"], "v3.date.date_id[order]")
+            == 20250101
+        )
+
+    def test_bounds_are_computed_once_per_node_revision(self):
+        ctx = make_context(["v3.date.date_id <= 20250101"])
+        first = upper_bounds_by_ref(ctx, 1)
+        assert upper_bounds_by_ref(ctx, 1) is first
 
     def test_subscript_over_a_non_column_is_not_a_reference(self):
         subscript = ast.Subscript(
-            expr=ast.Number(1),
-            index=ast.Column(ast.Name("order")),
+            expr=ast.Number(value=1),
+            index=ast.Column(name=ast.Name("order")),
         )
-        assert _dimension_ref_of(make_context([]), 1, subscript) is None
+        assert dimension_ref_of_expression(subscript) is None
+
+    def test_non_column_expression_is_not_a_reference(self):
+        assert dimension_ref_of_expression(ast.Number(value=1)) is None
 
 
-class TestTemporalGrainRefs:
-    """Locating the pre-agg's temporal axis within its grain."""
+class TestTemporalGrainAxis:
+    """Finding the single temporal axis valid_through_ts describes."""
 
     def test_no_node_revision(self):
-        assert temporal_grain_refs(make_preagg(["v3.date.date_id"], 20250101)) == []
+        assert temporal_grain_axis(make_preagg(["v3.order_details.status"], 1)) is None
 
     def test_source_column_directly_in_grain(self):
         preagg = make_preagg(
             ["v3.order_details.order_date"],
             20250101,
-            make_partitioned_revision(),
+            node_revision=make_partitioned_revision(),
         )
-        assert temporal_grain_refs(preagg) == [
-            ("v3.order_details.order_date", "yyyyMMdd"),
-        ]
+        assert temporal_grain_axis(preagg) == (
+            "v3.order_details.order_date",
+            "yyyyMMdd",
+        )
 
     def test_temporal_column_absent_from_grain(self):
         preagg = make_preagg(
             ["v3.order_details.status"],
             20250101,
-            make_partitioned_revision(),
+            node_revision=make_partitioned_revision(),
         )
-        assert temporal_grain_refs(preagg) == []
+        assert temporal_grain_axis(preagg) is None
 
     def test_no_temporal_partition_at_all(self):
         revision = NodeRevision(
@@ -250,8 +233,29 @@ class TestTemporalGrainRefs:
             version="v1.0",
             columns=[Column(name="order_date", type=IntegerType(), order=0)],
         )
-        preagg = make_preagg(["v3.order_details.order_date"], 20250101, revision)
-        assert temporal_grain_refs(preagg) == []
+        preagg = make_preagg(
+            ["v3.order_details.order_date"],
+            20250101,
+            node_revision=revision,
+        )
+        assert temporal_grain_axis(preagg) is None
+
+    def test_two_temporal_axes_are_not_judged(self):
+        """One watermark can't say which of two axes it belongs to."""
+        revision = make_partitioned_revision()
+        hour_col = Column(name="order_hour", type=IntegerType(), order=1)
+        hour_col.partition = Partition(
+            type_=PartitionType.TEMPORAL,
+            granularity=Granularity.HOUR,
+            format="yyyyMMddHH",
+        )
+        revision.columns = list(revision.columns) + [hour_col]
+        preagg = make_preagg(
+            ["v3.order_details.order_date", "v3.order_details.order_hour"],
+            20250101,
+            node_revision=revision,
+        )
+        assert temporal_grain_axis(preagg) is None
 
 
 class TestPreaggIsFresh:
@@ -262,9 +266,9 @@ class TestPreaggIsFresh:
         preagg = make_preagg(
             ["v3.order_details.order_date"],
             20200101,
-            make_partitioned_revision(),
+            node_revision=make_partitioned_revision(),
         )
-        ctx = make_context(["v3.order_details.order_date <= 20260101"])
+        ctx = make_context(["v3.order_details.order_date <= 20250101"])
         assert preagg_is_fresh(ctx, preagg) is True
 
     def test_no_temporal_grain_is_not_judged(self, mocker):
@@ -276,10 +280,10 @@ class TestPreaggIsFresh:
         configure(mocker, gating=True)
         preagg = make_preagg(
             ["v3.order_details.order_date"],
-            20250101,
-            make_partitioned_revision(),
+            20250601,
+            node_revision=make_partitioned_revision(),
         )
-        ctx = make_context(["v3.order_details.order_date <= 20240301"])
+        ctx = make_context(["v3.order_details.order_date <= 20250101"])
         assert preagg_is_fresh(ctx, preagg) is True
 
     def test_query_bounded_past_the_watermark(self, mocker):
@@ -287,214 +291,77 @@ class TestPreaggIsFresh:
         preagg = make_preagg(
             ["v3.order_details.order_date"],
             20250101,
-            make_partitioned_revision(),
+            node_revision=make_partitioned_revision(),
         )
         ctx = make_context(["v3.order_details.order_date <= 20250601"])
         assert preagg_is_fresh(ctx, preagg) is False
+
+    def test_watermark_in_another_encoding_is_not_judged(self, mocker):
+        """An epoch watermark can't be compared to a partition-format bound."""
+        configure(mocker, gating=True)
+        preagg = make_preagg(
+            ["v3.order_details.order_date"],
+            1767225600000,
+            node_revision=make_partitioned_revision(),
+        )
+        ctx = make_context(["v3.order_details.order_date <= 20250601"])
+        assert preagg_is_fresh(ctx, preagg) is True
 
     def test_open_ended_query_without_a_budget(self, mocker):
         configure(mocker, gating=True)
         preagg = make_preagg(
             ["v3.order_details.order_date"],
             20200101,
-            make_partitioned_revision(),
+            node_revision=make_partitioned_revision(),
         )
         assert preagg_is_fresh(make_context([]), preagg) is True
 
     def test_open_ended_query_within_the_budget(self, mocker):
         configure(mocker, gating=True, max_staleness=86400 * 7)
-        yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+        now = datetime(2025, 1, 10, tzinfo=timezone.utc)
         preagg = make_preagg(
             ["v3.order_details.order_date"],
-            int(yesterday.strftime("%Y%m%d")),
-            make_partitioned_revision(),
+            20250108,
+            node_revision=make_partitioned_revision(),
         )
-        assert preagg_is_fresh(make_context([]), preagg) is True
+        assert preagg_is_fresh(make_context([], build_timestamp=now), preagg) is True
 
     def test_open_ended_query_past_the_budget(self, mocker):
         configure(mocker, gating=True, max_staleness=86400)
+        now = datetime(2025, 1, 10, tzinfo=timezone.utc)
         preagg = make_preagg(
             ["v3.order_details.order_date"],
-            20200101,
-            make_partitioned_revision(),
+            20240101,
+            node_revision=make_partitioned_revision(),
         )
-        assert preagg_is_fresh(make_context([]), preagg) is False
+        assert preagg_is_fresh(make_context([], build_timestamp=now), preagg) is False
 
     def test_open_ended_query_with_an_unrenderable_format(self, mocker):
         configure(mocker, gating=True, max_staleness=86400)
         preagg = make_preagg(
             ["v3.order_details.order_date"],
             20200101,
-            make_partitioned_revision(format_="yyyy-MM-dd"),
+            node_revision=make_partitioned_revision(format_="yyyy-MM-dd"),
         )
         assert preagg_is_fresh(make_context([]), preagg) is True
 
-    def test_one_unbounded_axis_makes_the_query_open_ended(self, mocker):
-        """A bound on one temporal axis doesn't cover a second, unfiltered one."""
-        configure(mocker, gating=True)
-        revision = make_partitioned_revision()
-        second = Column(name="ship_date", type=IntegerType(), order=1)
-        second.partition = Partition(
-            type_=PartitionType.TEMPORAL,
-            granularity=Granularity.DAY,
-            format="yyyyMMdd",
-        )
-        revision.columns.append(second)
+    def test_open_ended_watermark_in_another_encoding(self, mocker):
+        configure(mocker, gating=True, max_staleness=86400)
+        now = datetime(2025, 1, 10, tzinfo=timezone.utc)
         preagg = make_preagg(
-            ["v3.order_details.order_date", "v3.order_details.ship_date"],
-            20200101,
-            revision,
+            ["v3.order_details.order_date"],
+            1767225600000,
+            node_revision=make_partitioned_revision(),
         )
-        # The bound on order_date alone would reject; with ship_date unbounded the
-        # gate falls through to the (unset) staleness budget and allows instead.
-        ctx = make_context(["v3.order_details.order_date <= 20260101"])
-        assert preagg_is_fresh(ctx, preagg) is True
+        assert preagg_is_fresh(make_context([], build_timestamp=now), preagg) is True
+
+    def test_the_whole_build_is_judged_against_one_instant(self, mocker):
+        """build_timestamp is fixed per request, not read per pre-agg."""
+        configure(mocker, gating=True, max_staleness=86400)
+        ctx = make_context([])
+        assert ctx.build_timestamp is ctx.build_timestamp
 
 
 def test_freshness_gating_enabled_reads_settings(mocker):
-    """The loader's cheap check reads the same setting."""
     configure(mocker, gating=True)
     assert freshness_gating_enabled() is True
-    configure(mocker, gating=False)
-    assert freshness_gating_enabled() is False
-
-
-@pytest_asyncio.fixture
-async def linked_preagg(session: AsyncSession) -> PreAggregation:
-    """
-    A pre-agg on a fact whose temporal partition column feeds a dimension link,
-    with the linked dimension attribute — not the source column — in its grain.
-    """
-    user = (await session.execute(select(User).limit(1))).scalars().one()
-
-    date_node = Node(
-        name="freshness.dim_date",
-        type=NodeType.DIMENSION,
-        created_by_id=user.id,
-    )
-    fact_node = Node(
-        name="freshness.fact",
-        type=NodeType.SOURCE,
-        created_by_id=user.id,
-    )
-    session.add_all([date_node, fact_node])
-    await session.flush()
-
-    date_rev = NodeRevision(
-        name=date_node.name,
-        node_id=date_node.id,
-        type=NodeType.DIMENSION,
-        version="v1.0",
-        columns=[Column(name="dateint", type=IntegerType(), order=0)],
-        created_by_id=user.id,
-    )
-    order_date = Column(name="order_date", type=IntegerType(), order=0)
-    fact_rev = NodeRevision(
-        name=fact_node.name,
-        node_id=fact_node.id,
-        type=NodeType.SOURCE,
-        version="v1.0",
-        columns=[order_date, Column(name="amount", type=IntegerType(), order=1)],
-        created_by_id=user.id,
-    )
-    session.add_all([date_rev, fact_rev])
-    await session.flush()
-    date_node.current_version = "v1.0"
-    date_node.current = date_rev
-    fact_node.current_version = "v1.0"
-    fact_node.current = fact_rev
-
-    partition = Partition(
-        column_id=order_date.id,
-        type_=PartitionType.TEMPORAL,
-        granularity=Granularity.DAY,
-        format="yyyyMMdd",
-    )
-    session.add(partition)
-    await session.flush()
-    order_date.partition = partition
-
-    session.add(
-        DimensionLink(
-            node_revision=fact_rev,
-            dimension=date_node,
-            join_sql="freshness.fact.order_date = freshness.dim_date.dateint",
-            join_type=JoinType.LEFT,
-        ),
-    )
-    availability = AvailabilityState(
-        catalog="default",
-        schema_="analytics",
-        table="fact_preagg",
-        valid_through_ts=20250101,
-    )
-    session.add(availability)
-    await session.flush()
-
-    preagg = PreAggregation(
-        node_revision_id=fact_rev.id,
-        grain_columns=["freshness.dim_date.dateint"],
-        measures=[
-            PreAggMeasure(
-                name="amount_sum",
-                expression="amount",
-                aggregation="SUM",
-                merge="SUM",
-                rule=AggregationRule(type=Aggregability.FULL),
-                expr_hash=compute_expression_hash("amount"),
-            ),
-        ],
-        sql="SELECT 1",
-        grain_group_hash="freshness_hash",
-        preagg_hash="fresh002",
-        availability_id=availability.id,
-    )
-    session.add(preagg)
-    await session.flush()
-
-    # Re-query with the eager loads that load_available_preaggs applies, since
-    # temporal_grain_refs walks these relationships synchronously.
-    result = await session.execute(
-        select(PreAggregation)
-        .where(PreAggregation.id == preagg.id)
-        .options(
-            joinedload(PreAggregation.availability),
-            joinedload(PreAggregation.node_revision).options(
-                selectinload(NodeRevision.columns).joinedload(Column.partition),
-                selectinload(NodeRevision.dimension_links).joinedload(
-                    DimensionLink.dimension,
-                ),
-            ),
-        ),
-    )
-    return result.unique().scalar_one()
-
-
-@pytest.mark.asyncio
-async def test_temporal_axis_resolved_through_a_dimension_link(
-    linked_preagg: PreAggregation,
-):
-    """The grain's dimension attribute is the axis, reached via the FK mapping."""
-    assert temporal_grain_refs(linked_preagg) == [
-        ("freshness.dim_date.dateint", "yyyyMMdd"),
-    ]
-
-
-@pytest.mark.asyncio
-async def test_linked_axis_absent_from_the_grain(linked_preagg: PreAggregation):
-    """A linked temporal column that no grain entry reaches yields no axis."""
-    linked_preagg.grain_columns = ["freshness.fact.region"]
-    assert temporal_grain_refs(linked_preagg) == []
-
-
-@pytest.mark.asyncio
-async def test_linked_axis_gates_on_the_dimension_filter(
-    linked_preagg: PreAggregation,
-    mocker,
-):
-    """A filter written against the linked dimension is what the gate compares."""
-    configure(mocker, gating=True)
-    within = make_context(["freshness.dim_date.dateint <= 20241231"])
-    beyond = make_context(["freshness.dim_date.dateint <= 20250102"])
-    assert preagg_is_fresh(within, linked_preagg) is True
-    assert preagg_is_fresh(beyond, linked_preagg) is False

--- a/datajunction-server/tests/construction/build_v3/preagg_freshness_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_freshness_test.py
@@ -208,6 +208,31 @@ class TestUpperBounds:
     def test_upper_bound(self, filters, expected):
         assert upper_bound_for(filters) == expected
 
+    @pytest.mark.parametrize(
+        "filters",
+        [
+            # A negated comparison asserts the opposite of what it reads as.
+            ["NOT v3.date.date_id <= 20200101"],
+            ["NOT (v3.date.date_id <= 20200101)"],
+            # A comparison inside CASE is not asserted by the query at all.
+            ["CASE WHEN v3.date.date_id < 20200101 THEN 0 ELSE 1 END = 1"],
+            # Either side of a disjunction can widen the range.
+            ["v3.date.date_id <= 20200101 OR v3.date.date_id <= 20990101"],
+        ],
+    )
+    def test_bounds_are_only_read_from_asserted_predicates(self, filters):
+        """Reading a bound out of a negation would invert its meaning."""
+        ctx = make_context(filters)
+        assert upper_bounds_by_ref(ctx, 1) == {}
+        assert lower_bounds_by_ref(ctx, 1) == {}
+
+    def test_conjuncts_beside_a_disjunction_still_count(self):
+        """An AND-ed bound holds regardless of what the other conjunct says."""
+        ctx = make_context(
+            ["v3.date.date_id <= 20250101 AND (status = 'a' OR status = 'b')"],
+        )
+        assert upper_bounds_by_ref(ctx, 1) == {"v3.date.date_id": 20250101}
+
     def test_role_qualified_reference(self):
         assert (
             upper_bound_for(

--- a/datajunction-server/tests/construction/build_v3/preagg_freshness_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_freshness_test.py
@@ -1,0 +1,500 @@
+"""Tests for preagg_freshness.py - freshness gating for pre-aggregations."""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload, selectinload
+
+from datajunction_server.construction.build_v3.preagg_freshness import (
+    _dimension_ref_of,
+    freshness_gating_enabled,
+    preagg_is_fresh,
+    query_upper_bound,
+    render_partition_value,
+    temporal_grain_refs,
+)
+from datajunction_server.construction.build_v3.types import BuildContext
+from datajunction_server.database.availabilitystate import AvailabilityState
+from datajunction_server.database.column import Column
+from datajunction_server.database.dimensionlink import DimensionLink
+from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.partition import Partition
+from datajunction_server.database.preaggregation import (
+    PreAggregation,
+    compute_expression_hash,
+)
+from datajunction_server.database.user import User
+from datajunction_server.models.decompose import (
+    Aggregability,
+    AggregationRule,
+    PreAggMeasure,
+)
+from datajunction_server.models.dimensionlink import JoinType
+from datajunction_server.models.node_type import NodeType
+from datajunction_server.models.partition import Granularity, PartitionType
+from datajunction_server.sql.parsing import ast
+from datajunction_server.sql.parsing.types import IntegerType
+
+SETTINGS_PATH = (
+    "datajunction_server.construction.build_v3.preagg_freshness.get_settings"
+)
+
+
+def configure(mocker, *, gating: bool, max_staleness: int | None = None) -> None:
+    """Point the module's settings lookup at an explicit gating configuration."""
+    mocker.patch(
+        SETTINGS_PATH,
+        return_value=SimpleNamespace(
+            preagg_freshness_gating=gating,
+            preagg_max_staleness_seconds=max_staleness,
+        ),
+    )
+
+
+def make_context(filters: list[str]) -> BuildContext:
+    """A build context carrying nothing but the query's dimension filters."""
+    return BuildContext(
+        session=None,
+        metrics=[],
+        dimensions=[],
+        dimension_filters=filters,
+    )
+
+
+def make_preagg(
+    grain_columns: list[str],
+    valid_through_ts: int,
+    node_revision: NodeRevision | None = None,
+) -> PreAggregation:
+    """A pre-agg with availability, detached from any session."""
+    preagg = PreAggregation(
+        id=7,
+        node_revision_id=1,
+        grain_columns=grain_columns,
+        measures=[
+            PreAggMeasure(
+                name="line_total_sum",
+                expression="line_total",
+                aggregation="SUM",
+                merge="SUM",
+                rule=AggregationRule(type=Aggregability.FULL),
+                expr_hash=compute_expression_hash("line_total"),
+            ),
+        ],
+        sql="SELECT 1",
+        grain_group_hash="hash",
+        preagg_hash="fresh001",
+    )
+    preagg.availability = AvailabilityState(
+        catalog="default",
+        schema_="analytics",
+        table="preagg",
+        valid_through_ts=valid_through_ts,
+    )
+    if node_revision is not None:
+        preagg.node_revision = node_revision
+    return preagg
+
+
+def make_partitioned_revision(
+    column_name: str = "order_date",
+    format_: str | None = "yyyyMMdd",
+) -> NodeRevision:
+    """A detached node revision with one temporal partition column."""
+    column = Column(name=column_name, type=IntegerType(), order=0)
+    column.partition = Partition(
+        type_=PartitionType.TEMPORAL,
+        granularity=Granularity.DAY,
+        format=format_,
+    )
+    return NodeRevision(
+        name="v3.order_details",
+        type=NodeType.TRANSFORM,
+        version="v1.0",
+        columns=[column],
+    )
+
+
+class TestRenderPartitionValue:
+    """Rendering a moment into a partition format's integer encoding."""
+
+    def test_day_granularity(self):
+        moment = datetime(2026, 7, 21, 5, 4, 3, tzinfo=timezone.utc)
+        assert render_partition_value(moment, "yyyyMMdd") == 20260721
+
+    def test_sub_day_granularity(self):
+        moment = datetime(2026, 7, 21, 5, 4, 3, tzinfo=timezone.utc)
+        assert render_partition_value(moment, "yyyyMMddHHmmss") == 20260721050403
+
+    def test_coarse_granularity(self):
+        moment = datetime(2026, 7, 21, tzinfo=timezone.utc)
+        assert render_partition_value(moment, "yyyyMM") == 202607
+
+    def test_no_format(self):
+        assert render_partition_value(datetime(2026, 7, 21), None) is None
+
+    def test_non_numeric_format(self):
+        assert render_partition_value(datetime(2026, 7, 21), "yyyy-MM-dd") is None
+
+
+class TestQueryUpperBound:
+    """Reading the query's ceiling on a temporal dimension out of its filters."""
+
+    def test_no_filters(self):
+        assert query_upper_bound(make_context([]), 1, "v3.date.date_id") is None
+
+    def test_less_than_or_equal(self):
+        ctx = make_context(["v3.date.date_id <= 20250101"])
+        assert query_upper_bound(ctx, 1, "v3.date.date_id") == 20250101
+
+    def test_strict_less_than_lowers_the_bound(self):
+        ctx = make_context(["v3.date.date_id < 20250102"])
+        assert query_upper_bound(ctx, 1, "v3.date.date_id") == 20250101
+
+    def test_equality(self):
+        ctx = make_context(["v3.date.date_id = 20250101"])
+        assert query_upper_bound(ctx, 1, "v3.date.date_id") == 20250101
+
+    def test_between(self):
+        ctx = make_context(["v3.date.date_id BETWEEN 20240101 AND 20250101"])
+        assert query_upper_bound(ctx, 1, "v3.date.date_id") == 20250101
+
+    def test_between_on_another_dimension(self):
+        ctx = make_context(["v3.product.price BETWEEN 1 AND 20250101"])
+        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
+
+    def test_between_non_integer_literal(self):
+        ctx = make_context(["v3.date.date_id BETWEEN '2024-01-01' AND '2025-01-01'"])
+        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
+
+    def test_negated_between_is_not_a_bound(self):
+        ctx = make_context(["v3.date.date_id NOT BETWEEN 20240101 AND 20250101"])
+        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
+
+    def test_tightest_of_several_filters_wins(self):
+        ctx = make_context(
+            [
+                "v3.date.date_id <= 20250601",
+                "v3.date.date_id <= 20250101",
+                "v3.order_details.status = 'shipped'",
+            ],
+        )
+        assert query_upper_bound(ctx, 1, "v3.date.date_id") == 20250101
+
+    def test_lower_bound_only(self):
+        ctx = make_context(["v3.date.date_id >= 20250101"])
+        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
+
+    def test_other_dimension(self):
+        ctx = make_context(["v3.product.category <= 20250101"])
+        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
+
+    def test_non_integer_literal(self):
+        ctx = make_context(["v3.date.date_id <= '2025-01-01'"])
+        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
+
+    def test_disjunction_is_skipped(self):
+        ctx = make_context(
+            ["v3.date.date_id <= 20250101 OR v3.order_details.status = 'shipped'"],
+        )
+        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
+
+    def test_expression_over_the_column_is_not_a_bound(self):
+        ctx = make_context(["DATE_TRUNC('day', v3.date.date_id) <= 20250101"])
+        assert query_upper_bound(ctx, 1, "v3.date.date_id") is None
+
+    def test_role_qualified_reference(self):
+        ctx = make_context(["v3.date.date_id[order] <= 20250101"])
+        assert query_upper_bound(ctx, 1, "v3.date.date_id[order]") == 20250101
+
+    def test_subscript_over_a_non_column_is_not_a_reference(self):
+        subscript = ast.Subscript(
+            expr=ast.Number(1),
+            index=ast.Column(ast.Name("order")),
+        )
+        assert _dimension_ref_of(make_context([]), 1, subscript) is None
+
+
+class TestTemporalGrainRefs:
+    """Locating the pre-agg's temporal axis within its grain."""
+
+    def test_no_node_revision(self):
+        assert temporal_grain_refs(make_preagg(["v3.date.date_id"], 20250101)) == []
+
+    def test_source_column_directly_in_grain(self):
+        preagg = make_preagg(
+            ["v3.order_details.order_date"],
+            20250101,
+            make_partitioned_revision(),
+        )
+        assert temporal_grain_refs(preagg) == [
+            ("v3.order_details.order_date", "yyyyMMdd"),
+        ]
+
+    def test_temporal_column_absent_from_grain(self):
+        preagg = make_preagg(
+            ["v3.order_details.status"],
+            20250101,
+            make_partitioned_revision(),
+        )
+        assert temporal_grain_refs(preagg) == []
+
+    def test_no_temporal_partition_at_all(self):
+        revision = NodeRevision(
+            name="v3.order_details",
+            type=NodeType.TRANSFORM,
+            version="v1.0",
+            columns=[Column(name="order_date", type=IntegerType(), order=0)],
+        )
+        preagg = make_preagg(["v3.order_details.order_date"], 20250101, revision)
+        assert temporal_grain_refs(preagg) == []
+
+
+class TestPreaggIsFresh:
+    """The gate itself."""
+
+    def test_gating_off_allows_anything(self, mocker):
+        configure(mocker, gating=False)
+        preagg = make_preagg(
+            ["v3.order_details.order_date"],
+            20200101,
+            make_partitioned_revision(),
+        )
+        ctx = make_context(["v3.order_details.order_date <= 20260101"])
+        assert preagg_is_fresh(ctx, preagg) is True
+
+    def test_no_temporal_grain_is_not_judged(self, mocker):
+        configure(mocker, gating=True)
+        preagg = make_preagg(["v3.order_details.status"], 20200101)
+        assert preagg_is_fresh(make_context([]), preagg) is True
+
+    def test_query_bounded_within_the_watermark(self, mocker):
+        configure(mocker, gating=True)
+        preagg = make_preagg(
+            ["v3.order_details.order_date"],
+            20250101,
+            make_partitioned_revision(),
+        )
+        ctx = make_context(["v3.order_details.order_date <= 20240301"])
+        assert preagg_is_fresh(ctx, preagg) is True
+
+    def test_query_bounded_past_the_watermark(self, mocker):
+        configure(mocker, gating=True)
+        preagg = make_preagg(
+            ["v3.order_details.order_date"],
+            20250101,
+            make_partitioned_revision(),
+        )
+        ctx = make_context(["v3.order_details.order_date <= 20250601"])
+        assert preagg_is_fresh(ctx, preagg) is False
+
+    def test_open_ended_query_without_a_budget(self, mocker):
+        configure(mocker, gating=True)
+        preagg = make_preagg(
+            ["v3.order_details.order_date"],
+            20200101,
+            make_partitioned_revision(),
+        )
+        assert preagg_is_fresh(make_context([]), preagg) is True
+
+    def test_open_ended_query_within_the_budget(self, mocker):
+        configure(mocker, gating=True, max_staleness=86400 * 7)
+        yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+        preagg = make_preagg(
+            ["v3.order_details.order_date"],
+            int(yesterday.strftime("%Y%m%d")),
+            make_partitioned_revision(),
+        )
+        assert preagg_is_fresh(make_context([]), preagg) is True
+
+    def test_open_ended_query_past_the_budget(self, mocker):
+        configure(mocker, gating=True, max_staleness=86400)
+        preagg = make_preagg(
+            ["v3.order_details.order_date"],
+            20200101,
+            make_partitioned_revision(),
+        )
+        assert preagg_is_fresh(make_context([]), preagg) is False
+
+    def test_open_ended_query_with_an_unrenderable_format(self, mocker):
+        configure(mocker, gating=True, max_staleness=86400)
+        preagg = make_preagg(
+            ["v3.order_details.order_date"],
+            20200101,
+            make_partitioned_revision(format_="yyyy-MM-dd"),
+        )
+        assert preagg_is_fresh(make_context([]), preagg) is True
+
+    def test_one_unbounded_axis_makes_the_query_open_ended(self, mocker):
+        """A bound on one temporal axis doesn't cover a second, unfiltered one."""
+        configure(mocker, gating=True)
+        revision = make_partitioned_revision()
+        second = Column(name="ship_date", type=IntegerType(), order=1)
+        second.partition = Partition(
+            type_=PartitionType.TEMPORAL,
+            granularity=Granularity.DAY,
+            format="yyyyMMdd",
+        )
+        revision.columns.append(second)
+        preagg = make_preagg(
+            ["v3.order_details.order_date", "v3.order_details.ship_date"],
+            20200101,
+            revision,
+        )
+        # The bound on order_date alone would reject; with ship_date unbounded the
+        # gate falls through to the (unset) staleness budget and allows instead.
+        ctx = make_context(["v3.order_details.order_date <= 20260101"])
+        assert preagg_is_fresh(ctx, preagg) is True
+
+
+def test_freshness_gating_enabled_reads_settings(mocker):
+    """The loader's cheap check reads the same setting."""
+    configure(mocker, gating=True)
+    assert freshness_gating_enabled() is True
+    configure(mocker, gating=False)
+    assert freshness_gating_enabled() is False
+
+
+@pytest_asyncio.fixture
+async def linked_preagg(session: AsyncSession) -> PreAggregation:
+    """
+    A pre-agg on a fact whose temporal partition column feeds a dimension link,
+    with the linked dimension attribute — not the source column — in its grain.
+    """
+    user = (await session.execute(select(User).limit(1))).scalars().one()
+
+    date_node = Node(
+        name="freshness.dim_date",
+        type=NodeType.DIMENSION,
+        created_by_id=user.id,
+    )
+    fact_node = Node(
+        name="freshness.fact",
+        type=NodeType.SOURCE,
+        created_by_id=user.id,
+    )
+    session.add_all([date_node, fact_node])
+    await session.flush()
+
+    date_rev = NodeRevision(
+        name=date_node.name,
+        node_id=date_node.id,
+        type=NodeType.DIMENSION,
+        version="v1.0",
+        columns=[Column(name="dateint", type=IntegerType(), order=0)],
+        created_by_id=user.id,
+    )
+    order_date = Column(name="order_date", type=IntegerType(), order=0)
+    fact_rev = NodeRevision(
+        name=fact_node.name,
+        node_id=fact_node.id,
+        type=NodeType.SOURCE,
+        version="v1.0",
+        columns=[order_date, Column(name="amount", type=IntegerType(), order=1)],
+        created_by_id=user.id,
+    )
+    session.add_all([date_rev, fact_rev])
+    await session.flush()
+    date_node.current_version = "v1.0"
+    date_node.current = date_rev
+    fact_node.current_version = "v1.0"
+    fact_node.current = fact_rev
+
+    partition = Partition(
+        column_id=order_date.id,
+        type_=PartitionType.TEMPORAL,
+        granularity=Granularity.DAY,
+        format="yyyyMMdd",
+    )
+    session.add(partition)
+    await session.flush()
+    order_date.partition = partition
+
+    session.add(
+        DimensionLink(
+            node_revision=fact_rev,
+            dimension=date_node,
+            join_sql="freshness.fact.order_date = freshness.dim_date.dateint",
+            join_type=JoinType.LEFT,
+        ),
+    )
+    availability = AvailabilityState(
+        catalog="default",
+        schema_="analytics",
+        table="fact_preagg",
+        valid_through_ts=20250101,
+    )
+    session.add(availability)
+    await session.flush()
+
+    preagg = PreAggregation(
+        node_revision_id=fact_rev.id,
+        grain_columns=["freshness.dim_date.dateint"],
+        measures=[
+            PreAggMeasure(
+                name="amount_sum",
+                expression="amount",
+                aggregation="SUM",
+                merge="SUM",
+                rule=AggregationRule(type=Aggregability.FULL),
+                expr_hash=compute_expression_hash("amount"),
+            ),
+        ],
+        sql="SELECT 1",
+        grain_group_hash="freshness_hash",
+        preagg_hash="fresh002",
+        availability_id=availability.id,
+    )
+    session.add(preagg)
+    await session.flush()
+
+    # Re-query with the eager loads that load_available_preaggs applies, since
+    # temporal_grain_refs walks these relationships synchronously.
+    result = await session.execute(
+        select(PreAggregation)
+        .where(PreAggregation.id == preagg.id)
+        .options(
+            joinedload(PreAggregation.availability),
+            joinedload(PreAggregation.node_revision).options(
+                selectinload(NodeRevision.columns).joinedload(Column.partition),
+                selectinload(NodeRevision.dimension_links).joinedload(
+                    DimensionLink.dimension,
+                ),
+            ),
+        ),
+    )
+    return result.unique().scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_temporal_axis_resolved_through_a_dimension_link(
+    linked_preagg: PreAggregation,
+):
+    """The grain's dimension attribute is the axis, reached via the FK mapping."""
+    assert temporal_grain_refs(linked_preagg) == [
+        ("freshness.dim_date.dateint", "yyyyMMdd"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_linked_axis_absent_from_the_grain(linked_preagg: PreAggregation):
+    """A linked temporal column that no grain entry reaches yields no axis."""
+    linked_preagg.grain_columns = ["freshness.fact.region"]
+    assert temporal_grain_refs(linked_preagg) == []
+
+
+@pytest.mark.asyncio
+async def test_linked_axis_gates_on_the_dimension_filter(
+    linked_preagg: PreAggregation,
+    mocker,
+):
+    """A filter written against the linked dimension is what the gate compares."""
+    configure(mocker, gating=True)
+    within = make_context(["freshness.dim_date.dateint <= 20241231"])
+    beyond = make_context(["freshness.dim_date.dateint <= 20250102"])
+    assert preagg_is_fresh(within, linked_preagg) is True
+    assert preagg_is_fresh(beyond, linked_preagg) is False

--- a/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
@@ -7,6 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
 from datajunction_server.construction.build_v3.preagg_matcher import (
+    match_temporal_columns_to_grain,
+    temporal_output_name,
     find_matching_preagg,
     get_preagg_dimension_column,
     get_preagg_measure_column,
@@ -1242,3 +1244,84 @@ class TestGetTemporalPartitionsMultipleDimLinks:
 
         assert len(partitions) == 1
         assert partitions[0].column_name == "dateint"
+
+
+def _temporal_column(name: str, format_: str = "yyyyMMdd") -> Column:
+    """A temporal partition column, detached from any session."""
+    column = Column(name=name, type=IntegerType(), order=0)
+    column.partition = Partition(
+        type_=PartitionType.TEMPORAL,
+        granularity=Granularity.DAY,
+        format=format_,
+    )
+    return column
+
+
+def _preagg_with(columns: list[Column], grain_columns: list[str]) -> PreAggregation:
+    """A pre-agg over a detached parent revision carrying the given columns."""
+    preagg = PreAggregation(grain_columns=grain_columns)
+    preagg.node_revision = NodeRevision(
+        name="v3.order_details",
+        type=NodeType.TRANSFORM,
+        version="v1.0",
+        columns=columns,
+    )
+    return preagg
+
+
+class TestMatchTemporalColumnsToGrain:
+    """Pairing a parent's temporal partition columns with the grain entries they reach."""
+
+    def test_no_node_revision(self):
+        assert match_temporal_columns_to_grain(PreAggregation(grain_columns=[])) == []
+
+    def test_no_temporal_columns(self):
+        preagg = _preagg_with(
+            [Column(name="order_date", type=IntegerType(), order=0)],
+            ["v3.order_details.order_date"],
+        )
+        assert match_temporal_columns_to_grain(preagg) == []
+
+    def test_matched_via_the_columns_own_dimension_reference(self):
+        """Strategy 3: the column carries a dimension reference of its own."""
+        column = _temporal_column("date_int")
+        column.dimension = Node(name="v3.date", type=NodeType.DIMENSION)
+        preagg = _preagg_with([column], ["v3.date.week[order]"])
+        assert match_temporal_columns_to_grain(preagg) == [
+            (column, "v3.date.week[order]"),
+        ]
+
+    def test_dimension_reference_not_in_grain(self):
+        column = _temporal_column("date_int")
+        column.dimension = Node(name="v3.date", type=NodeType.DIMENSION)
+        preagg = _preagg_with([column], ["v3.order_details.status"])
+        assert match_temporal_columns_to_grain(preagg) == [(column, None)]
+
+    def test_second_column_reuses_the_link_map(self):
+        """The dimension-link map is built once, not per temporal column."""
+        first = _temporal_column("date_int")
+        second = _temporal_column("hour_int")
+        preagg = _preagg_with([first, second], ["v3.order_details.status"])
+        assert match_temporal_columns_to_grain(preagg) == [
+            (first, None),
+            (second, None),
+        ]
+
+
+class TestTemporalOutputName:
+    """Naming the output column from the grain entry a temporal column matched."""
+
+    def test_falls_back_to_the_source_name(self):
+        assert (
+            temporal_output_name(_temporal_column("order_date"), None) == "order_date"
+        )
+
+    def test_plain_grain_reference(self):
+        column = _temporal_column("order_date")
+        assert (
+            temporal_output_name(column, "v3.order_details.order_date") == "order_date"
+        )
+
+    def test_role_qualified_grain_reference(self):
+        column = _temporal_column("date_int")
+        assert temporal_output_name(column, "v3.date.week[order]") == "week_order"

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -3123,3 +3123,173 @@ class TestBuildGrainGroupFromPreaggErrorPaths:
         )
         # Only one component should appear in output despite two in input
         assert len(result.components) == 1
+
+
+class TestPreAggFreshnessGating:
+    """
+    Routing decisions made against a pre-agg's reported ``valid_through_ts``.
+
+    The pre-agg below is valid through 2025-01-01 on a date grain, which is stale
+    in wall-clock terms but perfectly good for a query bounded before it.
+    """
+
+    PREAGG_SQL = """
+    WITH order_details_0 AS (
+        SELECT date_id_order, SUM(revenue_sum) revenue_sum
+        FROM default.analytics.revenue_by_date
+        GROUP BY date_id_order
+    )
+    SELECT order_details_0.date_id_order AS date_id_order,
+           SUM(order_details_0.revenue_sum) AS total_revenue
+    FROM order_details_0
+    WHERE order_details_0.date_id_order <= {bound}
+    GROUP BY order_details_0.date_id_order
+    """
+
+    SOURCE_SQL = """
+    WITH v3_order_details AS (
+        SELECT o.order_date, oi.quantity * oi.unit_price AS line_total
+        FROM default.v3.orders o
+        JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+        WHERE o.order_date <= 20260101
+    ),
+    order_details_0 AS (
+        SELECT t1.order_date date_id_order,
+               SUM(t1.line_total) line_total_sum_e1f61696
+        FROM v3_order_details t1
+        GROUP BY t1.order_date
+    )
+    SELECT order_details_0.date_id_order AS date_id_order,
+           SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+    FROM order_details_0
+    WHERE order_details_0.date_id_order <= 20260101
+    GROUP BY order_details_0.date_id_order
+    """
+
+    UNFILTERED_SOURCE_SQL = """
+    WITH v3_order_details AS (
+        SELECT o.order_date, oi.quantity * oi.unit_price AS line_total
+        FROM default.v3.orders o
+        JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+    ),
+    order_details_0 AS (
+        SELECT t1.order_date date_id_order,
+               SUM(t1.line_total) line_total_sum_e1f61696
+        FROM v3_order_details t1
+        GROUP BY t1.order_date
+    )
+    SELECT order_details_0.date_id_order AS date_id_order,
+           SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+    FROM order_details_0
+    GROUP BY order_details_0.date_id_order
+    """
+
+    async def _register(self, client):
+        """Partition the fact on order_date, then adopt a date-grain pre-agg."""
+        partition_response = await client.post(
+            "/nodes/v3.order_details/columns/order_date/partition",
+            json={"type_": "temporal", "format": "yyyyMMdd", "granularity": "day"},
+        )
+        assert partition_response.status_code == 201
+        await _register_external_preagg(
+            client,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.date.date_id[order]"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "revenue_by_date",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "revenue_sum"},
+            table_columns={"date_id_order": "int", "revenue_sum": "double"},
+        )
+
+    def _configure(self, mocker, *, gating: bool, max_staleness: int | None = None):
+        mocker.patch(
+            "datajunction_server.construction.build_v3.preagg_freshness.get_settings",
+            return_value=SimpleNamespace(
+                preagg_freshness_gating=gating,
+                preagg_max_staleness_seconds=max_staleness,
+            ),
+        )
+
+    async def _metrics_sql(self, client, filters: list[str]) -> str:
+        response = await client.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.total_revenue"],
+                "dimensions": ["v3.date.date_id[order]"],
+                "filters": filters,
+            },
+        )
+        assert response.status_code == 200
+        return response.json()["sql"]
+
+    @pytest.mark.asyncio
+    async def test_historical_query_uses_a_stale_preagg(
+        self,
+        client_with_build_v3,
+        mocker,
+    ):
+        """A query bounded inside the watermark is served, however old the table."""
+        await self._register(client_with_build_v3)
+        self._configure(mocker, gating=True)
+        assert_sql_equal(
+            await self._metrics_sql(
+                client_with_build_v3,
+                ["v3.date.date_id[order] <= 20240101"],
+            ),
+            self.PREAGG_SQL.format(bound=20240101),
+        )
+
+    @pytest.mark.asyncio
+    async def test_query_past_the_watermark_falls_back_to_source(
+        self,
+        client_with_build_v3,
+        mocker,
+    ):
+        """A query reaching past the watermark computes from source instead."""
+        await self._register(client_with_build_v3)
+        self._configure(mocker, gating=True)
+        assert_sql_equal(
+            await self._metrics_sql(
+                client_with_build_v3,
+                ["v3.date.date_id[order] <= 20260101"],
+            ),
+            self.SOURCE_SQL,
+        )
+
+    @pytest.mark.asyncio
+    async def test_gating_off_serves_the_same_query_from_the_preagg(
+        self,
+        client_with_build_v3,
+        mocker,
+    ):
+        """Default configuration routes exactly as it did before the gate."""
+        await self._register(client_with_build_v3)
+        self._configure(mocker, gating=False)
+        assert_sql_equal(
+            await self._metrics_sql(
+                client_with_build_v3,
+                ["v3.date.date_id[order] <= 20260101"],
+            ),
+            self.PREAGG_SQL.format(bound=20260101),
+        )
+
+    @pytest.mark.asyncio
+    async def test_open_ended_query_falls_back_under_a_staleness_budget(
+        self,
+        client_with_build_v3,
+        mocker,
+    ):
+        """
+        An unfiltered query implicitly asks for data through now, so a configured
+        staleness budget rejects a watermark that far behind.
+        """
+        await self._register(client_with_build_v3)
+        self._configure(mocker, gating=True, max_staleness=86400)
+        assert_sql_equal(
+            await self._metrics_sql(client_with_build_v3, []),
+            self.UNFILTERED_SOURCE_SQL,
+        )

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -17,6 +17,7 @@ Key scenarios:
 
 import pytest
 
+from datajunction_server.config import Settings
 from datajunction_server.construction.build_v3.measures import (
     build_grain_group_from_preagg,
 )
@@ -3127,10 +3128,10 @@ class TestBuildGrainGroupFromPreaggErrorPaths:
 
 class TestPreAggFreshnessGating:
     """
-    Routing decisions made against a pre-agg's reported ``valid_through_ts``.
+    Routing decisions made against the temporal range a pre-agg's table covers.
 
-    The pre-agg below is valid through 2025-01-01 on a date grain, which is stale
-    in wall-clock terms but perfectly good for a query bounded before it.
+    The pre-agg below sits on a date grain and is stale in wall-clock terms, but
+    perfectly good for a query bounded inside the range it holds.
     """
 
     PREAGG_SQL = """
@@ -3142,7 +3143,7 @@ class TestPreAggFreshnessGating:
     SELECT order_details_0.date_id_order AS date_id_order,
            SUM(order_details_0.revenue_sum) AS total_revenue
     FROM order_details_0
-    WHERE order_details_0.date_id_order <= {bound}
+    WHERE order_details_0.date_id_order {predicate}
     GROUP BY order_details_0.date_id_order
     """
 
@@ -3151,7 +3152,7 @@ class TestPreAggFreshnessGating:
         SELECT o.order_date, oi.quantity * oi.unit_price AS line_total
         FROM default.v3.orders o
         JOIN default.v3.order_items oi ON o.order_id = oi.order_id
-        WHERE o.order_date <= 20260101
+        WHERE o.order_date {predicate}
     ),
     order_details_0 AS (
         SELECT t1.order_date date_id_order,
@@ -3162,7 +3163,7 @@ class TestPreAggFreshnessGating:
     SELECT order_details_0.date_id_order AS date_id_order,
            SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
     FROM order_details_0
-    WHERE order_details_0.date_id_order <= 20260101
+    WHERE order_details_0.date_id_order {predicate}
     GROUP BY order_details_0.date_id_order
     """
 
@@ -3184,31 +3185,47 @@ class TestPreAggFreshnessGating:
     GROUP BY order_details_0.date_id_order
     """
 
-    async def _register(self, client):
+    TABLE_REF = {
+        "catalog": "default",
+        "schema": "analytics",
+        "table": "revenue_by_date",
+    }
+
+    async def _register(self, client) -> int:
         """Partition the fact on order_date, then adopt a date-grain pre-agg."""
         partition_response = await client.post(
             "/nodes/v3.order_details/columns/order_date/partition",
             json={"type_": "temporal", "format": "yyyyMMdd", "granularity": "day"},
         )
         assert partition_response.status_code == 201
-        await _register_external_preagg(
+        response = await _register_external_preagg(
             client,
             metrics=["v3.total_revenue"],
             dimensions=["v3.date.date_id[order]"],
-            table_ref={
-                "catalog": "default",
-                "schema": "analytics",
-                "table": "revenue_by_date",
-                "valid_through_ts": 20250101,
-            },
+            table_ref={**self.TABLE_REF, "valid_through_ts": 20250101},
             measure_columns={"v3.total_revenue": "revenue_sum"},
             table_columns={"date_id_order": "int", "revenue_sum": "double"},
         )
+        return response.json()["preaggs"][0]["id"]
+
+    async def _report_range(self, client, preagg_id: int, min_: str, max_: str):
+        """Report the actual partition range the external table holds."""
+        response = await client.post(
+            f"/preaggs/{preagg_id}/availability/",
+            json={
+                **self.TABLE_REF,
+                "valid_through_ts": 20250101,
+                "min_temporal_partition": [min_],
+                "max_temporal_partition": [max_],
+            },
+        )
+        assert response.status_code == 200, response.text
 
     def _configure(self, mocker, *, gating: bool, max_staleness: int | None = None):
+        # A real Settings instance, so renaming a setting fails here loudly.
         mocker.patch(
             "datajunction_server.construction.build_v3.preagg_freshness.get_settings",
-            return_value=SimpleNamespace(
+            return_value=Settings(
                 preagg_freshness_gating=gating,
                 preagg_max_staleness_seconds=max_staleness,
             ),
@@ -3240,7 +3257,7 @@ class TestPreAggFreshnessGating:
                 client_with_build_v3,
                 ["v3.date.date_id[order] <= 20240101"],
             ),
-            self.PREAGG_SQL.format(bound=20240101),
+            self.PREAGG_SQL.format(predicate="<= 20240101"),
         )
 
     @pytest.mark.asyncio
@@ -3249,7 +3266,10 @@ class TestPreAggFreshnessGating:
         client_with_build_v3,
         mocker,
     ):
-        """A query reaching past the watermark computes from source instead."""
+        """
+        A query reaching past the watermark computes from source instead. Nothing
+        but ``valid_through_ts`` has been reported, so that is what it's judged on.
+        """
         await self._register(client_with_build_v3)
         self._configure(mocker, gating=True)
         assert_sql_equal(
@@ -3257,7 +3277,79 @@ class TestPreAggFreshnessGating:
                 client_with_build_v3,
                 ["v3.date.date_id[order] <= 20260101"],
             ),
-            self.SOURCE_SQL,
+            self.SOURCE_SQL.format(predicate="<= 20260101"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_query_below_the_covered_range_falls_back_to_source(
+        self,
+        client_with_build_v3,
+        mocker,
+    ):
+        """The table starts in 2024, so it cannot answer a query reaching to 2020."""
+        preagg_id = await self._register(client_with_build_v3)
+        await self._report_range(
+            client_with_build_v3,
+            preagg_id,
+            "20240101",
+            "20260601",
+        )
+        self._configure(mocker, gating=True)
+        assert_sql_equal(
+            await self._metrics_sql(
+                client_with_build_v3,
+                ["v3.date.date_id[order] >= 20200101"],
+            ),
+            self.SOURCE_SQL.format(predicate=">= 20200101"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_query_inside_the_covered_range_uses_the_preagg(
+        self,
+        client_with_build_v3,
+        mocker,
+    ):
+        """The same table answers a query that starts after its first partition."""
+        preagg_id = await self._register(client_with_build_v3)
+        await self._report_range(
+            client_with_build_v3,
+            preagg_id,
+            "20240101",
+            "20260601",
+        )
+        self._configure(mocker, gating=True)
+        assert_sql_equal(
+            await self._metrics_sql(
+                client_with_build_v3,
+                ["v3.date.date_id[order] >= 20240201"],
+            ),
+            self.PREAGG_SQL.format(predicate=">= 20240201"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_reported_max_supersedes_the_watermark(
+        self,
+        client_with_build_v3,
+        mocker,
+    ):
+        """
+        A query past ``valid_through_ts`` but inside the reported partition range
+        is served: the range the table actually holds is the stronger signal.
+        """
+        preagg_id = await self._register(client_with_build_v3)
+        await self._report_range(
+            client_with_build_v3,
+            preagg_id,
+            "20240101",
+            "20260601",
+        )
+        self._configure(mocker, gating=True)
+        assert_sql_equal(
+            await self._metrics_sql(
+                client_with_build_v3,
+                ["v3.date.date_id[order] <= 20260101"],
+            ),
+            self.PREAGG_SQL.format(predicate="<= 20260101"),
         )
 
     @pytest.mark.asyncio
@@ -3274,7 +3366,7 @@ class TestPreAggFreshnessGating:
                 client_with_build_v3,
                 ["v3.date.date_id[order] <= 20260101"],
             ),
-            self.PREAGG_SQL.format(bound=20260101),
+            self.PREAGG_SQL.format(predicate="<= 20260101"),
         )
 
     @pytest.mark.asyncio
@@ -3285,9 +3377,15 @@ class TestPreAggFreshnessGating:
     ):
         """
         An unfiltered query implicitly asks for data through now, so a configured
-        staleness budget rejects a watermark that far behind.
+        staleness budget rejects a covered range that far behind.
         """
-        await self._register(client_with_build_v3)
+        preagg_id = await self._register(client_with_build_v3)
+        await self._report_range(
+            client_with_build_v3,
+            preagg_id,
+            "20240101",
+            "20250101",
+        )
         self._configure(mocker, gating=True, max_staleness=86400)
         assert_sql_equal(
             await self._metrics_sql(client_with_build_v3, []),

--- a/docs/content/0.1.0/docs/dj-concepts/aggregate-awareness.md
+++ b/docs/content/0.1.0/docs/dj-concepts/aggregate-awareness.md
@@ -339,25 +339,40 @@ that hasn't finished its first build.
 ### Freshness gating
 
 By default, DJ treats a pre-aggregation with any availability at all as eligible: once you've reported
-`valid_through_ts` once, routing keeps sending queries there even if the pipeline behind it later stops
-running. Setting `PREAGG_FRESHNESS_GATING=true` makes DJ consult the watermark on every query instead.
+availability once, routing keeps sending queries there even if the table only ever got a partial
+backfill, or the pipeline behind it later stops running. Setting `PREAGG_FRESHNESS_GATING=true` makes
+DJ check, on every query, that the range the table actually covers contains the range the query asks
+for.
 
-What it compares against is the time range the query itself asks for, not wall clock. A query with an
-upper bound on the pre-aggregation's temporal partition — `date_id <= 20250101`, or the high side of a
-`BETWEEN` — is served whenever that bound falls within `valid_through_ts`, so a report for last March
-keeps reading the aggregate even if the table hasn't been rebuilt since. A query whose bound reaches
-past the watermark falls back to computing from source, since the aggregate would silently return
-truncated numbers.
+The coverage DJ trusts is `min_temporal_partition` and `max_temporal_partition` — the lowest and
+highest partition values you report alongside `valid_through_ts`. The check is two-sided, and both
+sides matter. A query reaching above the covered range gets silently truncated numbers; a query
+reaching below it gets numbers missing everything before the first backfilled partition, which is the
+more common failure of the two. Either one falls back to computing from source instead.
 
-A query with no discoverable upper bound implicitly asks for data through the present, and no watermark
-comparison can make that safe. Those queries are allowed through unless you also set
-`PREAGG_MAX_STALENESS_SECONDS`, which gives them a wall-clock budget: DJ renders `now - budget` into the
-partition's format and requires `valid_through_ts` to be at least that recent.
+What DJ compares against is the time range the query itself asks for, not wall clock. Bounds are read
+off the query's filters on the pre-aggregation's temporal partition — `date_id >= 20240101`,
+`date_id <= 20250101`, an `=`, or either side of a `BETWEEN`. A query bounded inside the covered range
+is served however old the table is, so a report from last March keeps reading the aggregate. A side
+the query leaves open places no constraint, so a table holding only the last two years still answers a
+query with no lower bound.
 
-Gating only applies to pre-aggregations whose grain includes a temporal partition column — that's the
-axis `valid_through_ts` describes. A pre-aggregation with no temporal dimension is never rejected for
-staleness, because there's nothing to compare it against. Rejection is silent: the query falls back to
-source and returns correct (if slower) results, the same as any other non-match.
+If you report no `max_temporal_partition`, DJ falls back to `valid_through_ts` for the upper side.
+That's the usual case for a table registered through `/preaggs/register`, which takes only the scalar.
+Since `valid_through_ts` is written in a few different encodings in practice, DJ compares it only when
+its magnitude is consistent with the bound it's being compared against, and logs a warning rather than
+guessing when it isn't.
+
+A query with no upper bound at all implicitly asks for data through the present, and no partition
+comparison can settle that on its own. Those queries are allowed through unless you also set
+`PREAGG_MAX_STALENESS_SECONDS`, which gives them a wall-clock budget: DJ renders `now - budget` into
+the partition's format and requires the covered range to reach it.
+
+Gating only applies to pre-aggregations whose grain includes exactly one temporal partition column —
+that's the axis the covered range describes. A pre-aggregation with no temporal dimension, or with two
+of them, is never rejected, because there's nothing unambiguous to compare against. Rejection is
+silent: the query falls back to source and returns correct (if slower) results, the same as any other
+non-match.
 
 ### External pre-aggregations are read-only to DJ
 

--- a/docs/content/0.1.0/docs/dj-concepts/aggregate-awareness.md
+++ b/docs/content/0.1.0/docs/dj-concepts/aggregate-awareness.md
@@ -336,6 +336,29 @@ Until this call has been made at least once, the pre-aggregation exists but has 
 routing won't send queries to it — the same rule that applies to any DJ-materialized pre-aggregation
 that hasn't finished its first build.
 
+### Freshness gating
+
+By default, DJ treats a pre-aggregation with any availability at all as eligible: once you've reported
+`valid_through_ts` once, routing keeps sending queries there even if the pipeline behind it later stops
+running. Setting `PREAGG_FRESHNESS_GATING=true` makes DJ consult the watermark on every query instead.
+
+What it compares against is the time range the query itself asks for, not wall clock. A query with an
+upper bound on the pre-aggregation's temporal partition — `date_id <= 20250101`, or the high side of a
+`BETWEEN` — is served whenever that bound falls within `valid_through_ts`, so a report for last March
+keeps reading the aggregate even if the table hasn't been rebuilt since. A query whose bound reaches
+past the watermark falls back to computing from source, since the aggregate would silently return
+truncated numbers.
+
+A query with no discoverable upper bound implicitly asks for data through the present, and no watermark
+comparison can make that safe. Those queries are allowed through unless you also set
+`PREAGG_MAX_STALENESS_SECONDS`, which gives them a wall-clock budget: DJ renders `now - budget` into the
+partition's format and requires `valid_through_ts` to be at least that recent.
+
+Gating only applies to pre-aggregations whose grain includes a temporal partition column — that's the
+axis `valid_through_ts` describes. A pre-aggregation with no temporal dimension is never rejected for
+staleness, because there's nothing to compare it against. Rejection is silent: the query falls back to
+source and returns correct (if slower) results, the same as any other non-match.
+
 ### External pre-aggregations are read-only to DJ
 
 Registering a table this way sets its materialization strategy to `external`. DJ will refuse to


### PR DESCRIPTION
### Summary

DJ records how far a pre-aggregation's data goes but doesn't take that into account when routing. A pre-agg whose pipeline died will continue to serve truncated results.

This change adds a gate in `load_available_preaggs` (off by default), that compares what the query asks for against what the table actually covers. For example, a query bounded at last March can be served by a table that stopped updating yesterday, but a query asking for today's data will build from the upstream tables, so that results stay correct.

#### Config

Both preserve today's behavior:
```
preagg_freshness_gating: bool = False
preagg_max_staleness_seconds: Optional[int] = None
```

### Test Plan

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

No migration. Off by default, so deploying changes nothing until `preagg_freshness_gating` is enabled.
