### PR TITLE
Route queries for dimension attributes to pre-aggs holding the dimension node PK

### DIFF
--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -247,12 +247,6 @@ class Settings(BaseSettings):  # pragma: no cover
     # enabling it can route queries away from pre-aggs that serve them today.
     preagg_freshness_gating: bool = False
 
-    # Allow a pre-aggregation to answer a query for an attribute it doesn't hold,
-    # by joining the dimension whose key it retained. Off by default: it widens
-    # what routes, and a wrong match would multiply the measures rather than
-    # error.
-    preagg_join_back: bool = False
-
     # Wall-clock staleness budget, in seconds, applied only when a query has no
     # discoverable upper bound on the pre-agg's temporal partition (such a query
     # implicitly asks for data through the present). When None, unbounded

--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -247,6 +247,12 @@ class Settings(BaseSettings):  # pragma: no cover
     # enabling it can route queries away from pre-aggs that serve them today.
     preagg_freshness_gating: bool = False
 
+    # Allow a pre-aggregation to answer a query for an attribute it doesn't hold,
+    # by joining the dimension whose key it retained. Off by default: it widens
+    # what routes, and a wrong match would multiply the measures rather than
+    # error.
+    preagg_join_back: bool = False
+
     # Wall-clock staleness budget, in seconds, applied only when a query has no
     # discoverable upper bound on the pre-agg's temporal partition (such a query
     # implicitly asks for data through the present). When None, unbounded

--- a/datajunction-server/datajunction_server/construction/build_v3/filters.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/filters.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from functools import reduce
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from datajunction_server.errors import (
@@ -138,7 +139,7 @@ def _raise_for_unresolved_filter_refs(
 
 def resolve_filter_references(
     filter_ast: ast.Expression,
-    column_aliases: dict[str, str],
+    column_aliases: Mapping[str, str | ast.Name],
     cte_alias: str | None = None,
     nodes: dict[str, Node] | None = None,
 ) -> ast.Expression:
@@ -147,6 +148,11 @@ def resolve_filter_references(
 
     This replaces references like "v3.product.category" with the appropriate
     table-qualified column reference like "t2.category".
+
+    A mapping value may be an ``ast.Name`` rather than a bare column name, in
+    which case it is used verbatim -- letting a caller qualify each reference
+    with its own table instead of sharing one ``cte_alias``. Names read off two
+    different relations can then collide without being confused.
 
     Also handles role-suffixed dimensions expressed as subscript syntax, e.g.:
     "v3.date.month[order] >= 2024" where [order] is the role indicator.
@@ -222,9 +228,13 @@ def resolve_filter_references(
                 # maps to the dimension's table alias. For skip-join (local) dimensions this is
                 # the FK column on the fact table (e.g., "utc_date_id").
                 col_name_for_replacement = alias_to_use
-            replacement = ast.Column(
-                name=ast.Name(col_name_for_replacement),
-                _table=ast.Table(ast.Name(cte_alias)) if cte_alias else None,
+            replacement = (
+                ast.Column(name=deepcopy(col_name_for_replacement))
+                if isinstance(col_name_for_replacement, ast.Name)
+                else ast.Column(
+                    name=ast.Name(col_name_for_replacement),
+                    _table=ast.Table(ast.Name(cte_alias)) if cte_alias else None,
+                )
             )
             already_resolved_ids.add(id(replacement))
             subscript.swap(replacement)
@@ -248,7 +258,9 @@ def resolve_filter_references(
             if full_ref in column_aliases:
                 col_alias = column_aliases[full_ref]
                 # Replace with table-aliased reference
-                if cte_alias:
+                if isinstance(col_alias, ast.Name):
+                    node.name = deepcopy(col_alias)
+                elif cte_alias:
                     node.name = ast.Name(col_alias, namespace=ast.Name(cte_alias))
                 else:
                     node.name = ast.Name(col_alias)

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -45,6 +45,7 @@ from datajunction_server.construction.build_v3.materialization import (
     should_use_materialized_table,
 )
 from datajunction_server.construction.build_v3.preagg_matcher import (
+    JoinBackCoverage,
     find_matching_preagg,
     get_preagg_dimension_column,
     get_preagg_measure_column,
@@ -1750,12 +1751,135 @@ def find_upstream_temporal_source_node(
     return None
 
 
+def _preagg_column(name: str, table: str | None, alias: str | None = None) -> Any:
+    """A pre-agg column reference, table-qualified when the scan became a CTE."""
+    col = make_column_ref(name, table) if table else ast.Column(name=ast.Name(name))
+    if alias is not None and alias != name:
+        col.alias = ast.Name(alias)
+    return col
+
+
+def _unique_name(base: str, taken: dict[str, str]) -> str:
+    """``base``, numerically suffixed until it collides with nothing in ``taken``."""
+    name = base
+    suffix = 0
+    while name in taken:
+        suffix += 1
+        name = f"{base}_{suffix}"
+    return name
+
+
+def _joined_dimension_type(ctx: BuildContext, rdim: ResolvedDimension) -> str:
+    """Declared type of a dimension attribute read from the dimension node."""
+    dim_node = ctx.nodes[rdim.node_name]
+    assert dim_node.current is not None  # join_back_coverage checked both
+    return next(
+        (
+            str(col.type)
+            for col in dim_node.current.columns
+            if col.name == rdim.column_name
+        ),
+        "string",
+    )
+
+
+def _preagg_join_key_projection(
+    ctx: BuildContext,
+    preagg: PreAggregation,
+    join_back: tuple[JoinBackCoverage, ...],
+) -> dict[str, str]:
+    """
+    Names the pre-agg scan must expose for the joins, and the column each reads.
+
+    Each retained key is projected under the *parent's* foreign key column name,
+    which is what the dimension link's join SQL refers to. Shaping the scan like
+    the parent fact this way is what lets the ordinary dimension-join machinery
+    join onto it unchanged.
+    """
+    projection: dict[str, str] = {}
+    for coverage in join_back:
+        join_path = coverage.dimension.join_path
+        assert join_path is not None  # is_join_back_safe guarantees a single link
+        link = join_path.links[0]
+        # foreign_key_mapping is keyed by the dimension's primary key column.
+        fk_by_pk = {
+            pk.name.name: fk.name.name for pk, fk in link.foreign_key_mapping().items()
+        }
+        for key_ref in coverage.key_refs:
+            key_col = parse_dimension_ref(key_ref).column_name
+            projection.setdefault(
+                fk_by_pk.get(key_col, key_col),
+                get_preagg_dimension_column(
+                    ctx,
+                    preagg.node_revision_id,
+                    preagg,
+                    key_ref,
+                    key_col,
+                ),
+            )
+    return projection
+
+
+def _preagg_dimension_ctes(
+    ctx: BuildContext,
+    join_back: tuple[JoinBackCoverage, ...],
+) -> tuple[list[tuple[str, ast.Query]], list[str]]:
+    """
+    CTEs for the dimensions joined onto the pre-agg scan, and the sources they read.
+
+    A materialized dimension contributes no CTE -- ``build_join_clause`` points
+    the join straight at its table instead.
+    """
+    dim_nodes: list[Node] = []
+    needed_columns: dict[str, set[str]] = {}
+    for coverage in join_back:
+        rdim = coverage.dimension
+        join_path = rdim.join_path
+        assert join_path is not None  # is_join_back_safe guarantees a single link
+        link = join_path.links[0]
+        dim_node = ctx.nodes.get(link.dimension.name, link.dimension)
+        if dim_node not in dim_nodes:
+            dim_nodes.append(dim_node)
+        cols = needed_columns.setdefault(dim_node.name, set())
+        cols.add(rdim.column_name)
+        if link.join_sql:  # pragma: no branch
+            cols.update(extract_join_columns_for_node(link.join_sql, dim_node.name))
+    ctes, scanned_sources, _ = collect_node_ctes(ctx, dim_nodes, needed_columns)
+    return ctes, scanned_sources
+
+
+def _resolve_preagg_filter(
+    filter_ast: ast.Expression,
+    ref_columns: dict[str, tuple[str, str | None]],
+) -> None:
+    """
+    Resolve a filter's dimension references to the columns backing them.
+
+    ``ref_columns`` maps each dimension reference to the column name and table
+    alias it reads. Resolution goes through a placeholder per reference rather
+    than through column names, so an attribute read off a joined dimension can't
+    be confused with a pre-agg column that happens to be spelled the same.
+    """
+    tokens = {ref: f"__preagg_ref_{index}" for index, ref in enumerate(ref_columns)}
+    resolve_filter_references(filter_ast, tokens, cte_alias=None)
+    for ref, (col_name, table_alias) in ref_columns.items():
+        resolved = (
+            ast.Name(col_name, namespace=ast.Name(table_alias))
+            if table_alias
+            else ast.Name(col_name)
+        )
+        for col in filter_ast.find_all(ast.Column):
+            if col.name.name == tokens[ref]:
+                col.name = deepcopy(resolved)
+
+
 def build_grain_group_from_preagg(
     ctx: BuildContext,
     grain_group: GrainGroup,
     preagg: PreAggregation,
     resolved_dimensions: list[ResolvedDimension],
     components_per_metric: dict[str, int],
+    join_back: tuple[JoinBackCoverage, ...] = (),
 ) -> GrainGroupSQL:
     """
     Build SQL for a grain group using a pre-aggregation table.
@@ -1768,12 +1892,27 @@ def build_grain_group_from_preagg(
         FROM catalog.schema.preagg_table
         GROUP BY dim1, dim2
 
+    When ``join_back`` is non-empty the pre-agg holds a dimension's key rather
+    than the attribute asked for. The scan then becomes a CTE shaped like the
+    parent fact -- retained keys projected under the parent's foreign key column
+    names -- and the dimension is joined onto it:
+
+        WITH v3_customer AS (...),
+             order_details_preagg AS (
+               SELECT cust_key AS customer_id, revenue FROM catalog.schema.table
+             )
+        SELECT t2.name, SUM(t1.revenue)
+        FROM order_details_preagg t1
+        LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+        GROUP BY t2.name
+
     Args:
         ctx: Build context
         grain_group: The grain group to generate SQL for
         preagg: The pre-aggregation to use
         resolved_dimensions: Pre-resolved dimensions with join paths
         components_per_metric: Metric name -> component count mapping
+        join_back: Requested dimensions reachable only by joining a retained key
 
     Returns:
         GrainGroupSQL with SQL and metadata for this grain group
@@ -1786,6 +1925,7 @@ def build_grain_group_from_preagg(
 
     # Build table reference
     table_parts = [p for p in [avail.catalog, avail.schema_, avail.table] if p]
+    preagg_table = SEPARATOR.join(table_parts)
 
     # Build SELECT columns
     select_items: list[ast.Aliasable | ast.Expression | ast.Column] = []
@@ -1795,13 +1935,32 @@ def build_grain_group_from_preagg(
     unique_components: list[MetricComponent] = []
     seen_components: set[str] = set()
 
-    # Dimension (grain) columns. grain_col_names = logical output names;
-    # group_by_cols = physical columns read (they differ only when an external
-    # pre-agg remaps a dimension's column).
+    # Join layer. Set up only when a join is actually needed, so the far more
+    # common covering pre-agg still reads as a bare table scan.
+    joined_refs = {coverage.dimension.original_ref for coverage in join_back}
+    scan_alias: str | None = None
+    dim_aliases: dict[tuple[str, str | None], str] = {}
+    joins: list[ast.Join] = []
+    ctes: list[tuple[str, ast.Query]] = []
+    scanned_sources = [preagg_table]
+    # Scan CTE projection: output name -> the pre-agg column it reads.
+    scan_projection: dict[str, str] = {}
+    if join_back:
+        scan_alias = ctx.next_table_alias(parent_node.name)
+        scan_projection = _preagg_join_key_projection(ctx, preagg, join_back)
+        dim_aliases, joins = build_dimension_joins(
+            ctx,
+            [coverage.dimension for coverage in join_back],
+            scan_alias,
+        )
+        ctes, dim_sources = _preagg_dimension_ctes(ctx, join_back)
+        scanned_sources.extend(dim_sources)
+
+    # Dimension (grain) columns.
     grain_col_names: list[str] = []
-    group_by_cols: list[str] = []
-    # Dimension ref -> physical column, for the filter pushdown below.
-    ref_to_physical: dict[str, str] = {}
+    group_by: list[ast.Expression] = []
+    # Dimension ref -> (column, table alias) backing it, for the filter pushdown.
+    ref_columns: dict[str, tuple[str, str | None]] = {}
     for dim in resolved_dimensions:
         # Output name, via the alias registry so it matches what the source-built
         # path emits -- the metrics layer references grain columns by that alias.
@@ -1812,30 +1971,47 @@ def build_grain_group_from_preagg(
         output_alias = ctx.alias_registry.register(dim.original_ref)
         grain_col_names.append(output_alias)
 
-        # Physical column read from the table, remapped via dimension_columns if
-        # present. Independent of the output alias above.
-        physical_col = get_preagg_dimension_column(
-            ctx,
-            preagg.node_revision_id,
-            preagg,
-            dim.original_ref,
-            dim.column_name,
-        )
-        group_by_cols.append(physical_col)
-        ref_to_physical[dim.original_ref] = physical_col
-
-        if physical_col == output_alias:
-            select_items.append(ast.Column(name=ast.Name(output_alias)))
-        else:
+        if dim.original_ref in joined_refs:
+            # Read off the joined dimension: the scan has no such column.
+            dim_table = get_dimension_table_alias(
+                dim,
+                cast(str, scan_alias),
+                dim_aliases,
+            )
+            col_type = _joined_dimension_type(ctx, dim)
             select_items.append(
-                ast.Alias(
-                    child=ast.Column(name=ast.Name(physical_col)),
-                    alias=ast.Name(output_alias),
+                build_dimension_col_expr(
+                    dim,
+                    cast(str, scan_alias),
+                    dim_aliases,
+                    output_alias,
                 ),
             )
+            group_by.append(make_column_ref(dim.column_name, dim_table))
+            ref_columns[dim.original_ref] = (dim.column_name, dim_table)
+        else:
+            # Physical column read from the table, remapped via dimension_columns
+            # if present. Independent of the output alias above.
+            physical_col = get_preagg_dimension_column(
+                ctx,
+                preagg.node_revision_id,
+                preagg,
+                dim.original_ref,
+                dim.column_name,
+            )
+            # Type metadata is keyed by the output (DJ) name, not the physical column.
+            col_type = preagg.get_column_type(output_alias, default="string")
+            if scan_alias is None:
+                scan_name = physical_col
+            else:
+                # Names inside the scan CTE are private to it, so they yield to
+                # the foreign key names the joins need rather than colliding.
+                scan_name = _unique_name(output_alias, scan_projection)
+                scan_projection[scan_name] = physical_col
+            select_items.append(_preagg_column(scan_name, scan_alias, output_alias))
+            group_by.append(_preagg_column(scan_name, scan_alias))
+            ref_columns[dim.original_ref] = (scan_name, scan_alias)
 
-        # Type metadata is keyed by the output (DJ) name, not the physical column.
-        col_type = preagg.get_column_type(output_alias, default="string")
         columns.append(
             ColumnMetadata(
                 name=output_alias,
@@ -1868,24 +2044,26 @@ def build_grain_group_from_preagg(
 
         component_aliases[component.name] = output_alias
 
-        col_ref = ast.Column(name=ast.Name(measure_col))
+        if scan_alias is None:
+            scan_name = measure_col
+        else:
+            scan_name = _unique_name(measure_col, scan_projection)
+            scan_projection[scan_name] = measure_col
 
         # If no merge function, output column directly (e.g., grain column for LIMITED)
         # Otherwise, apply the merge function for re-aggregation
         if component.merge:
             agg_expr = ast.Function(
                 name=ast.Name(component.merge),
-                args=[col_ref],
+                args=[_preagg_column(scan_name, scan_alias)],
             )
             aliased = ast.Alias(child=agg_expr, alias=ast.Name(output_alias))
             select_items.append(aliased)
         else:
             # No merge - output grain column directly, add to GROUP BY
-            select_items.append(col_ref)
+            select_items.append(_preagg_column(scan_name, scan_alias, measure_col))
             grain_col_names.append(measure_col)
-            group_by_cols.append(measure_col)
-            output_alias = measure_col
-            component_aliases[component.name] = output_alias
+            group_by.append(_preagg_column(scan_name, scan_alias))
 
         # Get type from pre-agg columns
         col_type = preagg.get_column_type(measure_col, default="double")
@@ -1898,14 +2076,39 @@ def build_grain_group_from_preagg(
             ),
         )
 
-    # Build GROUP BY clause (physical columns actually read from the table)
-    group_by: list[ast.Expression] = []
-    if group_by_cols:
-        group_by = [ast.Column(name=ast.Name(col)) for col in group_by_cols]
-
-    # Build FROM clause using the helper method
-    preagg_table = SEPARATOR.join(table_parts)
-    from_clause = ast.From.Table(preagg_table)
+    # Build FROM clause: the table itself, or the scan CTE plus its dim joins.
+    if scan_alias is None:
+        from_clause = ast.From.Table(preagg_table)
+    else:
+        scan_cte_name = f"{get_cte_name(parent_node.name)}_preagg"
+        ctes.append(
+            (
+                scan_cte_name,
+                ast.Query(
+                    select=ast.Select(
+                        projection=[
+                            _preagg_column(source_col, None, name)
+                            for name, source_col in scan_projection.items()
+                        ],
+                        from_=ast.From.Table(preagg_table),
+                    ),
+                ),
+            ),
+        )
+        from_clause = ast.From(
+            relations=[
+                ast.Relation(
+                    primary=cast(
+                        ast.Expression,
+                        ast.Alias(
+                            child=ast.Table(name=make_name(scan_cte_name)),
+                            alias=ast.Name(scan_alias),
+                        ),
+                    ),
+                    extensions=joins,
+                ),
+            ],
+        )
 
     # Build SELECT statement
     select = ast.Select(
@@ -1917,9 +2120,11 @@ def build_grain_group_from_preagg(
     # Push filter-only dimension filters into the scan, on the physical column and
     # before the roll-up. The outer query skips these (the grain group is expected
     # to apply them), so without this the predicate lands nowhere and the result
-    # over-counts. Projected-dimension filters are left to the outer query.
-    # Guarded on filter_dimensions: when empty -- the common case -- nothing can
-    # qualify and the ANTLR parse below would be wasted.
+    # over-counts. A predicate on a joined-back attribute lands on the joined
+    # dimension instead -- after the join, since the scan has no such column.
+    # Projected-dimension filters are left to the outer query. Guarded on
+    # filter_dimensions: when empty -- the common case -- nothing can qualify and
+    # the ANTLR parse below would be wasted.
     if ctx.filter_dimensions:
         for filter_str in ctx.dimension_filters or []:
             filter_ast = parse_filter(filter_str)
@@ -1928,13 +2133,28 @@ def build_grain_group_from_preagg(
                 ctx.filter_dimensions,
             ):
                 continue
-            resolve_filter_references(filter_ast, ref_to_physical, cte_alias=None)
-            inject_filter_into_select(select, filter_ast)
+            _resolve_preagg_filter(filter_ast, ref_columns)
+            # ANDed straight into the WHERE rather than pushed onto a joined
+            # dimension's side of its LEFT JOIN: excluding the fact rows that
+            # don't match is the whole point of the predicate, and it matches
+            # where the source-built path puts the same filter.
+            select.where = (
+                cast(ast.Expression, ast.BinaryOp.And(select.where, filter_ast))
+                if select.where
+                else filter_ast
+            )
 
     # Build the query
     query = ast.Query(select=select)
+    if ctes:
+        cte_list = []
+        for cte_name, cte_query in ctes:
+            cte_query.to_cte(ast.Name(cte_name), query)
+            cte_list.append(cte_query)
+        query.ctes = cte_list
 
-    # Pre-aggregation path: no raw sources scanned (uses materialized table)
+    # Pre-aggregation path: the only raw sources scanned are those behind the
+    # dimensions joined back onto the pre-agg.
     # TODO: Consider tracking the pre-agg table itself as a "materialized source"
     return GrainGroupSQL(
         query=query,
@@ -1948,7 +2168,7 @@ def build_grain_group_from_preagg(
         component_aggregabilities=grain_group.component_aggregabilities,
         components=unique_components,
         dialect=ctx.dialect,
-        scanned_sources=[preagg_table],
+        scanned_sources=scanned_sources,
     )
 
 
@@ -1977,20 +2197,20 @@ def build_grain_group_sql(
 
     # Check for matching pre-aggregation
     if ctx.use_materialized and ctx.available_preaggs:
-        requested_grain = [dim.original_ref for dim in resolved_dimensions]
-        matching_preagg = find_matching_preagg(
+        match = find_matching_preagg(
             ctx,
             parent_node,
-            requested_grain,
+            resolved_dimensions,
             grain_group,
         )
-        if matching_preagg:
+        if match:
             return build_grain_group_from_preagg(
                 ctx,
                 grain_group,
-                matching_preagg,
+                match.preagg,
                 resolved_dimensions,
                 components_per_metric,
+                match.join_back,
             )
 
     # Build list of component expressions with their aliases

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -1751,9 +1751,13 @@ def find_upstream_temporal_source_node(
     return None
 
 
-def _preagg_column(name: str, table: str | None, alias: str | None = None) -> Any:
+def _preagg_column(
+    name: str,
+    table: str | None,
+    alias: str | None = None,
+) -> ast.Column:
     """A pre-agg column reference, table-qualified when the scan became a CTE."""
-    col = make_column_ref(name, table) if table else ast.Column(name=ast.Name(name))
+    col = make_column_ref(name, table)
     if alias is not None and alias != name:
         col.alias = ast.Name(alias)
     return col
@@ -1767,20 +1771,6 @@ def _unique_name(base: str, taken: dict[str, str]) -> str:
         suffix += 1
         name = f"{base}_{suffix}"
     return name
-
-
-def _joined_dimension_type(ctx: BuildContext, rdim: ResolvedDimension) -> str:
-    """Declared type of a dimension attribute read from the dimension node."""
-    dim_node = ctx.nodes[rdim.node_name]
-    assert dim_node.current is not None  # join_back_coverage checked both
-    return next(
-        (
-            str(col.type)
-            for col in dim_node.current.columns
-            if col.name == rdim.column_name
-        ),
-        "string",
-    )
 
 
 def _preagg_join_key_projection(
@@ -1798,12 +1788,12 @@ def _preagg_join_key_projection(
     """
     projection: dict[str, str] = {}
     for coverage in join_back:
-        join_path = coverage.dimension.join_path
-        assert join_path is not None  # is_join_back_safe guarantees a single link
-        link = join_path.links[0]
-        # foreign_key_mapping is keyed by the dimension's primary key column.
+        link = coverage.link
+        # Already computed: resolve_dimensions touches this on every non-local
+        # dimension's links, and a join-back dimension is non-local by construction.
         fk_by_pk = {
-            pk.name.name: fk.name.name for pk, fk in link.foreign_key_mapping().items()
+            get_short_name(pk): get_short_name(fk)
+            for pk, fk in link.foreign_keys_reversed.items()
         }
         for key_ref in coverage.key_refs:
             key_col = parse_dimension_ref(key_ref).column_name
@@ -1834,9 +1824,7 @@ def _preagg_dimension_ctes(
     needed_columns: dict[str, set[str]] = {}
     for coverage in join_back:
         rdim = coverage.dimension
-        join_path = rdim.join_path
-        assert join_path is not None  # is_join_back_safe guarantees a single link
-        link = join_path.links[0]
+        link = coverage.link
         dim_node = ctx.nodes.get(link.dimension.name, link.dimension)
         if dim_node not in dim_nodes:
             dim_nodes.append(dim_node)
@@ -1846,31 +1834,6 @@ def _preagg_dimension_ctes(
             cols.update(extract_join_columns_for_node(link.join_sql, dim_node.name))
     ctes, scanned_sources, _ = collect_node_ctes(ctx, dim_nodes, needed_columns)
     return ctes, scanned_sources
-
-
-def _resolve_preagg_filter(
-    filter_ast: ast.Expression,
-    ref_columns: dict[str, tuple[str, str | None]],
-) -> None:
-    """
-    Resolve a filter's dimension references to the columns backing them.
-
-    ``ref_columns`` maps each dimension reference to the column name and table
-    alias it reads. Resolution goes through a placeholder per reference rather
-    than through column names, so an attribute read off a joined dimension can't
-    be confused with a pre-agg column that happens to be spelled the same.
-    """
-    tokens = {ref: f"__preagg_ref_{index}" for index, ref in enumerate(ref_columns)}
-    resolve_filter_references(filter_ast, tokens, cte_alias=None)
-    for ref, (col_name, table_alias) in ref_columns.items():
-        resolved = (
-            ast.Name(col_name, namespace=ast.Name(table_alias))
-            if table_alias
-            else ast.Name(col_name)
-        )
-        for col in filter_ast.find_all(ast.Column):
-            if col.name.name == tokens[ref]:
-                col.name = deepcopy(resolved)
 
 
 def build_grain_group_from_preagg(
@@ -1943,6 +1906,7 @@ def build_grain_group_from_preagg(
     joins: list[ast.Join] = []
     ctes: list[tuple[str, ast.Query]] = []
     scanned_sources = [preagg_table]
+    spark_hints: list[ast.Hint] = []
     # Scan CTE projection: output name -> the pre-agg column it reads.
     scan_projection: dict[str, str] = {}
     if join_back:
@@ -1952,6 +1916,12 @@ def build_grain_group_from_preagg(
             ctx,
             [coverage.dimension for coverage in join_back],
             scan_alias,
+        )
+        # Same hints the source-built path attaches, so routing to a pre-agg
+        # doesn't silently change the plan for the same query.
+        spark_hints = _collect_spark_hints(
+            [coverage.dimension for coverage in join_back],
+            dim_aliases,
         )
         ctes, dim_sources = _preagg_dimension_ctes(ctx, join_back)
         scanned_sources.extend(dim_sources)
@@ -1978,7 +1948,7 @@ def build_grain_group_from_preagg(
                 cast(str, scan_alias),
                 dim_aliases,
             )
-            col_type = _joined_dimension_type(ctx, dim)
+            col_type = get_column_type(ctx.nodes[dim.node_name], dim.column_name)
             select_items.append(
                 build_dimension_col_expr(
                     dim,
@@ -2115,6 +2085,7 @@ def build_grain_group_from_preagg(
         projection=select_items,
         from_=from_clause,
         group_by=group_by,
+        hints=spark_hints if spark_hints else None,
     )
 
     # Push filter-only dimension filters into the scan, on the physical column and
@@ -2133,7 +2104,20 @@ def build_grain_group_from_preagg(
                 ctx.filter_dimensions,
             ):
                 continue
-            _resolve_preagg_filter(filter_ast, ref_columns)
+            # Qualified per reference: a joined attribute can share a name with
+            # a pre-agg column, so the table has to travel with the column.
+            resolve_filter_references(
+                filter_ast,
+                {
+                    ref: (
+                        ast.Name(col, namespace=ast.Name(table))
+                        if table
+                        else ast.Name(col)
+                    )
+                    for ref, (col, table) in ref_columns.items()
+                },
+                cte_alias=None,
+            )
             # ANDed straight into the WHERE rather than pushed onto a joined
             # dimension's side of its LEFT JOIN: excluding the fact rows that
             # don't match is the whole point of the predicate, and it matches

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -25,10 +25,14 @@ from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models.decompose import Aggregability, MetricComponent
 from datajunction_server.models.preaggregation import TemporalPartitionColumn
 from datajunction_server.naming import SEPARATOR
-from datajunction_server.utils import get_settings
 
 if TYPE_CHECKING:
-    from datajunction_server.construction.build_v3.types import BuildContext, GrainGroup
+    from datajunction_server.construction.build_v3.types import (
+        BuildContext,
+        GrainGroup,
+        JoinPath,
+        ResolvedDimension,
+    )
     from datajunction_server.database.column import Column
     from datajunction_server.database.node import Node
 
@@ -95,46 +99,51 @@ class JoinBackCoverage:
     The pre-agg's grain holds a dimension's key rather than the attribute asked
     for, so the attribute is one join away: read the pre-agg, join the dimension
     on the retained key, and group by the attribute.
+
+    ``key_refs`` are the canonical grain entries holding that key -- the columns
+    the join reads on the pre-agg side.
     """
 
-    dimension_ref: str
+    dimension: ResolvedDimension
     key_refs: tuple[str, ...]
-    dimension_node: str
-    role: str
 
 
-def join_back_enabled() -> bool:
-    """Whether pre-aggregations may be joined back to a retained dimension key."""
-    return get_settings().preagg_join_back
+@dataclass(frozen=True)
+class PreaggMatch:
+    """
+    A pre-aggregation chosen for a grain group, with the joins it needs.
+
+    ``join_back`` is empty for the common case where the stored grain covers the
+    request outright.
+    """
+
+    preagg: PreAggregation
+    join_back: tuple[JoinBackCoverage, ...] = ()
 
 
-def is_join_back_safe(
-    ctx: BuildContext,
-    node_rev_id: int,
-    dim_node_name: str,
-    role: str,
-) -> bool:
+def is_join_back_safe(join_path: JoinPath | None) -> bool:
     """
     Whether joining a dimension onto a retained key is safe to re-aggregate over.
 
     A single link whose join is on the dimension's primary key is many-to-one, so
     it cannot multiply the measures. Multi-hop paths are refused for now: each
-    additional link is only safe if it too cannot fan out, and nothing declares
+    additional link is only safe if it too cannot fan out, and nothing checks
     that yet.
 
-    This is the seam for #2346, which adds a declared ``JoinCardinality`` to
-    dimension links. Once that lands, this should ask whether any link on the
-    path can fan out rather than counting hops -- which also lifts the single-hop
-    restriction.
+    This is the seam for asking each link on the path whether it can fan out --
+    ``DimensionLink.join_cardinality`` already records that, but it defaults to
+    ``MANY_TO_ONE`` for every link nobody annotated, so trusting it today would
+    assume safety rather than establish it. Once it is reliably populated this
+    should test the path's links rather than count them, which also lifts the
+    single-hop restriction.
     """
-    path = ctx.join_paths.get((node_rev_id, dim_node_name, role))
-    return path is not None and len(path) == 1
+    return join_path is not None and len(join_path.links) == 1
 
 
 def join_back_coverage(
     ctx: BuildContext,
     node_rev_id: int,
-    requested_grain_set: set[str],
+    resolved_dimensions: list[ResolvedDimension],
     preagg_grain_set: set[str],
 ) -> list[JoinBackCoverage] | None:
     """
@@ -150,55 +159,50 @@ def join_back_coverage(
     row and multiply the measures.
     """
     coverage: list[JoinBackCoverage] = []
-    for ref in sorted(requested_grain_set - preagg_grain_set):
-        try:
-            dim_ref = parse_dimension_ref(ref)
-        except DJInvalidInputException:
-            return None
+    for rdim in resolved_dimensions:
+        if (
+            canonical_dimension_ref(ctx, node_rev_id, rdim.original_ref)
+            in preagg_grain_set
+        ):
+            continue
 
-        dim_node = ctx.nodes.get(dim_ref.node_name)
+        # A locally-owned column has no dimension node to join, and neither does
+        # a reference that named no node at all.
+        dim_node = ctx.nodes.get(rdim.node_name)
         if not dim_node or not dim_node.current:
             return None
 
         primary_key = [col.name for col in dim_node.current.primary_key()]
-        if not primary_key or dim_ref.column_name in primary_key:
+        if not primary_key or rdim.column_name in primary_key:
             # No key to join on, or the request *is* the key -- which would have
             # matched directly, so reaching here means the grain lacks it.
             return None
 
-        role = dim_ref.role or ""
-        suffix = f"[{role}]" if role else ""
+        suffix = f"[{rdim.role}]" if rdim.role else ""
         key_refs = tuple(
             canonical_dimension_ref(
                 ctx,
                 node_rev_id,
-                f"{dim_ref.node_name}{SEPARATOR}{key_col}{suffix}",
+                f"{rdim.node_name}{SEPARATOR}{key_col}{suffix}",
             )
             for key_col in primary_key
         )
         if not set(key_refs).issubset(preagg_grain_set):
             return None
 
-        if not is_join_back_safe(ctx, node_rev_id, dim_ref.node_name, role):
+        if not is_join_back_safe(rdim.join_path):
             return None
 
-        coverage.append(
-            JoinBackCoverage(
-                dimension_ref=ref,
-                key_refs=key_refs,
-                dimension_node=dim_ref.node_name,
-                role=role,
-            ),
-        )
+        coverage.append(JoinBackCoverage(dimension=rdim, key_refs=key_refs))
     return coverage
 
 
 def find_matching_preagg(
     ctx: BuildContext,
     parent_node: Node,
-    requested_grain: list[str],
+    resolved_dimensions: list[ResolvedDimension],
     grain_group: GrainGroup,
-) -> PreAggregation | None:
+) -> PreaggMatch | None:
     """
     Find a pre-aggregation that can satisfy the grain group requirements.
 
@@ -211,11 +215,11 @@ def find_matching_preagg(
     Args:
         ctx: Build context with available_preaggs cache
         parent_node: The parent node for this grain group
-        requested_grain: List of dimension references requested
+        resolved_dimensions: The requested dimensions, resolved to join paths
         grain_group: The grain group with required components
 
     Returns:
-        Matching PreAggregation if found, None otherwise
+        The chosen ``PreaggMatch`` if one was found, None otherwise
     """
     if not ctx.use_materialized:
         return None
@@ -235,7 +239,8 @@ def find_matching_preagg(
         return None
 
     requested_grain_set = {
-        canonical_dimension_ref(ctx, node_rev_id, ref) for ref in requested_grain
+        canonical_dimension_ref(ctx, node_rev_id, rdim.original_ref)
+        for rdim in resolved_dimensions
     }
 
     # Non-additive measures (e.g. COUNT(DISTINCT ...), raw AVG components) cannot
@@ -251,7 +256,7 @@ def find_matching_preagg(
     # Find a matching pre-agg. Ranked by joins first, then grain size: a pre-agg
     # that covers the request directly always beats one needing a join back, even
     # when the joining one is at a coarser grain.
-    best_match: PreAggregation | None = None
+    best_match: PreaggMatch | None = None
     best_cost: tuple[int, float] = (sys.maxsize, float("inf"))
 
     for preagg in available:
@@ -278,16 +283,12 @@ def find_matching_preagg(
             preagg_grain_set,
         ):
             # The grain may still reach the request by joining a dimension whose
-            # key it retained. Nothing to try when the gate is off.
-            coverage = (
-                join_back_coverage(
-                    ctx,
-                    node_rev_id,
-                    requested_grain_set,
-                    preagg_grain_set,
-                )
-                if join_back_enabled()
-                else None
+            # key it retained.
+            coverage = join_back_coverage(
+                ctx,
+                node_rev_id,
+                resolved_dimensions,
+                preagg_grain_set,
             )
             if coverage is None:
                 logger.debug(
@@ -315,7 +316,7 @@ def find_matching_preagg(
         # (closest to requested grain = less roll-up work)
         cost = (len(join_back), float(len(preagg_grain_set)))
         if cost < best_cost:  # pragma: no branch
-            best_match = preagg
+            best_match = PreaggMatch(preagg=preagg, join_back=tuple(join_back))
             best_cost = cost
             logger.debug(
                 f"[BuildV3] Found matching pre-agg {preagg.id} "
@@ -325,8 +326,8 @@ def find_matching_preagg(
 
     if best_match:
         logger.info(
-            f"[BuildV3] Using pre-agg {best_match.id} for parent={parent_node.name} "
-            f"grain={requested_grain_set}",
+            f"[BuildV3] Using pre-agg {best_match.preagg.id} for "
+            f"parent={parent_node.name} grain={requested_grain_set}",
         )
 
     return best_match

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -9,7 +9,6 @@ tables are available.
 from __future__ import annotations
 
 import logging
-import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -23,6 +22,7 @@ from datajunction_server.database.preaggregation import (
 )
 from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models.decompose import Aggregability, MetricComponent
+from datajunction_server.models.dimensionlink import JoinType
 from datajunction_server.models.preaggregation import TemporalPartitionColumn
 from datajunction_server.naming import SEPARATOR
 
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
         ResolvedDimension,
     )
     from datajunction_server.database.column import Column
+    from datajunction_server.database.dimensionlink import DimensionLink
     from datajunction_server.database.node import Node
 
 logger = logging.getLogger(__name__)
@@ -106,6 +107,9 @@ class JoinBackCoverage:
 
     dimension: ResolvedDimension
     key_refs: tuple[str, ...]
+    # The one link reaching the dimension; is_join_back_safe established there is
+    # exactly one, so consumers don't re-derive it or re-assert the invariant.
+    link: DimensionLink
 
 
 @dataclass(frozen=True)
@@ -130,6 +134,11 @@ def is_join_back_safe(join_path: JoinPath | None) -> bool:
     additional link is only safe if it too cannot fan out, and nothing checks
     that yet.
 
+    The join type matters too: a RIGHT or FULL link makes the *dimension* the
+    preserved side, so a predicate on the pre-agg's own columns would have to be
+    absorbed into the join rather than applied after it -- machinery the source
+    path has and this one doesn't.
+
     This is the seam for asking each link on the path whether it can fan out --
     ``DimensionLink.join_cardinality`` already records that, but it defaults to
     ``MANY_TO_ONE`` for every link nobody annotated, so trusting it today would
@@ -137,7 +146,9 @@ def is_join_back_safe(join_path: JoinPath | None) -> bool:
     should test the path's links rather than count them, which also lifts the
     single-hop restriction.
     """
-    return join_path is not None and len(join_path.links) == 1
+    if join_path is None or len(join_path.links) != 1:
+        return False
+    return join_path.links[0].join_type in (None, JoinType.LEFT, JoinType.INNER)
 
 
 def join_back_coverage(
@@ -192,8 +203,15 @@ def join_back_coverage(
 
         if not is_join_back_safe(rdim.join_path):
             return None
+        assert rdim.join_path is not None  # narrowed by is_join_back_safe
 
-        coverage.append(JoinBackCoverage(dimension=rdim, key_refs=key_refs))
+        coverage.append(
+            JoinBackCoverage(
+                dimension=rdim,
+                key_refs=key_refs,
+                link=rdim.join_path.links[0],
+            ),
+        )
     return coverage
 
 
@@ -256,8 +274,7 @@ def find_matching_preagg(
     # Find a matching pre-agg. Ranked by joins first, then grain size: a pre-agg
     # that covers the request directly always beats one needing a join back, even
     # when the joining one is at a coarser grain.
-    best_match: PreaggMatch | None = None
-    best_cost: tuple[int, float] = (sys.maxsize, float("inf"))
+    candidates: list[tuple[tuple[int, int], PreaggMatch]] = []
 
     for preagg in available:
         preagg_grain_set = {
@@ -312,18 +329,22 @@ def find_matching_preagg(
             )
             continue
 
-        # Found a compatible pre-agg - prefer fewest joins, then smallest grain
-        # (closest to requested grain = less roll-up work)
-        cost = (len(join_back), float(len(preagg_grain_set)))
-        if cost < best_cost:  # pragma: no branch
-            best_match = PreaggMatch(preagg=preagg, join_back=tuple(join_back))
-            best_cost = cost
-            logger.debug(
-                f"[BuildV3] Found matching pre-agg {preagg.id} "
-                f"(grain={preagg_grain_set}, measures={len(preagg_measures)}, "
-                f"joins={len(join_back)})",
-            )
+        logger.debug(
+            f"[BuildV3] Pre-agg {preagg.id} is a candidate "
+            f"(grain={preagg_grain_set}, measures={len(preagg_measures)}, "
+            f"joins={len(join_back)})",
+        )
+        candidates.append(
+            (
+                (len(join_back), len(preagg_grain_set)),
+                PreaggMatch(preagg=preagg, join_back=tuple(join_back)),
+            ),
+        )
 
+    # Fewest joins first, then smallest grain: a pre-agg covering the request
+    # outright always beats one needing a join, and among equals the one closest
+    # to the requested grain is the least roll-up work.
+    best_match = min(candidates, key=lambda c: c[0])[1] if candidates else None
     if best_match:
         logger.info(
             f"[BuildV3] Using pre-agg {best_match.preagg.id} for "

--- a/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/preagg_matcher.py
@@ -9,6 +9,8 @@ tables are available.
 from __future__ import annotations
 
 import logging
+import sys
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from datajunction_server.construction.build_v3.dimensions import (
@@ -23,6 +25,7 @@ from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models.decompose import Aggregability, MetricComponent
 from datajunction_server.models.preaggregation import TemporalPartitionColumn
 from datajunction_server.naming import SEPARATOR
+from datajunction_server.utils import get_settings
 
 if TYPE_CHECKING:
     from datajunction_server.construction.build_v3.types import BuildContext, GrainGroup
@@ -84,6 +87,112 @@ def canonical_dimension_ref(
     return f"{ref}[{roles.pop()}]"
 
 
+@dataclass(frozen=True)
+class JoinBackCoverage:
+    """
+    A requested dimension reachable by joining a dimension the pre-agg keyed on.
+
+    The pre-agg's grain holds a dimension's key rather than the attribute asked
+    for, so the attribute is one join away: read the pre-agg, join the dimension
+    on the retained key, and group by the attribute.
+    """
+
+    dimension_ref: str
+    key_refs: tuple[str, ...]
+    dimension_node: str
+    role: str
+
+
+def join_back_enabled() -> bool:
+    """Whether pre-aggregations may be joined back to a retained dimension key."""
+    return get_settings().preagg_join_back
+
+
+def is_join_back_safe(
+    ctx: BuildContext,
+    node_rev_id: int,
+    dim_node_name: str,
+    role: str,
+) -> bool:
+    """
+    Whether joining a dimension onto a retained key is safe to re-aggregate over.
+
+    A single link whose join is on the dimension's primary key is many-to-one, so
+    it cannot multiply the measures. Multi-hop paths are refused for now: each
+    additional link is only safe if it too cannot fan out, and nothing declares
+    that yet.
+
+    This is the seam for #2346, which adds a declared ``JoinCardinality`` to
+    dimension links. Once that lands, this should ask whether any link on the
+    path can fan out rather than counting hops -- which also lifts the single-hop
+    restriction.
+    """
+    path = ctx.join_paths.get((node_rev_id, dim_node_name, role))
+    return path is not None and len(path) == 1
+
+
+def join_back_coverage(
+    ctx: BuildContext,
+    node_rev_id: int,
+    requested_grain_set: set[str],
+    preagg_grain_set: set[str],
+) -> list[JoinBackCoverage] | None:
+    """
+    How each requested dimension the pre-agg lacks could be reached by a join.
+
+    Returns one entry per dimension that needs a join, or ``None`` when any
+    requested dimension can be reached no other way -- in which case the pre-agg
+    cannot serve the query at all.
+
+    A dimension qualifies only when the grain retains its *whole* primary key at
+    the same role. Joining on part of a composite key, or on a column that merely
+    happens to be present, can match several dimension rows per pre-aggregated
+    row and multiply the measures.
+    """
+    coverage: list[JoinBackCoverage] = []
+    for ref in sorted(requested_grain_set - preagg_grain_set):
+        try:
+            dim_ref = parse_dimension_ref(ref)
+        except DJInvalidInputException:
+            return None
+
+        dim_node = ctx.nodes.get(dim_ref.node_name)
+        if not dim_node or not dim_node.current:
+            return None
+
+        primary_key = [col.name for col in dim_node.current.primary_key()]
+        if not primary_key or dim_ref.column_name in primary_key:
+            # No key to join on, or the request *is* the key -- which would have
+            # matched directly, so reaching here means the grain lacks it.
+            return None
+
+        role = dim_ref.role or ""
+        suffix = f"[{role}]" if role else ""
+        key_refs = tuple(
+            canonical_dimension_ref(
+                ctx,
+                node_rev_id,
+                f"{dim_ref.node_name}{SEPARATOR}{key_col}{suffix}",
+            )
+            for key_col in primary_key
+        )
+        if not set(key_refs).issubset(preagg_grain_set):
+            return None
+
+        if not is_join_back_safe(ctx, node_rev_id, dim_ref.node_name, role):
+            return None
+
+        coverage.append(
+            JoinBackCoverage(
+                dimension_ref=ref,
+                key_refs=key_refs,
+                dimension_node=dim_ref.node_name,
+                role=role,
+            ),
+        )
+    return coverage
+
+
 def find_matching_preagg(
     ctx: BuildContext,
     parent_node: Node,
@@ -139,9 +248,11 @@ def find_matching_preagg(
         for _, component in grain_group.components
     )
 
-    # Find a matching pre-agg
+    # Find a matching pre-agg. Ranked by joins first, then grain size: a pre-agg
+    # that covers the request directly always beats one needing a join back, even
+    # when the joining one is at a coarser grain.
     best_match: PreAggregation | None = None
-    best_grain_size = float("inf")
+    best_cost: tuple[int, float] = (sys.maxsize, float("inf"))
 
     for preagg in available:
         preagg_grain_set = {
@@ -152,20 +263,39 @@ def find_matching_preagg(
         # Check grain compatibility. For additive measures the pre-agg may be at
         # the same or a finer grain (roll-up allowed → subset match). For
         # non-additive measures the pre-agg grain must exactly match the request.
-        if requires_exact_grain:
-            if requested_grain_set != preagg_grain_set:
-                logger.debug(
-                    f"[BuildV3] Pre-agg {preagg.id} grain {preagg_grain_set} "
-                    f"must exactly match requested grain {requested_grain_set} "
-                    f"because the grain group has non-additive measures",
-                )
-                continue
-        elif not requested_grain_set.issubset(preagg_grain_set):
+        if requires_exact_grain and requested_grain_set != preagg_grain_set:
             logger.debug(
                 f"[BuildV3] Pre-agg {preagg.id} grain {preagg_grain_set} "
-                f"doesn't cover requested grain {requested_grain_set}",
+                f"must exactly match requested grain {requested_grain_set} "
+                f"because the grain group has non-additive measures",
             )
             continue
+
+        # Non-additive measures never reach a join back: exact grain demands set
+        # equality, and needing a join means the request isn't in the grain.
+        join_back: list[JoinBackCoverage] = []
+        if not requires_exact_grain and not requested_grain_set.issubset(
+            preagg_grain_set,
+        ):
+            # The grain may still reach the request by joining a dimension whose
+            # key it retained. Nothing to try when the gate is off.
+            coverage = (
+                join_back_coverage(
+                    ctx,
+                    node_rev_id,
+                    requested_grain_set,
+                    preagg_grain_set,
+                )
+                if join_back_enabled()
+                else None
+            )
+            if coverage is None:
+                logger.debug(
+                    f"[BuildV3] Pre-agg {preagg.id} grain {preagg_grain_set} "
+                    f"doesn't cover requested grain {requested_grain_set}",
+                )
+                continue
+            join_back = coverage
 
         # Coverage check on (expression hash, Phase-1 aggregation) -- see
         # get_required_measure_identities for why the aggregation is part of it.
@@ -181,14 +311,16 @@ def find_matching_preagg(
             )
             continue
 
-        # Found a compatible pre-agg - prefer the one with smallest grain
+        # Found a compatible pre-agg - prefer fewest joins, then smallest grain
         # (closest to requested grain = less roll-up work)
-        if len(preagg_grain_set) < best_grain_size:  # pragma: no branch
+        cost = (len(join_back), float(len(preagg_grain_set)))
+        if cost < best_cost:  # pragma: no branch
             best_match = preagg
-            best_grain_size = len(preagg_grain_set)
+            best_cost = cost
             logger.debug(
                 f"[BuildV3] Found matching pre-agg {preagg.id} "
-                f"(grain={preagg_grain_set}, measures={len(preagg_measures)})",
+                f"(grain={preagg_grain_set}, measures={len(preagg_measures)}, "
+                f"joins={len(join_back)})",
             )
 
     if best_match:

--- a/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
@@ -6,7 +6,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
+from datajunction_server.config import Settings
 from datajunction_server.construction.build_v3.preagg_matcher import (
+    JoinBackCoverage,
+    is_join_back_safe,
+    join_back_coverage,
     match_temporal_columns_to_grain,
     temporal_output_name,
     find_matching_preagg,
@@ -1325,3 +1329,433 @@ class TestTemporalOutputName:
     def test_role_qualified_grain_reference(self):
         column = _temporal_column("date_int")
         assert temporal_output_name(column, "v3.date.week[order]") == "week_order"
+
+
+JOIN_BACK_SETTINGS = (
+    "datajunction_server.construction.build_v3.preagg_matcher.get_settings"
+)
+
+
+def _dimension_node(name: str, columns: list[str], primary_key: list[str]) -> Node:
+    """A dimension node whose current revision declares a primary key."""
+    from datajunction_server.database.attributetype import (
+        AttributeType,
+        ColumnAttribute,
+    )
+
+    pk_attr = AttributeType(namespace="system", name="primary_key")
+    cols = []
+    for order, col_name in enumerate(columns):
+        col = Column(name=col_name, type=IntegerType(), order=order)
+        if col_name in primary_key:
+            col.attributes = [ColumnAttribute(attribute_type=pk_attr)]
+        cols.append(col)
+    node = Node(name=name, type=NodeType.DIMENSION, current_version="v1.0")
+    node.current = NodeRevision(
+        name=name,
+        type=NodeType.DIMENSION,
+        version="v1.0",
+        columns=cols,
+    )
+    return node
+
+
+def _ctx_with(dimension: Node, hops: int = 1, role: str = "customer") -> BuildContext:
+    """A build context knowing one dimension, reachable in ``hops`` links."""
+    ctx = BuildContext(session=None, metrics=[], dimensions=[])
+    ctx.nodes[dimension.name] = dimension
+    ctx.join_paths[(1, dimension.name, role)] = [
+        DimensionLink(join_sql="a = b") for _ in range(hops)
+    ]
+    return ctx
+
+
+class TestJoinBackCoverage:
+    """Deciding whether a requested attribute is one join off a retained key."""
+
+    def test_attribute_of_a_dimension_whose_key_is_retained(self):
+        ctx = _ctx_with(
+            _dimension_node("v3.customer", ["customer_id", "name"], ["customer_id"]),
+        )
+        coverage = join_back_coverage(
+            ctx,
+            1,
+            {"v3.customer.name[customer]", "v3.order_details.status"},
+            {"v3.customer.customer_id[customer]", "v3.order_details.status"},
+        )
+        assert coverage == [
+            JoinBackCoverage(
+                dimension_ref="v3.customer.name[customer]",
+                key_refs=("v3.customer.customer_id[customer]",),
+                dimension_node="v3.customer",
+                role="customer",
+            ),
+        ]
+
+    def test_retained_column_is_not_the_key(self):
+        """Joining on a non-key column can match many rows and multiply measures."""
+        ctx = _ctx_with(
+            _dimension_node(
+                "v3.customer",
+                ["customer_id", "name", "location_id"],
+                ["customer_id"],
+            ),
+        )
+        assert (
+            join_back_coverage(
+                ctx,
+                1,
+                {"v3.customer.name[customer]"},
+                {"v3.customer.location_id[customer]"},
+            )
+            is None
+        )
+
+    def test_composite_key_only_partly_retained(self):
+        ctx = _ctx_with(
+            _dimension_node(
+                "v3.customer",
+                ["customer_id", "region", "name"],
+                ["customer_id", "region"],
+            ),
+        )
+        assert (
+            join_back_coverage(
+                ctx,
+                1,
+                {"v3.customer.name[customer]"},
+                {"v3.customer.customer_id[customer]"},
+            )
+            is None
+        )
+
+    def test_composite_key_fully_retained(self):
+        ctx = _ctx_with(
+            _dimension_node(
+                "v3.customer",
+                ["customer_id", "region", "name"],
+                ["customer_id", "region"],
+            ),
+        )
+        coverage = join_back_coverage(
+            ctx,
+            1,
+            {"v3.customer.name[customer]"},
+            {"v3.customer.customer_id[customer]", "v3.customer.region[customer]"},
+        )
+        assert coverage is not None
+        assert coverage[0].key_refs == (
+            "v3.customer.customer_id[customer]",
+            "v3.customer.region[customer]",
+        )
+
+    def test_role_must_match(self):
+        """Same dimension at another role is a different join path."""
+        ctx = _ctx_with(
+            _dimension_node("v3.customer", ["customer_id", "name"], ["customer_id"]),
+            role="billing",
+        )
+        assert (
+            join_back_coverage(
+                ctx,
+                1,
+                {"v3.customer.name[billing]"},
+                {"v3.customer.customer_id[customer]"},
+            )
+            is None
+        )
+
+    def test_two_dimensions_each_joined_back(self):
+        ctx = BuildContext(session=None, metrics=[], dimensions=[])
+        for name, cols in (
+            ("v3.customer", ["customer_id", "name"]),
+            ("v3.product", ["product_id", "category"]),
+        ):
+            node = _dimension_node(name, cols, [cols[0]])
+            ctx.nodes[name] = node
+            ctx.join_paths[(1, name, "")] = [DimensionLink(join_sql="a = b")]
+        coverage = join_back_coverage(
+            ctx,
+            1,
+            {"v3.customer.name", "v3.product.category"},
+            {"v3.customer.customer_id", "v3.product.product_id"},
+        )
+        assert coverage is not None
+        assert [c.dimension_ref for c in coverage] == [
+            "v3.customer.name",
+            "v3.product.category",
+        ]
+
+    def test_dimension_not_loaded(self):
+        ctx = BuildContext(session=None, metrics=[], dimensions=[])
+        assert (
+            join_back_coverage(
+                ctx,
+                1,
+                {"v3.customer.name"},
+                {"v3.customer.customer_id"},
+            )
+            is None
+        )
+
+    def test_dimension_without_a_primary_key(self):
+        ctx = _ctx_with(_dimension_node("v3.customer", ["customer_id", "name"], []))
+        assert (
+            join_back_coverage(
+                ctx,
+                1,
+                {"v3.customer.name[customer]"},
+                {"v3.customer.customer_id[customer]"},
+            )
+            is None
+        )
+
+    def test_unparseable_reference(self):
+        ctx = _ctx_with(
+            _dimension_node("v3.customer", ["customer_id", "name"], ["customer_id"]),
+        )
+        assert join_back_coverage(ctx, 1, {"status"}, set()) is None
+
+    def test_multi_hop_dimension_is_not_covered(self):
+        """The seam refuses chains, so a two-link path can't be joined back."""
+        ctx = _ctx_with(
+            _dimension_node("v3.customer", ["customer_id", "name"], ["customer_id"]),
+            hops=2,
+        )
+        assert (
+            join_back_coverage(
+                ctx,
+                1,
+                {"v3.customer.name[customer]"},
+                {"v3.customer.customer_id[customer]"},
+            )
+            is None
+        )
+
+    def test_requested_column_is_itself_the_key(self):
+        """A key request would have matched directly; reaching here means it's absent."""
+        ctx = _ctx_with(
+            _dimension_node("v3.customer", ["customer_id", "name"], ["customer_id"]),
+        )
+        assert (
+            join_back_coverage(ctx, 1, {"v3.customer.customer_id[customer]"}, set())
+            is None
+        )
+
+
+class TestIsJoinBackSafe:
+    """The seam that #2346's declared cardinality will replace."""
+
+    def test_single_hop_is_safe(self):
+        ctx = _ctx_with(
+            _dimension_node("v3.customer", ["customer_id", "name"], ["customer_id"]),
+        )
+        assert is_join_back_safe(ctx, 1, "v3.customer", "customer") is True
+
+    def test_multi_hop_is_refused_for_now(self):
+        ctx = _ctx_with(
+            _dimension_node("v3.customer", ["customer_id", "name"], ["customer_id"]),
+            hops=2,
+        )
+        assert is_join_back_safe(ctx, 1, "v3.customer", "customer") is False
+
+    def test_no_path_is_not_safe(self):
+        ctx = BuildContext(session=None, metrics=[], dimensions=[])
+        assert is_join_back_safe(ctx, 1, "v3.customer", "customer") is False
+
+
+class TestFindMatchingPreaggJoinBack:
+    """find_matching_preagg with the join-back gate on."""
+
+    def _setup(self, session, parent_node, metric_node, grain_columns, preagg_hash):
+        avail = AvailabilityState(
+            catalog="test",
+            schema_="test",
+            table="preagg",
+            valid_through_ts=9999999999,
+        )
+        session.add(avail)
+        return avail, PreAggregation(
+            node_revision_id=parent_node.current.id,
+            grain_columns=grain_columns,
+            measures=[make_preagg_measure("sum_x", "x")],
+            sql="SELECT ...",
+            grain_group_hash=preagg_hash,
+            preagg_hash=preagg_hash,
+        )
+
+    def _customer_ctx(self, session, parent_node, preaggs):
+        ctx = BuildContext(
+            session=session,
+            metrics=["test.metric"],
+            dimensions=["test.dim"],
+            use_materialized=True,
+            available_preaggs={parent_node.current.id: preaggs},
+        )
+        customer = _dimension_node(
+            "v3.customer",
+            ["customer_id", "name"],
+            ["customer_id"],
+        )
+        ctx.nodes["v3.customer"] = customer
+        ctx.join_paths[(parent_node.current.id, "v3.customer", "")] = [
+            DimensionLink(join_sql="a = b"),
+        ]
+        return ctx
+
+    @pytest.mark.asyncio
+    async def test_matches_by_joining_back_to_a_retained_key(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+        metric_node: Node,
+        mocker,
+    ):
+        """An attribute absent from the grain is reachable via the retained key."""
+        mocker.patch(
+            JOIN_BACK_SETTINGS,
+            return_value=Settings(preagg_join_back=True),
+        )
+        avail, preagg = self._setup(
+            session,
+            parent_node,
+            metric_node,
+            ["v3.customer.customer_id"],
+            "jb01",
+        )
+        await session.flush()
+        preagg.availability_id = avail.id
+        session.add(preagg)
+        await session.flush()
+
+        ctx = self._customer_ctx(session, parent_node, [preagg])
+        grain_group = make_grain_group(
+            parent_node,
+            [(metric_node, make_component("sum_x", "x"))],
+        )
+        result = find_matching_preagg(
+            ctx,
+            parent_node,
+            ["v3.customer.name"],
+            grain_group,
+        )
+        assert result is not None
+        assert result.id == preagg.id
+
+    @pytest.mark.asyncio
+    async def test_gate_off_does_not_match(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+        metric_node: Node,
+        mocker,
+    ):
+        """Default configuration leaves routing exactly as it was."""
+        mocker.patch(
+            JOIN_BACK_SETTINGS,
+            return_value=Settings(preagg_join_back=False),
+        )
+        avail, preagg = self._setup(
+            session,
+            parent_node,
+            metric_node,
+            ["v3.customer.customer_id"],
+            "jb02",
+        )
+        await session.flush()
+        preagg.availability_id = avail.id
+        session.add(preagg)
+        await session.flush()
+
+        ctx = self._customer_ctx(session, parent_node, [preagg])
+        grain_group = make_grain_group(
+            parent_node,
+            [(metric_node, make_component("sum_x", "x"))],
+        )
+        assert (
+            find_matching_preagg(ctx, parent_node, ["v3.customer.name"], grain_group)
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_direct_match_beats_a_join_back_at_finer_grain(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+        metric_node: Node,
+        mocker,
+    ):
+        """Joins rank ahead of grain size, so a direct scan always wins."""
+        mocker.patch(
+            JOIN_BACK_SETTINGS,
+            return_value=Settings(preagg_join_back=True),
+        )
+        # The joining candidate has the smaller grain, so grain size alone would
+        # pick it over the one that covers the request outright.
+        avail_a, joining = self._setup(
+            session,
+            parent_node,
+            metric_node,
+            ["v3.customer.customer_id"],
+            "jb03a",
+        )
+        avail_b, direct = self._setup(
+            session,
+            parent_node,
+            metric_node,
+            ["v3.customer.name", "dim2", "dim3"],
+            "jb03b",
+        )
+        await session.flush()
+        joining.availability_id = avail_a.id
+        direct.availability_id = avail_b.id
+        session.add_all([joining, direct])
+        await session.flush()
+
+        ctx = self._customer_ctx(session, parent_node, [joining, direct])
+        grain_group = make_grain_group(
+            parent_node,
+            [(metric_node, make_component("sum_x", "x"))],
+        )
+        result = find_matching_preagg(
+            ctx,
+            parent_node,
+            ["v3.customer.name"],
+            grain_group,
+        )
+        assert result is not None
+        assert result.id == direct.id
+
+    @pytest.mark.asyncio
+    async def test_non_additive_measure_never_joins_back(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+        metric_node: Node,
+        mocker,
+    ):
+        """Exact-grain demands set equality, which a join back can never satisfy."""
+        mocker.patch(
+            JOIN_BACK_SETTINGS,
+            return_value=Settings(preagg_join_back=True),
+        )
+        avail, preagg = self._setup(
+            session,
+            parent_node,
+            metric_node,
+            ["v3.customer.customer_id"],
+            "jb04",
+        )
+        await session.flush()
+        preagg.availability_id = avail.id
+        session.add(preagg)
+        await session.flush()
+
+        ctx = self._customer_ctx(session, parent_node, [preagg])
+        limited = make_component("count_distinct_x", "x")
+        limited.rule = AggregationRule(type=Aggregability.LIMITED, level=["x"])
+        grain_group = make_grain_group(parent_node, [(metric_node, limited)])
+        assert (
+            find_matching_preagg(ctx, parent_node, ["v3.customer.name"], grain_group)
+            is None
+        )

--- a/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
@@ -7,7 +7,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
 from datajunction_server.construction.build_v3.preagg_matcher import (
-    JoinBackCoverage,
     is_join_back_safe,
     join_back_coverage,
     match_temporal_columns_to_grain,
@@ -1484,12 +1483,11 @@ class TestJoinBackCoverage:
             resolved,
             {"v3.customer.customer_id[customer]", "v3.order_details.status"},
         )
-        assert coverage == [
-            JoinBackCoverage(
-                dimension=resolved[0],
-                key_refs=("v3.customer.customer_id[customer]",),
-            ),
-        ]
+        assert coverage is not None
+        assert len(coverage) == 1
+        assert coverage[0].dimension == resolved[0]
+        assert coverage[0].key_refs == ("v3.customer.customer_id[customer]",)
+        assert coverage[0].link is resolved[0].join_path.links[0]
 
     def test_retained_column_is_not_the_key(self):
         """Joining on a non-key column can match many rows and multiply measures."""

--- a/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_matcher_test.py
@@ -6,7 +6,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
-from datajunction_server.config import Settings
 from datajunction_server.construction.build_v3.preagg_matcher import (
     JoinBackCoverage,
     is_join_back_safe,
@@ -19,7 +18,13 @@ from datajunction_server.construction.build_v3.preagg_matcher import (
     get_required_measure_identities,
     get_temporal_partitions,
 )
-from datajunction_server.construction.build_v3.types import BuildContext, GrainGroup
+from datajunction_server.construction.build_v3.dimensions import parse_dimension_ref
+from datajunction_server.construction.build_v3.types import (
+    BuildContext,
+    GrainGroup,
+    JoinPath,
+    ResolvedDimension,
+)
 from datajunction_server.database.availabilitystate import AvailabilityState
 from datajunction_server.database.column import Column
 from datajunction_server.database.dimensionlink import DimensionLink
@@ -30,6 +35,7 @@ from datajunction_server.database.preaggregation import (
     compute_expression_hash,
 )
 from datajunction_server.database.user import User
+from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models.decompose import (
     Aggregability,
     AggregationRule,
@@ -312,7 +318,12 @@ class TestFindMatchingPreagg:
         )
         grain_group = make_grain_group(parent_node, [])
 
-        result = find_matching_preagg(ctx, parent_node, ["dim1"], grain_group)
+        result = find_matching_preagg(
+            ctx,
+            parent_node,
+            _resolved_grain(ctx, ["dim1"]),
+            grain_group,
+        )
 
         assert result is None
 
@@ -343,7 +354,12 @@ class TestFindMatchingPreagg:
         )
         grain_group = make_grain_group(node, [])
 
-        result = find_matching_preagg(ctx, node, ["dim1"], grain_group)
+        result = find_matching_preagg(
+            ctx,
+            node,
+            _resolved_grain(ctx, ["dim1"]),
+            grain_group,
+        )
 
         assert result is None
 
@@ -366,7 +382,12 @@ class TestFindMatchingPreagg:
         components = [(metric_node, make_component("sum_x", "x"))]
         grain_group = make_grain_group(parent_node, components)
 
-        result = find_matching_preagg(ctx, parent_node, ["dim1"], grain_group)
+        result = find_matching_preagg(
+            ctx,
+            parent_node,
+            _resolved_grain(ctx, ["dim1"]),
+            grain_group,
+        )
 
         assert result is None
 
@@ -409,7 +430,12 @@ class TestFindMatchingPreagg:
 
         grain_group = make_grain_group(parent_node, [])  # No components
 
-        result = find_matching_preagg(ctx, parent_node, ["dim1"], grain_group)
+        result = find_matching_preagg(
+            ctx,
+            parent_node,
+            _resolved_grain(ctx, ["dim1"]),
+            grain_group,
+        )
 
         assert result is None
 
@@ -457,7 +483,7 @@ class TestFindMatchingPreagg:
         result = find_matching_preagg(
             ctx,
             parent_node,
-            ["dim1", "dim2"],  # Requested grain requires dim2
+            _resolved_grain(ctx, ["dim1", "dim2"]),  # Requested grain requires dim2
             grain_group,
         )
 
@@ -504,7 +530,12 @@ class TestFindMatchingPreagg:
         components = [(metric_node, make_component("sum_y", "y"))]  # Different expr
         grain_group = make_grain_group(parent_node, components)
 
-        result = find_matching_preagg(ctx, parent_node, ["dim1"], grain_group)
+        result = find_matching_preagg(
+            ctx,
+            parent_node,
+            _resolved_grain(ctx, ["dim1"]),
+            grain_group,
+        )
 
         assert result is None
 
@@ -551,10 +582,15 @@ class TestFindMatchingPreagg:
         components = [(metric_node, make_component("sum_x", "x"))]
         grain_group = make_grain_group(parent_node, components)
 
-        result = find_matching_preagg(ctx, parent_node, ["dim1"], grain_group)
+        result = find_matching_preagg(
+            ctx,
+            parent_node,
+            _resolved_grain(ctx, ["dim1"]),
+            grain_group,
+        )
 
         assert result is not None
-        assert result.id == preagg.id
+        assert result.preagg.id == preagg.id
 
     @pytest.mark.asyncio
     async def test_prefers_smaller_grain(
@@ -613,10 +649,15 @@ class TestFindMatchingPreagg:
         components = [(metric_node, make_component("sum_x", "x"))]
         grain_group = make_grain_group(parent_node, components)
 
-        result = find_matching_preagg(ctx, parent_node, ["dim1"], grain_group)
+        result = find_matching_preagg(
+            ctx,
+            parent_node,
+            _resolved_grain(ctx, ["dim1"]),
+            grain_group,
+        )
 
         assert result is not None
-        assert result.id == preagg_fine.id  # Fine grain preferred
+        assert result.preagg.id == preagg_fine.id  # Fine grain preferred
 
     @pytest.mark.asyncio
     async def test_exact_grain_match(
@@ -658,10 +699,15 @@ class TestFindMatchingPreagg:
         components = [(metric_node, make_component("sum_x", "x"))]
         grain_group = make_grain_group(parent_node, components)
 
-        result = find_matching_preagg(ctx, parent_node, ["dim1", "dim2"], grain_group)
+        result = find_matching_preagg(
+            ctx,
+            parent_node,
+            _resolved_grain(ctx, ["dim1", "dim2"]),
+            grain_group,
+        )
 
         assert result is not None
-        assert result.id == preagg.id
+        assert result.preagg.id == preagg.id
 
     @pytest.mark.asyncio
     async def test_superset_grain_match(
@@ -705,10 +751,15 @@ class TestFindMatchingPreagg:
         grain_group = make_grain_group(parent_node, components)
 
         # Requesting only dim1 - preagg can roll up
-        result = find_matching_preagg(ctx, parent_node, ["dim1"], grain_group)
+        result = find_matching_preagg(
+            ctx,
+            parent_node,
+            _resolved_grain(ctx, ["dim1"]),
+            grain_group,
+        )
 
         assert result is not None
-        assert result.id == preagg.id
+        assert result.preagg.id == preagg.id
 
     @pytest.mark.asyncio
     async def test_non_additive_measure_requires_exact_grain(
@@ -765,7 +816,12 @@ class TestFindMatchingPreagg:
         grain_group = make_grain_group(parent_node, [(metric_node, component)])
 
         # Requesting a coarser grain than the pre-agg: must NOT match.
-        result = find_matching_preagg(ctx, parent_node, ["dim1"], grain_group)
+        result = find_matching_preagg(
+            ctx,
+            parent_node,
+            _resolved_grain(ctx, ["dim1"]),
+            grain_group,
+        )
 
         assert result is None
 
@@ -826,12 +882,12 @@ class TestFindMatchingPreagg:
         result = find_matching_preagg(
             ctx,
             parent_node,
-            ["dim1", "dim2"],
+            _resolved_grain(ctx, ["dim1", "dim2"]),
             grain_group,
         )
 
         assert result is not None
-        assert result.id == preagg.id
+        assert result.preagg.id == preagg.id
 
 
 class TestGetPreaggMeasureColumn:
@@ -1331,11 +1387,6 @@ class TestTemporalOutputName:
         assert temporal_output_name(column, "v3.date.week[order]") == "week_order"
 
 
-JOIN_BACK_SETTINGS = (
-    "datajunction_server.construction.build_v3.preagg_matcher.get_settings"
-)
-
-
 def _dimension_node(name: str, columns: list[str], primary_key: list[str]) -> Node:
     """A dimension node whose current revision declares a primary key."""
     from datajunction_server.database.attributetype import (
@@ -1360,14 +1411,60 @@ def _dimension_node(name: str, columns: list[str], primary_key: list[str]) -> No
     return node
 
 
-def _ctx_with(dimension: Node, hops: int = 1, role: str = "customer") -> BuildContext:
-    """A build context knowing one dimension, reachable in ``hops`` links."""
+def _ctx_with(dimension: Node, role: str = "customer") -> BuildContext:
+    """A build context knowing one dimension, reachable at ``role``.
+
+    ``join_paths`` still backs reference canonicalization; the hop count that
+    decides join-back safety now travels on the ResolvedDimension instead.
+    """
     ctx = BuildContext(session=None, metrics=[], dimensions=[])
     ctx.nodes[dimension.name] = dimension
-    ctx.join_paths[(1, dimension.name, role)] = [
-        DimensionLink(join_sql="a = b") for _ in range(hops)
-    ]
+    ctx.join_paths[(1, dimension.name, role)] = [DimensionLink(join_sql="a = b")]
     return ctx
+
+
+def _resolved_grain(
+    ctx: BuildContext,
+    refs: list[str],
+    hops: int = 1,
+) -> list[ResolvedDimension]:
+    """Resolve dimension references the way the dimension resolver would.
+
+    A reference naming a dimension the context knows gets a join path of ``hops``
+    links; anything else is treated as locally owned.
+    """
+    resolved: list[ResolvedDimension] = []
+    for ref in refs:
+        try:
+            parsed = parse_dimension_ref(ref)
+            node_name, column_name, role = (
+                parsed.node_name,
+                parsed.column_name,
+                parsed.role,
+            )
+        except DJInvalidInputException:
+            node_name, column_name, role = "", ref, None
+        dim_node = ctx.nodes.get(node_name)
+        join_path = (
+            JoinPath(
+                links=[DimensionLink(join_sql="a = b") for _ in range(hops)],
+                target_dimension=dim_node,
+                role=role,
+            )
+            if dim_node
+            else None
+        )
+        resolved.append(
+            ResolvedDimension(
+                original_ref=ref,
+                node_name=node_name,
+                column_name=column_name,
+                role=role,
+                join_path=join_path,
+                is_local=join_path is None,
+            ),
+        )
+    return resolved
 
 
 class TestJoinBackCoverage:
@@ -1377,18 +1474,20 @@ class TestJoinBackCoverage:
         ctx = _ctx_with(
             _dimension_node("v3.customer", ["customer_id", "name"], ["customer_id"]),
         )
+        resolved = _resolved_grain(
+            ctx,
+            ["v3.customer.name[customer]", "v3.order_details.status"],
+        )
         coverage = join_back_coverage(
             ctx,
             1,
-            {"v3.customer.name[customer]", "v3.order_details.status"},
+            resolved,
             {"v3.customer.customer_id[customer]", "v3.order_details.status"},
         )
         assert coverage == [
             JoinBackCoverage(
-                dimension_ref="v3.customer.name[customer]",
+                dimension=resolved[0],
                 key_refs=("v3.customer.customer_id[customer]",),
-                dimension_node="v3.customer",
-                role="customer",
             ),
         ]
 
@@ -1405,7 +1504,7 @@ class TestJoinBackCoverage:
             join_back_coverage(
                 ctx,
                 1,
-                {"v3.customer.name[customer]"},
+                _resolved_grain(ctx, ["v3.customer.name[customer]"]),
                 {"v3.customer.location_id[customer]"},
             )
             is None
@@ -1423,7 +1522,7 @@ class TestJoinBackCoverage:
             join_back_coverage(
                 ctx,
                 1,
-                {"v3.customer.name[customer]"},
+                _resolved_grain(ctx, ["v3.customer.name[customer]"]),
                 {"v3.customer.customer_id[customer]"},
             )
             is None
@@ -1440,7 +1539,7 @@ class TestJoinBackCoverage:
         coverage = join_back_coverage(
             ctx,
             1,
-            {"v3.customer.name[customer]"},
+            _resolved_grain(ctx, ["v3.customer.name[customer]"]),
             {"v3.customer.customer_id[customer]", "v3.customer.region[customer]"},
         )
         assert coverage is not None
@@ -1459,7 +1558,7 @@ class TestJoinBackCoverage:
             join_back_coverage(
                 ctx,
                 1,
-                {"v3.customer.name[billing]"},
+                _resolved_grain(ctx, ["v3.customer.name[billing]"]),
                 {"v3.customer.customer_id[customer]"},
             )
             is None
@@ -1477,22 +1576,26 @@ class TestJoinBackCoverage:
         coverage = join_back_coverage(
             ctx,
             1,
-            {"v3.customer.name", "v3.product.category"},
+            _resolved_grain(ctx, ["v3.customer.name", "v3.product.category"]),
             {"v3.customer.customer_id", "v3.product.product_id"},
         )
         assert coverage is not None
-        assert [c.dimension_ref for c in coverage] == [
+        assert [c.dimension.original_ref for c in coverage] == [
             "v3.customer.name",
             "v3.product.category",
         ]
 
     def test_dimension_not_loaded(self):
-        ctx = BuildContext(session=None, metrics=[], dimensions=[])
+        """Nothing to read a primary key from, so nothing can be joined back."""
+        ctx = _ctx_with(
+            _dimension_node("v3.customer", ["customer_id", "name"], ["customer_id"]),
+        )
+        del ctx.nodes["v3.customer"]
         assert (
             join_back_coverage(
                 ctx,
                 1,
-                {"v3.customer.name"},
+                _resolved_grain(ctx, ["v3.customer.name"]),
                 {"v3.customer.customer_id"},
             )
             is None
@@ -1504,29 +1607,31 @@ class TestJoinBackCoverage:
             join_back_coverage(
                 ctx,
                 1,
-                {"v3.customer.name[customer]"},
+                _resolved_grain(ctx, ["v3.customer.name[customer]"]),
                 {"v3.customer.customer_id[customer]"},
             )
             is None
         )
 
-    def test_unparseable_reference(self):
+    def test_locally_owned_column(self):
+        """A bare column names no dimension node, so there is nothing to join."""
         ctx = _ctx_with(
             _dimension_node("v3.customer", ["customer_id", "name"], ["customer_id"]),
         )
-        assert join_back_coverage(ctx, 1, {"status"}, set()) is None
+        assert (
+            join_back_coverage(ctx, 1, _resolved_grain(ctx, ["status"]), set()) is None
+        )
 
     def test_multi_hop_dimension_is_not_covered(self):
         """The seam refuses chains, so a two-link path can't be joined back."""
         ctx = _ctx_with(
             _dimension_node("v3.customer", ["customer_id", "name"], ["customer_id"]),
-            hops=2,
         )
         assert (
             join_back_coverage(
                 ctx,
                 1,
-                {"v3.customer.name[customer]"},
+                _resolved_grain(ctx, ["v3.customer.name[customer]"], hops=2),
                 {"v3.customer.customer_id[customer]"},
             )
             is None
@@ -1538,34 +1643,39 @@ class TestJoinBackCoverage:
             _dimension_node("v3.customer", ["customer_id", "name"], ["customer_id"]),
         )
         assert (
-            join_back_coverage(ctx, 1, {"v3.customer.customer_id[customer]"}, set())
+            join_back_coverage(
+                ctx,
+                1,
+                _resolved_grain(ctx, ["v3.customer.customer_id[customer]"]),
+                set(),
+            )
             is None
         )
 
 
 class TestIsJoinBackSafe:
-    """The seam that #2346's declared cardinality will replace."""
+    """The seam that a declared join cardinality will one day replace."""
 
     def test_single_hop_is_safe(self):
         ctx = _ctx_with(
             _dimension_node("v3.customer", ["customer_id", "name"], ["customer_id"]),
         )
-        assert is_join_back_safe(ctx, 1, "v3.customer", "customer") is True
+        resolved = _resolved_grain(ctx, ["v3.customer.name[customer]"])
+        assert is_join_back_safe(resolved[0].join_path) is True
 
     def test_multi_hop_is_refused_for_now(self):
         ctx = _ctx_with(
             _dimension_node("v3.customer", ["customer_id", "name"], ["customer_id"]),
-            hops=2,
         )
-        assert is_join_back_safe(ctx, 1, "v3.customer", "customer") is False
+        resolved = _resolved_grain(ctx, ["v3.customer.name[customer]"], hops=2)
+        assert is_join_back_safe(resolved[0].join_path) is False
 
     def test_no_path_is_not_safe(self):
-        ctx = BuildContext(session=None, metrics=[], dimensions=[])
-        assert is_join_back_safe(ctx, 1, "v3.customer", "customer") is False
+        assert is_join_back_safe(None) is False
 
 
 class TestFindMatchingPreaggJoinBack:
-    """find_matching_preagg with the join-back gate on."""
+    """find_matching_preagg reaching a request by joining a retained key."""
 
     def _setup(self, session, parent_node, metric_node, grain_columns, preagg_hash):
         avail = AvailabilityState(
@@ -1609,13 +1719,8 @@ class TestFindMatchingPreaggJoinBack:
         session: AsyncSession,
         parent_node: Node,
         metric_node: Node,
-        mocker,
     ):
         """An attribute absent from the grain is reachable via the retained key."""
-        mocker.patch(
-            JOIN_BACK_SETTINGS,
-            return_value=Settings(preagg_join_back=True),
-        )
         avail, preagg = self._setup(
             session,
             parent_node,
@@ -1636,46 +1741,11 @@ class TestFindMatchingPreaggJoinBack:
         result = find_matching_preagg(
             ctx,
             parent_node,
-            ["v3.customer.name"],
+            _resolved_grain(ctx, ["v3.customer.name"]),
             grain_group,
         )
         assert result is not None
-        assert result.id == preagg.id
-
-    @pytest.mark.asyncio
-    async def test_gate_off_does_not_match(
-        self,
-        session: AsyncSession,
-        parent_node: Node,
-        metric_node: Node,
-        mocker,
-    ):
-        """Default configuration leaves routing exactly as it was."""
-        mocker.patch(
-            JOIN_BACK_SETTINGS,
-            return_value=Settings(preagg_join_back=False),
-        )
-        avail, preagg = self._setup(
-            session,
-            parent_node,
-            metric_node,
-            ["v3.customer.customer_id"],
-            "jb02",
-        )
-        await session.flush()
-        preagg.availability_id = avail.id
-        session.add(preagg)
-        await session.flush()
-
-        ctx = self._customer_ctx(session, parent_node, [preagg])
-        grain_group = make_grain_group(
-            parent_node,
-            [(metric_node, make_component("sum_x", "x"))],
-        )
-        assert (
-            find_matching_preagg(ctx, parent_node, ["v3.customer.name"], grain_group)
-            is None
-        )
+        assert result.preagg.id == preagg.id
 
     @pytest.mark.asyncio
     async def test_direct_match_beats_a_join_back_at_finer_grain(
@@ -1683,13 +1753,8 @@ class TestFindMatchingPreaggJoinBack:
         session: AsyncSession,
         parent_node: Node,
         metric_node: Node,
-        mocker,
     ):
         """Joins rank ahead of grain size, so a direct scan always wins."""
-        mocker.patch(
-            JOIN_BACK_SETTINGS,
-            return_value=Settings(preagg_join_back=True),
-        )
         # The joining candidate has the smaller grain, so grain size alone would
         # pick it over the one that covers the request outright.
         avail_a, joining = self._setup(
@@ -1720,11 +1785,12 @@ class TestFindMatchingPreaggJoinBack:
         result = find_matching_preagg(
             ctx,
             parent_node,
-            ["v3.customer.name"],
+            _resolved_grain(ctx, ["v3.customer.name"]),
             grain_group,
         )
         assert result is not None
-        assert result.id == direct.id
+        assert result.preagg.id == direct.id
+        assert result.join_back == ()
 
     @pytest.mark.asyncio
     async def test_non_additive_measure_never_joins_back(
@@ -1732,13 +1798,8 @@ class TestFindMatchingPreaggJoinBack:
         session: AsyncSession,
         parent_node: Node,
         metric_node: Node,
-        mocker,
     ):
         """Exact-grain demands set equality, which a join back can never satisfy."""
-        mocker.patch(
-            JOIN_BACK_SETTINGS,
-            return_value=Settings(preagg_join_back=True),
-        )
         avail, preagg = self._setup(
             session,
             parent_node,
@@ -1756,6 +1817,11 @@ class TestFindMatchingPreaggJoinBack:
         limited.rule = AggregationRule(type=Aggregability.LIMITED, level=["x"])
         grain_group = make_grain_group(parent_node, [(metric_node, limited)])
         assert (
-            find_matching_preagg(ctx, parent_node, ["v3.customer.name"], grain_group)
+            find_matching_preagg(
+                ctx,
+                parent_node,
+                _resolved_grain(ctx, ["v3.customer.name"]),
+                grain_group,
+            )
             is None
         )

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -3392,3 +3392,980 @@ class TestPreAggFreshnessGating:
             await self._metrics_sql(client_with_build_v3, []),
             self.UNFILTERED_SOURCE_SQL,
         )
+
+
+class TestPreAggJoinBack:
+    """
+    Queries routed to a pre-agg that retained a dimension's key but not the
+    attribute asked for. The pre-agg scan becomes a CTE shaped like the parent
+    fact -- its retained key projected under the parent's FK column name -- and
+    the dimension is joined back onto it.
+    """
+
+    TABLE = {
+        "catalog": "default",
+        "schema": "analytics",
+        "table": "rev_by_cust",
+        "valid_through_ts": 20250101,
+    }
+
+    async def _measures_sql(self, client, params):
+        response = await client.get("/sql/measures/v3/", params=params)
+        assert response.status_code == 200, response.text
+        return get_first_grain_group(response.json())["sql"]
+
+    async def _metrics_sql(self, client, params):
+        response = await client.get("/sql/metrics/v3/", params=params)
+        assert response.status_code == 200, response.text
+        return response.json()["sql"]
+
+    @pytest.mark.asyncio
+    async def test_joins_back_to_a_retained_key(self, client_with_build_v3):
+        """The grain keeps the customer key under a physical name of its own; the
+        requested attribute is read by joining the customer dimension on it.
+
+        The emitted join key is the physical column (``cust_key``), aliased to the
+        parent's FK column name (``customer_id``) so the dimension link's join SQL
+        resolves against the scan.
+        """
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=[
+                "v3.customer.customer_id[customer]",
+                "v3.order_details.status",
+            ],
+            table_ref=self.TABLE,
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.customer.customer_id[customer]": "cust_key"},
+            table_columns={"cust_key": "int", "status": "string", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.customer.name[customer]"],
+        }
+        assert_sql_equal(
+            await self._measures_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_order_details_preagg AS (
+                SELECT cust_key customer_id, rev_sum
+                FROM default.analytics.rev_by_cust
+            )
+            SELECT t2.name name_customer, SUM(t1.rev_sum) rev_sum
+            FROM v3_order_details_preagg t1
+            LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+            GROUP BY t2.name
+            """,
+        )
+        assert_sql_equal(
+            await self._metrics_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_order_details_preagg AS (
+                SELECT cust_key customer_id, rev_sum
+                FROM default.analytics.rev_by_cust
+            ),
+            order_details_0 AS (
+                SELECT t2.name name_customer, SUM(t1.rev_sum) rev_sum
+                FROM v3_order_details_preagg t1
+                LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+                GROUP BY t2.name
+            )
+            SELECT order_details_0.name_customer AS name_customer,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.name_customer
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_direct_match_beats_a_joining_one(self, client_with_build_v3):
+        """A pre-agg covering the request outright wins even when it is at the
+        larger grain -- joins rank ahead of grain size, so no join is emitted."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.customer.customer_id[customer]"],
+            table_ref={**self.TABLE, "table": "rev_by_cust_key"},
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.customer.customer_id[customer]": "cust_key"},
+            table_columns={"cust_key": "int", "rev_sum": "double"},
+        )
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=[
+                "v3.customer.name[customer]",
+                "v3.order_details.status",
+                "v3.product.category",
+            ],
+            table_ref={**self.TABLE, "table": "rev_by_name_status_cat"},
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            table_columns={
+                "name_customer": "string",
+                "status": "string",
+                "category": "string",
+                "rev_sum": "double",
+            },
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.customer.name[customer]"],
+        }
+        assert_sql_equal(
+            await self._measures_sql(client_with_build_v3, params),
+            """
+            SELECT name_customer, SUM(rev_sum) rev_sum
+            FROM default.analytics.rev_by_name_status_cat
+            GROUP BY name_customer
+            """,
+        )
+        assert_sql_equal(
+            await self._metrics_sql(client_with_build_v3, params),
+            """
+            WITH order_details_0 AS (
+                SELECT name_customer, SUM(rev_sum) rev_sum
+                FROM default.analytics.rev_by_name_status_cat
+                GROUP BY name_customer
+            )
+            SELECT order_details_0.name_customer AS name_customer,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.name_customer
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_additive_measure_builds_from_source(
+        self,
+        client_with_build_v3,
+    ):
+        """A distinct count can't be re-aggregated over a rolled-up grain, and a
+        join back is by definition a roll-up -- so the query builds from source."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.order_count"],
+            dimensions=["v3.customer.customer_id[customer]"],
+            table_ref={**self.TABLE, "table": "orders_by_cust"},
+            measure_columns={"v3.order_count": "order_cnt"},
+            dimension_columns={"v3.customer.customer_id[customer]": "cust_key"},
+            table_columns={"cust_key": "int", "order_cnt": "bigint"},
+        )
+        params = {
+            "metrics": ["v3.order_count"],
+            "dimensions": ["v3.customer.name[customer]"],
+        }
+        assert_sql_equal(
+            await self._measures_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_order_details AS (
+                SELECT o.order_id, o.customer_id
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT t2.name name_customer, t1.order_id
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+            GROUP BY t2.name, t1.order_id
+            """,
+        )
+        assert_sql_equal(
+            await self._metrics_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_order_details AS (
+                SELECT o.order_id, o.customer_id
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            order_details_0 AS (
+                SELECT t2.name name_customer, t1.order_id
+                FROM v3_order_details t1
+                LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+                GROUP BY t2.name, t1.order_id
+            )
+            SELECT order_details_0.name_customer AS name_customer,
+                   COUNT(DISTINCT order_details_0.order_id) AS order_count
+            FROM order_details_0
+            GROUP BY order_details_0.name_customer
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_filter_on_a_joined_back_attribute(self, client_with_build_v3):
+        """A predicate on the joined attribute lands after the join: the pre-agg
+        scan has no such column, and pushing it into the scan would reference one
+        that doesn't exist."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=[
+                "v3.customer.customer_id[customer]",
+                "v3.order_details.status",
+            ],
+            table_ref=self.TABLE,
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.customer.customer_id[customer]": "cust_key"},
+            table_columns={"cust_key": "int", "status": "string", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_details.status"],
+            "filters": ["v3.customer.name[customer] = 'Alice'"],
+        }
+        assert_sql_equal(
+            await self._measures_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_order_details_preagg AS (
+                SELECT cust_key customer_id, status, rev_sum
+                FROM default.analytics.rev_by_cust
+            )
+            SELECT t1.status, t2.name name_customer, SUM(t1.rev_sum) rev_sum
+            FROM v3_order_details_preagg t1
+            LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+            WHERE t2.name = 'Alice'
+            GROUP BY t1.status, t2.name
+            """,
+        )
+        assert_sql_equal(
+            await self._metrics_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_order_details_preagg AS (
+                SELECT cust_key customer_id, status, rev_sum
+                FROM default.analytics.rev_by_cust
+            ),
+            order_details_0 AS (
+                SELECT t1.status, t2.name name_customer, SUM(t1.rev_sum) rev_sum
+                FROM v3_order_details_preagg t1
+                LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+                WHERE t2.name = 'Alice'
+                GROUP BY t1.status, t2.name
+            )
+            SELECT order_details_0.status AS status,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_two_joined_back_attributes_are_both_filtered(
+        self,
+        client_with_build_v3,
+    ):
+        """Two filter-only attributes, each one join off a retained key, are ANDed
+        into the same WHERE against their own dimension aliases."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=[
+                "v3.customer.customer_id[customer]",
+                "v3.product.product_id",
+                "v3.order_details.status",
+            ],
+            table_ref={**self.TABLE, "table": "rev_cust_prod_status"},
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={
+                "v3.customer.customer_id[customer]": "cust_key",
+                "v3.product.product_id": "prod_key",
+            },
+            table_columns={
+                "cust_key": "int",
+                "prod_key": "int",
+                "status": "string",
+                "rev_sum": "double",
+            },
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_details.status"],
+            "filters": [
+                "v3.customer.name[customer] = 'Alice'",
+                "v3.product.category = 'Electronics'",
+            ],
+        }
+        assert_sql_equal(
+            await self._measures_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_product AS (
+                SELECT product_id, category FROM default.v3.products
+            ),
+            v3_order_details_preagg AS (
+                SELECT cust_key customer_id, prod_key product_id, status, rev_sum
+                FROM default.analytics.rev_cust_prod_status
+            )
+            SELECT t1.status,
+                   t2.name name_customer,
+                   t3.category,
+                   SUM(t1.rev_sum) rev_sum
+            FROM v3_order_details_preagg t1
+            LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+            LEFT OUTER JOIN v3_product t3 ON t1.product_id = t3.product_id
+            WHERE t2.name = 'Alice' AND t3.category = 'Electronics'
+            GROUP BY t1.status, t2.name, t3.category
+            """,
+        )
+        assert_sql_equal(
+            await self._metrics_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_product AS (
+                SELECT product_id, category FROM default.v3.products
+            ),
+            v3_order_details_preagg AS (
+                SELECT cust_key customer_id, prod_key product_id, status, rev_sum
+                FROM default.analytics.rev_cust_prod_status
+            ),
+            order_details_0 AS (
+                SELECT t1.status,
+                       t2.name name_customer,
+                       t3.category,
+                       SUM(t1.rev_sum) rev_sum
+                FROM v3_order_details_preagg t1
+                LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+                LEFT OUTER JOIN v3_product t3 ON t1.product_id = t3.product_id
+                WHERE t2.name = 'Alice' AND t3.category = 'Electronics'
+                GROUP BY t1.status, t2.name, t3.category
+            )
+            SELECT order_details_0.status AS status,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_retained_column_that_is_not_the_key(self, client_with_build_v3):
+        """The grain keeps ``location_id``, a plain attribute of the customer
+        dimension. Joining on it could match many customers per pre-aggregated row
+        and multiply the revenue, so the query builds from source instead."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.customer.location_id[customer]"],
+            table_ref={**self.TABLE, "table": "rev_by_cust_loc"},
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            table_columns={"location_id_customer": "int", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.customer.name[customer]"],
+        }
+        assert_sql_equal(
+            await self._measures_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_order_details AS (
+                SELECT o.customer_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT t2.name name_customer,
+                   SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+            GROUP BY t2.name
+            """,
+        )
+        assert_sql_equal(
+            await self._metrics_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_order_details AS (
+                SELECT o.customer_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            order_details_0 AS (
+                SELECT t2.name name_customer,
+                       SUM(t1.line_total) line_total_sum_e1f61696
+                FROM v3_order_details t1
+                LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+                GROUP BY t2.name
+            )
+            SELECT order_details_0.name_customer AS name_customer,
+                   SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.name_customer
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_key_retained_at_another_role(self, client_with_build_v3):
+        """The grain keeps the location key at the ``from`` role while the query
+        asks for the ``to`` role: a different join path, so no match."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.location.location_id[from]"],
+            table_ref={**self.TABLE, "table": "rev_by_from_loc"},
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            table_columns={"location_id_from": "int", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.location.city[to]"],
+        }
+        assert_sql_equal(
+            await self._measures_sql(client_with_build_v3, params),
+            """
+            WITH v3_location AS (
+                SELECT location_id, city FROM default.v3.locations
+            ),
+            v3_order_details AS (
+                SELECT o.to_location_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT t2.city city_to, SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_location t2 ON t1.to_location_id = t2.location_id
+            GROUP BY t2.city
+            """,
+        )
+        assert_sql_equal(
+            await self._metrics_sql(client_with_build_v3, params),
+            """
+            WITH v3_location AS (
+                SELECT location_id, city FROM default.v3.locations
+            ),
+            v3_order_details AS (
+                SELECT o.to_location_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            order_details_0 AS (
+                SELECT t2.city city_to, SUM(t1.line_total) line_total_sum_e1f61696
+                FROM v3_order_details t1
+                LEFT OUTER JOIN v3_location t2 ON t1.to_location_id = t2.location_id
+                GROUP BY t2.city
+            )
+            SELECT order_details_0.city_to AS city_to,
+                   SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.city_to
+            """,
+        )
+
+    async def _add_composite_key_dimension(self, client):
+        """A dimension keyed on (order_id, line_number), linked to the fact."""
+        response = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": "v3.order_line",
+                "description": "Order line dimension with a composite primary key",
+                "query": (
+                    "SELECT order_id, line_number, product_id FROM v3.src_order_items"
+                ),
+                "mode": "published",
+                "primary_key": ["order_id", "line_number"],
+            },
+        )
+        assert response.status_code == 201, response.text
+        response = await client.post(
+            "/nodes/v3.order_details/link",
+            json={
+                "dimension_node": "v3.order_line",
+                "join_type": "left",
+                "join_on": (
+                    "v3.order_details.order_id = v3.order_line.order_id "
+                    "AND v3.order_details.line_number = v3.order_line.line_number"
+                ),
+                "role": "line",
+            },
+        )
+        assert response.status_code == 201, response.text
+
+    @pytest.mark.asyncio
+    async def test_composite_key_fully_retained(self, client_with_build_v3):
+        """Both key columns are in the grain, so the join ANDs them together --
+        each pre-aggregated row matches exactly one dimension row."""
+        await self._add_composite_key_dimension(client_with_build_v3)
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=[
+                "v3.order_line.order_id[line]",
+                "v3.order_line.line_number[line]",
+            ],
+            table_ref={**self.TABLE, "table": "rev_by_line"},
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={
+                "v3.order_line.order_id[line]": "ord",
+                "v3.order_line.line_number[line]": "ln",
+            },
+            table_columns={"ord": "int", "ln": "int", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_line.product_id[line]"],
+        }
+        assert_sql_equal(
+            await self._measures_sql(client_with_build_v3, params),
+            """
+            WITH v3_order_line AS (
+                SELECT order_id, line_number, product_id
+                FROM default.v3.order_items
+            ),
+            v3_order_details_preagg AS (
+                SELECT ord order_id, ln line_number, rev_sum
+                FROM default.analytics.rev_by_line
+            )
+            SELECT t2.product_id product_id_line, SUM(t1.rev_sum) rev_sum
+            FROM v3_order_details_preagg t1
+            LEFT OUTER JOIN v3_order_line t2
+                ON t1.order_id = t2.order_id AND t1.line_number = t2.line_number
+            GROUP BY t2.product_id
+            """,
+        )
+        assert_sql_equal(
+            await self._metrics_sql(client_with_build_v3, params),
+            """
+            WITH v3_order_line AS (
+                SELECT order_id, line_number, product_id
+                FROM default.v3.order_items
+            ),
+            v3_order_details_preagg AS (
+                SELECT ord order_id, ln line_number, rev_sum
+                FROM default.analytics.rev_by_line
+            ),
+            order_details_0 AS (
+                SELECT t2.product_id product_id_line, SUM(t1.rev_sum) rev_sum
+                FROM v3_order_details_preagg t1
+                LEFT OUTER JOIN v3_order_line t2
+                    ON t1.order_id = t2.order_id
+                    AND t1.line_number = t2.line_number
+                GROUP BY t2.product_id
+            )
+            SELECT order_details_0.product_id_line AS product_id_line,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.product_id_line
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_composite_key_only_partly_retained(self, client_with_build_v3):
+        """Half a composite key can match several dimension rows per pre-aggregated
+        row, so the pre-agg is refused and the query builds from source."""
+        await self._add_composite_key_dimension(client_with_build_v3)
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_line.order_id[line]"],
+            table_ref={**self.TABLE, "table": "rev_by_order"},
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            table_columns={"order_id_line": "int", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_line.product_id[line]"],
+        }
+        assert_sql_equal(
+            await self._measures_sql(client_with_build_v3, params),
+            """
+            WITH v3_order_details AS (
+                SELECT o.order_id,
+                       oi.line_number,
+                       oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_order_line AS (
+                SELECT order_id, line_number, product_id
+                FROM default.v3.order_items
+            )
+            SELECT t2.product_id product_id_line,
+                   SUM(t1.line_total) line_total_sum_e1f61696
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_order_line t2
+                ON t1.order_id = t2.order_id AND t1.line_number = t2.line_number
+            GROUP BY t2.product_id
+            """,
+        )
+        assert_sql_equal(
+            await self._metrics_sql(client_with_build_v3, params),
+            """
+            WITH v3_order_details AS (
+                SELECT o.order_id,
+                       oi.line_number,
+                       oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            ),
+            v3_order_line AS (
+                SELECT order_id, line_number, product_id
+                FROM default.v3.order_items
+            ),
+            order_details_0 AS (
+                SELECT t2.product_id product_id_line,
+                       SUM(t1.line_total) line_total_sum_e1f61696
+                FROM v3_order_details t1
+                LEFT OUTER JOIN v3_order_line t2
+                    ON t1.order_id = t2.order_id
+                    AND t1.line_number = t2.line_number
+                GROUP BY t2.product_id
+            )
+            SELECT order_details_0.product_id_line AS product_id_line,
+                   SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.product_id_line
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_two_dimensions_joined_back(self, client_with_build_v3):
+        """Two retained keys, two dimensions joined onto the same scan."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=[
+                "v3.customer.customer_id[customer]",
+                "v3.product.product_id",
+            ],
+            table_ref={**self.TABLE, "table": "rev_by_cust_prod"},
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={
+                "v3.customer.customer_id[customer]": "cust_key",
+                "v3.product.product_id": "prod_key",
+            },
+            table_columns={"cust_key": "int", "prod_key": "int", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.customer.name[customer]", "v3.product.category"],
+        }
+        assert_sql_equal(
+            await self._measures_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_product AS (
+                SELECT product_id, category FROM default.v3.products
+            ),
+            v3_order_details_preagg AS (
+                SELECT cust_key customer_id, prod_key product_id, rev_sum
+                FROM default.analytics.rev_by_cust_prod
+            )
+            SELECT t2.name name_customer, t3.category, SUM(t1.rev_sum) rev_sum
+            FROM v3_order_details_preagg t1
+            LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+            LEFT OUTER JOIN v3_product t3 ON t1.product_id = t3.product_id
+            GROUP BY t2.name, t3.category
+            """,
+        )
+        assert_sql_equal(
+            await self._metrics_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_product AS (
+                SELECT product_id, category FROM default.v3.products
+            ),
+            v3_order_details_preagg AS (
+                SELECT cust_key customer_id, prod_key product_id, rev_sum
+                FROM default.analytics.rev_by_cust_prod
+            ),
+            order_details_0 AS (
+                SELECT t2.name name_customer, t3.category, SUM(t1.rev_sum) rev_sum
+                FROM v3_order_details_preagg t1
+                LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+                LEFT OUTER JOIN v3_product t3 ON t1.product_id = t3.product_id
+                GROUP BY t2.name, t3.category
+            )
+            SELECT order_details_0.name_customer AS name_customer,
+                   order_details_0.category AS category,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.name_customer, order_details_0.category
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_one_dimension_joined_back_at_two_roles(self, client_with_build_v3):
+        """Both location keys are retained, so the same dimension is joined twice
+        under distinct aliases -- the two ``city`` columns don't collide."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=[
+                "v3.location.location_id[from]",
+                "v3.location.location_id[to]",
+            ],
+            table_ref={**self.TABLE, "table": "rev_by_lanes"},
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={
+                "v3.location.location_id[from]": "orig",
+                "v3.location.location_id[to]": "dest",
+            },
+            table_columns={"orig": "int", "dest": "int", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.location.city[from]", "v3.location.city[to]"],
+        }
+        assert_sql_equal(
+            await self._measures_sql(client_with_build_v3, params),
+            """
+            WITH v3_location AS (
+                SELECT location_id, city FROM default.v3.locations
+            ),
+            v3_order_details_preagg AS (
+                SELECT orig from_location_id, dest to_location_id, rev_sum
+                FROM default.analytics.rev_by_lanes
+            )
+            SELECT t2.city city_from, t3.city city_to, SUM(t1.rev_sum) rev_sum
+            FROM v3_order_details_preagg t1
+            LEFT OUTER JOIN v3_location t2 ON t1.from_location_id = t2.location_id
+            LEFT OUTER JOIN v3_location t3 ON t1.to_location_id = t3.location_id
+            GROUP BY t2.city, t3.city
+            """,
+        )
+        assert_sql_equal(
+            await self._metrics_sql(client_with_build_v3, params),
+            """
+            WITH v3_location AS (
+                SELECT location_id, city FROM default.v3.locations
+            ),
+            v3_order_details_preagg AS (
+                SELECT orig from_location_id, dest to_location_id, rev_sum
+                FROM default.analytics.rev_by_lanes
+            ),
+            order_details_0 AS (
+                SELECT t2.city city_from, t3.city city_to, SUM(t1.rev_sum) rev_sum
+                FROM v3_order_details_preagg t1
+                LEFT OUTER JOIN v3_location t2 ON t1.from_location_id = t2.location_id
+                LEFT OUTER JOIN v3_location t3 ON t1.to_location_id = t3.location_id
+                GROUP BY t2.city, t3.city
+            )
+            SELECT order_details_0.city_from AS city_from,
+                   order_details_0.city_to AS city_to,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.city_from, order_details_0.city_to
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_joined_attribute_shares_a_name_with_a_preagg_column(
+        self,
+        client_with_build_v3,
+    ):
+        """The pre-agg stores ``status`` in a physical column called ``name``, the
+        same name as the joined customer attribute. Every reference is
+        table-qualified, so the predicate binds to the dimension's ``name`` rather
+        than the pre-agg's."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=[
+                "v3.customer.customer_id[customer]",
+                "v3.order_details.status",
+            ],
+            table_ref={**self.TABLE, "table": "rev_shadowed"},
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={
+                "v3.customer.customer_id[customer]": "cust_key",
+                "v3.order_details.status": "name",
+            },
+            table_columns={"cust_key": "int", "name": "string", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.order_details.status"],
+            "filters": ["v3.customer.name[customer] = 'Alice'"],
+        }
+        assert_sql_equal(
+            await self._measures_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_order_details_preagg AS (
+                SELECT cust_key customer_id, name status, rev_sum
+                FROM default.analytics.rev_shadowed
+            )
+            SELECT t1.status, t2.name name_customer, SUM(t1.rev_sum) rev_sum
+            FROM v3_order_details_preagg t1
+            LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+            WHERE t2.name = 'Alice'
+            GROUP BY t1.status, t2.name
+            """,
+        )
+        assert_sql_equal(
+            await self._metrics_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_order_details_preagg AS (
+                SELECT cust_key customer_id, name status, rev_sum
+                FROM default.analytics.rev_shadowed
+            ),
+            order_details_0 AS (
+                SELECT t1.status, t2.name name_customer, SUM(t1.rev_sum) rev_sum
+                FROM v3_order_details_preagg t1
+                LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+                WHERE t2.name = 'Alice'
+                GROUP BY t1.status, t2.name
+            )
+            SELECT order_details_0.status AS status,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_joins_back_to_a_materialized_dimension(self, client_with_build_v3):
+        """A materialized dimension is joined as its physical table, with no CTE."""
+        response = await client_with_build_v3.post(
+            "/data/v3.customer/availability/",
+            json={
+                "catalog": "analytics",
+                "schema_": "dim",
+                "table": "customer_dim",
+                "valid_through_ts": 9999999999,
+            },
+        )
+        assert response.status_code == 200, response.text
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.customer.customer_id[customer]"],
+            table_ref={**self.TABLE, "table": "rev_by_cust_key"},
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.customer.customer_id[customer]": "cust_key"},
+            table_columns={"cust_key": "int", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.customer.name[customer]"],
+        }
+        assert_sql_equal(
+            await self._measures_sql(client_with_build_v3, params),
+            """
+            WITH v3_order_details_preagg AS (
+                SELECT cust_key customer_id, rev_sum
+                FROM default.analytics.rev_by_cust_key
+            )
+            SELECT t2.name name_customer, SUM(t1.rev_sum) rev_sum
+            FROM v3_order_details_preagg t1
+            LEFT OUTER JOIN analytics.dim.customer_dim t2
+                ON t1.customer_id = t2.customer_id
+            GROUP BY t2.name
+            """,
+        )
+        assert_sql_equal(
+            await self._metrics_sql(client_with_build_v3, params),
+            """
+            WITH v3_order_details_preagg AS (
+                SELECT cust_key customer_id, rev_sum
+                FROM default.analytics.rev_by_cust_key
+            ),
+            order_details_0 AS (
+                SELECT t2.name name_customer, SUM(t1.rev_sum) rev_sum
+                FROM v3_order_details_preagg t1
+                LEFT OUTER JOIN analytics.dim.customer_dim t2
+                    ON t1.customer_id = t2.customer_id
+                GROUP BY t2.name
+            )
+            SELECT order_details_0.name_customer AS name_customer,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.name_customer
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_retained_key_is_also_requested(self, client_with_build_v3):
+        """Asking for the key alongside the attribute projects the key twice out of
+        the scan: once under the parent's FK name for the join, once under the name
+        the outer query selects. The second yields to the first, so the two don't
+        collide."""
+        await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_revenue"],
+            dimensions=[
+                "v3.customer.customer_id[customer]",
+                "v3.order_details.status",
+            ],
+            table_ref=self.TABLE,
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            dimension_columns={"v3.customer.customer_id[customer]": "cust_key"},
+            table_columns={"cust_key": "int", "status": "string", "rev_sum": "double"},
+        )
+        params = {
+            "metrics": ["v3.total_revenue"],
+            "dimensions": ["v3.customer.customer_id", "v3.customer.name[customer]"],
+        }
+        assert_sql_equal(
+            await self._measures_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_order_details_preagg AS (
+                SELECT cust_key customer_id, cust_key customer_id_1, rev_sum
+                FROM default.analytics.rev_by_cust
+            )
+            SELECT t1.customer_id_1 customer_id,
+                   t2.name name_customer,
+                   SUM(t1.rev_sum) rev_sum
+            FROM v3_order_details_preagg t1
+            LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+            GROUP BY t1.customer_id_1, t2.name
+            """,
+        )
+        assert_sql_equal(
+            await self._metrics_sql(client_with_build_v3, params),
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name FROM default.v3.customers
+            ),
+            v3_order_details_preagg AS (
+                SELECT cust_key customer_id, cust_key customer_id_1, rev_sum
+                FROM default.analytics.rev_by_cust
+            ),
+            order_details_0 AS (
+                SELECT t1.customer_id_1 customer_id,
+                       t2.name name_customer,
+                       SUM(t1.rev_sum) rev_sum
+                FROM v3_order_details_preagg t1
+                LEFT OUTER JOIN v3_customer t2 ON t1.customer_id = t2.customer_id
+                GROUP BY t1.customer_id_1, t2.name
+            )
+            SELECT order_details_0.customer_id AS customer_id,
+                   order_details_0.name_customer AS name_customer,
+                   SUM(order_details_0.rev_sum) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.customer_id, order_details_0.name_customer
+            """,
+        )


### PR DESCRIPTION
### Summary

A pre-aggregation that retains a dimension node's primary key can now answer a query for an attribute of that dimension node, instead of falling back to a full source scan. For example, an aggregate keeping `account_id` could previously be sliced by `account_id` but not by an account-level attribute.

The pre-agg scan is emitted as a CTE shaped like the parent fact, projecting each retained key under the parent's foreign-key column name. Once the names line up, the existing dimension-join machinery joins onto it unchanged (the join SQL comes from the same code path as the live build). This means that we get handling of role-playing dimensions and materialized dimension targets for free.

A dimension qualifies only when the grain retains its whole primary key at the same role, and only over a single `LEFT`/`INNER` link. Non-additive measures can't reach it and ranking prefers fewest joins before smallest grain.

A few bugfixes:
1. `inject_filter_into_select` pushed a predicate on a joined attribute into the inner side of the `LEFT JOIN`, which kept non-matching rows and made the outer SUM total everything.
2. `resolve_filter_references` couldn't qualify references per-reference, so a joined attribute sharing a name with a pre-agg column resolved to the wrong column. Its value type now accepts an `ast.Name`.
3. Spark join hints were dropped on the pre-agg path and are now restored.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
