### PR TITLE
Stop old materialization workflows for non-trivial cube changes

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -47,6 +47,7 @@ from datajunction_server.database.node import (
     NodeRevision,
 )
 from datajunction_server.database.partition import Partition
+from datajunction_server.database.preaggregation import compute_expression_hash
 from datajunction_server.database.user import User
 from datajunction_server.database.measure import FrozenMeasure
 from datajunction_server.sql.decompose import MetricComponentExtractor
@@ -1484,6 +1485,82 @@ def node_update_history_event(new_revision: NodeRevision, current_user: User):
     )
 
 
+async def _cube_materialization_invalidation_signature(
+    session: AsyncSession,
+    node_revision: NodeRevision,
+) -> tuple[set[tuple[str, str, str, str]], set[str], tuple[str, ...]]:
+    """
+    Signature of cube fields that make old materializations unsafe when changed.
+    """
+    metric_components = set()
+    for metric_revision in node_revision.metric_node_revisions():
+        extractor = MetricComponentExtractor(metric_revision.id)
+        components, _ = await extractor.extract(session)
+        for component in components:
+            metric_components.add(
+                (
+                    metric_revision.name,
+                    component.name,
+                    compute_expression_hash(component.expression),
+                    component.normalized_aggregation,
+                ),
+            )
+    return (
+        metric_components,
+        set(node_revision.cube_dimensions()),
+        tuple(sorted(node_revision.cube_filters or [])),
+    )
+
+
+async def _deactivate_old_cube_materializations(
+    node_revision: NodeRevision,
+    active_materializations: list,
+    query_service_client: QueryServiceClient,
+    request_headers: Dict[str, str],
+) -> None:
+    """
+    Best-effort stop of workflows for a superseded cube revision.
+    """
+    deactivated_at = datetime.now(timezone.utc)
+    for materialization in active_materializations:
+        mat_config = (
+            materialization.config if isinstance(materialization.config, dict) else {}
+        )
+        workflow_names = mat_config.get("workflow_names", [])
+        try:
+            if workflow_names:
+                query_service_client.deactivate_workflows(
+                    workflow_names=workflow_names,
+                    request_headers=request_headers,
+                )
+                _logger.info(
+                    "Deactivated workflows for cube=%s revision=%s: %s",
+                    node_revision.name,
+                    node_revision.version,
+                    workflow_names,
+                )
+            else:
+                query_service_client.deactivate_cube_workflow(
+                    node_revision.name,
+                    version=node_revision.version,
+                    request_headers=request_headers,
+                )
+                _logger.info(
+                    "Deactivated workflow for cube=%s revision=%s",
+                    node_revision.name,
+                    node_revision.version,
+                )
+        except Exception as exc:  # pragma: no cover
+            _logger.warning(
+                "Failed to deactivate workflow for cube=%s revision=%s: %s "
+                "(continuing with cube update)",
+                node_revision.name,
+                node_revision.version,
+                str(exc),
+            )
+        materialization.deactivated_at = deactivated_at
+
+
 async def update_cube_node(
     session: AsyncSession,
     node_revision: NodeRevision,
@@ -1573,6 +1650,11 @@ async def update_cube_node(
             )
         return None
 
+    await session.refresh(node_revision, ["materializations"])
+    active_materializations = [
+        mat for mat in node_revision.materializations if not mat.deactivated_at
+    ]
+
     # Disable autoflush to prevent partial state from being persisted if an error
     # occurs during revision creation. This ensures that node.current_version and
     # the new NodeRevision are committed atomically - either both succeed or both
@@ -1633,13 +1715,25 @@ async def update_cube_node(
         # Users should explicitly set up materializations for the new cube version
         # after updating the cube definition.
 
+        if active_materializations and (
+            await _cube_materialization_invalidation_signature(session, node_revision)
+            != await _cube_materialization_invalidation_signature(
+                session,
+                new_cube_revision,
+            )
+        ):
+            await _deactivate_old_cube_materializations(
+                node_revision,
+                active_materializations,
+                query_service_client,
+                request_headers,
+            )
+
         # Notify if the old revision had active materializations that won't be migrated
-        active_materializations = [
-            mat
-            for mat in node_revision.materializations
-            if not mat.deactivated_at and mat.name != "default"
+        non_default_active_materializations = [
+            mat for mat in active_materializations if mat.name != "default"
         ]
-        if active_materializations:
+        if non_default_active_materializations:
             await save_history(
                 event=History(
                     entity_type=EntityType.MATERIALIZATION,
@@ -1656,7 +1750,7 @@ async def update_cube_node(
                         "previous_version": node_revision.version,
                         "new_version": new_cube_revision.version,
                         "invalidated_materializations": [
-                            mat.name for mat in active_materializations
+                            mat.name for mat in non_default_active_materializations
                         ],
                     },
                     user=current_user.username,

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -2628,6 +2628,211 @@ async def test_updating_cube_with_existing_cube_materialization(
 
 
 @pytest.mark.asyncio
+async def test_updating_materialized_cube_dimensions_deactivates_old_workflow(
+    client_with_repairs_cube: AsyncClient,
+    module__session,
+    module__query_service_client: QueryServiceClient,
+    mocker,
+):
+    """
+    Dimension changes make the old cube revision's materialization unsafe.
+    """
+    from sqlalchemy import select
+
+    from datajunction_server.database.materialization import Materialization
+    from datajunction_server.database.node import NodeRevision
+
+    cube_name = "default.repairs_cube_dimension_workflow_deactivation"
+    await make_a_test_cube(
+        client_with_repairs_cube,
+        cube_name,
+        with_materialization=False,
+    )
+
+    result = await module__session.execute(
+        select(NodeRevision).where(NodeRevision.name == cube_name),
+    )
+    old_revision = result.scalars().one()
+    old_materialization = Materialization(
+        node_revision_id=old_revision.id,
+        name="druid_cube_v3",
+        strategy=None,
+        schedule="0 0 * * *",
+        config={"workflow_names": ["cube-update-wf"]},
+        job="DruidCubeMaterializationJob",
+    )
+    module__session.add(old_materialization)
+    await module__session.commit()
+
+    deactivate_workflows = mocker.patch.object(
+        module__query_service_client,
+        "deactivate_workflows",
+        return_value={"status": "deactivated"},
+    )
+    deactivate_cube_workflow = mocker.patch.object(
+        module__query_service_client,
+        "deactivate_cube_workflow",
+        return_value={"status": "deactivated"},
+    )
+
+    response = await client_with_repairs_cube.patch(
+        f"/nodes/{cube_name}",
+        json={
+            "dimensions": [
+                "default.hard_hat.city",
+                "default.hard_hat.hire_date",
+            ],
+        },
+    )
+    assert response.status_code == 200, response.json()
+    assert response.json()["version"] == "v2.0"
+
+    deactivate_workflows.assert_called_once_with(
+        workflow_names=["cube-update-wf"],
+        request_headers=mocker.ANY,
+    )
+    deactivate_cube_workflow.assert_not_called()
+    await module__session.refresh(old_materialization)
+    assert old_materialization.deactivated_at is not None
+
+    result = await module__session.execute(
+        select(NodeRevision).where(
+            NodeRevision.name == cube_name,
+            NodeRevision.version == "v2.0",
+        ),
+    )
+    new_revision = result.scalars().one()
+    await module__session.refresh(new_revision, ["materializations"])
+    assert new_revision.materializations == []
+
+
+@pytest.mark.asyncio
+async def test_updating_materialized_cube_filters_deactivates_old_workflow(
+    client_with_repairs_cube: AsyncClient,
+    module__session,
+    module__query_service_client: QueryServiceClient,
+    mocker,
+):
+    """
+    Filter changes are non-trivial for materializations, even with minor versions.
+    """
+    from sqlalchemy import select
+
+    from datajunction_server.database.materialization import Materialization
+    from datajunction_server.database.node import NodeRevision
+
+    cube_name = "default.repairs_cube_filter_workflow_deactivation"
+    await make_a_test_cube(
+        client_with_repairs_cube,
+        cube_name,
+        with_materialization=False,
+    )
+
+    result = await module__session.execute(
+        select(NodeRevision).where(NodeRevision.name == cube_name),
+    )
+    old_revision = result.scalars().one()
+    old_materialization = Materialization(
+        node_revision_id=old_revision.id,
+        name="druid_cube_v3",
+        strategy=None,
+        schedule="0 0 * * *",
+        config={},
+        job="DruidCubeMaterializationJob",
+    )
+    module__session.add(old_materialization)
+    await module__session.commit()
+
+    deactivate_workflows = mocker.patch.object(
+        module__query_service_client,
+        "deactivate_workflows",
+        return_value={"status": "deactivated"},
+    )
+    deactivate_cube_workflow = mocker.patch.object(
+        module__query_service_client,
+        "deactivate_cube_workflow",
+        return_value={"status": "deactivated"},
+    )
+
+    response = await client_with_repairs_cube.patch(
+        f"/nodes/{cube_name}",
+        json={"filters": ["default.hard_hat.state='CA'"]},
+    )
+    assert response.status_code == 200, response.json()
+    assert response.json()["version"] == "v1.1"
+
+    deactivate_cube_workflow.assert_called_once_with(
+        cube_name,
+        version="v1.0",
+        request_headers=mocker.ANY,
+    )
+    deactivate_workflows.assert_not_called()
+    await module__session.refresh(old_materialization)
+    assert old_materialization.deactivated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_updating_materialized_cube_metadata_keeps_old_workflow(
+    client_with_repairs_cube: AsyncClient,
+    module__session,
+    module__query_service_client: QueryServiceClient,
+    mocker,
+):
+    """
+    Metadata-only cube updates should not stop the old revision's workflow.
+    """
+    from sqlalchemy import select
+
+    from datajunction_server.database.materialization import Materialization
+    from datajunction_server.database.node import NodeRevision
+
+    cube_name = "default.repairs_cube_metadata_no_workflow_deactivation"
+    await make_a_test_cube(
+        client_with_repairs_cube,
+        cube_name,
+        with_materialization=False,
+    )
+
+    result = await module__session.execute(
+        select(NodeRevision).where(NodeRevision.name == cube_name),
+    )
+    old_revision = result.scalars().one()
+    old_materialization = Materialization(
+        node_revision_id=old_revision.id,
+        name="druid_cube_v3",
+        strategy=None,
+        schedule="0 0 * * *",
+        config={"workflow_names": ["metadata-wf"]},
+        job="DruidCubeMaterializationJob",
+    )
+    module__session.add(old_materialization)
+    await module__session.commit()
+
+    deactivate_workflows = mocker.patch.object(
+        module__query_service_client,
+        "deactivate_workflows",
+        return_value={"status": "deactivated"},
+    )
+    deactivate_cube_workflow = mocker.patch.object(
+        module__query_service_client,
+        "deactivate_cube_workflow",
+        return_value={"status": "deactivated"},
+    )
+
+    response = await client_with_repairs_cube.patch(
+        f"/nodes/{cube_name}",
+        json={"description": "Updated cube description only"},
+    )
+    assert response.status_code == 200, response.json()
+    assert response.json()["version"] == "v1.1"
+
+    deactivate_workflows.assert_not_called()
+    deactivate_cube_workflow.assert_not_called()
+    await module__session.refresh(old_materialization)
+    assert old_materialization.deactivated_at is None
+
+
+@pytest.mark.asyncio
 async def test_updating_cube_with_existing_materialization(
     client_with_repairs_cube: AsyncClient,
     module__query_service_client: QueryServiceClient,


### PR DESCRIPTION
Issue #2357 reports that active materialization workflows remain on the previous cube revision after non-trivial cube changes.

Root cause: cube updates create a new NodeRevision and intentionally leave materializations on the previous revision behind, but the update path only wrote a history warning. It did not call the query service to stop the old workflow or mark the old Materialization rows inactive. Change detection also treated filter changes as minor and only compared metric node names and dimensions, so there was no explicit non-trivial predicate matching the issue definition.

This change adds small internal helpers in `nodes.py` to compute a cube revision signature for materialization invalidation from metric component identity, dimension set, and normalized cube filters. Metric component identity uses `MetricComponentExtractor` plus `compute_expression_hash` and normalized aggregation.

In `update_cube_node`, after creating the new cube revision and before committing, the old and new signatures are compared. When they differ, active materializations on the old revision are deactivated by calling `query_service_client.deactivate_workflows` with `config.workflow_names` when present, or `deactivate_cube_workflow` with the old version as fallback. The old Materialization rows also get `deactivated_at` set so DJ no longer reports them as active.

Existing behavior is preserved for not migrating materializations to the new revision, and trivial metadata-only cube updates are left untouched.

Files changed:
- `datajunction-server/datajunction_server/internal/nodes.py`
- `datajunction-server/tests/api/cubes_test.py`

`ruff check datajunction-server/datajunction_server/internal/nodes.py datajunction-server/tests/api/cubes_test.py` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
