### PR TITLE
Add change tiering for deployments

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -67,6 +67,7 @@ from datajunction_server.internal.nodes import (
 from datajunction_server.models.access import ResourceAction
 from datajunction_server.models.base import labelize
 from datajunction_server.models.deployment import (
+    ChangeTier,
     ColumnSpec,
     CubeSpec,
     DeploymentResult,
@@ -79,6 +80,7 @@ from datajunction_server.models.deployment import (
     NodeSpec,
     SourceSpec,
     TagSpec,
+    bump_version,
     eq_or_fallback,
     render_prefixes,
 )
@@ -106,7 +108,6 @@ from datajunction_server.models.unit import (
 from datajunction_server.sql.dag import get_metric_parents_map
 from datajunction_server.utils import (
     SEPARATOR,
-    Version,
     get_namespace_from_name,
     get_settings,
 )
@@ -2805,11 +2806,14 @@ class DeploymentOrchestrator:
             # Get pre-computed validation data to avoid re-validation
             assert result._cube_validation_data is not None
             validation_data = result._cube_validation_data
-            changelog, changed_fields = await self._generate_changelog(result)
+            changelog, changed_fields, change_tier = await self._generate_changelog(
+                result,
+            )
             if existing:
                 new_node = existing
-                new_node.current_version = str(
-                    Version.parse(new_node.current_version).next_major_version(),
+                new_node.current_version = self._deployed_version(
+                    new_node.current_version,
+                    change_tier,
                 )
                 new_node.display_name = cube_spec.display_name
                 new_node.owners = [
@@ -3291,6 +3295,13 @@ class DeploymentOrchestrator:
         self,
         existing_nodes_map: dict[str, NodeSpec],
     ):
+        """Split the deployment's nodes into ones to process and ones to skip.
+
+        Decides only whether to process a node, not how significant its change was
+        -- `change_tier` decides that and `_deployed_version` turns it into a
+        version. So `force` and the INVALID re-deploy below can re-process a node
+        without that implying anything about what changed.
+        """
         to_create: list[NodeSpec] = []
         to_update: list[NodeSpec] = []
         to_skip: list[NodeSpec] = []
@@ -3808,8 +3819,8 @@ class DeploymentOrchestrator:
             if existing
             else DeploymentResult.Operation.CREATE
         )
-        changelog, changed_fields = await self._generate_changelog(result)
-        new_node = self._create_or_update_node(result.spec, existing)
+        changelog, changed_fields, change_tier = await self._generate_changelog(result)
+        new_node = self._create_or_update_node(result.spec, existing, change_tier)
         new_revision = await self._create_node_revision(
             new_node,
             result,
@@ -3857,12 +3868,16 @@ class DeploymentOrchestrator:
     async def _generate_changelog(
         self,
         result: NodeValidationResult,
-    ) -> tuple[list[str], list[str]]:
+    ) -> tuple[list[str], list[str], ChangeTier]:
         """Generate changelog entries for a node update.
 
-        Returns (changelog_lines, changed_fields) where changelog_lines are
-        human-readable strings for the deployment message and changed_fields
-        are the raw field names (for structured display in the dry-run impact response).
+        Returns (changelog_lines, changed_fields, change_tier) where changelog_lines
+        are human-readable strings for the deployment message, changed_fields are the
+        raw field names (for structured display in the dry-run impact response), and
+        change_tier says how significant the change is, i.e. what kind of version
+        bump it earns. The tier is computed here because this is where the full set
+        of changed fields is already known -- the same classification the PATCH path
+        uses, so the two paths cannot drift apart.
         """
         changelog: list[str] = []
         changed_fields: list[str] = []
@@ -3870,7 +3885,7 @@ class DeploymentOrchestrator:
         # No changes if the node is new
         existing = self.registry.nodes.get(result.spec.rendered_name)
         if not existing:
-            return changelog, changed_fields
+            return changelog, changed_fields, ChangeTier.NONE
 
         # Track changes to node columns
         old_revision = existing.current if existing else None
@@ -3921,8 +3936,35 @@ class DeploymentOrchestrator:
                 for note in col_change_notes:
                     changelog.append(f"└─ {note}")
 
+        # A cube's columns are derived from its metrics and dimensions; the only
+        # user-authored thing on them is partition config, which is exactly what
+        # CubeSpec.__eq__ compares. So a partition-only edit reaches the update path
+        # and has to be visible here too, or it would earn no version at all.
+        if isinstance(result.spec, CubeSpec) and isinstance(
+            existing_node_spec,
+            CubeSpec,
+        ):
+            incoming_partitions = {
+                col.name: col.partition
+                for col in result.spec.rendered_columns
+                if col.partition
+            }
+            existing_partitions = {
+                col.name: col.partition
+                for col in existing_node_spec.rendered_columns
+                if col.partition
+            }
+            if incoming_partitions != existing_partitions:
+                changed_fields = changed_fields + ["columns"]
+
         if changed_fields:
             changelog.append("└─ Updated " + ", ".join(changed_fields))
+
+        # Fields whose contents are unchanged but whose ordering moved. diff()
+        # compares list fields as sets and so cannot see these on its own.
+        reordered_fields = existing_node_spec.order_diff(result.spec)
+        if reordered_fields:
+            changelog.append("└─ Reordered " + ", ".join(reordered_fields))
 
         # If the node has dimension links and is being updated (even if link specs
         # didn't change), the links will be re-deployed — note this in the message.
@@ -3933,14 +3975,33 @@ class DeploymentOrchestrator:
         ):
             changelog.append("└─ Updated dimension_links")
 
-        return changelog, changed_fields
+        change_tier = type(result.spec).change_tier(changed_fields, reordered_fields)
+        return changelog, changed_fields, change_tier
+
+    @staticmethod
+    def _deployed_version(current_version: str, change_tier: ChangeTier) -> str:
+        """The version an updated node's new revision should carry.
+
+        Floored at MINOR because the deployment path always writes a new revision
+        for a node it processes, and (node_id, version) is unique, so the revision
+        needs a version of its own. A node re-processed without having changed --
+        a forced re-deploy, or one stuck in INVALID being revalidated -- therefore
+        earns a minor version rather than none. The PATCH path calls `bump_version`
+        unfloored, since there a NONE tier can write nothing at all.
+        """
+        return bump_version(current_version, max(change_tier, ChangeTier.MINOR))
 
     def _create_or_update_node(
         self,
         node_spec: NodeSpec,
         existing: Node | None,
+        change_tier: ChangeTier,
     ) -> Node:
-        """Create or update a Node object based on the spec and existing node"""
+        """Create or update a Node object based on the spec and existing node.
+
+        `change_tier` drives the version bump on an update, via `_deployed_version`:
+        a metadata-only edit earns a minor version rather than a major one.
+        """
         new_node = (
             Node(
                 name=node_spec.rendered_name,
@@ -3964,8 +4025,9 @@ class DeploymentOrchestrator:
             else existing
         )
         if existing:
-            new_node.current_version = str(
-                Version.parse(new_node.current_version).next_major_version(),
+            new_node.current_version = self._deployed_version(
+                new_node.current_version,
+                change_tier,
             )
             new_node.display_name = node_spec.display_name
             new_node.owners = [

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -81,7 +81,12 @@ from datajunction_server.models.attribute import (
 from datajunction_server.models.base import labelize
 from datajunction_server.models.cube import CubeRevisionMetadata
 from datajunction_server.models.cube_materialization import UpsertCubeMaterialization
-from datajunction_server.models.deployment import DeploymentResult
+from datajunction_server.models.deployment import (
+    ChangeTier,
+    CubeSpec,
+    DeploymentResult,
+    bump_version,
+)
 from datajunction_server.models.dimensionlink import (
     JoinLinkInput,
     JoinType,
@@ -1442,37 +1447,55 @@ async def update_owners(
     await session.commit()
 
 
-def has_minor_changes(
+def cube_changed_fields(
     old_revision: NodeRevision,
-    data: UpdateNode,
-):
+    new_cube: CreateCubeNode,
+) -> tuple[list[str], list[str]]:
     """
-    Whether the node has minor changes
+    Compare a cube's current revision against the fully resolved cube about to
+    replace it, returning the fields whose value changed and the fields whose
+    contents only moved. `CubeSpec.change_tier` turns those two into a version bump.
+
+    Compares against the resolved `CreateCubeNode`, not the raw `UpdateNode` payload,
+    because the resolved object is what gets persisted: a field the payload omitted,
+    or supplied a value that resolution then discarded, cannot be reported as changed.
+    That rules out guard bugs like `metrics: []` reading as "not supplied" under a
+    truthiness check.
     """
-    return (
-        (
-            data
-            and data.description
-            and old_revision.description
-            and (old_revision.description != data.description)
-        )
-        or (data and data.mode and old_revision.mode != data.mode)
-        or (
-            data
-            and data.display_name
-            and old_revision.display_name != data.display_name
-        )
-        or (
-            data
-            and data.filters is not None
-            and data.filters != (old_revision.cube_filters or [])
-        )
-        or (
-            data
-            and data.custom_metadata is not None
-            and old_revision.custom_metadata != data.custom_metadata
-        )
-    )
+    changed: list[str] = []
+    reordered: list[str] = []
+
+    old_metrics = [metric.name for metric in old_revision.cube_metrics()]
+    old_dimensions = old_revision.cube_dimensions()
+    old_filters = old_revision.cube_filters or []
+
+    # Metrics and dimensions: adding or removing one is major, reordering them is
+    # minor (it moves the cube's column order but no values). Both tiers live in
+    # CubeSpec, so all this has to do is say which of the two happened.
+    for field, new_value, old_value in (
+        ("metrics", list(new_cube.metrics or []), old_metrics),
+        ("dimensions", list(new_cube.dimensions or []), old_dimensions),
+    ):
+        if set(new_value) != set(old_value):
+            changed.append(field)
+        elif new_value != old_value:
+            reordered.append(field)
+
+    # Filters are compared as sets: they are ANDed, so their ordering carries no
+    # meaning, but which rows they keep does -- hence major, not minor.
+    if set(new_cube.filters or []) != set(old_filters):
+        changed.append("filters")
+
+    if new_cube.description != old_revision.description:
+        changed.append("description")
+    if new_cube.display_name != old_revision.display_name:
+        changed.append("display_name")
+    if new_cube.mode != old_revision.mode:
+        changed.append("mode")
+    if new_cube.custom_metadata != old_revision.custom_metadata:
+        changed.append("custom_metadata")
+
+    return changed, reordered
 
 
 def node_update_history_event(new_revision: NodeRevision, current_user: User):
@@ -1564,9 +1587,11 @@ async def is_non_trivial_cube_change(
     because filters are ANDed and dimension ordering does not affect the
     materialized table, so neither carries meaning through its ordering.
 
-    This is deliberately a different question from ``major_changes`` in
-    ``update_cube_node`` (which decides the version bump from the request payload):
-    here we ask whether the previously materialized table is still usable.
+    Deliberately a different question from the change tier that `cube_changed_fields`
+    and `CubeSpec.change_tier` compute: that one decides the version bump, this one
+    asks whether the previously materialized table is still usable. The two can and
+    do diverge -- reordering dimensions earns a minor bump but leaves the table
+    valid, while a filters change is major and invalidates it.
     """
     if set(old_revision.cube_dimensions()) != set(new_revision.cube_dimensions()):
         return True
@@ -1603,12 +1628,8 @@ async def update_cube_node(
     """
     node = await Node.get_cube_by_name(session, node_revision.name)
     node_revision = node.current  # type: ignore
-    minor_changes = has_minor_changes(node_revision, data)
     old_metrics = [m.name for m in node_revision.cube_metrics()]
     old_dimensions = node_revision.cube_dimensions()
-    major_changes = (data.metrics and data.metrics != old_metrics) or (
-        data.dimensions and data.dimensions != old_dimensions
-    )
     create_cube = CreateCubeNode(
         name=node_revision.name,
         display_name=data.display_name or node_revision.display_name,
@@ -1625,7 +1646,11 @@ async def update_cube_node(
         if data.custom_metadata is not None
         else node_revision.custom_metadata,
     )
-    if not major_changes and not minor_changes:
+    # "Did anything change?" and "how significant was it?" are one question here:
+    # the tier answers both, and it is the same classifier the deployment path uses.
+    changed_fields, reordered_fields = cube_changed_fields(node_revision, create_cube)
+    change_tier = CubeSpec.change_tier(changed_fields, reordered_fields)
+    if change_tier is ChangeTier.NONE:
         # If refresh_materialization requested but no other changes, refresh and return
         if refresh_materialization and query_service_client:
             _logger.info(
@@ -1686,13 +1711,7 @@ async def update_cube_node(
             current_user,
         )
 
-        old_version = Version.parse(node_revision.version)
-        if major_changes:
-            new_cube_revision.version = str(old_version.next_major_version())
-        else:
-            # Reaching here without major changes means there were minor ones:
-            # the "no changes at all" case returned above.
-            new_cube_revision.version = str(old_version.next_minor_version())
+        new_cube_revision.version = bump_version(node_revision.version, change_tier)
         new_cube_revision.node = node_revision.node
         new_cube_revision.node.current_version = new_cube_revision.version  # type: ignore
 

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -1,4 +1,5 @@
-from enum import Enum
+from collections.abc import Iterable
+from enum import Enum, IntEnum
 from typing import Annotated, Any, ClassVar, Literal
 
 from pydantic import (
@@ -36,7 +37,48 @@ from datajunction_server.models.unit import (
     legacy_unit_to_structured,
     unit_to_dict,
 )
-from datajunction_server.utils import SEPARATOR
+from datajunction_server.utils import SEPARATOR, Version
+
+
+class ChangeTier(IntEnum):
+    """
+    How significant a change to a node is, and so what kind of new version it earns.
+
+    A different question from `NodeSpec.__eq__`, which says only whether anything
+    changed at all. Both the deployment path and `PATCH /nodes/{name}` classify
+    significance through this enum, so the two cannot drift apart.
+
+    Values are spaced rather than consecutive so a future tier -- the node changed
+    but earns no new revision, which is what materialization config will need --
+    slots between two existing tiers without renumbering. Only the ordering matters:
+    `fold_change_tiers` takes a maximum and nothing reads the numbers.
+    """
+
+    NONE = 0
+    MINOR = 10
+    MAJOR = 20
+
+
+def fold_change_tiers(tiers: Iterable[ChangeTier]) -> ChangeTier:
+    """
+    Reduce the tiers of several individual changes to the tier of the change as a
+    whole: the most significant one wins, and no changes at all is NONE.
+    """
+    return max(tiers, default=ChangeTier.NONE)
+
+
+def bump_version(version: str, tier: ChangeTier) -> str:
+    """
+    Apply a change tier to a version string. NONE leaves the version alone, so
+    re-processing an unchanged node -- a forced re-deploy, or a re-deploy of a node
+    stuck in INVALID -- does not invent a version for it.
+    """
+    parsed = Version.parse(version)
+    if tier >= ChangeTier.MAJOR:
+        return str(parsed.next_major_version())
+    if tier >= ChangeTier.MINOR:
+        return str(parsed.next_minor_version())
+    return str(parsed)
 
 
 class DeploymentStatus(str, Enum):
@@ -363,6 +405,35 @@ class NodeSpec(NamespacedSpec):
     mode: NodeMode = NodeMode.PUBLISHED
     custom_metadata: dict | None = None
 
+    # How significant a change to each field is. Data rather than a chain of
+    # conditionals so that adding a field forces someone to classify it: a test
+    # walks `model_fields` on every subclass and fails on anything missing here.
+    # Each class declares only the fields it introduces; lookup walks the MRO.
+    # An unclassified field falls back to MAJOR, so the failure mode is an
+    # over-eager version bump rather than a silently swallowed change.
+    FIELD_CHANGE_TIERS: ClassVar[dict[str, ChangeTier]] = {
+        # Identity, not content: a different name is a different node. `diff()`
+        # ignores both fields, so neither ever reaches the classifier.
+        "name": ChangeTier.NONE,
+        "namespace": ChangeTier.NONE,
+        # Never changes in place; MAJOR so that if it somehow did, it could not
+        # slip through as a minor bump.
+        "node_type": ChangeTier.MAJOR,
+        # Metadata only: leaves the query, the columns and the built output alone.
+        "owners": ChangeTier.MINOR,
+        "display_name": ChangeTier.MINOR,
+        "description": ChangeTier.MINOR,
+        "tags": ChangeTier.MINOR,
+        "mode": ChangeTier.MINOR,
+        "custom_metadata": ChangeTier.MINOR,
+    }
+
+    # How significant it is to reorder a list field without adding or removing
+    # anything. Fields absent here are not order-sensitive, so reordering them is
+    # not a change at all. `diff()` compares list fields as sets and cannot see a
+    # reorder on its own, which is why `order_diff()` exists alongside it.
+    FIELD_ORDER_CHANGE_TIERS: ClassVar[dict[str, ChangeTier]] = {}
+
     _query_ast: Any | None = PrivateAttr(default=None)
     # Internal: marks specs from already-validated sources (e.g., branch copies)
     # that can skip expensive SQL parsing and validation
@@ -449,6 +520,98 @@ class NodeSpec(NamespacedSpec):
             ignore_fields=["name", "namespace", "query", "columns"],
         )
 
+    @classmethod
+    def _declared_tier(
+        cls,
+        mapping_name: str,
+        field: str,
+    ) -> ChangeTier | None:
+        """
+        Look a field up in one of the tier mappings, walking the MRO so that each
+        spec class only has to declare the fields it introduces. Returns None
+        when no class in the MRO classifies the field.
+        """
+        for klass in cls.__mro__:
+            mapping = klass.__dict__.get(mapping_name)
+            if mapping and field in mapping:
+                return mapping[field]
+        return None
+
+    @classmethod
+    def field_change_tier(cls, field: str) -> ChangeTier:
+        """
+        Tier of a change to `field`'s value. Unclassified fields are MAJOR so an
+        unclassified field can never be treated as trivial.
+        """
+        declared = cls._declared_tier("FIELD_CHANGE_TIERS", field)
+        return ChangeTier.MAJOR if declared is None else declared
+
+    @classmethod
+    def field_order_change_tier(cls, field: str) -> ChangeTier:
+        """
+        Tier of a reorder of `field` that leaves its contents intact. Fields that
+        no class classifies carry no meaning in their ordering.
+        """
+        declared = cls._declared_tier("FIELD_ORDER_CHANGE_TIERS", field)
+        return ChangeTier.NONE if declared is None else declared
+
+    @classmethod
+    def has_explicit_change_tier(cls, field: str) -> bool:
+        """Whether some class in the MRO classifies `field`."""
+        return cls._declared_tier("FIELD_CHANGE_TIERS", field) is not None
+
+    @classmethod
+    def unclassified_fields(cls) -> list[str]:
+        """Fields on this spec class that nobody classified. Should always be empty."""
+        return [
+            field
+            for field in cls.model_fields
+            if not cls.has_explicit_change_tier(field)
+        ]
+
+    @classmethod
+    def order_sensitive_fields(cls) -> list[str]:
+        """Fields for which some class in the MRO classifies a reorder."""
+        fields: dict[str, None] = {}
+        for klass in cls.__mro__:
+            for field in klass.__dict__.get("FIELD_ORDER_CHANGE_TIERS", {}):
+                fields.setdefault(field, None)
+        return list(fields)
+
+    @classmethod
+    def change_tier(
+        cls,
+        changed_fields: Iterable[str],
+        reordered_fields: Iterable[str] = (),
+    ) -> ChangeTier:
+        """
+        Classify how significant a set of changes is. `changed_fields` are fields
+        whose value differs; `reordered_fields` are fields whose contents are the
+        same but whose ordering differs.
+        """
+        return fold_change_tiers(
+            [cls.field_change_tier(field) for field in changed_fields]
+            + [cls.field_order_change_tier(field) for field in reordered_fields],
+        )
+
+    def order_diff(self, other: "NodeSpec") -> list[str]:
+        """
+        Return the order-sensitive fields whose ordering differs between this and
+        another NodeSpec while their contents stay the same.
+
+        `diff()` compares list fields as sets, so a pure reorder is invisible to
+        it. Renders `${prefix}` placeholders in `other` first, exactly as `diff()`
+        does, so unresolved prefixes don't produce false positives.
+        """
+        rendered = other.rendered_spec()
+        reordered = []
+        for field in self.order_sensitive_fields():
+            mine = list(getattr(self, field, None) or [])
+            theirs = list(getattr(rendered, field, None) or [])
+            if mine != theirs and set(mine) == set(theirs):
+                reordered.append(field)
+        return reordered
+
 
 class LinkableNodeSpec(NodeSpec):
     """
@@ -464,6 +627,13 @@ class LinkableNodeSpec(NodeSpec):
         ]
     ] = Field(default_factory=list)
     primary_key: list[str] = Field(default_factory=list)
+
+    # All three change the node's shape or how it joins, so all three are major.
+    FIELD_CHANGE_TIERS: ClassVar[dict[str, ChangeTier]] = {
+        "columns": ChangeTier.MAJOR,
+        "dimension_links": ChangeTier.MAJOR,
+        "primary_key": ChangeTier.MAJOR,
+    }
 
     @model_validator(mode="after")
     def set_namespaces(self):
@@ -515,6 +685,13 @@ class SourceSpec(LinkableNodeSpec):
     schema_: str | None = Field(alias="schema")
     table: str
 
+    # The source node points at a different physical table.
+    FIELD_CHANGE_TIERS: ClassVar[dict[str, ChangeTier]] = {
+        "catalog": ChangeTier.MAJOR,
+        "schema_": ChangeTier.MAJOR,
+        "table": ChangeTier.MAJOR,
+    }
+
     model_config = ConfigDict(populate_by_name=True)
 
     def __eq__(self, other: object) -> bool:
@@ -535,6 +712,10 @@ class TransformSpec(LinkableNodeSpec):
     node_type: Literal[NodeType.TRANSFORM] = NodeType.TRANSFORM
     query: str
 
+    FIELD_CHANGE_TIERS: ClassVar[dict[str, ChangeTier]] = {
+        "query": ChangeTier.MAJOR,
+    }
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, TransformSpec):
             return False
@@ -548,6 +729,10 @@ class DimensionSpec(LinkableNodeSpec):
 
     node_type: Literal[NodeType.DIMENSION] = NodeType.DIMENSION
     query: str
+
+    FIELD_CHANGE_TIERS: ClassVar[dict[str, ChangeTier]] = {
+        "query": ChangeTier.MAJOR,
+    }
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, DimensionSpec):
@@ -587,6 +772,22 @@ class MetricSpec(NodeSpec):
     significant_digits: int | None = None
     min_decimal_exponent: int | None = None
     max_decimal_exponent: int | None = None
+
+    FIELD_CHANGE_TIERS: ClassVar[dict[str, ChangeTier]] = {
+        "query": ChangeTier.MAJOR,
+        "columns": ChangeTier.MAJOR,
+        # Required dimensions constrain which queries the metric can answer.
+        "required_dimensions": ChangeTier.MAJOR,
+        # Everything below is presentation metadata on the metric's single output
+        # column -- the same set the PATCH path already treats as minor via
+        # `metric_metadata` in `create_new_revision_from_existing`.
+        "direction": ChangeTier.MINOR,
+        "unit_enum": ChangeTier.MINOR,
+        "unit_structured": ChangeTier.MINOR,
+        "significant_digits": ChangeTier.MINOR,
+        "min_decimal_exponent": ChangeTier.MINOR,
+        "max_decimal_exponent": ChangeTier.MINOR,
+    }
 
     # Class-level adapter used by __init__ to eagerly validate structured
     # unit input. `ClassVar` keeps Pydantic from treating it as a field.
@@ -713,6 +914,32 @@ class CubeSpec(NodeSpec):
     filters: list[str] | None = None
     columns: list[ColumnSpec] | None = None
 
+    FIELD_CHANGE_TIERS: ClassVar[dict[str, ChangeTier]] = {
+        # Adding or removing a metric or a dimension changes the cube's columns.
+        "metrics": ChangeTier.MAJOR,
+        "dimensions": ChangeTier.MAJOR,
+        # Filters decide which rows the cube contains, so a filter change
+        # invalidates any table materialized from the previous revision --
+        # `is_non_trivial_cube_change` already treats it that way, and it would be
+        # absurd for that to coexist with a mere minor version bump.
+        "filters": ChangeTier.MAJOR,
+        # Only user-authored partition config is compared here (see __eq__);
+        # everything else about cube columns is auto-derived.
+        "columns": ChangeTier.MAJOR,
+    }
+
+    FIELD_ORDER_CHANGE_TIERS: ClassVar[dict[str, ChangeTier]] = {
+        # Metric and dimension ordering determines the cube's column order via
+        # `NodeRevision.cube_dimensions()`, which is the shape of the result sets
+        # users see. A reorder is therefore a real change worth recording, just
+        # not one that moves any value -- so it earns a minor version.
+        "metrics": ChangeTier.MINOR,
+        "dimensions": ChangeTier.MINOR,
+        # Filters are ANDed together, so their ordering carries no meaning at all
+        # and reordering them is genuinely a no-op.
+        "filters": ChangeTier.NONE,
+    }
+
     @property
     def rendered_metrics(self) -> list[str]:
         return [render_prefixes(metric, self.namespace) for metric in self.metrics]
@@ -744,10 +971,15 @@ class CubeSpec(NodeSpec):
             return False
         if not super().__eq__(other):
             return False
+        # Metrics and dimensions are compared in order: their ordering sets the
+        # cube's column order, so a reorder is a change the deployment path has to
+        # be able to see (compared as sets, a YAML reorder was silently ignored).
+        # Filters are compared as sets: they are ANDed, so reordering them is
+        # cosmetic and must not trigger a redeploy.
         if not (
-            set(self.rendered_metrics) == set(other.rendered_metrics)
-            and set(self.rendered_dimensions) == set(other.rendered_dimensions)
-            and (self.rendered_filters or []) == (other.rendered_filters or [])
+            self.rendered_metrics == other.rendered_metrics
+            and self.rendered_dimensions == other.rendered_dimensions
+            and set(self.rendered_filters or []) == set(other.rendered_filters or [])
         ):
             return False
         # Compare only partition config for user-specified columns.
@@ -776,6 +1008,33 @@ def _norm(v: Any) -> Any:
     return v
 
 
+def _as_comparable_set(value: Any) -> set:
+    """Reduce a list field to a set of hashable, comparable items."""
+    return {
+        tuple(sorted(item.model_dump().items()))
+        if isinstance(item, BaseModel)
+        else item
+        for item in value or []
+    }
+
+
+def _values_differ(left: Any, right: Any) -> bool:
+    """
+    Whether two field values differ.
+
+    Dicts are compared by value: iterating a dict yields only its keys, so the
+    set comparison lists use would miss a changed value (`custom_metadata` going
+    from `{"tier": "1"}` to `{"tier": "2"}` looked identical). Lists are compared
+    as sets, so reordering one is not a difference -- see `NodeSpec.order_diff`
+    for the fields where ordering does carry meaning.
+    """
+    if isinstance(left or right, dict):
+        return (left or {}) != (right or {})
+    if isinstance(left or right, list):
+        return _as_comparable_set(left) != _as_comparable_set(right)
+    return _norm(left) != _norm(right)
+
+
 def diff(
     one: BaseModel,
     two: BaseModel,
@@ -784,35 +1043,14 @@ def diff(
     """
     Compare two Pydantic models and return a list of fields that have changed.
     """
-    changed_fields = [
+    return [
         field
         for field in one.model_fields.keys()
         if field not in (ignore_fields or [])
         and hasattr(one, field)
         and hasattr(two, field)
-        and (
-            (
-                isinstance(getattr(one, field) or getattr(two, field), (list, dict))
-                and {
-                    tuple(sorted(item.model_dump().items()))
-                    if isinstance(item, BaseModel)
-                    else item
-                    for item in getattr(one, field) or []
-                }
-                != {
-                    tuple(sorted(item.model_dump().items()))
-                    if isinstance(item, BaseModel)
-                    else item
-                    for item in getattr(two, field) or []
-                }
-            )
-            or (
-                not isinstance(getattr(one, field) or getattr(two, field), (list, dict))
-                and _norm(getattr(one, field)) != _norm(getattr(two, field))
-            )
-        )
+        and _values_differ(getattr(one, field), getattr(two, field))
     ]
-    return changed_fields
 
 
 class GitDeploymentSource(BaseModel):

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -2539,12 +2539,104 @@ async def test_updating_cube(
 
 
 @pytest.mark.asyncio
+async def test_reordering_cube_dimensions(
+    client_with_repairs_cube: AsyncClient,
+):
+    """
+    Reordering a cube's dimensions without adding or removing any is a minor
+    version bump — the ordering determines the cube's column order, so it is a real
+    change, but no value moves. Crucially the reorder must actually persist: the
+    dimension set is compared as a set to decide "major", so if nothing checked the
+    ordering the PATCH would report success and quietly discard the edit.
+    """
+    cube_name = "default.repairs_cube_dimension_reorder"
+    await make_a_test_cube(client_with_repairs_cube, cube_name)
+
+    original = (await client_with_repairs_cube.get(f"/cubes/{cube_name}/")).json()
+    dimensions = original["cube_node_dimensions"]
+    reordered = list(reversed(dimensions))
+    assert reordered != dimensions
+
+    response = await client_with_repairs_cube.patch(
+        f"/nodes/{cube_name}",
+        json={"dimensions": reordered},
+    )
+    assert response.status_code == 200, response.json()
+    assert response.json()["version"] == "v1.1"
+
+    updated = (await client_with_repairs_cube.get(f"/cubes/{cube_name}/")).json()
+    assert updated["version"] == "v1.1"
+    assert updated["cube_node_dimensions"] == reordered
+
+
+@pytest.mark.asyncio
+async def test_reordering_cube_metrics(
+    client_with_repairs_cube: AsyncClient,
+):
+    """
+    Reordering a cube's metrics is a minor version bump, and the new order has to
+    persist — the same trap as the dimension reorder above.
+    """
+    cube_name = "default.repairs_cube_metric_reorder"
+    await make_a_test_cube(client_with_repairs_cube, cube_name)
+
+    original = (await client_with_repairs_cube.get(f"/cubes/{cube_name}/")).json()
+    metrics = original["cube_node_metrics"]
+    reordered = list(reversed(metrics))
+    assert reordered != metrics
+
+    response = await client_with_repairs_cube.patch(
+        f"/nodes/{cube_name}",
+        json={"metrics": reordered},
+    )
+    assert response.status_code == 200, response.json()
+    assert response.json()["version"] == "v1.1"
+
+    updated = (await client_with_repairs_cube.get(f"/cubes/{cube_name}/")).json()
+    assert updated["version"] == "v1.1"
+    assert updated["cube_node_metrics"] == reordered
+
+
+@pytest.mark.asyncio
+async def test_reordering_cube_filters_is_not_a_change(
+    client_with_repairs_cube: AsyncClient,
+):
+    """
+    Filters are ANDed together, so their ordering carries no meaning: reordering
+    them is not a change at all and earns no new revision.
+    """
+    cube_name = "default.repairs_cube_filter_reorder"
+    await make_a_test_cube(client_with_repairs_cube, cube_name)
+
+    filters = ["default.hard_hat.state='AZ'", "default.hard_hat.city='Phoenix'"]
+    response = await client_with_repairs_cube.patch(
+        f"/nodes/{cube_name}",
+        json={"filters": filters},
+    )
+    assert response.status_code == 200, response.json()
+    assert response.json()["version"] == "v2.0"
+
+    response = await client_with_repairs_cube.patch(
+        f"/nodes/{cube_name}",
+        json={"filters": list(reversed(filters))},
+    )
+    assert response.status_code == 200, response.json()
+    assert response.json()["version"] == "v2.0"
+
+    revisions = (
+        await client_with_repairs_cube.get(f"/nodes/{cube_name}/revisions/")
+    ).json()
+    assert [revision["version"] for revision in revisions] == ["v1.0", "v2.0"]
+
+
+@pytest.mark.asyncio
 async def test_updating_cube_filters(
     client_with_repairs_cube: AsyncClient,
 ):
     """
-    Verify that cube filters can be updated via the PATCH endpoint and
-    that the change is detected as a minor version bump.
+    Verify that cube filters can be updated via the PATCH endpoint and that the
+    change is detected as a major version bump: filters decide which rows the cube
+    contains, so changing them changes the cube's data.
     """
     cube_name = "default.repairs_cube_filters_update"
     await make_a_test_cube(
@@ -2564,7 +2656,7 @@ async def test_updating_cube_filters(
         },
     )
     data = response.json()
-    assert data["version"] == "v1.1"
+    assert data["version"] == "v2.0"
 
     # Verify the updated filters are returned from the /cubes/ endpoint
     response = await client_with_repairs_cube.get(f"/cubes/{cube_name}/")
@@ -2578,7 +2670,7 @@ async def test_updating_cube_filters(
         },
     )
     data = response.json()
-    assert data["version"] == "v1.2"
+    assert data["version"] == "v3.0"
 
     response = await client_with_repairs_cube.get(f"/cubes/{cube_name}/")
     assert response.json()["cube_filters"] is None
@@ -6308,8 +6400,9 @@ class TestStopStaleCubeMaterializationWorkflows:
         mocker,
     ):
         """
-        A filters-only change is only a minor version bump, but it still changes
-        which rows land in the materialized table, so it is non-trivial.
+        A filters-only change is a major version bump — it changes which rows the
+        cube contains — and for the same reason it is non-trivial, so the previous
+        version's workflows are stopped.
         """
         cube_name = "default.stop_workflows_filters_change"
         await self._make_materialized_cube(
@@ -6331,7 +6424,7 @@ class TestStopStaleCubeMaterializationWorkflows:
             json={"filters": ["default.hard_hat.state='CA'"]},
         )
         assert response.status_code == 200, response.json()
-        assert response.json()["version"] == "v1.1"
+        assert response.json()["version"] == "v2.0"
 
         mock_deactivate_cube_workflow.assert_called_once_with(
             cube_name,

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -2630,6 +2630,39 @@ async def test_reordering_cube_filters_is_not_a_change(
 
 
 @pytest.mark.asyncio
+async def test_updating_cube_display_name_and_mode_are_minor(
+    client_with_repairs_cube: AsyncClient,
+):
+    """
+    Display name and mode are metadata: they leave the cube's metrics, dimensions
+    and filters alone, so each earns a minor version rather than a major one.
+    """
+    cube_name = "default.repairs_cube_metadata_update"
+    await make_a_test_cube(client_with_repairs_cube, cube_name)
+
+    response = await client_with_repairs_cube.patch(
+        f"/nodes/{cube_name}",
+        json={"display_name": "Repairs Cube, Renamed"},
+    )
+    assert response.status_code == 200, response.json()
+    assert response.json()["version"] == "v1.1"
+    assert response.json()["display_name"] == "Repairs Cube, Renamed"
+
+    response = await client_with_repairs_cube.patch(
+        f"/nodes/{cube_name}",
+        json={"mode": "draft"},
+    )
+    assert response.status_code == 200, response.json()
+    assert response.json()["version"] == "v1.2"
+    assert response.json()["mode"] == "draft"
+
+    revisions = (
+        await client_with_repairs_cube.get(f"/nodes/{cube_name}/revisions/")
+    ).json()
+    assert [revision["version"] for revision in revisions] == ["v1.0", "v1.1", "v1.2"]
+
+
+@pytest.mark.asyncio
 async def test_updating_cube_filters(
     client_with_repairs_cube: AsyncClient,
 ):

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -2336,6 +2336,228 @@ class TestDeployments:
         assert cube_result["status"] == "success"
 
     @pytest.mark.asyncio
+    async def test_deploy_cube_metadata_only_change_is_a_minor_bump(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        A description-only edit re-deployed must earn a minor version, not a new
+        major one. Deploying such an edit used to mint v2.0 because every node that
+        reached the update path was given `next_major_version()` unconditionally.
+        """
+        namespace = "cube_metadata_only"
+        cube = CubeSpec(
+            name="default.repairs_cube",
+            display_name="Repairs Cube",
+            description="""Cube for analyzing repair orders""",
+            dimensions=["${prefix}default.hard_hat.state"],
+            metrics=["${prefix}default.avg_length_of_employment"],
+            owners=["dj"],
+        )
+        nodes_list = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            cube,
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        fetched = (await client.get(f"/nodes/{namespace}.default.repairs_cube/")).json()
+        assert fetched["version"] == "v1.0"
+
+        cube.description = "Cube for analyzing repair orders, revised"
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        assert data["results"][-1] == {
+            "deploy_type": "node",
+            "message": "Updated cube (v1.1)\n└─ Updated description",
+            "name": f"{namespace}.default.repairs_cube",
+            "operation": "update",
+            "changed_fields": ["description"],
+            "status": "success",
+        }
+        fetched = (await client.get(f"/nodes/{namespace}.default.repairs_cube/")).json()
+        assert fetched["version"] == "v1.1"
+        assert fetched["description"] == "Cube for analyzing repair orders, revised"
+
+    @pytest.mark.asyncio
+    async def test_deploy_cube_dimension_reorder(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        Reordering a cube's dimensions in YAML is a real change: the ordering sets
+        the cube's column order. It used to be invisible to the deployment path,
+        which compared dimensions as sets and so skipped the node entirely; now it
+        earns a minor version and the new order persists. Reordering the filters at
+        the same time changes nothing, because filters are ANDed.
+        """
+        namespace = "cube_dimension_reorder"
+        dimensions = [
+            "${prefix}default.hard_hat.state",
+            "${prefix}default.hard_hat.city",
+        ]
+        filters = [
+            "${prefix}default.hard_hat.state='AZ'",
+            "${prefix}default.hard_hat.city='Phoenix'",
+        ]
+        cube = CubeSpec(
+            name="default.repairs_cube",
+            display_name="Repairs Cube",
+            description="""Cube for analyzing repair orders""",
+            dimensions=dimensions,
+            metrics=["${prefix}default.avg_length_of_employment"],
+            filters=filters,
+            owners=["dj"],
+        )
+        nodes_list = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            cube,
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+
+        cube_url = f"/cubes/{namespace}.default.repairs_cube/"
+        assert (await client.get(cube_url)).json()["cube_node_dimensions"] == [
+            f"{namespace}.default.hard_hat.state",
+            f"{namespace}.default.hard_hat.city",
+        ]
+
+        cube.dimensions = list(reversed(dimensions))
+        cube.filters = list(reversed(filters))
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        assert data["results"][-1] == {
+            "deploy_type": "node",
+            # The filter reorder is reported for the reader's benefit but earns no
+            # version of its own: v1.1 comes from the dimension reorder alone.
+            "message": "Updated cube (v1.1)\n└─ Reordered dimensions, filters",
+            "name": f"{namespace}.default.repairs_cube",
+            "operation": "update",
+            "changed_fields": [],
+            "status": "success",
+        }
+        fetched = (await client.get(cube_url)).json()
+        assert fetched["version"] == "v1.1"
+        assert fetched["cube_node_dimensions"] == [
+            f"{namespace}.default.hard_hat.city",
+            f"{namespace}.default.hard_hat.state",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_patch_and_deployment_agree_on_version(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        The same edit, applied once through `PATCH /nodes/{name}` and once through a
+        deployment, must land on the same version. Both paths classify significance
+        through the one shared classifier, and this is the test that keeps that a
+        fact rather than an aspiration.
+        """
+        upstreams = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+        ]
+
+        def build_cube(**overrides) -> CubeSpec:
+            fields: dict = {
+                "name": "default.repairs_cube",
+                "display_name": "Repairs Cube",
+                "description": "Cube for analyzing repair orders",
+                "dimensions": ["${prefix}default.hard_hat.state"],
+                "metrics": ["${prefix}default.avg_length_of_employment"],
+                "filters": ["${prefix}default.hard_hat.state='AZ'"],
+                "owners": ["dj"],
+            }
+            return CubeSpec(**{**fields, **overrides})
+
+        async def deploy(namespace: str, cube: CubeSpec) -> None:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace=namespace,
+                    nodes=[spec.model_copy(deep=True) for spec in upstreams] + [cube],
+                ),
+            )
+            assert data["status"] == "success", data
+
+        async def version_of(namespace: str) -> str:
+            response = await client.get(f"/nodes/{namespace}.default.repairs_cube/")
+            return response.json()["version"]
+
+        patch_ns, deploy_ns = "cube_equivalence_patch", "cube_equivalence_deploy"
+        await deploy(patch_ns, build_cube())
+        await deploy(deploy_ns, build_cube())
+        assert await version_of(patch_ns) == "v1.0"
+        assert await version_of(deploy_ns) == "v1.0"
+
+        # A metadata-only edit is minor on both paths.
+        response = await client.patch(
+            f"/nodes/{patch_ns}.default.repairs_cube",
+            json={"description": "Cube for analyzing repair orders, revised"},
+        )
+        assert response.status_code == 200, response.json()
+        await deploy(
+            deploy_ns,
+            build_cube(description="Cube for analyzing repair orders, revised"),
+        )
+        assert await version_of(patch_ns) == "v1.1"
+        assert await version_of(deploy_ns) == "v1.1"
+
+        # A filters-only edit is major on both paths.
+        response = await client.patch(
+            f"/nodes/{patch_ns}.default.repairs_cube",
+            json={"filters": [f"{patch_ns}.default.hard_hat.state='CA'"]},
+        )
+        assert response.status_code == 200, response.json()
+        await deploy(
+            deploy_ns,
+            build_cube(
+                description="Cube for analyzing repair orders, revised",
+                filters=["${prefix}default.hard_hat.state='CA'"],
+            ),
+        )
+        assert await version_of(patch_ns) == "v2.0"
+        assert await version_of(deploy_ns) == "v2.0"
+
+    @pytest.mark.asyncio
     async def test_deploy_cube_with_custom_metadata(
         self,
         client,

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -2394,6 +2394,87 @@ class TestDeployments:
         assert fetched["description"] == "Cube for analyzing repair orders, revised"
 
     @pytest.mark.asyncio
+    async def test_deploy_cube_partition_change_is_major(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        A cube's partition config lives on its columns, which `diff()` does not
+        compare, so a partition-only edit would otherwise reach the update path with
+        nothing named as changed. It is reported as `columns` and earns a major
+        version: the partition decides how the cube is built and materialized.
+        """
+        namespace = "cube_partition_change"
+        cube = CubeSpec(
+            name="default.repairs_cube",
+            display_name="Repairs Cube",
+            description="""Cube for analyzing repair orders""",
+            dimensions=[
+                "${prefix}default.hard_hat.state",
+                "${prefix}default.hard_hat.birth_date",
+            ],
+            metrics=["${prefix}default.avg_length_of_employment"],
+            columns=[
+                ColumnSpec(
+                    name="${prefix}default.hard_hat.birth_date",
+                    partition={
+                        "type": "temporal",
+                        "granularity": "day",
+                        "format": "yyyyMMdd",
+                    },
+                ),
+            ],
+            owners=["dj"],
+        )
+        nodes_list = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            cube,
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        fetched = (await client.get(f"/nodes/{namespace}.default.repairs_cube/")).json()
+        assert fetched["version"] == "v1.0"
+
+        cube.columns[0].partition.format = "yyyy-MM-dd"
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        assert [
+            result
+            for result in data["results"]
+            if result["name"] == f"{namespace}.default.repairs_cube"
+        ] == [
+            {
+                "deploy_type": "node",
+                "message": (
+                    "Updated cube (v2.0)\n"
+                    "└─ Set properties for 1 columns\n"
+                    "└─ Updated columns"
+                ),
+                "name": f"{namespace}.default.repairs_cube",
+                "operation": "update",
+                "changed_fields": ["columns"],
+                "status": "success",
+            },
+        ]
+        fetched = (await client.get(f"/nodes/{namespace}.default.repairs_cube/")).json()
+        assert fetched["version"] == "v2.0"
+
+    @pytest.mark.asyncio
     async def test_deploy_cube_dimension_reorder(
         self,
         client,

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -33,6 +33,7 @@ from datajunction_server.internal.deployment.validation import (
     NodeValidationResult,
 )
 from datajunction_server.models.deployment import (
+    ChangeTier,
     ColumnSpec,
     CubeSpec,
     DeploymentResult,
@@ -1140,7 +1141,9 @@ class TestCubeDeployment:
         orchestrator._create_cube_node_revision_from_validation_data = AsyncMock(
             return_value=mock_revision,
         )
-        orchestrator._generate_changelog = AsyncMock(return_value=([], []))
+        orchestrator._generate_changelog = AsyncMock(
+            return_value=([], [], ChangeTier.NONE),
+        )
 
         with patch(
             "datajunction_server.internal.deployment.orchestrator.get_node_namespace",
@@ -2737,10 +2740,15 @@ class TestGenerateChangelog:
             dependencies=[],
         )
 
-        changelog, changed_fields = await orchestrator._generate_changelog(result)
+        (
+            changelog,
+            changed_fields,
+            change_tier,
+        ) = await orchestrator._generate_changelog(result)
 
         assert changed_fields == []
         assert changelog == ["└─ Updated dimension_links"]
+        assert change_tier == ChangeTier.NONE
 
     @pytest.mark.asyncio
     async def test_cube_column_change_uses_role_qualified_identity(
@@ -2789,10 +2797,15 @@ class TestGenerateChangelog:
             dependencies=[],
         )
 
-        changelog, changed_fields = await orchestrator._generate_changelog(result)
+        (
+            changelog,
+            changed_fields,
+            change_tier,
+        ) = await orchestrator._generate_changelog(result)
 
         assert changed_fields == []
         assert changelog == ["└─ Set properties for 1 columns"]
+        assert change_tier == ChangeTier.NONE
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -2,7 +2,9 @@ import pytest
 
 from datajunction_server.errors import DJInvalidDeploymentConfig
 from datajunction_server.models.deployment import (
+    ChangeTier,
     ColumnSpec,
+    CubeSpec,
     DeploymentSpec,
     DimensionJoinLinkSpec,
     DimensionReferenceLinkSpec,
@@ -10,14 +12,17 @@ from datajunction_server.models.deployment import (
     Granularity,
     MetricSpec,
     NamespaceGitConfig,
+    NodeSpec,
     PartitionSpec,
     PartitionType,
     PreAggSpec,
     SourceSpec,
     TagSpec,
     TransformSpec,
+    bump_version,
     eq_columns,
     eq_or_fallback,
+    fold_change_tiers,
 )
 from datajunction_server.models.node import MetricUnit, NodeMode, NodeType
 
@@ -682,3 +687,154 @@ def test_tag_spec_metadata_aliases():
         "tag_type": "Maintenance",
         "tag_metadata": None,
     }
+
+
+def all_node_spec_classes() -> list[type[NodeSpec]]:
+    """Every NodeSpec class, including the abstract intermediate ones."""
+
+    def descendants(klass):
+        for subclass in klass.__subclasses__():
+            yield subclass
+            yield from descendants(subclass)
+
+    return [NodeSpec, *descendants(NodeSpec)]
+
+
+def test_every_spec_field_has_an_explicit_change_tier():
+    """
+    Every field on every NodeSpec class must be explicitly classified into a
+    ChangeTier. This is what turns "someone added a field and forgot to say how
+    significant a change to it is" into a red test instead of a silent fallback.
+    """
+    unclassified = {
+        spec_class.__name__: spec_class.unclassified_fields()
+        for spec_class in all_node_spec_classes()
+        if spec_class.unclassified_fields()
+    }
+    assert unclassified == {}
+
+
+def test_change_tier_lookup_walks_the_mro():
+    """
+    Each spec class declares only the fields it introduces; lookup finds inherited
+    classifications, and anything unclassified falls back to MAJOR (fail safe).
+    """
+    assert CubeSpec.field_change_tier("metrics") == ChangeTier.MAJOR
+    assert CubeSpec.field_change_tier("description") == ChangeTier.MINOR
+    assert CubeSpec.field_change_tier("name") == ChangeTier.NONE
+    assert CubeSpec.field_change_tier("a_field_nobody_classified") == ChangeTier.MAJOR
+
+    assert CubeSpec.field_order_change_tier("metrics") == ChangeTier.MINOR
+    assert CubeSpec.field_order_change_tier("dimensions") == ChangeTier.MINOR
+    assert CubeSpec.field_order_change_tier("filters") == ChangeTier.NONE
+    assert CubeSpec.field_order_change_tier("description") == ChangeTier.NONE
+
+    assert TransformSpec.field_change_tier("query") == ChangeTier.MAJOR
+    assert TransformSpec.field_change_tier("primary_key") == ChangeTier.MAJOR
+    assert TransformSpec.field_change_tier("tags") == ChangeTier.MINOR
+    assert TransformSpec.order_sensitive_fields() == []
+    assert CubeSpec.order_sensitive_fields() == ["metrics", "dimensions", "filters"]
+
+
+def test_fold_change_tiers():
+    """The most significant change wins; no changes at all is NONE."""
+    assert fold_change_tiers([]) == ChangeTier.NONE
+    assert fold_change_tiers([ChangeTier.NONE]) == ChangeTier.NONE
+    assert fold_change_tiers([ChangeTier.NONE, ChangeTier.MINOR]) == ChangeTier.MINOR
+    assert (
+        fold_change_tiers([ChangeTier.MINOR, ChangeTier.MAJOR, ChangeTier.NONE])
+        == ChangeTier.MAJOR
+    )
+    # The tiers are ordered, and spaced so a future tier fits between them.
+    assert ChangeTier.NONE < ChangeTier.MINOR < ChangeTier.MAJOR
+    assert ChangeTier.MINOR - ChangeTier.NONE > 1
+
+
+def test_change_tier_classification():
+    """The table of decisions, exercised through the shared classifier."""
+    assert CubeSpec.change_tier([], []) == ChangeTier.NONE
+    # metric / dimension / filter set changes are major
+    assert CubeSpec.change_tier(["metrics"]) == ChangeTier.MAJOR
+    assert CubeSpec.change_tier(["dimensions"]) == ChangeTier.MAJOR
+    assert CubeSpec.change_tier(["filters"]) == ChangeTier.MAJOR
+    # reordering metrics or dimensions is minor, reordering filters is nothing
+    assert CubeSpec.change_tier([], ["metrics"]) == ChangeTier.MINOR
+    assert CubeSpec.change_tier([], ["dimensions"]) == ChangeTier.MINOR
+    assert CubeSpec.change_tier([], ["filters"]) == ChangeTier.NONE
+    # metadata is minor
+    for field in ("description", "display_name", "mode", "custom_metadata"):
+        assert CubeSpec.change_tier([field]) == ChangeTier.MINOR
+    # a major change alongside a minor one is still major
+    assert CubeSpec.change_tier(["description", "filters"]) == ChangeTier.MAJOR
+    # query, columns, primary key and dimension links are major
+    assert TransformSpec.change_tier(["query"]) == ChangeTier.MAJOR
+    assert TransformSpec.change_tier(["columns"]) == ChangeTier.MAJOR
+    assert TransformSpec.change_tier(["primary_key"]) == ChangeTier.MAJOR
+    assert TransformSpec.change_tier(["dimension_links"]) == ChangeTier.MAJOR
+
+
+def test_bump_version():
+    """NONE keeps the version: an unchanged node must not be given a new one."""
+    assert bump_version("v1.3", ChangeTier.NONE) == "v1.3"
+    assert bump_version("v1.3", ChangeTier.MINOR) == "v1.4"
+    assert bump_version("v1.3", ChangeTier.MAJOR) == "v2.0"
+
+
+def a_cube(**kwargs) -> CubeSpec:
+    """A minimal cube spec, overridable field by field."""
+    defaults: dict = {
+        "name": "test_cube",
+        "metrics": ["ns.a", "ns.b"],
+        "dimensions": ["ns.d.one", "ns.d.two"],
+    }
+    return CubeSpec(**{**defaults, **kwargs})
+
+
+def test_cube_spec_eq_is_order_sensitive_for_metrics_and_dimensions():
+    """
+    Metric and dimension ordering sets the cube's column order, so a reorder is a
+    real difference the deployment path has to be able to see.
+    """
+    assert a_cube() == a_cube()
+    assert a_cube() != a_cube(metrics=["ns.b", "ns.a"])
+    assert a_cube() != a_cube(dimensions=["ns.d.two", "ns.d.one"])
+    assert a_cube() != a_cube(metrics=["ns.a"])
+
+
+def test_cube_spec_eq_treats_filters_as_a_set():
+    """Filters are ANDed, so reordering them is cosmetic and not a change."""
+    one = a_cube(filters=["x = 1", "y = 2"])
+    assert one == a_cube(filters=["y = 2", "x = 1"])
+    assert one != a_cube(filters=["x = 1"])
+    assert one != a_cube(filters=["x = 1", "y = 3"])
+
+
+def test_cube_spec_order_diff():
+    """
+    order_diff names the order-sensitive fields whose contents held still while
+    their ordering moved -- the changes diff()'s set comparison cannot see.
+    """
+    one = a_cube(filters=["x = 1", "y = 2"])
+    assert one.order_diff(a_cube(filters=["x = 1", "y = 2"])) == []
+    assert one.order_diff(
+        a_cube(metrics=["ns.b", "ns.a"], filters=["x = 1", "y = 2"]),
+    ) == ["metrics"]
+    assert one.order_diff(
+        a_cube(dimensions=["ns.d.two", "ns.d.one"], filters=["x = 1", "y = 2"]),
+    ) == ["dimensions"]
+    assert one.order_diff(a_cube(filters=["y = 2", "x = 1"])) == ["filters"]
+    # A set change is not a reorder — diff() reports that one instead.
+    assert one.order_diff(a_cube(metrics=["ns.a"], filters=["x = 1", "y = 2"])) == []
+    assert one.diff(a_cube(metrics=["ns.a"], filters=["x = 1", "y = 2"])) == ["metrics"]
+
+
+def test_diff_compares_dicts_by_value():
+    """
+    A dict field whose keys are unchanged but whose values moved is a change.
+    Iterating a dict yields only its keys, so the set comparison lists use missed
+    this and `custom_metadata` edits were reported as no change at all.
+    """
+    one = a_cube(custom_metadata={"tier": "1"})
+    assert one.diff(a_cube(custom_metadata={"tier": "2"})) == ["custom_metadata"]
+    assert one.diff(a_cube(custom_metadata={"tier": "1"})) == []
+    assert a_cube().diff(a_cube(custom_metadata={})) == []


### PR DESCRIPTION
### Summary

On the deployment path, "did anything change?" and "how big was the change?" were treated the same. `filter_nodes_to_deploy` used `__eq__` to pick nodes to process, and anything it picked got a major version bump. So fixing a typo in a description took a cube from v1.0 to v2.0. The information to do better was already being computed but it wasn't being used in the actual application of the update.

This change splits the two questions. `__eq__` still answers "process this or skip it," but we're also adding a new `ChangeTier` classifier that answers "how big was the change."

For users, metadata edits result in minor version bumps instead of major ones. Filters result in a major version bump since they change which rows a cube contains, which the old code treated as minor. Reordering dimensions or metrics is now visible (it was ignored before) and earns a minor bump, since order determines the cube's column order.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
