### PR TITLE
Surface deployment warnings on successful deploys

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2026_08_05_0000-dw0001warnings_add_warnings_to_deployments.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_08_05_0000-dw0001warnings_add_warnings_to_deployments.py
@@ -1,0 +1,28 @@
+"""add warnings to deployments
+
+Revision ID: dw0001warnings
+Revises: rbacenumfix1
+Create Date: 2026-08-05 00:00:00.000000+00:00
+
+"""
+# pylint: disable=no-member, invalid-name, missing-function-docstring, unused-import, no-name-in-module
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "dw0001warnings"
+down_revision = "rbacenumfix1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Warnings accumulated during a deploy, so they surface even when it succeeds.
+    op.add_column(
+        "deployments",
+        sa.Column("warnings", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("deployments", "warnings")

--- a/datajunction-server/datajunction_server/api/deployments.py
+++ b/datajunction-server/datajunction_server/api/deployments.py
@@ -15,7 +15,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from datajunction_server.database.deployment import Deployment
 from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.user import User
-from datajunction_server.errors import DJDoesNotExistException, DJInvalidInputException
+from datajunction_server.errors import (
+    DJDoesNotExistException,
+    DJError,
+    DJInvalidInputException,
+)
 from datajunction_server.instrumentation.provider import get_metrics_provider
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.access.authorization import (
@@ -238,6 +242,7 @@ class InProcessExecutor(DeploymentExecutor):
         status: DeploymentStatus,
         results: list[DeploymentResult] | None = None,
         downstream_impacts: list | None = None,
+        warnings: list[DJError] | None = None,
     ):
         async with session_context() as session:
             deployment = await session.get(Deployment, deployment_uuid)
@@ -247,6 +252,8 @@ class InProcessExecutor(DeploymentExecutor):
             deployment.status = status
             if results is not None:
                 deployment.results = [r.model_dump() for r in results]
+            if warnings is not None:
+                deployment.deployment_warnings = warnings
             if downstream_impacts is not None:
                 deployment.downstream_impacts = [
                     d.model_dump() for d in downstream_impacts
@@ -278,6 +285,7 @@ class InProcessExecutor(DeploymentExecutor):
                             DeploymentResult.Status.SUCCESS,
                             DeploymentResult.Status.SKIPPED,
                             DeploymentResult.Status.INVALID,
+                            DeploymentResult.Status.WARNING,
                         )
                         for r in results
                     )
@@ -288,6 +296,7 @@ class InProcessExecutor(DeploymentExecutor):
                     final_status,
                     results,
                     downstream_impacts=execute_result.downstream_impacts,
+                    warnings=execute_result.warnings,
                 )
                 if final_status == DeploymentStatus.SUCCESS:
                     await _maybe_autolock_git_namespace(deployment_spec)
@@ -394,6 +403,7 @@ async def create_deployment(
         namespace=deployment.namespace,
         status=deployment.status.value,
         results=deployment.deployment_results,
+        warnings=deployment.deployment_warnings,
         downstream_impacts=deployment.deployment_downstream_impacts,
     )
 
@@ -413,6 +423,7 @@ async def get_deployment_status(
         namespace=deployment.namespace,
         status=deployment.status.value,
         results=deployment.deployment_results,
+        warnings=deployment.deployment_warnings,
         downstream_impacts=deployment.deployment_downstream_impacts,
     )
 
@@ -445,6 +456,7 @@ async def list_deployments(  # pragma: no cover
                 namespace=deployment.namespace,
                 status=deployment.status,
                 results=deployment.deployment_results,
+                warnings=deployment.deployment_warnings,
                 created_at=deployment.created_at.isoformat()
                 if deployment.created_at
                 else None,
@@ -514,5 +526,6 @@ async def preview_deployment_impact(
         namespace=deployment_spec.namespace,
         status=DeploymentStatus.SUCCESS,
         results=execute_result.results,
+        warnings=execute_result.warnings,
         downstream_impacts=execute_result.downstream_impacts,
     )

--- a/datajunction-server/datajunction_server/api/git_sync.py
+++ b/datajunction-server/datajunction_server/api/git_sync.py
@@ -969,6 +969,7 @@ async def sync_namespace_from_git(
         namespace=namespace,
         status=DeploymentStatus.SUCCESS,
         results=execute_result.results,
+        warnings=execute_result.warnings,
         downstream_impacts=execute_result.downstream_impacts,
         source=GitDeploymentSource(
             type="git",

--- a/datajunction-server/datajunction_server/database/deployment.py
+++ b/datajunction-server/datajunction_server/database/deployment.py
@@ -8,6 +8,7 @@ from sqlalchemy_utils import UUIDType
 
 from datajunction_server.database.base import Base
 from datajunction_server.database.user import User
+from datajunction_server.errors import DJError, ErrorCode
 from datajunction_server.models.deployment import (
     DeploymentResult,
     DeploymentSpec,
@@ -41,6 +42,7 @@ class Deployment(Base):
     )
     spec: Mapped[dict] = mapped_column(JSON, default={})
     results: Mapped[dict] = mapped_column(JSON, default={})
+    warnings: Mapped[list | None] = mapped_column(JSON, default=list)
     downstream_impacts: Mapped[list | None] = mapped_column(JSON, default=list)
 
     created_by_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
@@ -71,6 +73,19 @@ class Deployment(Base):
     @deployment_results.setter
     def deployment_results(self, value: list[DeploymentResult]):
         self.results = [result.model_dump() for result in value]  # pragma: no cover
+
+    @property
+    def deployment_warnings(self) -> list[DJError]:
+        # ``code`` is stored as the symbolic ErrorCode name (see
+        # DJError.serialize_code), so resolve it back to the enum member.
+        return [
+            DJError(**{**warning, "code": ErrorCode[warning["code"]]})
+            for warning in (self.warnings or [])
+        ]
+
+    @deployment_warnings.setter
+    def deployment_warnings(self, value: list[DJError]):
+        self.warnings = [warning.model_dump() for warning in value]
 
     @property
     def deployment_downstream_impacts(self) -> list[DownstreamImpact]:

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -255,6 +255,7 @@ class DeploymentExecuteResult:
 
     results: list  # list[DeploymentResult]
     downstream_impacts: list  # list[ImpactedNode]
+    warnings: list = field(default_factory=list)  # list[DJError]
 
 
 @dataclass
@@ -390,6 +391,11 @@ class DeploymentOrchestrator:
             # `else` only fires when no _DryRunRollback was raised, which
             # implies wet-run — commit the outer transaction.
             await self.session.commit()
+
+        # Warnings are only surfaced by the failure path (they ride along on
+        # DJInvalidDeploymentConfig), so hand them back here too — otherwise a
+        # deploy that succeeds with warnings silently drops them.
+        result.warnings = list(self.warnings)
 
         elapsed_ms = (time.perf_counter() - start_total) * 1000
         _metrics_tags = {
@@ -1112,15 +1118,27 @@ class DeploymentOrchestrator:
         # guard). This is the real footgun -- the fully-empty-spec case is
         # already refused upstream because a pre-agg's parent node is deleted too.
         if not specs and not self.deployment_spec.allow_empty:
+            message = (
+                f"{len(existing)} external pre-aggregation(s) in "
+                f"namespace '{namespace}' were left intact because the "
+                f"deployment declares none. Re-run with allow_empty to "
+                f"deregister them."
+            )
             self.warnings.append(
                 DJError(
                     code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
-                    message=(
-                        f"{len(existing)} external pre-aggregation(s) in "
-                        f"namespace '{namespace}' were left intact because the "
-                        f"deployment declares none. Re-run with allow_empty to "
-                        f"deregister them."
-                    ),
+                    message=message,
+                ),
+            )
+            # Also emit a per-item result: the deploy succeeds, and per-item
+            # results are what actually get rendered back to the user.
+            self.deployed_results.append(
+                DeploymentResult(
+                    name=namespace,
+                    deploy_type=DeploymentResult.Type.PREAGG,
+                    status=DeploymentResult.Status.WARNING,
+                    operation=DeploymentResult.Operation.NOOP,
+                    message=message,
                 ),
             )
             logger.info(

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -12,6 +12,7 @@ from pydantic import (
 )
 
 from datajunction_server.errors import (
+    DJError,
     DJInvalidDeploymentConfig,
     DJInvalidInputException,
 )
@@ -1006,6 +1007,7 @@ class DeploymentResult(BaseModel):
         FAILED = "failed"
         SKIPPED = "skipped"
         INVALID = "invalid"  # deployed but node status is INVALID
+        WARNING = "warning"  # deployed successfully, but something needs attention
 
     class Operation(str, Enum):
         CREATE = "create"
@@ -1039,6 +1041,7 @@ class DeploymentInfo(BaseModel):
     namespace: str
     status: DeploymentStatus
     results: list[DeploymentResult] = Field(default_factory=list)
+    warnings: list[DJError] = Field(default_factory=list)
     downstream_impacts: list[DownstreamImpact] = Field(default_factory=list)
     created_at: str | None = None  # ISO datetime
     created_by: str | None = None  # Username

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -2643,6 +2643,7 @@ class TestDeployments:
             ],
             "created_at": None,
             "created_by": None,
+            "warnings": [],
             "downstream_impacts": [],
             "source": None,
         }
@@ -2718,6 +2719,7 @@ class TestDeployments:
             ],
             "created_at": mock.ANY,
             "created_by": mock.ANY,
+            "warnings": [],
             "downstream_impacts": [],
             "source": mock.ANY,
         }
@@ -3489,6 +3491,7 @@ class TestDeployments:
             ],
             "created_at": mock.ANY,
             "created_by": mock.ANY,
+            "warnings": [],
             "downstream_impacts": [],
             "source": mock.ANY,
         }
@@ -6143,6 +6146,84 @@ class TestExternalPreAggDeploy:
             assert data["status"] == "success", data["results"]
             listing = await client.get("/preaggs/", params={"node_name": fact_node})
             assert listing.json()["items"] == []
+        finally:
+            _clear_query_service(client)
+
+    @pytest.mark.asyncio
+    async def test_preagg_kept_warning_is_surfaced(
+        self,
+        client,
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+    ):
+        """The "left intact" warning is reported by the successful deploy that
+        skipped the deregistration -- both as a top-level warning and as a
+        per-item pre-aggregation result."""
+        _override_query_service(client, ["hard_hat_count", "state_name"])
+        try:
+            nodes = _hard_hat_deploy_nodes(
+                default_hard_hats,
+                default_us_states,
+                default_us_state,
+            )
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace="preagg_warn",
+                    nodes=nodes,
+                    preaggregations=[
+                        _preagg_spec(
+                            "warn_me",
+                            "hh_warn",
+                            {"${prefix}default.count_hard_hats": "hard_hat_count"},
+                        ),
+                    ],
+                ),
+            )
+            assert data["status"] == "success", data["results"]
+            assert data["warnings"] == []
+
+            # Re-deploy with no pre-aggs declared: succeeds, keeps the pre-agg,
+            # and says so.
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace="preagg_warn", nodes=nodes),
+            )
+            message = (
+                "1 external pre-aggregation(s) in namespace 'preagg_warn' were "
+                "left intact because the deployment declares none. Re-run with "
+                "allow_empty to deregister them."
+            )
+            assert data["status"] == "success", data["results"]
+            assert data["warnings"] == [
+                {
+                    "code": "INVALID_ARGUMENTS_TO_FUNCTION",
+                    "message": message,
+                    "debug": None,
+                    "context": "",
+                },
+            ]
+            assert [
+                result
+                for result in data["results"]
+                if result["deploy_type"] == "preaggregation"
+            ] == [
+                {
+                    "name": "preagg_warn",
+                    "deploy_type": "preaggregation",
+                    "status": "warning",
+                    "operation": "noop",
+                    "message": message,
+                    "changed_fields": [],
+                },
+            ]
+
+            listing = await client.get(
+                "/preaggs/",
+                params={"node_name": "preagg_warn.default.hard_hat_facts"},
+            )
+            assert len(listing.json()["items"]) == 1
         finally:
             _clear_query_service(client)
 


### PR DESCRIPTION
### Summary

The deployment orchestrator accumulates warnings, but the only sites that surfaced that list did so while raising `DJInvalidDeploymentConfig`. So on a deploy that succeeded, the warnings were built and then thrown away.

For example, `_reconcile_preaggregations` deliberately refuses to mass-deregister external pre-aggregations when a deployment declares none, and records a warning saying they were left intact and that `allow_empty` is needed to remove them. That deploy succeeds, so the user never sees it.

Warnings are now returned by `DeploymentOrchestrator.execute()` and persisted on the `Deployment` record in a new JSON warnings column, and returned as `DeploymentInfo.warnings` from the deployment endpoints. The pre-agg site also emits a per-item `DeploymentResult` with the new `WARNING` status.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
