### PR TITLE
Accept a declarative materialization block on cube specs

### DIFF
--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -66,11 +66,13 @@ from datajunction_server.models.deployment import (
     CubeSpec,
     DimensionReferenceLinkSpec,
     DimensionSpec,
+    MaterializationSpec,
     MetricSpec,
     NodeSpec,
     SourceSpec,
     TransformSpec,
 )
+from datajunction_server.models.materialization import MaterializationJobTypeEnum
 from datajunction_server.models.node import (
     DEFAULT_DRAFT_VERSION,
     BuildCriteria,
@@ -98,6 +100,12 @@ if TYPE_CHECKING:
 
 
 _logger = logging.getLogger(__name__)
+
+# The job class behind a cube's Druid materialization. Stored on
+# `Materialization.job`, and the stable way to pick a cube's materialization out
+# of a revision -- unlike `name`, which encodes the strategy and partition and so
+# changes when either does.
+CUBE_MATERIALIZATION_JOB = MaterializationJobTypeEnum.DRUID_CUBE.value.job_class
 
 # Weights for the three searchable fields on NodeRevision. `name` is the
 # authoritative identifier and gets full weight; `display_name` is almost
@@ -668,10 +676,54 @@ class Node(Base):
                 metrics=self.current.cube_node_metrics,
                 dimensions=self.current.cube_node_dimensions,
                 filters=self.current.cube_filters or None,
+                materialization=await self._materialization_spec(session),
             )
 
         node_spec_cls = node_spec_class_map[self.type]
         return node_spec_cls(**base_kwargs, **extra_kwargs)
+
+    async def _materialization_spec(
+        self,
+        session: AsyncSession,
+    ) -> MaterializationSpec | None:
+        """
+        Project this cube's persisted materialization back into the declarative form.
+
+        Only the three authored fields round-trip. Everything else on the stored
+        config -- measures queries, combiner SQL, the Druid spec, output tables --
+        is derived by DJ on every build, so re-exporting it would put generated
+        artifacts into a hand-edited file and make the YAML churn on each rebuild.
+
+        Loaded lazily rather than through `export_load_options`: cubes are a small
+        minority of exported nodes, so paying a SELECT for every source and metric
+        to serve them is the wrong trade.
+        """
+        from sqlalchemy import inspect as sa_inspect
+
+        if "materializations" in sa_inspect(self.current).unloaded:
+            await session.refresh(self.current, ["materializations"])
+
+        cube_materializations = sorted(
+            (
+                materialization
+                for materialization in self.current.materializations
+                if materialization.job == CUBE_MATERIALIZATION_JOB
+                and materialization.deactivated_at is None
+            ),
+            key=lambda materialization: materialization.name,
+        )
+        if not cube_materializations:
+            return None
+
+        materialization = cube_materializations[0]
+        config = (
+            materialization.config if isinstance(materialization.config, dict) else {}
+        )
+        return MaterializationSpec(
+            schedule=materialization.schedule,
+            strategy=materialization.strategy,
+            lookback_window=config.get("lookback_window"),
+        )
 
     @classmethod
     def cube_load_options(cls) -> list[ExecutableOption]:

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -24,6 +24,7 @@ from datajunction_server.models.dimensionlink import (
     SparkJoinStrategy,
 )
 from datajunction_server.models.impact import DownstreamImpact
+from datajunction_server.models.materialization import MaterializationStrategy
 from datajunction_server.models.node import (
     MetricDirection,
     MetricUnit,
@@ -222,6 +223,33 @@ class PartitionSpec(BaseModel):
     type: PartitionType
     granularity: Granularity | None = None
     format: str | None = None
+
+
+class MaterializationSpec(BaseModel):
+    """
+    Declarative materialization config for a cube.
+
+    Deliberately carries only what the author decides: when to build, how, and
+    how far back to look. The backend that runs it (and everything it derives --
+    the measures queries, combiner SQL, Druid spec, output tables) is DJ's
+    choice, so no `job` field is exposed here and the block stays portable if
+    that choice changes.
+    """
+
+    schedule: str
+    strategy: MaterializationStrategy = MaterializationStrategy.INCREMENTAL_TIME
+    lookback_window: str | None = "1 DAY"
+
+    @model_validator(mode="after")
+    def clear_lookback_for_full(self) -> "MaterializationSpec":
+        """
+        `lookback_window` only means something for INCREMENTAL_TIME. Normalize it
+        away for FULL so an ignored value can't make two equivalent specs compare
+        unequal and churn a live workflow on deploy.
+        """
+        if self.strategy != MaterializationStrategy.INCREMENTAL_TIME:
+            self.lookback_window = None
+        return self
 
 
 class ColumnSpec(BaseModel):
@@ -913,6 +941,7 @@ class CubeSpec(NodeSpec):
     dimensions: list[str] = Field(default_factory=list)
     filters: list[str] | None = None
     columns: list[ColumnSpec] | None = None
+    materialization: MaterializationSpec | None = None
 
     FIELD_CHANGE_TIERS: ClassVar[dict[str, ChangeTier]] = {
         # Adding or removing a metric or a dimension changes the cube's columns.
@@ -926,6 +955,19 @@ class CubeSpec(NodeSpec):
         # Only user-authored partition config is compared here (see __eq__);
         # everything else about cube columns is auto-derived.
         "columns": ChangeTier.MAJOR,
+        # Materialization is not part of a cube's definition. Configuring one
+        # through `POST /nodes/{name}/materialization/` has never created a node
+        # revision, and a YAML-declared schedule has to behave the same way, or
+        # the same edit would cut a version through one door and not the other.
+        # Because `materialization` is also excluded from `__eq__`, a
+        # materialization-only edit leaves the cube in the deployment's skip list
+        # and never reaches the classifier at all; NONE records that intent rather
+        # than describing a reachable code path. Nothing is lost by the exclusion:
+        # reconciling the declared block against the persisted config is a separate
+        # concern that runs over every declared cube whether or not the node
+        # changed, which is also what catches a materialization changed outside
+        # YAML.
+        "materialization": ChangeTier.NONE,
     }
 
     FIELD_ORDER_CHANGE_TIERS: ClassVar[dict[str, ChangeTier]] = {
@@ -939,6 +981,34 @@ class CubeSpec(NodeSpec):
         # and reordering them is genuinely a no-op.
         "filters": ChangeTier.NONE,
     }
+
+    @model_validator(mode="after")
+    def validate_materialization(self) -> "CubeSpec":
+        """
+        An INCREMENTAL_TIME materialization has nothing to increment over without a
+        temporal partition, so require one up front rather than failing later in the
+        build. The partition is read from the cube's own columns (see ColumnSpec.
+        partition) -- it is not restated on the materialization block, so that a cube
+        carrying the same dimension in two roles can say which role partitions it.
+        """
+        if (
+            self.materialization
+            and self.materialization.strategy
+            == MaterializationStrategy.INCREMENTAL_TIME
+            and not any(
+                col.partition and col.partition.type == PartitionType.TEMPORAL
+                for col in self.columns or []
+            )
+        ):
+            raise DJInvalidDeploymentConfig(
+                message=(
+                    f"Cube `{self.name}` declares an `incremental_time` "
+                    "materialization but no temporal partition. Add `partition: "
+                    "{type: temporal, ...}` to the cube column that partitions it, "
+                    "or use `strategy: full`."
+                ),
+            )
+        return self
 
     @property
     def rendered_metrics(self) -> list[str]:
@@ -982,6 +1052,14 @@ class CubeSpec(NodeSpec):
             and set(self.rendered_filters or []) == set(other.rendered_filters or [])
         ):
             return False
+        # `materialization` is deliberately absent from this comparison. Equality
+        # here decides whether the cube's definition changed, and any inequality
+        # routes the cube to the update path, which always writes a new revision and
+        # so mints at least a minor version. Rescheduling a build is not a definition
+        # change and must not mint one (nor trip the workflow stop that a material
+        # cube change triggers); see `materialization` in FIELD_CHANGE_TIERS. It is
+        # reconciled separately, against the persisted config rather than this spec.
+
         # Compare only partition config for user-specified columns.
         # Cube element columns (types, order, attributes) are auto-derived and ignored.
         incoming_partitions = {

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -25,8 +25,12 @@ from datajunction_server.models.deployment import (
     DimensionReferenceLinkSpec,
     DimensionSpec,
     GitDeploymentSource,
+    Granularity,
     LocalDeploymentSource,
+    MaterializationSpec,
     MetricSpec,
+    PartitionSpec,
+    PartitionType,
     PreAggSpec,
     SourceSpec,
     TagSpec,
@@ -2637,6 +2641,112 @@ class TestDeployments:
         )
         assert await version_of(patch_ns) == "v2.0"
         assert await version_of(deploy_ns) == "v2.0"
+
+    @pytest.mark.asyncio
+    async def test_deploy_cube_with_materialization_block(
+        self,
+        session,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        A cube can declare `materialization:` alongside its definition, and the block
+        survives the deploy/export round trip so a repo-managed cube keeps it.
+
+        Nothing is scheduled yet -- the reconciler that turns the block into a
+        workflow lands separately. This pins that the spec parses, deploys, and
+        exports, and that a schedule edit alone does not mint a new cube version.
+        """
+        namespace = "cube_materialization"
+        cube = CubeSpec(
+            name="default.repairs_cube",
+            display_name="Repairs Cube",
+            description="""Cube for analyzing repair orders""",
+            dimensions=[
+                "${prefix}default.hard_hat.state",
+                "${prefix}default.hard_hat.birth_date",
+            ],
+            metrics=[
+                "${prefix}default.avg_length_of_employment",
+            ],
+            columns=[
+                ColumnSpec(
+                    name="${prefix}default.hard_hat.birth_date",
+                    partition=PartitionSpec(
+                        type=PartitionType.TEMPORAL,
+                        granularity=Granularity.DAY,
+                        format="yyyyMMdd",
+                    ),
+                ),
+            ],
+            materialization=MaterializationSpec(
+                schedule="0 6 * * *",
+                lookback_window="1 DAY",
+            ),
+            owners=["dj"],
+        )
+        nodes_list = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            cube,
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+
+        deployed = await Node.get_by_name(
+            session,
+            f"{namespace}.default.repairs_cube",
+            options=Node.cube_load_options(),
+        )
+        assert deployed.current.version == "v1.0"
+
+        # The block is accepted but not yet acted on, so nothing is scheduled.
+        assert (await deployed.to_spec(session)).materialization is None
+
+        # Editing only the schedule is not a definition change: the cube compares
+        # equal, is skipped rather than updated, and so is never given a version.
+        cube.materialization = MaterializationSpec(
+            schedule="0 3 * * *",
+            lookback_window="1 DAY",
+        )
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        cube_results = [
+            result
+            for result in data["results"]
+            if result["name"] == f"{namespace}.default.repairs_cube"
+        ]
+        assert cube_results == [
+            {
+                "deploy_type": "node",
+                "message": "Unchanged",
+                "name": f"{namespace}.default.repairs_cube",
+                "operation": "noop",
+                "changed_fields": [],
+                "status": "skipped",
+            },
+        ]
+
+        session.expire_all()
+        deployed = await Node.get_by_name(
+            session,
+            f"{namespace}.default.repairs_cube",
+            options=Node.cube_load_options(),
+        )
+        assert deployed.current.version == "v1.0"
 
     @pytest.mark.asyncio
     async def test_deploy_cube_with_custom_metadata(

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -1999,3 +1999,93 @@ async def test_list_node_availability_states_with_links_and_partitions(
     partition = state["partitions"][0]
     assert partition["value"] == ["US", "west"]
     assert partition["valid_through_ts"] == 20220115
+
+
+@pytest.mark.asyncio
+async def test_cube_materialization_round_trips_to_spec(
+    module__session,
+    client_with_repairs_cube: AsyncClient,
+    module__query_service_client: QueryServiceClient,
+    set_temporal_column,
+):
+    """
+    A cube materialized through the API exports as a declarative `materialization:`
+    block, so a repo-managed cube can be pulled and re-deployed without losing it.
+
+    Only the three authored fields come back. The stored config also holds the
+    measures queries, combiner SQL and Druid spec, all of which DJ regenerates on
+    every build -- re-exporting those would drop generated artifacts into a
+    hand-edited file.
+    """
+    from sqlalchemy import inspect as sa_inspect
+
+    from datajunction_server.database.node import Node
+    from datajunction_server.models.deployment import MaterializationSpec
+    from datajunction_server.models.materialization import MaterializationStrategy
+
+    cube_name = "default.repairs_cube__spec_round_trip"
+    client = await client_with_repairs_cube(cube_name=cube_name)  # type: ignore
+
+    # An unmaterialized cube exports no block at all, rather than an empty one.
+    cube = await Node.get_by_name(
+        module__session,
+        cube_name,
+        options=Node.cube_load_options(),
+    )
+    assert cube is not None
+    assert (await cube.to_spec(module__session)).materialization is None
+
+    await set_temporal_column(
+        client,
+        cube_name,
+        "default.repair_orders_fact.order_date",
+    )
+    response = await client.post(
+        f"/nodes/{cube_name}/materialization/",
+        json={
+            "job": "druid_cube",
+            "strategy": "incremental_time",
+            "schedule": "0 6 * * *",
+            "lookback_window": "7 DAY",
+        },
+    )
+    assert response.status_code in (200, 201)
+
+    module__session.expire_all()
+    cube = await Node.get_by_name(
+        module__session,
+        cube_name,
+        options=Node.cube_load_options(),
+    )
+    assert cube is not None
+    spec = await cube.to_spec(module__session)
+    assert spec.materialization == MaterializationSpec(
+        schedule="0 6 * * *",
+        strategy=MaterializationStrategy.INCREMENTAL_TIME,
+        lookback_window="7 DAY",
+    )
+
+    # The exported block is exactly the authored surface -- no derived config leaks.
+    assert spec.model_dump(mode="json", exclude_none=True)["materialization"] == {
+        "schedule": "0 6 * * *",
+        "strategy": "incremental_time",
+        "lookback_window": "7 DAY",
+    }
+
+    # The export path itself loads with `export_load_options`, which deliberately
+    # omits materializations so that exporting a source or metric does not pay a
+    # SELECT to serve the cube minority. The block still has to come back there, so
+    # the relationship is refreshed on demand rather than eagerly loaded.
+    module__session.expire_all()
+    cube = await Node.get_by_name(
+        module__session,
+        cube_name,
+        options=Node.export_load_options(),
+    )
+    assert cube is not None
+    assert "materializations" in sa_inspect(cube.current).unloaded
+    assert (await cube.to_spec(module__session)).materialization == MaterializationSpec(
+        schedule="0 6 * * *",
+        strategy=MaterializationStrategy.INCREMENTAL_TIME,
+        lookback_window="7 DAY",
+    )

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -10,6 +10,7 @@ from datajunction_server.models.deployment import (
     DimensionReferenceLinkSpec,
     DimensionSpec,
     Granularity,
+    MaterializationSpec,
     MetricSpec,
     NamespaceGitConfig,
     NodeSpec,
@@ -24,6 +25,7 @@ from datajunction_server.models.deployment import (
     eq_or_fallback,
     fold_change_tiers,
 )
+from datajunction_server.models.materialization import MaterializationStrategy
 from datajunction_server.models.node import MetricUnit, NodeMode, NodeType
 
 
@@ -838,3 +840,146 @@ def test_diff_compares_dicts_by_value():
     assert one.diff(a_cube(custom_metadata={"tier": "2"})) == ["custom_metadata"]
     assert one.diff(a_cube(custom_metadata={"tier": "1"})) == []
     assert a_cube().diff(a_cube(custom_metadata={})) == []
+
+
+def _partitioned_cube(**materialization) -> CubeSpec:
+    """A cube with a temporal partition, optionally carrying a materialization block."""
+    return CubeSpec(
+        namespace="test",
+        name="my_cube",
+        metrics=["${prefix}num_orders"],
+        dimensions=["${prefix}date_dim.dateint"],
+        columns=[
+            ColumnSpec(
+                name="${prefix}date_dim.dateint",
+                partition=PartitionSpec(
+                    type=PartitionType.TEMPORAL,
+                    granularity=Granularity.DAY,
+                    format="yyyyMMdd",
+                ),
+            ),
+        ],
+        materialization=MaterializationSpec(**materialization)
+        if materialization
+        else None,
+    )
+
+
+def test_materialization_spec_defaults():
+    """An author supplying only a schedule gets incremental daily-lookback defaults."""
+    spec = MaterializationSpec(schedule="0 6 * * *")
+    assert spec.model_dump() == {
+        "schedule": "0 6 * * *",
+        "strategy": MaterializationStrategy.INCREMENTAL_TIME,
+        "lookback_window": "1 DAY",
+    }
+
+
+def test_materialization_spec_full_strategy_drops_lookback():
+    """
+    ``lookback_window`` is meaningless for FULL, so it is normalized away -- otherwise
+    two equivalent specs could compare unequal and churn a live workflow on deploy.
+    """
+    declared = MaterializationSpec(
+        schedule="0 6 * * *",
+        strategy=MaterializationStrategy.FULL,
+        lookback_window="7 DAY",
+    )
+    assert declared.model_dump() == {
+        "schedule": "0 6 * * *",
+        "strategy": MaterializationStrategy.FULL,
+        "lookback_window": None,
+    }
+    assert declared == MaterializationSpec(
+        schedule="0 6 * * *",
+        strategy=MaterializationStrategy.FULL,
+    )
+
+
+def test_cube_spec_incremental_requires_temporal_partition():
+    """An incremental cube with no temporal partition has nothing to increment over."""
+    with pytest.raises(DJInvalidDeploymentConfig) as exc_info:
+        CubeSpec(
+            namespace="test",
+            name="my_cube",
+            metrics=["${prefix}num_orders"],
+            dimensions=["${prefix}date_dim.dateint"],
+            materialization=MaterializationSpec(schedule="0 6 * * *"),
+        )
+    assert exc_info.value.message == (
+        "Cube `my_cube` declares an `incremental_time` materialization but no "
+        "temporal partition. Add `partition: {type: temporal, ...}` to the cube "
+        "column that partitions it, or use `strategy: full`."
+    )
+
+
+def test_cube_spec_full_strategy_needs_no_partition():
+    """FULL rebuilds everything, so it carries no partition requirement."""
+    spec = CubeSpec(
+        namespace="test",
+        name="my_cube",
+        metrics=["${prefix}num_orders"],
+        dimensions=["${prefix}date_dim.dateint"],
+        materialization=MaterializationSpec(
+            schedule="0 6 * * *",
+            strategy=MaterializationStrategy.FULL,
+        ),
+    )
+    assert spec.materialization == MaterializationSpec(
+        schedule="0 6 * * *",
+        strategy=MaterializationStrategy.FULL,
+        lookback_window=None,
+    )
+
+
+def test_cube_spec_partition_satisfies_incremental():
+    """The partition is read off the cube's columns, not restated on the block."""
+    spec = _partitioned_cube(schedule="0 6 * * *", lookback_window="3 DAY")
+    assert spec.materialization == MaterializationSpec(
+        schedule="0 6 * * *",
+        strategy=MaterializationStrategy.INCREMENTAL_TIME,
+        lookback_window="3 DAY",
+    )
+
+
+def test_cube_spec_eq_ignores_materialization():
+    """
+    Equality decides whether the cube's *definition* changed, which gates a new node
+    revision. Rescheduling a build is not a definition change.
+    """
+    six_am = _partitioned_cube(schedule="0 6 * * *")
+    midnight = _partitioned_cube(schedule="0 0 * * *")
+    unscheduled = _partitioned_cube()
+
+    assert six_am == midnight
+    assert six_am == unscheduled
+
+    # ...while the definition itself still drives inequality.
+    renamed = _partitioned_cube(schedule="0 6 * * *")
+    renamed.metrics = ["${prefix}num_returns"]
+    assert six_am != renamed
+
+
+def test_materialization_change_tier_is_none():
+    """
+    `materialization` is explicitly classified, so the "every field is classified"
+    test stays green rather than falling back to MAJOR -- and it is classified NONE
+    because configuring a materialization has never cut a node revision.
+
+    A materialization-only edit is equal under `__eq__` and so never reaches the
+    classifier; this pins the tier that would apply if it ever did.
+    """
+    assert CubeSpec.has_explicit_change_tier("materialization") is True
+    assert CubeSpec.field_change_tier("materialization") == ChangeTier.NONE
+    assert CubeSpec.change_tier(["materialization"]) == ChangeTier.NONE
+
+    six_am = _partitioned_cube(schedule="0 6 * * *").rendered_spec()
+    assert six_am.diff(_partitioned_cube(schedule="0 0 * * *")) == ["materialization"]
+    assert CubeSpec.change_tier(six_am.diff(_partitioned_cube())) == ChangeTier.NONE
+
+
+def test_cube_spec_without_materialization_omits_it_from_export():
+    """Unmaterialized cubes must not gain a `materialization: null` key on export."""
+    spec = _partitioned_cube()
+    assert spec.materialization is None
+    assert "materialization" not in spec.model_dump(mode="json", exclude_none=True)


### PR DESCRIPTION
### Summary

First step toward #1912. A cube can declare when and how it should be built alongside its definition, so materialization config shares the review, history, promotion and rollback of the cube instead of living only in the UI where the two can drift apart.
```yaml
name: ${prefix}my_cube
node_type: cube
metrics: [...]
dimensions: [...]
columns:
  - name: shared.dims.date.dateint
    partition: {type: temporal, granularity: day, format: yyyyMMdd}

materialization:
  schedule: "0 6 * * *"
  strategy: incremental_time
  lookback_window: 1 DAY
```
Deploying a block does nothing yet -- this just handles parsing and validating of the new YAML block as part of the deployment.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
