### PR TITLE
Evaluate scope patterns with the input grammar

### DIFF
--- a/datajunction-server/datajunction_server/internal/access/authorization/service.py
+++ b/datajunction-server/datajunction_server/internal/access/authorization/service.py
@@ -265,23 +265,26 @@ class RBACAuthorizationService(AuthorizationService):
         resource_matches_pattern("marketing.revenue", "finance.*") --> False
         resource_matches_pattern("anything", "*") --> True
         resource_matches_pattern("finance", "finance.*") --> False
+        resource_matches_pattern("anything", ".*") --> False (outside the grammar)
+
+        Parsing is shared with scope input validation, so a scope means the same
+        thing when it is written and when it is evaluated. A value outside the
+        grammar grants nothing: evaluation used to strip stars and read ``.*`` or
+        ``**`` as a global match, so a row predating that validation, or written
+        outside the API, could silently grant everything.
         """
-        if pattern == "*":
-            return True  # Match everything
+        parsed = parse_scope_pattern(pattern)
+        if parsed is None:
+            return False
 
-        if "*" not in pattern:
-            return resource_name == pattern  # Exact match
-
-        # Wildcard pattern: finance.* matches finance.revenue and finance.quarterly.revenue
-        # But NOT just "finance" (must have something after the dot)
-        pattern_prefix = pattern.rstrip("*").rstrip(SEPARATOR)
-
-        if not pattern_prefix:
-            return True  # Pattern was just "*"
-
-        # Resource must start with pattern_prefix followed by a dot
-        # (not an exact match to pattern_prefix, that would be handled by exact pattern)
-        return resource_name.startswith(pattern_prefix + SEPARATOR)
+        kind, prefix = parsed
+        if kind == "global":
+            return True
+        if kind == "exact":
+            return resource_name == prefix
+        # Subtree: finance.* covers finance.revenue and finance.quarterly.revenue,
+        # but not finance itself.
+        return resource_name.startswith(prefix + SEPARATOR)
 
     @classmethod
     def has_permission(

--- a/datajunction-server/datajunction_server/internal/access/authorization/service.py
+++ b/datajunction-server/datajunction_server/internal/access/authorization/service.py
@@ -406,17 +406,20 @@ class RBACAuthorizationService(AuthorizationService):
 
         Handles:
         1. Permission hierarchy (MANAGE > DELETE > WRITE > READ, EXECUTE > READ)
-        2. Empty/None scope_value or "*" = global access
+        2. "*" scope_value = global access, within the scope's own resource type
         3. Wildcard pattern matching (finance.*)
         4. Cross-resource-type: namespace scope covers nodes in that namespace
+
+        Values outside the supported grammar, blanks included, grant nothing.
         """
         # Check permission hierarchy: does scope.action grant the requested action?
         granted_actions = cls.PERMISSION_HIERARCHY.get(scope.action, {scope.action})
         if action not in granted_actions:
             return False
 
-        # Handle global access (empty string, None, or "*" scope_value)
-        if not scope.scope_value or scope.scope_value == "" or scope.scope_value == "*":
+        # Handle global access. Blank is not global -- it is outside the grammar,
+        # so it falls through to the matcher below and grants nothing.
+        if scope.scope_value == "*":
             # Global scope matches any resource of the same type
             return scope.scope_type == resource_type
 

--- a/datajunction-server/datajunction_server/models/access.py
+++ b/datajunction-server/datajunction_server/models/access.py
@@ -31,8 +31,17 @@ class ResourceAction(StrEnum):
 
 
 def parse_scope_pattern(value: str) -> tuple[str, str] | None:
-    """Parse exact, trailing-wildcard, and global scope patterns."""
-    if not value or value == "*":
+    """
+    Parse exact, trailing-wildcard, and global scope patterns.
+
+    A blank value is outside the grammar rather than a global scope: the global
+    scope is spelled ``*``, which is what scope input has required since #2339.
+    Reading blanks as global would let a legacy or out-of-band row grant every
+    resource of its type.
+    """
+    if not value:
+        return None
+    if value == "*":
         return ("global", "")
     if (
         value.startswith(SEPARATOR)

--- a/datajunction-server/tests/internal/authorization_test.py
+++ b/datajunction-server/tests/internal/authorization_test.py
@@ -112,36 +112,25 @@ class TestResourceMatching:
             "users.alice.*",
         )
 
-    def test_edge_case_patterns(self):
-        """Test edge case patterns that reach the fallback logic (line 167-168).
-
-        These patterns are unusual but should be handled gracefully:
-        - ".*" -> strips to empty string
-        - "**" -> strips to empty string
-        These are treated as global wildcards (match everything).
+    @pytest.mark.parametrize(
+        "pattern",
+        [".*", "**", "finance*", "finance.", ".finance", "finance..sub", "fin*ance"],
+    )
+    @pytest.mark.parametrize("resource", ["anything", "finance", "finance.revenue"])
+    def test_patterns_outside_the_grammar_match_nothing(self, pattern, resource):
         """
-        # ".*" pattern - after stripping "*" and ".", becomes empty
-        assert RBACAuthorizationService.resource_matches_pattern(
-            "anything",
-            ".*",
-        )
-        assert RBACAuthorizationService.resource_matches_pattern(
-            "finance.revenue",
-            ".*",
-        )
-        assert RBACAuthorizationService.resource_matches_pattern(
-            "",
-            ".*",
-        )
+        A value outside the supported grammar grants nothing.
 
-        # "**" pattern - after stripping "*", becomes empty
-        assert RBACAuthorizationService.resource_matches_pattern(
-            "anything",
-            "**",
-        )
-        assert RBACAuthorizationService.resource_matches_pattern(
-            "deeply.nested.resource.name",
-            "**",
+        The grammar is ``*``, an exact name, or a subtree ending in ``.*``; scope
+        input has been validated against it since #2339. Evaluation used to parse
+        separately and stripped stars, so ``.*`` and ``**`` collapsed to a global
+        match -- a silent grant of everything for any row predating that
+        validation or written outside the API. ``finance*`` was quietly read as
+        ``finance.*``, which is not what the syntax suggests either.
+        """
+        assert not RBACAuthorizationService.resource_matches_pattern(
+            resource,
+            pattern,
         )
 
     def test_wildcard_in_middle_not_supported(self):

--- a/datajunction-server/tests/internal/authorization_test.py
+++ b/datajunction-server/tests/internal/authorization_test.py
@@ -114,7 +114,16 @@ class TestResourceMatching:
 
     @pytest.mark.parametrize(
         "pattern",
-        [".*", "**", "finance*", "finance.", ".finance", "finance..sub", "fin*ance"],
+        [
+            "",
+            ".*",
+            "**",
+            "finance*",
+            "finance.",
+            ".finance",
+            "finance..sub",
+            "fin*ance",
+        ],
     )
     @pytest.mark.parametrize("resource", ["anything", "finance", "finance.revenue"])
     def test_patterns_outside_the_grammar_match_nothing(self, pattern, resource):
@@ -158,7 +167,9 @@ class TestScopeContainment:
         "granted_type,granted_value,delegated_type,delegated_value,expected",
         [
             (ResourceType.NAMESPACE, "*", ResourceType.NAMESPACE, "*", True),
-            (ResourceType.NAMESPACE, "", ResourceType.NAMESPACE, "finance", True),
+            # Blank is outside the grammar, so it delegates nothing -- the global
+            # grant is spelled "*".
+            (ResourceType.NAMESPACE, "", ResourceType.NAMESPACE, "finance", False),
             (ResourceType.NAMESPACE, "finance.*", ResourceType.NAMESPACE, "*", False),
             (ResourceType.NODE, "*", ResourceType.NODE, "*", True),
             (ResourceType.NODE, "finance.*", ResourceType.NODE, "*", False),
@@ -1444,14 +1455,19 @@ class TestCrossResourceTypePermissions:
 class TestGlobalAccessScope:
     """Tests for global access (empty or * scope_value)."""
 
-    async def test_empty_scope_grants_global_access(
+    async def test_empty_scope_grants_nothing(
         self,
-        # client_with_basic: AsyncClient,
         session: AsyncSession,
         default_user: User,
     ):
-        """Test that empty scope_value grants access to all resources of that type."""
-        # Create role with empty scope_value (global)
+        """
+        A blank scope_value grants nothing, through the full has_permission path.
+
+        Blank is outside the grammar -- the global scope is spelled "*", which
+        scope input has required since #2339. Evaluation used to read blanks as
+        global, so a legacy or out-of-band row granted every resource of its
+        type; the API rejects such a value, so nothing can create one now.
+        """
         role = Role(name="global-reader", created_by_id=default_user.id)
         session.add(role)
         await session.flush()
@@ -1460,7 +1476,7 @@ class TestGlobalAccessScope:
             role_id=role.id,
             action=ResourceAction.READ,
             scope_type=ResourceType.NAMESPACE,
-            scope_value="",  # Global! (empty string)
+            scope_value="",  # Outside the grammar; written directly, not via the API
         )
         session.add(scope)
 
@@ -1476,31 +1492,17 @@ class TestGlobalAccessScope:
         await session.refresh(default_user)
         user = await get_user(username=default_user.username, session=session)
 
-        # Should grant for any namespace
-        result1 = RBACAuthorizationService.has_permission(
-            assignments=user.role_assignments,
-            action=ResourceAction.READ,
-            resource_type=ResourceType.NAMESPACE,
-            resource_name="finance.revenue",
-        )
-        assert result1 is True
-
-        result2 = RBACAuthorizationService.has_permission(
-            assignments=user.role_assignments,
-            action=ResourceAction.READ,
-            resource_type=ResourceType.NAMESPACE,
-            resource_name="marketing.anything",
-        )
-        assert result2 is True
-
-        # Should NOT grant for different resource type
-        result3 = RBACAuthorizationService.has_permission(
-            assignments=user.role_assignments,
-            action=ResourceAction.READ,
-            resource_type=ResourceType.NODE,  # Different type
-            resource_name="finance.revenue",
-        )
-        assert result3 is False
+        for resource_type in (ResourceType.NAMESPACE, ResourceType.NODE):
+            for resource_name in ("finance.revenue", "marketing.anything", "finance"):
+                assert (
+                    RBACAuthorizationService.has_permission(
+                        assignments=user.role_assignments,
+                        action=ResourceAction.READ,
+                        resource_type=resource_type,
+                        resource_name=resource_name,
+                    )
+                    is False
+                ), f"blank scope granted {resource_type.value} {resource_name}"
 
     async def test_star_scope_grants_global_access(
         self,


### PR DESCRIPTION
Tracking: #2234 (step 4) — "define one supported scope grammar and reject ambiguous patterns such as `finance*`, `.*`, and `**`".

Scope input has been validated against a grammar since #2339 (`*`, an exact name, or a subtree ending in `.*`), but evaluation parsed patterns separately. Values outside the grammar were therefore reinterpreted rather than rejected, and two of them silently meant "everything":

- `.*` and `**` collapsed to a global match, because evaluation stripped stars.
- A blank value was read as global in two more places — `parse_scope_pattern` returned global for it, and `_scope_grants_permission` had its own blank shortcut — even though scope input rejects blank outright, telling callers to use `*`.

The API can no longer create any of these, but rows predating that validation, or written outside the API, are still evaluated.

This makes one parser authoritative. `resource_matches_pattern` delegates to `parse_scope_pattern`, blank is outside the grammar, and the global shortcut recognises only `*`. A scope now means the same thing when it is written and when it is evaluated.

Valid patterns are unchanged, including `finance.*` still excluding the `finance` namespace object — that root mismatch is open decision 9 and is deliberately untouched. The rest of the global shortcut also stays, since it encodes that a global scope matches solely its own resource type, which is what keeps `namespace:*` from covering nodes.

---

Before and after, for the same values:

```
""          vs any resource        ->  granted  (now denied)
".*"        vs "secret"            ->  True     (now False)
"**"        vs "anything.at.all"   ->  True     (now False)
"finance*"  vs "finance.revenue"   ->  True     (now False)
"finance*"  vs "financial_reports" ->  False    (unchanged)
"finance.*" vs "finance.revenue"   ->  True     (unchanged)
"finance.*" vs "finance"           ->  False    (unchanged)
```

This withdraws three grants that were previously asserted as intended: `.*`/`**` matching everything, a blank scope granting through `has_permission`, and a blank grant delegating through scope containment. Each of those tests is replaced rather than deleted — an eight-pattern parametrized case for the matcher, and a blank-scope case asserting nothing is granted across both resource types.

Note for deployments: an existing grant whose value falls outside the grammar stops matching. Since those values currently mean "everything", that is the intended direction, but a quiet grant may disappear. Blanks are deliberately **not** migrated to `*` — that would preserve access where the rest of this change fails closed, and a blank row is more likely legacy than an intended global grant.