### PR TITLE
Stop active materialization workflows on non-trivial cube changes

### DIFF
--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -31,7 +31,10 @@ from datajunction_server.internal.access.authorization import (
     get_access_checker,
 )
 from datajunction_server.models.access import ResourceAction
-from datajunction_server.internal.materializations import build_cube_materialization
+from datajunction_server.internal.materializations import (
+    build_cube_materialization,
+    stop_cube_materialization_workflows,
+)
 from datajunction_server.internal.nodes import (
     get_all_cube_revisions_metadata,
     get_single_cube_revision_metadata,
@@ -888,48 +891,14 @@ async def deactivate_cube_materialization(
 
     mat = existing_mats[0]
 
-    # Extract stored workflow names from the materialization config
-    mat_config = mat.config if isinstance(mat.config, dict) else {}
-    workflow_names = mat_config.get("workflow_names", [])
-
-    # Deactivate workflows in the query service using stored names
-    request_headers = dict(request.headers)
-    if workflow_names:
-        try:
-            query_service_client.deactivate_workflows(
-                workflow_names=workflow_names,
-                request_headers=request_headers,
-            )
-            _logger.info(
-                "Deactivated workflows for cube=%s: %s",
-                name,
-                workflow_names,
-            )
-        except Exception as e:  # pragma: no cover
-            _logger.warning(
-                "Failed to deactivate workflows for cube=%s: %s (continuing with deletion)",
-                name,
-                str(e),
-            )
-    else:
-        # Fallback to old endpoint for backwards compatibility
-        try:
-            query_service_client.deactivate_cube_workflow(
-                name,
-                version=cube_revision.version,
-                request_headers=request_headers,
-            )
-            _logger.info(
-                "Deactivated workflow for cube=%s version=%s (legacy)",
-                name,
-                cube_revision.version,
-            )
-        except Exception as e:
-            _logger.warning(
-                "Failed to deactivate workflow for cube=%s: %s (continuing with deletion)",
-                name,
-                str(e),
-            )
+    # Deactivate workflows in the query service
+    stop_cube_materialization_workflows(
+        query_service_client=query_service_client,
+        cube_name=name,
+        cube_version=cube_revision.version,
+        materializations=[mat],
+        request_headers=dict(request.headers),
+    )
 
     # Delete the materialization record
     await session.delete(mat)

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -325,6 +325,66 @@ def _materialization_name(
     )
 
 
+def stop_cube_materialization_workflows(
+    query_service_client: QueryServiceClient,
+    cube_name: str,
+    cube_version: str,
+    materializations: list[Materialization],
+    request_headers: dict[str, str] | None = None,
+) -> None:
+    """
+    Ask the query service to stop the workflows behind cube materializations.
+
+    Workflow names recorded on the materialization configs are stopped together in
+    one call. Materializations predating persisted workflow names fall back to the
+    cube name + version endpoint, whose arguments are identical for every
+    materialization on a revision, so it is called at most once.
+
+    Never raises: a query service that is unreachable, or that has already forgotten
+    the workflow, must not block the DJ-side operation that triggered the teardown.
+    """
+    workflow_names: list[str] = []
+    needs_legacy_stop = False
+    for materialization in materializations:
+        config = (
+            materialization.config if isinstance(materialization.config, dict) else {}
+        )
+        names = config.get("workflow_names", [])
+        if names:
+            workflow_names.extend(names)
+        else:
+            needs_legacy_stop = True
+    try:
+        if workflow_names:
+            query_service_client.deactivate_workflows(
+                workflow_names=workflow_names,
+                request_headers=request_headers,
+            )
+            _logger.info(
+                "Deactivated workflows for cube=%s: %s",
+                cube_name,
+                workflow_names,
+            )
+        if needs_legacy_stop:
+            query_service_client.deactivate_cube_workflow(
+                cube_name,
+                version=cube_version,
+                request_headers=request_headers,
+            )
+            _logger.info(
+                "Deactivated workflow for cube=%s version=%s (legacy)",
+                cube_name,
+                cube_version,
+            )
+    except Exception as exc:
+        _logger.warning(
+            "Failed to deactivate workflows for cube=%s version=%s: %s (continuing)",
+            cube_name,
+            cube_version,
+            str(exc),
+        )
+
+
 async def schedule_materialization_jobs(
     session: AsyncSession,
     node_revision_id: int,

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -32,7 +32,10 @@ from datajunction_server.database.catalog import Catalog
 from datajunction_server.database.column import Column
 from datajunction_server.database.dimensionlink import DimensionLink
 from datajunction_server.database.history import History
-from datajunction_server.database.measure import FrozenMeasure
+from datajunction_server.database.measure import (
+    FrozenMeasure,
+    NodeRevisionFrozenMeasure,
+)
 from datajunction_server.database.metricmetadata import MetricMetadata
 from datajunction_server.database.node import (
     MissingParent,
@@ -42,6 +45,10 @@ from datajunction_server.database.node import (
     NodeRevision,
 )
 from datajunction_server.database.partition import Partition
+from datajunction_server.database.preaggregation import (
+    compute_expression_hash,
+    measure_identity_token,
+)
 from datajunction_server.database.user import User
 from datajunction_server.errors import (
     DJDoesNotExistException,
@@ -59,6 +66,7 @@ from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.internal.materializations import (
     create_new_materialization,
     schedule_materialization_jobs_bg,
+    stop_cube_materialization_workflows,
 )
 from datajunction_server.internal.validation import (
     NodeValidator,
@@ -1483,6 +1491,100 @@ def node_update_history_event(new_revision: NodeRevision, current_user: User):
     )
 
 
+def cube_metric_revision_ids(cube_revision: NodeRevision) -> set[int]:
+    """
+    Ids of the metric node revisions a cube revision points at.
+
+    Requires ``cube_elements`` and each element's ``node_revision`` to be loaded:
+    the relationship declares no lazy strategy, so an unloaded access raises
+    ``MissingGreenlet`` under async. ``Node.get_cube_by_name`` selectin-loads both,
+    and revisions freshly built by ``create_cube_node_revision`` hold them in memory.
+    """
+    return {
+        element.node_revision.id
+        for element in cube_revision.cube_elements
+        if element.node_revision.type == NodeType.METRIC
+    }
+
+
+async def cube_metric_component_identities(
+    session: AsyncSession,
+    cube_revision: NodeRevision,
+) -> set[str]:
+    """
+    Identity tokens for every metric component used by a cube revision's metrics.
+
+    A cube revision does not store its own components: it points at metric node
+    revisions (through ``cube_elements``) and each of those owns the frozen measures
+    derived from its query. A token combines the owning metric, the component name
+    and the component's expression hash + phase-1 aggregation, so a metric being
+    added, removed, or silently recompiled into a different expression all show up
+    as a change to this set.
+    """
+    metric_revision_ids = cube_metric_revision_ids(cube_revision)
+    statement = (
+        select(
+            NodeRevision.name,
+            FrozenMeasure.name,
+            FrozenMeasure.expression,
+            FrozenMeasure.aggregation,
+        )
+        .select_from(NodeRevisionFrozenMeasure)
+        .join(
+            NodeRevision,
+            NodeRevision.id == NodeRevisionFrozenMeasure.node_revision_id,
+        )
+        .join(
+            FrozenMeasure,
+            FrozenMeasure.id == NodeRevisionFrozenMeasure.frozen_measure_id,
+        )
+        .where(NodeRevisionFrozenMeasure.node_revision_id.in_(metric_revision_ids))
+    )
+    rows = (await session.execute(statement)).all()
+    return {
+        f"{metric_name}:{component_name}:"
+        + measure_identity_token(compute_expression_hash(expression), aggregation)
+        for metric_name, component_name, expression, aggregation in rows
+    }
+
+
+async def is_non_trivial_cube_change(
+    session: AsyncSession,
+    old_revision: NodeRevision,
+    new_revision: NodeRevision,
+) -> bool:
+    """
+    Whether a new cube revision differs from the previous one in a way that
+    invalidates the previous revision's materialized table.
+
+    A change is non-trivial when the set of metric components (including their
+    expression hashes), the dimension set, or the filters changed. Anything else
+    (description, display name, mode, custom metadata, dimension or filter ordering)
+    leaves the materialized table's schema and contents valid. Sets are compared
+    because filters are ANDed and dimension ordering does not affect the
+    materialized table, so neither carries meaning through its ordering.
+
+    This is deliberately a different question from ``major_changes`` in
+    ``update_cube_node`` (which decides the version bump from the request payload):
+    here we ask whether the previously materialized table is still usable.
+    """
+    if set(old_revision.cube_dimensions()) != set(new_revision.cube_dimensions()):
+        return True
+    if set(old_revision.cube_filters or []) != set(new_revision.cube_filters or []):
+        return True
+    # Both revisions pointing at the same metric revisions necessarily own the same
+    # frozen measures, so the components — and the table's schema — cannot differ.
+    # Checking ids in memory first avoids two joined queries on minor-only edits.
+    if cube_metric_revision_ids(old_revision) == cube_metric_revision_ids(
+        new_revision,
+    ):
+        return False
+    return await cube_metric_component_identities(
+        session,
+        old_revision,
+    ) != await cube_metric_component_identities(session, new_revision)
+
+
 async def update_cube_node(
     session: AsyncSession,
     node_revision: NodeRevision,
@@ -1587,7 +1689,9 @@ async def update_cube_node(
         old_version = Version.parse(node_revision.version)
         if major_changes:
             new_cube_revision.version = str(old_version.next_major_version())
-        elif minor_changes:  # pragma: no cover
+        else:
+            # Reaching here without major changes means there were minor ones:
+            # the "no changes at all" case returned above.
             new_cube_revision.version = str(old_version.next_minor_version())
         new_cube_revision.node = node_revision.node
         new_cube_revision.node.current_version = new_cube_revision.version  # type: ignore
@@ -1628,17 +1732,32 @@ async def update_cube_node(
                     granularity=col.partition.granularity,
                 )
 
-        # Note: Materializations are NOT auto-recreated on cube update.
-        # Users should explicitly set up materializations for the new cube version
-        # after updating the cube definition.
-
-        # Notify if the old revision had active materializations that won't be migrated
+        # Materializations are not migrated to the new revision. When the new
+        # revision is non-trivially different, the previous revision's workflows are
+        # also stopped: left running, they keep posting fresh availability for a
+        # table built from the old definition, and that stale-but-live availability
+        # record can then be used to route queries against the new revision,
+        # producing column-not-found errors.
+        #
+        # "default"-named materializations are included: they are legacy Druid
+        # materializations that post availability just like any other, so leaving
+        # them running reproduces exactly the failure we are preventing.
         active_materializations = [
-            mat
-            for mat in node_revision.materializations
-            if not mat.deactivated_at and mat.name != "default"
+            mat for mat in node_revision.materializations if not mat.deactivated_at
         ]
-        if active_materializations:
+        materializations_to_stop = (
+            active_materializations
+            if active_materializations
+            and await is_non_trivial_cube_change(
+                session,
+                node_revision,
+                new_cube_revision,
+            )
+            else []
+        )
+        if materializations_to_stop:
+            for mat in materializations_to_stop:
+                mat.deactivated_at = UTCDatetime.now(UTC)  # type: ignore
             await save_history(
                 event=History(
                     entity_type=EntityType.MATERIALIZATION,
@@ -1648,14 +1767,15 @@ async def update_cube_node(
                     details={
                         "message": (
                             f"Cube updated to {new_cube_revision.version}. "
-                            "Active materializations from the previous version were not migrated. "
-                            "Please reconfigure materializations if you want to continue "
+                            "Materializations from the previous version were stopped "
+                            "because the cube changed non-trivially. Please set up "
+                            "materializations again if you want to continue "
                             "materializing this cube."
                         ),
                         "previous_version": node_revision.version,
                         "new_version": new_cube_revision.version,
-                        "invalidated_materializations": [
-                            mat.name for mat in active_materializations
+                        "stopped_materializations": [
+                            mat.name for mat in materializations_to_stop
                         ],
                     },
                     user=current_user.username,
@@ -1666,6 +1786,22 @@ async def update_cube_node(
         session.add(new_cube_revision)
         session.add(new_cube_revision.node)
         await session.commit()
+
+    # Stop the remote workflows only once DJ's own state is committed, so a slow or
+    # failing query service can neither hold the transaction open nor leave DJ
+    # claiming the old materializations are still active. The call is batched rather
+    # than per-materialization: these are blocking HTTP requests, so a loop would
+    # stall the event loop once per materialization. The helper swallows query
+    # service errors: a stop that can't be delivered must not abort a legitimate
+    # cube edit, and the History event above records what we attempted.
+    if query_service_client and materializations_to_stop:
+        stop_cube_materialization_workflows(
+            query_service_client=query_service_client,
+            cube_name=node_revision.name,
+            cube_version=node_revision.version,
+            materializations=materializations_to_stop,
+            request_headers=request_headers,
+        )
 
     await session.refresh(new_cube_revision)
     await session.refresh(new_cube_revision.node)

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -9,12 +9,16 @@ from unittest import mock
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.api.cubes import _resolve_cube_partition_output_column
 from datajunction_server.construction.build_v3.combiners import (
     PreAggSourceInfo,
     TemporalPartitionInfo,
 )
+from datajunction_server.database.materialization import Materialization
+from datajunction_server.database.node import NodeRevision
 from datajunction_server.errors import (
     DJInvalidInputException,
     DJQueryServiceClientException,
@@ -6133,3 +6137,382 @@ class TestCubeRefreshMaterialization:
         # Verify version didn't change
         response = await client_with_repairs_cube.get(f"/nodes/{cube_name}/")
         assert response.json()["version"] == initial_version
+
+
+class TestStopStaleCubeMaterializationWorkflows:
+    """
+    A non-trivial cube revision must stop the previous revision's materialization
+    workflows. Left running, they keep posting availability for a table built from
+    the old definition, and that stale-but-live availability is then used to route
+    queries against the new revision, producing column-not-found errors.
+    """
+
+    METRICS = ["default.num_repair_orders", "default.avg_repair_price"]
+    DIMENSIONS = ["default.hard_hat.city", "default.hard_hat.hire_date"]
+    MATERIALIZATION_NAME = (
+        "druid_metrics_cube__incremental_time__default.hard_hat.hire_date"
+    )
+
+    @classmethod
+    async def _make_materialized_cube(
+        cls,
+        client: AsyncClient,
+        cube_name: str,
+        *,
+        filters: list[str] | None = None,
+    ) -> None:
+        """
+        Build a cube with a single active materialization on it.
+        """
+        payload = {
+            "metrics": list(cls.METRICS),
+            "dimensions": list(cls.DIMENSIONS),
+            "description": "Cube of repair metrics",
+            "mode": "published",
+            "name": cube_name,
+        }
+        if filters is not None:
+            payload["filters"] = filters
+        response = await client.post("/nodes/cube/", json=payload)
+        assert response.status_code < 400, response.json()
+
+        response = await client.post(
+            f"/nodes/{cube_name}/columns/default.hard_hat.hire_date/partition",
+            json={"type_": "temporal", "granularity": "day", "format": "yyyyMMdd"},
+        )
+        assert response.status_code < 400, response.json()
+
+        response = await client.post(
+            f"/nodes/{cube_name}/materialization/",
+            json={
+                "job": "druid_metrics_cube",
+                "strategy": "incremental_time",
+                "config": {"spark": {}},
+                "schedule": "",
+            },
+        )
+        assert response.status_code < 400, response.json()
+
+    @staticmethod
+    async def _materialization_states(
+        session: AsyncSession,
+        cube_name: str,
+    ) -> list[tuple[str, bool]]:
+        """
+        (materialization name, is deactivated) for every revision of the cube.
+        """
+        statement = (
+            select(Materialization.name, Materialization.deactivated_at)
+            .join(NodeRevision, NodeRevision.id == Materialization.node_revision_id)
+            .where(NodeRevision.name == cube_name)
+        )
+        return [
+            (name, deactivated_at is not None)
+            for name, deactivated_at in (await session.execute(statement)).all()
+        ]
+
+    @staticmethod
+    async def _materialization_history(
+        client: AsyncClient,
+        cube_name: str,
+    ) -> list[dict]:
+        """
+        Materialization status-change history entries recorded for the cube.
+        """
+        response = await client.get(f"/history?node={cube_name}")
+        assert response.status_code == 200, response.json()
+        return [
+            entry["details"]
+            for entry in response.json()
+            if entry["entity_type"] == "materialization"
+            and entry["activity_type"] == "status_change"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_dimension_change_stops_previous_workflows(
+        self,
+        client_with_repairs_cube: AsyncClient,
+        module__session: AsyncSession,
+        mocker,
+    ):
+        """
+        A swapped dimension is non-trivial: the previous revision's workflow is
+        stopped in the query service and marked deactivated in DJ.
+        """
+        cube_name = "default.stop_workflows_dimension_change"
+        await self._make_materialized_cube(
+            client_with_repairs_cube,
+            cube_name,
+            filters=["default.hard_hat.state='AZ'"],
+        )
+        qs_client = client_with_repairs_cube.app.dependency_overrides[
+            get_query_service_client
+        ]()
+        mock_deactivate_cube_workflow = mocker.patch.object(
+            qs_client,
+            "deactivate_cube_workflow",
+            return_value={"status": "deactivated"},
+        )
+        mock_deactivate_workflows = mocker.patch.object(
+            qs_client,
+            "deactivate_workflows",
+            return_value={"status": "deactivated"},
+        )
+
+        response = await client_with_repairs_cube.patch(
+            f"/nodes/{cube_name}",
+            json={
+                "dimensions": [
+                    "default.hard_hat.state",
+                    "default.hard_hat.hire_date",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v2.0"
+
+        # The legacy materialization config carries no workflow names, so the
+        # cube-name + version endpoint is used, targeting the *previous* version.
+        mock_deactivate_cube_workflow.assert_called_once_with(
+            cube_name,
+            version="v1.0",
+            request_headers=mock.ANY,
+        )
+        mock_deactivate_workflows.assert_not_called()
+
+        assert await self._materialization_states(module__session, cube_name) == [
+            (self.MATERIALIZATION_NAME, True),
+        ]
+        assert await self._materialization_history(
+            client_with_repairs_cube,
+            cube_name,
+        ) == [
+            {
+                "message": (
+                    "Cube updated to v2.0. Materializations from the previous "
+                    "version were stopped because the cube changed non-trivially. "
+                    "Please set up materializations again if you want to continue "
+                    "materializing this cube."
+                ),
+                "previous_version": "v1.0",
+                "new_version": "v2.0",
+                "stopped_materializations": [self.MATERIALIZATION_NAME],
+            },
+        ]
+
+    @pytest.mark.asyncio
+    async def test_filters_change_stops_previous_workflows(
+        self,
+        client_with_repairs_cube: AsyncClient,
+        module__session: AsyncSession,
+        mocker,
+    ):
+        """
+        A filters-only change is only a minor version bump, but it still changes
+        which rows land in the materialized table, so it is non-trivial.
+        """
+        cube_name = "default.stop_workflows_filters_change"
+        await self._make_materialized_cube(
+            client_with_repairs_cube,
+            cube_name,
+            filters=["default.hard_hat.state='AZ'"],
+        )
+        qs_client = client_with_repairs_cube.app.dependency_overrides[
+            get_query_service_client
+        ]()
+        mock_deactivate_cube_workflow = mocker.patch.object(
+            qs_client,
+            "deactivate_cube_workflow",
+            return_value={"status": "deactivated"},
+        )
+
+        response = await client_with_repairs_cube.patch(
+            f"/nodes/{cube_name}",
+            json={"filters": ["default.hard_hat.state='CA'"]},
+        )
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v1.1"
+
+        mock_deactivate_cube_workflow.assert_called_once_with(
+            cube_name,
+            version="v1.0",
+            request_headers=mock.ANY,
+        )
+        assert await self._materialization_states(module__session, cube_name) == [
+            (self.MATERIALIZATION_NAME, True),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_trivial_change_keeps_previous_workflows(
+        self,
+        client_with_repairs_cube: AsyncClient,
+        module__session: AsyncSession,
+        mocker,
+    ):
+        """
+        A description-only change still creates a new revision, but the materialized
+        table stays valid, so the running workflow is left alone.
+        """
+        cube_name = "default.keep_workflows_trivial_change"
+        await self._make_materialized_cube(client_with_repairs_cube, cube_name)
+        qs_client = client_with_repairs_cube.app.dependency_overrides[
+            get_query_service_client
+        ]()
+        mock_deactivate_cube_workflow = mocker.patch.object(
+            qs_client,
+            "deactivate_cube_workflow",
+            return_value={"status": "deactivated"},
+        )
+
+        response = await client_with_repairs_cube.patch(
+            f"/nodes/{cube_name}",
+            json={"description": "Cube of repair metrics, revisited"},
+        )
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v1.1"
+
+        mock_deactivate_cube_workflow.assert_not_called()
+        assert await self._materialization_states(module__session, cube_name) == [
+            (self.MATERIALIZATION_NAME, False),
+        ]
+        assert (
+            await self._materialization_history(client_with_repairs_cube, cube_name)
+            == []
+        )
+
+    @pytest.mark.asyncio
+    async def test_metric_component_change_stops_previous_workflows(
+        self,
+        client_with_repairs_cube: AsyncClient,
+        module__session: AsyncSession,
+        mocker,
+    ):
+        """
+        Swapping a metric changes the cube's component set even though dimensions
+        and filters are untouched.
+        """
+        cube_name = "default.stop_workflows_metric_change"
+        await self._make_materialized_cube(
+            client_with_repairs_cube,
+            cube_name,
+            filters=["default.hard_hat.state='AZ'"],
+        )
+        qs_client = client_with_repairs_cube.app.dependency_overrides[
+            get_query_service_client
+        ]()
+        mock_deactivate_cube_workflow = mocker.patch.object(
+            qs_client,
+            "deactivate_cube_workflow",
+            return_value={"status": "deactivated"},
+        )
+
+        response = await client_with_repairs_cube.patch(
+            f"/nodes/{cube_name}",
+            json={
+                "metrics": [
+                    "default.num_repair_orders",
+                    "default.total_repair_cost",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v2.0"
+
+        mock_deactivate_cube_workflow.assert_called_once_with(
+            cube_name,
+            version="v1.0",
+            request_headers=mock.ANY,
+        )
+        assert await self._materialization_states(module__session, cube_name) == [
+            (self.MATERIALIZATION_NAME, True),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_refresh_does_not_revive_stopped_workflows(
+        self,
+        client_with_repairs_cube: AsyncClient,
+        module__session: AsyncSession,
+        mocker,
+    ):
+        """
+        Asking for a materialization refresh after a non-trivial update must not
+        re-activate the previous revision's stopped materializations.
+        """
+        cube_name = "default.stop_workflows_then_refresh"
+        await self._make_materialized_cube(
+            client_with_repairs_cube,
+            cube_name,
+            filters=["default.hard_hat.state='AZ'"],
+        )
+        qs_client = client_with_repairs_cube.app.dependency_overrides[
+            get_query_service_client
+        ]()
+        mocker.patch.object(
+            qs_client,
+            "deactivate_cube_workflow",
+            return_value={"status": "deactivated"},
+        )
+        mock_refresh = mocker.patch.object(
+            qs_client,
+            "refresh_cube_materialization",
+            return_value={"status": "refreshed"},
+        )
+
+        response = await client_with_repairs_cube.patch(
+            f"/nodes/{cube_name}",
+            json={"dimensions": ["default.hard_hat.hire_date"]},
+        )
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v2.0"
+
+        response = await client_with_repairs_cube.patch(
+            f"/nodes/{cube_name}/?refresh_materialization=true",
+            json={},
+        )
+        assert response.status_code == 200, response.json()
+
+        # The new revision has no materializations of its own, so there is nothing
+        # to refresh -- and nothing revived on the previous revision.
+        assert mock_refresh.call_args_list == [
+            mock.call(
+                cube_name=cube_name,
+                cube_version="v2.0",
+                materializations=[],
+                request_headers=mock.ANY,
+            ),
+        ]
+        assert await self._materialization_states(module__session, cube_name) == [
+            (self.MATERIALIZATION_NAME, True),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_no_query_service_still_deactivates_in_dj(
+        self,
+        client_with_repairs_cube: AsyncClient,
+        module__session: AsyncSession,
+    ):
+        """
+        With no query service configured there is no workflow to stop remotely, but
+        DJ still stops treating the previous revision's materializations as active.
+        """
+        cube_name = "default.stop_workflows_without_query_service"
+        await self._make_materialized_cube(
+            client_with_repairs_cube,
+            cube_name,
+            filters=["default.hard_hat.state='AZ'"],
+        )
+        app = client_with_repairs_cube.app
+        original_override = app.dependency_overrides[get_query_service_client]
+        app.dependency_overrides[get_query_service_client] = lambda: None
+        try:
+            response = await client_with_repairs_cube.patch(
+                f"/nodes/{cube_name}",
+                json={"dimensions": ["default.hard_hat.hire_date"]},
+            )
+        finally:
+            app.dependency_overrides[get_query_service_client] = original_override
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v2.0"
+        assert await self._materialization_states(module__session, cube_name) == [
+            (self.MATERIALIZATION_NAME, True),
+        ]

--- a/datajunction-server/tests/internal/materializations_test.py
+++ b/datajunction-server/tests/internal/materializations_test.py
@@ -1,0 +1,119 @@
+"""
+Tests for node materialization helper functions.
+"""
+
+from unittest import mock
+
+from datajunction_server.database.materialization import Materialization
+from datajunction_server.internal.materializations import (
+    stop_cube_materialization_workflows,
+)
+
+
+def test_stop_cube_workflows_prefers_stored_workflow_names():
+    """
+    Recorded workflow names identify the workflows exactly, so they win over the
+    cube name + version fallback.
+    """
+    query_service_client = mock.MagicMock()
+    materialization = Materialization(
+        name="druid_cube_v3",
+        config={"workflow_names": ["cube_workflow_1", "cube_workflow_2"]},
+    )
+
+    stop_cube_materialization_workflows(
+        query_service_client=query_service_client,
+        cube_name="default.a_cube",
+        cube_version="v1.0",
+        materializations=[materialization],
+        request_headers={"cookie": "a-cookie"},
+    )
+
+    assert query_service_client.deactivate_workflows.call_args_list == [
+        mock.call(
+            workflow_names=["cube_workflow_1", "cube_workflow_2"],
+            request_headers={"cookie": "a-cookie"},
+        ),
+    ]
+    assert query_service_client.deactivate_cube_workflow.call_args_list == []
+
+
+def test_stop_cube_workflows_swallows_workflow_names_failure():
+    """
+    A query service that cannot stop the named workflows must not break the caller.
+    """
+    query_service_client = mock.MagicMock()
+    query_service_client.deactivate_workflows.side_effect = Exception("unreachable")
+    materialization = Materialization(
+        name="druid_cube_v3",
+        config={"workflow_names": ["cube_workflow_1"]},
+    )
+
+    stop_cube_materialization_workflows(
+        query_service_client=query_service_client,
+        cube_name="default.a_cube",
+        cube_version="v1.0",
+        materializations=[materialization],
+    )
+
+    assert query_service_client.deactivate_workflows.call_args_list == [
+        mock.call(workflow_names=["cube_workflow_1"], request_headers=None),
+    ]
+    assert query_service_client.deactivate_cube_workflow.call_args_list == []
+
+
+def test_stop_cube_workflows_batches_across_materializations():
+    """
+    Several materializations are stopped with one call, not one call each: these are
+    blocking HTTP requests, and the legacy fallback's arguments are identical for
+    every materialization on a revision, so it is issued at most once.
+    """
+    query_service_client = mock.MagicMock()
+    materializations = [
+        Materialization(
+            name="druid_cube_v3",
+            config={"workflow_names": ["cube_workflow_1"]},
+        ),
+        Materialization(
+            name="druid_cube_v3_backfill",
+            config={"workflow_names": ["cube_workflow_2", "cube_workflow_3"]},
+        ),
+        Materialization(name="default", config={}),
+    ]
+
+    stop_cube_materialization_workflows(
+        query_service_client=query_service_client,
+        cube_name="default.a_cube",
+        cube_version="v1.0",
+        materializations=materializations,
+    )
+
+    assert query_service_client.deactivate_workflows.call_args_list == [
+        mock.call(
+            workflow_names=["cube_workflow_1", "cube_workflow_2", "cube_workflow_3"],
+            request_headers=None,
+        ),
+    ]
+    assert query_service_client.deactivate_cube_workflow.call_args_list == [
+        mock.call("default.a_cube", version="v1.0", request_headers=None),
+    ]
+
+
+def test_stop_cube_workflows_without_a_config():
+    """
+    A materialization with no config at all falls back to cube name + version.
+    """
+    query_service_client = mock.MagicMock()
+    materialization = Materialization(name="druid_cube_v3", config=None)
+
+    stop_cube_materialization_workflows(
+        query_service_client=query_service_client,
+        cube_name="default.a_cube",
+        cube_version="v2.0",
+        materializations=[materialization],
+    )
+
+    assert query_service_client.deactivate_cube_workflow.call_args_list == [
+        mock.call("default.a_cube", version="v2.0", request_headers=None),
+    ]
+    assert query_service_client.deactivate_workflows.call_args_list == []


### PR DESCRIPTION
### Summary

When a cube's definition changed materially, a new cube revision was created but the previous revision's materialization workflow kept running and kept posting fresh table availability back to DJ. That availability record was then used to route queries against the new revision, producing column-not-found errors. The old code only wrote a History event saying the previous materializations "were not migrated" -- it never marked them deactivated and never told the query service to stop materializing.

A cube revision is now compared against its predecessor and treated as non-trivially changed when the set of metric components, the dimension set, or the filters changed. Comparing revisions rather than the request payload also catches revisions created by upstream propagation, where the cube's metric names are unchanged but the underlying components are not.

On a non-trivial change the previous revision's materializations are marked deactivated in the same transaction as the new revision, and the query service is then asked to stop the corresponding workflows. The remote call happens after the commit so a slow or failing query service cannot hold the transaction open or leave DJ claiming the old materializations are active, and its errors are logged rather than raised so a stop that cannot be delivered does not abort a legitimate cube edit.

The workflow-stopping logic shared with `DELETE /cubes/{name}/materialize` is extracted into `stop_cube_materialization_workflows`, which prefers the workflow names recorded on the materialization config and falls back to the cube name + version endpoint for older records.

"default"-named materializations are no longer excluded: they are legacy Druid materializations that post availability like any other, so leaving them running reproduces exactly the failure being fixed.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
