### PR TITLE
Document pre-aggregations in the repo-authoring skill

### DIFF
--- a/datajunction-clients/python/datajunction/skills/datajunction-repo/SKILL.md
+++ b/datajunction-clients/python/datajunction/skills/datajunction-repo/SKILL.md
@@ -567,76 +567,40 @@ columns:
 
 ## Pre-Aggregations / Aggregate Awareness
 
-This one concept goes by many names. All of the following describe it:
+One concept, many names — all of these mean the same thing: **aggregate awareness**,
+**aggregate navigation**, **query routing**, **pre-aggregations** / **pre-aggs**,
+**external** or **registered aggregates**, **multiple tables for a metric** (a raw
+fact table plus coarser aggregates), **summary tables**, **rollup tables**, **agg
+tables**, **materialized aggregates**, **fact/agg hierarchy**, **last-mile** and
+**intermediate aggregates**.
 
-- **aggregate awareness**, **aggregate navigation**, **query routing**
-- **pre-aggregations**, **pre-aggs**, **preaggs**
-- **external pre-aggregations**, **externally-built aggregates**, **registered aggregates**
-- **multiple tables for a metric** — a raw fact table *plus* one or more aggregate tables
-- **summary tables**, **rollup tables**, **agg tables**, **materialized aggregates**
-- **fact/agg hierarchy**, **last-mile aggregate**, **intermediate aggregate**
+A metric is defined once against its fact table; the same numbers often exist
+pre-summed in coarser tables. Register those tables and DJ picks per query which to
+read, falling back to the fact table when no aggregate can answer correctly.
 
-The idea: a metric is defined once against its fact table, but the same numbers
-often exist pre-summed in coarser tables. Rather than making callers choose,
-you register those tables and DJ decides per query which to read — falling back
-to the fact table when no aggregate can answer correctly.
+**The rules live in the docs, not here** — see
+[Query Routing & Aggregate Awareness](https://datajunction.io/docs/0.1.0/dj-concepts/query-routing-aggregate-awareness/)
+for the `kind: preagg` schema, `measure_columns` / `dimension_columns`, what makes a
+metric mappable, role-qualified dimension references, freshness reporting, and the
+current limitations. Read it before registering anything; the rules that decide
+whether your table actually gets used are not guessable.
 
-### Registering an externally-built aggregate
+### The one thing to get right before you author metrics
 
-When an outside pipeline already builds the table, describe the binding in a
-`kind: preagg` YAML file. You are telling DJ *which metrics* the table serves,
-*at what grain*, and *which physical column* holds each piece:
+`measure_columns` maps a **metric to one column**, so a metric decomposing into more
+than one component can never be bound to an aggregate — and its components are
+auto-named with a hash suffix that YAML cannot address. `SUM(revenue) /
+COUNT(DISTINCT view_id)` as a single node is unmappable forever; fixing it means
+refactoring a node other teams may already query.
 
-```yaml
-kind: preagg
-name: orders_by_day_country
-metrics: ['${prefix}total_revenue', '${prefix}order_count']
-dimensions:
-  - ${prefix}date.dateint
-  - ${prefix}location.country[shipping]     # role-qualified where needed
-catalog: warehouse
-schema: analytics
-table: orders_daily_agg
-measure_columns:                            # metric -> physical column
-  ${prefix}total_revenue: revenue_sum
-dimension_columns:                          # dimension -> physical column
-  ${prefix}date.dateint: utc_date
-```
+So **give every aggregation primitive its own metric node** and compose ratios as
+derived metrics referencing them. Free if done from the start, expensive to retrofit,
+worth doing even before an aggregate table exists.
 
-Only `measure_columns` and `dimension_columns` remap names — you cannot introduce
-a dimension that has no link path from the parent node. Add the dimension link to
-the model first, then map its column.
+### Repo-specific traps
 
-### Rules that decide whether your table gets used
-
-**A measure is its expression *and* its aggregation.** `SUM(price)` and
-`MAX(price)` are different measures that share an inner expression. A column of
-sums cannot serve a `MAX` metric. Map each metric to the column built with *that
-metric's* aggregation — DJ compares the aggregation but cannot inspect the data,
-so a mismapping is silently wrong.
-
-**Bare dimension references must be unambiguous.** If a fact reaches a dimension
-under two roles, a bare name identifies neither and registration is rejected with
-the qualified alternatives listed. Register `location.country[shipping]`, not
-`location.country`.
-
-**Non-additive metrics need an exact grain.** A `COUNT(DISTINCT x)` cannot be
-rolled up from pre-aggregated rows, so such a metric is served only when the
-requested grain matches the stored grain exactly. Additive measures roll up
-freely from any finer grain.
-
-**Attributes are reachable only through a retained whole key.** An aggregate that
-keeps a dimension's primary key can also answer queries for *attributes* of that
-dimension, by joining it back on the key. This needs the **entire** primary key
-at the same role — a daily-snapshot dimension keyed `(account_id, utc_date)` needs
-both registered, even when the aggregate's date is already present as some other
-dimension's column. Retaining part of a composite key would match many dimension
-rows per aggregated row and multiply the measures, so DJ refuses.
-
-### Declare partitions in YAML, not through the API
-
-A temporal partition on the parent's date column is what lets DJ reason about
-*when* an aggregate's data ends. Declare it on the column:
+**Declare partitions in YAML, never through the API.** A temporal partition on the
+parent's date column is what lets DJ reason about when an aggregate's data ends:
 
 ```yaml
 columns:
@@ -648,37 +612,15 @@ columns:
       format: yyyyMMdd
 ```
 
-Setting a partition through `POST /nodes/{node}/columns/{col}/partition/` works,
-but the next deploy recreates the node from YAML and reverts it. Without a
-temporal partition column, freshness checks have no axis to judge against and
-silently do nothing.
+`POST /nodes/{node}/columns/{col}/partition/` works, but the next deploy recreates
+the node from YAML and reverts it — and without a temporal partition column,
+freshness checks have no axis and silently do nothing.
 
-### Freshness is reported per build, not committed
-
-The YAML describes the durable binding — metrics, grain, table, columns — which
-does not change between runs. Freshness does, so it is reported after each build:
-
-```
-POST /preaggs/{preagg_id}/availability/
-```
-
-Supply `valid_through_ts` at minimum. Also supply `temporal_partitions` plus
-`min_temporal_partition` / `max_temporal_partition` if you want DJ to check the
-range a query asks for against the range the table actually holds — the scalar
-alone only describes the recent end, so it cannot catch a backfill gap.
-
-### Two operational traps
-
-**Any edit to the parent node strands its aggregates.** Registrations are keyed
-by node revision, so even a description-only change re-registers them at a new
-revision. A repo deploy re-creates the binding automatically, but **availability
-is not restored** — re-report it, or the aggregate stops being used entirely and
-every query silently reverts to the fact table.
-
-**Registration validates existence, not correctness.** DJ checks that each named
-column exists and that its type is compatible. It cannot check that the column's
-*values* match the aggregation you claimed. A column of sums registered against a
-`MAX` metric will be read as if it held maxima.
+**A parent-node edit strands its aggregates.** Registrations are keyed by node
+revision, so even a description-only change re-registers them at a new revision. A
+repo deploy re-creates the binding, but **availability is not restored** — until the
+pipeline re-reports it, the aggregate is unused and every query silently reverts to
+the fact table.
 
 ## Complete Workflow Example
 

--- a/datajunction-clients/python/datajunction/skills/datajunction-repo/SKILL.md
+++ b/datajunction-clients/python/datajunction/skills/datajunction-repo/SKILL.md
@@ -3,8 +3,9 @@ name: datajunction-repo
 description: |
   Activate this skill when authoring DataJunction (DJ) nodes via YAML files
   in a git repository — the repo-backed workflow. Covers YAML schemas per
-  node type, branch-based development, temporal partitions on cubes, and
-  the full PR-driven deployment flow. For modeling decisions (how to
+  node type, branch-based development, temporal partitions on cubes,
+  registering pre-aggregations / aggregate awareness, and the full
+  PR-driven deployment flow. For modeling decisions (how to
   structure metrics, decomposition workflow), invoke `datajunction-semantic-model`.
   For direct API authoring, invoke `datajunction-api`. For concepts,
   invoke `datajunction`.
@@ -16,6 +17,13 @@ description: |
   - create metric, create dimension, create cube, build cube
   - temporal partition, partition pushdown
   - pre-commit, push.sh
+  - pre-aggregation, pre-agg, preagg, kind: preagg
+  - aggregate awareness, aggregate navigation, query routing
+  - external pre-aggregation, externally-built aggregate, registered aggregate
+  - multiple tables for a metric, fact table and agg table, fact/agg hierarchy
+  - summary table, rollup table, agg table, materialized aggregate
+  - measure_columns, dimension_columns, valid_through_ts, availability
+  - freshness, join back, retained key
 user-invocable: false
 ---
 
@@ -556,6 +564,121 @@ columns:
 **Result**: Queries with `include_temporal_filters=True` push `WHERE order_date >= X AND order_date <= Y` to the `orders` transform.
 
 ---
+
+## Pre-Aggregations / Aggregate Awareness
+
+This one concept goes by many names. All of the following describe it:
+
+- **aggregate awareness**, **aggregate navigation**, **query routing**
+- **pre-aggregations**, **pre-aggs**, **preaggs**
+- **external pre-aggregations**, **externally-built aggregates**, **registered aggregates**
+- **multiple tables for a metric** — a raw fact table *plus* one or more aggregate tables
+- **summary tables**, **rollup tables**, **agg tables**, **materialized aggregates**
+- **fact/agg hierarchy**, **last-mile aggregate**, **intermediate aggregate**
+
+The idea: a metric is defined once against its fact table, but the same numbers
+often exist pre-summed in coarser tables. Rather than making callers choose,
+you register those tables and DJ decides per query which to read — falling back
+to the fact table when no aggregate can answer correctly.
+
+### Registering an externally-built aggregate
+
+When an outside pipeline already builds the table, describe the binding in a
+`kind: preagg` YAML file. You are telling DJ *which metrics* the table serves,
+*at what grain*, and *which physical column* holds each piece:
+
+```yaml
+kind: preagg
+name: orders_by_day_country
+metrics: ['${prefix}total_revenue', '${prefix}order_count']
+dimensions:
+  - ${prefix}date.dateint
+  - ${prefix}location.country[shipping]     # role-qualified where needed
+catalog: warehouse
+schema: analytics
+table: orders_daily_agg
+measure_columns:                            # metric -> physical column
+  ${prefix}total_revenue: revenue_sum
+dimension_columns:                          # dimension -> physical column
+  ${prefix}date.dateint: utc_date
+```
+
+Only `measure_columns` and `dimension_columns` remap names — you cannot introduce
+a dimension that has no link path from the parent node. Add the dimension link to
+the model first, then map its column.
+
+### Rules that decide whether your table gets used
+
+**A measure is its expression *and* its aggregation.** `SUM(price)` and
+`MAX(price)` are different measures that share an inner expression. A column of
+sums cannot serve a `MAX` metric. Map each metric to the column built with *that
+metric's* aggregation — DJ compares the aggregation but cannot inspect the data,
+so a mismapping is silently wrong.
+
+**Bare dimension references must be unambiguous.** If a fact reaches a dimension
+under two roles, a bare name identifies neither and registration is rejected with
+the qualified alternatives listed. Register `location.country[shipping]`, not
+`location.country`.
+
+**Non-additive metrics need an exact grain.** A `COUNT(DISTINCT x)` cannot be
+rolled up from pre-aggregated rows, so such a metric is served only when the
+requested grain matches the stored grain exactly. Additive measures roll up
+freely from any finer grain.
+
+**Attributes are reachable only through a retained whole key.** An aggregate that
+keeps a dimension's primary key can also answer queries for *attributes* of that
+dimension, by joining it back on the key. This needs the **entire** primary key
+at the same role — a daily-snapshot dimension keyed `(account_id, utc_date)` needs
+both registered, even when the aggregate's date is already present as some other
+dimension's column. Retaining part of a composite key would match many dimension
+rows per aggregated row and multiply the measures, so DJ refuses.
+
+### Declare partitions in YAML, not through the API
+
+A temporal partition on the parent's date column is what lets DJ reason about
+*when* an aggregate's data ends. Declare it on the column:
+
+```yaml
+columns:
+  - name: activity_date
+    type: int
+    partition:
+      type: temporal
+      granularity: day
+      format: yyyyMMdd
+```
+
+Setting a partition through `POST /nodes/{node}/columns/{col}/partition/` works,
+but the next deploy recreates the node from YAML and reverts it. Without a
+temporal partition column, freshness checks have no axis to judge against and
+silently do nothing.
+
+### Freshness is reported per build, not committed
+
+The YAML describes the durable binding — metrics, grain, table, columns — which
+does not change between runs. Freshness does, so it is reported after each build:
+
+```
+POST /preaggs/{preagg_id}/availability/
+```
+
+Supply `valid_through_ts` at minimum. Also supply `temporal_partitions` plus
+`min_temporal_partition` / `max_temporal_partition` if you want DJ to check the
+range a query asks for against the range the table actually holds — the scalar
+alone only describes the recent end, so it cannot catch a backfill gap.
+
+### Two operational traps
+
+**Any edit to the parent node strands its aggregates.** Registrations are keyed
+by node revision, so even a description-only change re-registers them at a new
+revision. A repo deploy re-creates the binding automatically, but **availability
+is not restored** — re-report it, or the aggregate stops being used entirely and
+every query silently reverts to the fact table.
+
+**Registration validates existence, not correctness.** DJ checks that each named
+column exists and that its type is compatible. It cannot check that the column's
+*values* match the aggregation you claimed. A column of sums registered against a
+`MAX` metric will be read as if it held maxima.
 
 ## Complete Workflow Example
 

--- a/docs/content/0.1.0/docs/dj-concepts/aggregate-awareness.md
+++ b/docs/content/0.1.0/docs/dj-concepts/aggregate-awareness.md
@@ -82,6 +82,13 @@ a finer-grained fallback when no whole cube fits. A pre-aggregation is eligible 
 3. It contains **all the measures** the requested metrics decompose into, and
 4. It has data available.
 
+A requested dimension that *isn't* in the grain can still be covered when the grain holds that
+dimension's **whole primary key**, at the same role, reachable over a single `LEFT` or `INNER` link: DJ
+joins the dimension back on the retained key and groups by the attribute. The whole key is required
+because retaining only part of a composite key would match several dimension rows per aggregated row and
+multiply the measures — so a daily-snapshot dimension keyed `(account_id, utc_date)` needs both columns
+registered, even when the aggregate's date is already present as another dimension's column.
+
 Measures are matched by **expression and aggregation**, not by name — two metrics that decompose to the
 same expression aggregated the same way share a pre-aggregation, while `SUM(x)` and `MAX(x)` are distinct
 measures that can't stand in for each other. As with cubes, when several pre-aggregations qualify, DJ
@@ -226,6 +233,11 @@ Two consequences when you register a table:
 So map each metric to the column that was built with *that metric's* aggregation. Mapping `MAX(price)`
 to a column holding sums is a modeling error DJ can't detect: the aggregation functions are compared,
 but the column's data isn't.
+
+One shape catches people out: a column backing `COUNT(DISTINCT x)` must hold the **raw values being
+counted** — one row per distinct value at that grain — not a pre-computed count. DJ re-applies
+`COUNT(DISTINCT ...)` to whatever the column holds, so mapping an already-counted `distinct_users`
+integer produces a count of counts.
 
 ### Registering a table
 
@@ -416,50 +428,3 @@ materialize or backfill an external pre-aggregation — there's no build SQL for
 table isn't DJ's to build. Ownership of the table's contents, refresh schedule, and correctness stays
 entirely with your external pipeline; DJ's role is limited to routing queries to it when it's a good
 match and staying out of its way otherwise.
-
-### Limitations
-
-External pre-aggregation registration covers the common case well, but there are some edges worth
-knowing about:
-
-- **Dimensions that live only in the aggregate table can't be introduced.** You can map a grain column
-  to a differently-named physical column with `dimension_columns` (see above), including a joined
-  attribute the table denormalized. But an attribute that exists *only* in the aggregate, with no link
-  path from the parent node, isn't a dimension DJ can route by — add the dimension link to the model
-  first, then map the column.
-- **Non-additive measures have a narrower routing window.** A column backing `COUNT(DISTINCT x)` can
-  only serve queries at the exact grain it was built at, since distinct counts can't be rolled up to a
-  coarser grain from a pre-aggregated table without the underlying row-level values. Note also that such
-  a column has to hold the *raw values being counted* — one row per distinct value at that grain — not a
-  pre-computed count. DJ re-applies `COUNT(DISTINCT ...)` to it.
-- **The table has to fully cover what you register.** Every component measure that your registered
-  metrics decompose into needs a column. DJ checks that the column exists, that its type is compatible,
-  and that the aggregation you're binding matches the metric's — but it can't check the column's
-  *data*, so a column of sums mapped to a `MAX` metric will be used as if it held maxima.
-- **Filtered or partial tables aren't supported yet.** A table that only covers a subset of rows (e.g.
-  a single region or a filtered cohort) can't be registered as a general-purpose pre-aggregation for the
-  unfiltered metric.
-- **Cross-fact metrics aren't supported for registration yet.** Registration assumes all the metrics and
-  measures you're binding trace back to a single parent node, the same restriction pre-aggregation
-  matching has generally.
-- **A retained key reaches that dimension's attributes, but only its whole key.** An aggregate that
-  keeps a dimension's primary key can answer queries for *attributes* of that dimension: DJ joins the
-  dimension back on the retained key and groups by the attribute. This needs the **entire** primary key,
-  at the same role, over a single `LEFT` or `INNER` link. Retaining part of a composite key would match
-  several dimension rows per aggregated row and multiply the measures, so it is refused — a
-  daily-snapshot dimension keyed `(account_id, utc_date)` needs both columns registered, even when the
-  aggregate's date is already present as some other dimension's column. Nothing else is reached by
-  joining: a daily aggregate still can't answer a weekly rollup unless the week is in its grain or is an
-  attribute of a dimension whose key it retained.
-- **A single uncovered metric affects the whole grain group.** Metrics are matched per grain group, so
-  asking for one metric no aggregate covers alongside several that are covered reverts all of them to the
-  source. This is intentional rather than a missed optimization: the source scan is needed for the
-  uncovered metric regardless, and computing the rest from that same scan is cheaper than a second scan
-  plus a join.
-- **Registrations are pinned to a node revision.** Any edit that creates a new revision of the parent
-  node — including changes that don't affect its query — strands existing registrations, and queries
-  quietly go back to the source. A YAML deployment re-registers in the same push, so it self-heals;
-  registrations made directly through `POST /preaggs/register` need to be repeated.
-- **Freshness doesn't gate routing yet.** DJ stores the `valid_through_ts` an external pipeline reports,
-  but it doesn't currently use it to decide whether an aggregate may answer a query. A query that routes
-  to an aggregate and the same query built from the source can therefore disagree for recent periods.

--- a/docs/content/0.1.0/docs/dj-concepts/aggregate-awareness.md
+++ b/docs/content/0.1.0/docs/dj-concepts/aggregate-awareness.md
@@ -442,11 +442,15 @@ knowing about:
 - **Cross-fact metrics aren't supported for registration yet.** Registration assumes all the metrics and
   measures you're binding trace back to a single parent node, the same restriction pre-aggregation
   matching has generally.
-- **Dimension tables aren't joined onto an aggregate.** An aggregate's grain is a closed set of
-  dimensions: DJ won't join a dimension node onto a key the aggregate retained. So a daily aggregate that
-  keeps a date key still can't answer a weekly rollup, and one that keeps an account key can't answer a
-  query sliced by an account *attribute* — both fall back to the source. Slice by the retained key
-  itself to stay on the aggregate.
+- **A retained key reaches that dimension's attributes, but only its whole key.** An aggregate that
+  keeps a dimension's primary key can answer queries for *attributes* of that dimension: DJ joins the
+  dimension back on the retained key and groups by the attribute. This needs the **entire** primary key,
+  at the same role, over a single `LEFT` or `INNER` link. Retaining part of a composite key would match
+  several dimension rows per aggregated row and multiply the measures, so it is refused — a
+  daily-snapshot dimension keyed `(account_id, utc_date)` needs both columns registered, even when the
+  aggregate's date is already present as some other dimension's column. Nothing else is reached by
+  joining: a daily aggregate still can't answer a weekly rollup unless the week is in its grain or is an
+  attribute of a dimension whose key it retained.
 - **A single uncovered metric affects the whole grain group.** Metrics are matched per grain group, so
   asking for one metric no aggregate covers alongside several that are covered reverts all of them to the
   source. This is intentional rather than a missed optimization: the source scan is needed for the

--- a/docs/content/0.1.0/docs/dj-concepts/aggregate-awareness.md
+++ b/docs/content/0.1.0/docs/dj-concepts/aggregate-awareness.md
@@ -166,6 +166,41 @@ mapping, because it's covered automatically once its component measures are cove
 "every aggregate is its own named metric" principle that underlies decomposition generally — you're
 just applying it at registration time instead of at materialization time.
 
+### Plan for this when you author metrics, not when you register tables
+
+This constraint reaches back into how you model, because it cannot be worked around
+later. `measure_columns` maps a **metric to a single column**, so a metric that
+decomposes into more than one component has nothing to map and registration refuses
+it. And the components it *does* decompose into are named automatically, with a hash
+suffix derived from the expression — `line_total_sum_e1f61696`,
+`customer_id_hll_23002251` — names that are deliberately not addressable from YAML.
+
+So a metric authored as
+
+```sql
+SELECT SUM(revenue) / COUNT(DISTINCT view_id) FROM fct_views
+```
+
+can never be bound to an aggregate table, no matter what columns that table holds.
+There is no spelling of `measure_columns` that reaches its two components. The only
+fix is to refactor the metric, which means changing a node other teams may already
+be querying.
+
+The habit that avoids this: **give every aggregation primitive its own metric node**,
+then compose. One node per `SUM(...)`, `COUNT(...)`, `COUNT(DISTINCT ...)`, and
+ratios or averages expressed as derived metrics referencing those:
+
+```yaml
+# revenue.yaml          query: SELECT SUM(revenue) FROM fct_views
+# view_count.yaml       query: SELECT COUNT(DISTINCT view_id) FROM fct_views
+# revenue_per_view.yaml query: SELECT revenue / view_count      <- derived
+```
+
+Each primitive is independently mappable, and the derived metric is covered for free
+once its components are. This costs nothing if you do it from the start and is
+expensive to retrofit, so it is worth doing even for metrics you have no aggregate
+table for yet.
+
 ### A measure is its expression *and* its aggregation
 
 A measure is identified by the pair (expression, aggregation), not by the expression alone. `SUM(price)`

--- a/plugins/datajunction/skills/datajunction-repo/SKILL.md
+++ b/plugins/datajunction/skills/datajunction-repo/SKILL.md
@@ -567,76 +567,40 @@ columns:
 
 ## Pre-Aggregations / Aggregate Awareness
 
-This one concept goes by many names. All of the following describe it:
+One concept, many names — all of these mean the same thing: **aggregate awareness**,
+**aggregate navigation**, **query routing**, **pre-aggregations** / **pre-aggs**,
+**external** or **registered aggregates**, **multiple tables for a metric** (a raw
+fact table plus coarser aggregates), **summary tables**, **rollup tables**, **agg
+tables**, **materialized aggregates**, **fact/agg hierarchy**, **last-mile** and
+**intermediate aggregates**.
 
-- **aggregate awareness**, **aggregate navigation**, **query routing**
-- **pre-aggregations**, **pre-aggs**, **preaggs**
-- **external pre-aggregations**, **externally-built aggregates**, **registered aggregates**
-- **multiple tables for a metric** — a raw fact table *plus* one or more aggregate tables
-- **summary tables**, **rollup tables**, **agg tables**, **materialized aggregates**
-- **fact/agg hierarchy**, **last-mile aggregate**, **intermediate aggregate**
+A metric is defined once against its fact table; the same numbers often exist
+pre-summed in coarser tables. Register those tables and DJ picks per query which to
+read, falling back to the fact table when no aggregate can answer correctly.
 
-The idea: a metric is defined once against its fact table, but the same numbers
-often exist pre-summed in coarser tables. Rather than making callers choose,
-you register those tables and DJ decides per query which to read — falling back
-to the fact table when no aggregate can answer correctly.
+**The rules live in the docs, not here** — see
+[Query Routing & Aggregate Awareness](https://datajunction.io/docs/0.1.0/dj-concepts/query-routing-aggregate-awareness/)
+for the `kind: preagg` schema, `measure_columns` / `dimension_columns`, what makes a
+metric mappable, role-qualified dimension references, freshness reporting, and the
+current limitations. Read it before registering anything; the rules that decide
+whether your table actually gets used are not guessable.
 
-### Registering an externally-built aggregate
+### The one thing to get right before you author metrics
 
-When an outside pipeline already builds the table, describe the binding in a
-`kind: preagg` YAML file. You are telling DJ *which metrics* the table serves,
-*at what grain*, and *which physical column* holds each piece:
+`measure_columns` maps a **metric to one column**, so a metric decomposing into more
+than one component can never be bound to an aggregate — and its components are
+auto-named with a hash suffix that YAML cannot address. `SUM(revenue) /
+COUNT(DISTINCT view_id)` as a single node is unmappable forever; fixing it means
+refactoring a node other teams may already query.
 
-```yaml
-kind: preagg
-name: orders_by_day_country
-metrics: ['${prefix}total_revenue', '${prefix}order_count']
-dimensions:
-  - ${prefix}date.dateint
-  - ${prefix}location.country[shipping]     # role-qualified where needed
-catalog: warehouse
-schema: analytics
-table: orders_daily_agg
-measure_columns:                            # metric -> physical column
-  ${prefix}total_revenue: revenue_sum
-dimension_columns:                          # dimension -> physical column
-  ${prefix}date.dateint: utc_date
-```
+So **give every aggregation primitive its own metric node** and compose ratios as
+derived metrics referencing them. Free if done from the start, expensive to retrofit,
+worth doing even before an aggregate table exists.
 
-Only `measure_columns` and `dimension_columns` remap names — you cannot introduce
-a dimension that has no link path from the parent node. Add the dimension link to
-the model first, then map its column.
+### Repo-specific traps
 
-### Rules that decide whether your table gets used
-
-**A measure is its expression *and* its aggregation.** `SUM(price)` and
-`MAX(price)` are different measures that share an inner expression. A column of
-sums cannot serve a `MAX` metric. Map each metric to the column built with *that
-metric's* aggregation — DJ compares the aggregation but cannot inspect the data,
-so a mismapping is silently wrong.
-
-**Bare dimension references must be unambiguous.** If a fact reaches a dimension
-under two roles, a bare name identifies neither and registration is rejected with
-the qualified alternatives listed. Register `location.country[shipping]`, not
-`location.country`.
-
-**Non-additive metrics need an exact grain.** A `COUNT(DISTINCT x)` cannot be
-rolled up from pre-aggregated rows, so such a metric is served only when the
-requested grain matches the stored grain exactly. Additive measures roll up
-freely from any finer grain.
-
-**Attributes are reachable only through a retained whole key.** An aggregate that
-keeps a dimension's primary key can also answer queries for *attributes* of that
-dimension, by joining it back on the key. This needs the **entire** primary key
-at the same role — a daily-snapshot dimension keyed `(account_id, utc_date)` needs
-both registered, even when the aggregate's date is already present as some other
-dimension's column. Retaining part of a composite key would match many dimension
-rows per aggregated row and multiply the measures, so DJ refuses.
-
-### Declare partitions in YAML, not through the API
-
-A temporal partition on the parent's date column is what lets DJ reason about
-*when* an aggregate's data ends. Declare it on the column:
+**Declare partitions in YAML, never through the API.** A temporal partition on the
+parent's date column is what lets DJ reason about when an aggregate's data ends:
 
 ```yaml
 columns:
@@ -648,37 +612,15 @@ columns:
       format: yyyyMMdd
 ```
 
-Setting a partition through `POST /nodes/{node}/columns/{col}/partition/` works,
-but the next deploy recreates the node from YAML and reverts it. Without a
-temporal partition column, freshness checks have no axis to judge against and
-silently do nothing.
+`POST /nodes/{node}/columns/{col}/partition/` works, but the next deploy recreates
+the node from YAML and reverts it — and without a temporal partition column,
+freshness checks have no axis and silently do nothing.
 
-### Freshness is reported per build, not committed
-
-The YAML describes the durable binding — metrics, grain, table, columns — which
-does not change between runs. Freshness does, so it is reported after each build:
-
-```
-POST /preaggs/{preagg_id}/availability/
-```
-
-Supply `valid_through_ts` at minimum. Also supply `temporal_partitions` plus
-`min_temporal_partition` / `max_temporal_partition` if you want DJ to check the
-range a query asks for against the range the table actually holds — the scalar
-alone only describes the recent end, so it cannot catch a backfill gap.
-
-### Two operational traps
-
-**Any edit to the parent node strands its aggregates.** Registrations are keyed
-by node revision, so even a description-only change re-registers them at a new
-revision. A repo deploy re-creates the binding automatically, but **availability
-is not restored** — re-report it, or the aggregate stops being used entirely and
-every query silently reverts to the fact table.
-
-**Registration validates existence, not correctness.** DJ checks that each named
-column exists and that its type is compatible. It cannot check that the column's
-*values* match the aggregation you claimed. A column of sums registered against a
-`MAX` metric will be read as if it held maxima.
+**A parent-node edit strands its aggregates.** Registrations are keyed by node
+revision, so even a description-only change re-registers them at a new revision. A
+repo deploy re-creates the binding, but **availability is not restored** — until the
+pipeline re-reports it, the aggregate is unused and every query silently reverts to
+the fact table.
 
 ## Complete Workflow Example
 

--- a/plugins/datajunction/skills/datajunction-repo/SKILL.md
+++ b/plugins/datajunction/skills/datajunction-repo/SKILL.md
@@ -3,8 +3,9 @@ name: datajunction-repo
 description: |
   Activate this skill when authoring DataJunction (DJ) nodes via YAML files
   in a git repository — the repo-backed workflow. Covers YAML schemas per
-  node type, branch-based development, temporal partitions on cubes, and
-  the full PR-driven deployment flow. For modeling decisions (how to
+  node type, branch-based development, temporal partitions on cubes,
+  registering pre-aggregations / aggregate awareness, and the full
+  PR-driven deployment flow. For modeling decisions (how to
   structure metrics, decomposition workflow), invoke `datajunction-semantic-model`.
   For direct API authoring, invoke `datajunction-api`. For concepts,
   invoke `datajunction`.
@@ -16,6 +17,13 @@ description: |
   - create metric, create dimension, create cube, build cube
   - temporal partition, partition pushdown
   - pre-commit, push.sh
+  - pre-aggregation, pre-agg, preagg, kind: preagg
+  - aggregate awareness, aggregate navigation, query routing
+  - external pre-aggregation, externally-built aggregate, registered aggregate
+  - multiple tables for a metric, fact table and agg table, fact/agg hierarchy
+  - summary table, rollup table, agg table, materialized aggregate
+  - measure_columns, dimension_columns, valid_through_ts, availability
+  - freshness, join back, retained key
 user-invocable: false
 ---
 
@@ -556,6 +564,121 @@ columns:
 **Result**: Queries with `include_temporal_filters=True` push `WHERE order_date >= X AND order_date <= Y` to the `orders` transform.
 
 ---
+
+## Pre-Aggregations / Aggregate Awareness
+
+This one concept goes by many names. All of the following describe it:
+
+- **aggregate awareness**, **aggregate navigation**, **query routing**
+- **pre-aggregations**, **pre-aggs**, **preaggs**
+- **external pre-aggregations**, **externally-built aggregates**, **registered aggregates**
+- **multiple tables for a metric** — a raw fact table *plus* one or more aggregate tables
+- **summary tables**, **rollup tables**, **agg tables**, **materialized aggregates**
+- **fact/agg hierarchy**, **last-mile aggregate**, **intermediate aggregate**
+
+The idea: a metric is defined once against its fact table, but the same numbers
+often exist pre-summed in coarser tables. Rather than making callers choose,
+you register those tables and DJ decides per query which to read — falling back
+to the fact table when no aggregate can answer correctly.
+
+### Registering an externally-built aggregate
+
+When an outside pipeline already builds the table, describe the binding in a
+`kind: preagg` YAML file. You are telling DJ *which metrics* the table serves,
+*at what grain*, and *which physical column* holds each piece:
+
+```yaml
+kind: preagg
+name: orders_by_day_country
+metrics: ['${prefix}total_revenue', '${prefix}order_count']
+dimensions:
+  - ${prefix}date.dateint
+  - ${prefix}location.country[shipping]     # role-qualified where needed
+catalog: warehouse
+schema: analytics
+table: orders_daily_agg
+measure_columns:                            # metric -> physical column
+  ${prefix}total_revenue: revenue_sum
+dimension_columns:                          # dimension -> physical column
+  ${prefix}date.dateint: utc_date
+```
+
+Only `measure_columns` and `dimension_columns` remap names — you cannot introduce
+a dimension that has no link path from the parent node. Add the dimension link to
+the model first, then map its column.
+
+### Rules that decide whether your table gets used
+
+**A measure is its expression *and* its aggregation.** `SUM(price)` and
+`MAX(price)` are different measures that share an inner expression. A column of
+sums cannot serve a `MAX` metric. Map each metric to the column built with *that
+metric's* aggregation — DJ compares the aggregation but cannot inspect the data,
+so a mismapping is silently wrong.
+
+**Bare dimension references must be unambiguous.** If a fact reaches a dimension
+under two roles, a bare name identifies neither and registration is rejected with
+the qualified alternatives listed. Register `location.country[shipping]`, not
+`location.country`.
+
+**Non-additive metrics need an exact grain.** A `COUNT(DISTINCT x)` cannot be
+rolled up from pre-aggregated rows, so such a metric is served only when the
+requested grain matches the stored grain exactly. Additive measures roll up
+freely from any finer grain.
+
+**Attributes are reachable only through a retained whole key.** An aggregate that
+keeps a dimension's primary key can also answer queries for *attributes* of that
+dimension, by joining it back on the key. This needs the **entire** primary key
+at the same role — a daily-snapshot dimension keyed `(account_id, utc_date)` needs
+both registered, even when the aggregate's date is already present as some other
+dimension's column. Retaining part of a composite key would match many dimension
+rows per aggregated row and multiply the measures, so DJ refuses.
+
+### Declare partitions in YAML, not through the API
+
+A temporal partition on the parent's date column is what lets DJ reason about
+*when* an aggregate's data ends. Declare it on the column:
+
+```yaml
+columns:
+  - name: activity_date
+    type: int
+    partition:
+      type: temporal
+      granularity: day
+      format: yyyyMMdd
+```
+
+Setting a partition through `POST /nodes/{node}/columns/{col}/partition/` works,
+but the next deploy recreates the node from YAML and reverts it. Without a
+temporal partition column, freshness checks have no axis to judge against and
+silently do nothing.
+
+### Freshness is reported per build, not committed
+
+The YAML describes the durable binding — metrics, grain, table, columns — which
+does not change between runs. Freshness does, so it is reported after each build:
+
+```
+POST /preaggs/{preagg_id}/availability/
+```
+
+Supply `valid_through_ts` at minimum. Also supply `temporal_partitions` plus
+`min_temporal_partition` / `max_temporal_partition` if you want DJ to check the
+range a query asks for against the range the table actually holds — the scalar
+alone only describes the recent end, so it cannot catch a backfill gap.
+
+### Two operational traps
+
+**Any edit to the parent node strands its aggregates.** Registrations are keyed
+by node revision, so even a description-only change re-registers them at a new
+revision. A repo deploy re-creates the binding automatically, but **availability
+is not restored** — re-report it, or the aggregate stops being used entirely and
+every query silently reverts to the fact table.
+
+**Registration validates existence, not correctness.** DJ checks that each named
+column exists and that its type is compatible. It cannot check that the column's
+*values* match the aggregation you claimed. A column of sums registered against a
+`MAX` metric will be read as if it held maxima.
 
 ## Complete Workflow Example
 


### PR DESCRIPTION
### Summary

The DJ contribution skills had nothing on aggregate awareness, so an agent authoring YAML had no way to learn that registering an aggregate table is possible.

This concept is called at least a dozen things -- aggregate awareness, aggregate navigation, pre-aggs, external pre-aggregations, summary/rollup tables, fact/agg hierarchy, "multiple tables for a metric" -- and someone searching for any of them should land here.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
