### PR TITLE
Order same-deployment dimension links before dependent validation

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -1844,6 +1844,17 @@ class DeploymentOrchestrator:
                     deps = ordering_graph.setdefault(node_spec.rendered_name, [])
                     if dim_node not in deps:
                         deps.append(dim_node)
+            if isinstance(node_spec, LinkableNodeSpec) and node_spec.dimension_links:
+                for link in node_spec.dimension_links:
+                    dim_node = link.rendered_dimension_node
+                    if (
+                        dim_node == node_spec.rendered_name
+                        or dim_node not in ordering_graph
+                    ):
+                        continue
+                    deps = ordering_graph.setdefault(node_spec.rendered_name, [])
+                    if dim_node not in deps:
+                        deps.append(dim_node)
 
         # Order nodes topologically based on dependencies
         levels = topological_levels(ordering_graph, ascending=False)

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -4663,6 +4663,91 @@ class TestDeploymentColumnOrdering:
 
 
 @pytest.mark.xdist_group(name="deployments")
+class TestDeploymentDimensionLinkOrdering:
+    @pytest.mark.asyncio
+    async def test_dimension_update_visible_to_dependent_join_link_in_same_deployment(
+        self,
+        client,
+    ):
+        namespace = "dimension_link_ordering"
+        dim_raw = SourceSpec(
+            name="dim_raw",
+            catalog="default",
+            schema="roads",
+            table="dim_raw",
+            columns=[
+                ColumnSpec(name="id", type="int"),
+                ColumnSpec(name="k", type="int"),
+            ],
+            dimension_links=[],
+            owners=["dj"],
+        )
+        dim_without_k = DimensionSpec(
+            name="dim_x",
+            query="SELECT id FROM ${prefix}dim_raw",
+            primary_key=["id"],
+            dimension_links=[],
+            owners=["dj"],
+        )
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=[dim_raw, dim_without_k]),
+        )
+        assert data["status"] == DeploymentStatus.SUCCESS.value, data["results"]
+
+        fact_raw = SourceSpec(
+            name="fact_raw",
+            catalog="default",
+            schema="roads",
+            table="fact_raw",
+            columns=[ColumnSpec(name="f", type="int")],
+            dimension_links=[],
+            owners=["dj"],
+        )
+        dim_with_k = DimensionSpec(
+            name="dim_x",
+            query="SELECT id, k FROM ${prefix}dim_raw",
+            primary_key=["id"],
+            dimension_links=[],
+            owners=["dj"],
+        )
+        fact_y = TransformSpec(
+            name="fact_y",
+            query="SELECT f FROM ${prefix}fact_raw",
+            dimension_links=[
+                DimensionJoinLinkSpec(
+                    dimension_node="${prefix}dim_x",
+                    join_type="left",
+                    join_on="${prefix}fact_y.f = ${prefix}dim_x.k",
+                ),
+            ],
+            owners=["dj"],
+        )
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(
+                namespace=namespace,
+                nodes=[dim_raw, dim_with_k, fact_raw, fact_y],
+            ),
+        )
+        assert data["status"] == DeploymentStatus.SUCCESS.value, data["results"]
+
+        node_results = {
+            result["name"]: result
+            for result in data["results"]
+            if result["deploy_type"] == "node"
+        }
+        assert node_results[f"{namespace}.dim_x"]["status"] == "success"
+        assert node_results[f"{namespace}.fact_y"]["status"] == "success"
+
+        response = await client.get(f"/nodes/{namespace}.fact_y/")
+        assert response.status_code == 200
+        assert response.json()["status"] == "valid"
+
+
+@pytest.mark.xdist_group(name="deployments")
 class TestGitOnlyNamespaceDeployments:
     """Tests for git_only namespace deployment verification."""
 


### PR DESCRIPTION
This fixes deployment validation when a dependent node references a dimension column that is added by another node revision in the same deployment.

Root cause: deployment node ordering included SQL parent dependencies and metric `required_dimensions`, but omitted `DimensionJoinLinkSpec` / `DimensionReferenceLinkSpec` targets as ordering-only dependencies. That allowed an updated dimension node and a dependent node with `join_on` pointing at the newly added dimension column to be validated in the same topological level. `NodeSpecBulkValidator._prefetch_dimension_link_nodes` then read the target dimension from the upfront `dependency_nodes` / pre-update DB state, causing `_validate_join_link` to reject the dependent node even though the dimension revision in the same deployment would make it valid.

The change extends `DeploymentOrchestrator._deploy_nodes` ordering with dimension-link target nodes from `LinkableNodeSpec.dimension_links`, while leaving `plan.node_graph` unchanged so these links do not become SQL parent relationships. Linked dimensions that are present in the same deployment now deploy in an earlier topological level, allowing `dependency_nodes` to receive the freshly flushed `Node.current` before dependent `join_on` validation runs.

A regression API deployment test covers deploying a dimension without column `k`, then deploying one batch that updates the dimension to expose `k` and updates/creates a dependent node whose `join_on` references `dim.k`, asserting the deployment leaves both nodes valid.

Files changed:
- `datajunction-server/datajunction_server/internal/deployment/orchestrator.py`
- `datajunction-server/tests/api/deployments_test.py`

`ruff check datajunction-server/datajunction_server/internal/deployment/orchestrator.py datajunction-server/tests/api/deployments_test.py` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
