### PR TITLE
feat: Support Declarative Materialization YAML

### DIFF
--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -48,6 +48,7 @@ from datajunction_server.models.cube import (
     ViewDDLResponse,
 )
 from datajunction_server.models.cube_materialization import (
+    DRUID_CUBE_V3_MATERIALIZATION_NAME,
     CubeMaterializationV2Input,
     CubeMaterializeRequest,
     CubeMaterializeResponse,
@@ -762,7 +763,7 @@ async def materialize_cube(
     )
 
     # Persist materialization record on the cube's node revision
-    materialization_name = "druid_cube_v3"
+    materialization_name = DRUID_CUBE_V3_MATERIALIZATION_NAME
     existing_mats = await Materialization.get_by_names(
         session,
         cube_revision.id,
@@ -877,7 +878,7 @@ async def deactivate_cube_materialization(
     cube_revision = node.current
 
     # Find and delete the druid_cube_v3 materialization
-    materialization_name = "druid_cube_v3"
+    materialization_name = DRUID_CUBE_V3_MATERIALIZATION_NAME
     existing_mats = await Materialization.get_by_names(
         session,
         cube_revision.id,
@@ -954,7 +955,7 @@ async def run_cube_backfill(
 
     # Verify cube has a materialization
     cube_revision = node.current
-    materialization_name = "druid_cube_v3"
+    materialization_name = DRUID_CUBE_V3_MATERIALIZATION_NAME
     existing_mats = await Materialization.get_by_names(
         session,
         cube_revision.id,

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -353,6 +353,12 @@ async def get_node(
     access_checker.add_request_by_node_name(name, ResourceAction.READ)
     await access_checker.check(on_denied=AccessDenialMode.RAISE)
 
+    # Answer from the database, not from the identity map: SQLAlchemy hands back an
+    # instance the session already holds without re-applying the load options below,
+    # which would serve a superseded revision, or one loaded without the relationships
+    # this response needs. A request's session is its own, so nothing is expired here
+    # that this request did not load itself.
+    session.expire_all()
     node = await Node.get_by_name(
         session,
         name,

--- a/datajunction-server/datajunction_server/database/materialization.py
+++ b/datajunction-server/datajunction_server/database/materialization.py
@@ -19,7 +19,10 @@ from sqlalchemy.orm import Mapped, joinedload, mapped_column, relationship
 from datajunction_server.database.backfill import Backfill
 from datajunction_server.database.base import Base
 from datajunction_server.database.column import Column
-from datajunction_server.models.cube_materialization import DruidCubeV3Config
+from datajunction_server.models.cube_materialization import (
+    DRUID_CUBE_V3_MATERIALIZATION_NAME,
+    DruidCubeV3Config,
+)
 from datajunction_server.models.materialization import (
     DruidMeasuresCubeConfig,
     GenericMaterializationConfig,
@@ -100,6 +103,23 @@ class Materialization(Base):
         cascade="all, delete",
         lazy="selectin",
     )
+
+    @property
+    def is_cube_planner(self) -> bool:
+        """
+        Whether this row was written by the cube planner (v3) rather than by the
+        fused cube materialization path.
+
+        The two dialects are indistinguishable by job: `POST /cubes/{name}/materialize`
+        persists the same `DruidCubeMaterializationJob` the fused path derives. What
+        separates them is the row name the planner writes and the version
+        discriminator its config carries, either of which is enough to recognize.
+        """
+        config = self.config if isinstance(self.config, dict) else {}
+        return (
+            self.name == DRUID_CUBE_V3_MATERIALIZATION_NAME
+            or config.get("version") == "v3"
+        )
 
     @classmethod
     async def get_by_names(

--- a/datajunction-server/datajunction_server/database/materialization.py
+++ b/datajunction-server/datajunction_server/database/materialization.py
@@ -114,6 +114,10 @@ class Materialization(Base):
         persists the same `DruidCubeMaterializationJob` the fused path derives. What
         separates them is the row name the planner writes and the version
         discriminator its config carries, either of which is enough to recognize.
+
+        The name is the authoritative signal, since the planner is the only writer of
+        it. The `version` check is a fallback for rows written before that name
+        settled, so a row matching either one is treated as the planner's.
         """
         config = self.config if isinstance(self.config, dict) else {}
         return (

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -697,6 +697,11 @@ class Node(Base):
         is derived by DJ on every build, so re-exporting it would put generated
         artifacts into a hand-edited file and make the YAML churn on each rebuild.
 
+        A cube planner materialization is skipped even though it shares the fused
+        job class, because the declarative block cannot describe it: exporting one
+        would write YAML that, pushed back, replaces the planner's materialization
+        with a fused one.
+
         Loaded lazily rather than through `export_load_options`: cubes are a small
         minority of exported nodes, so paying a SELECT for every source and metric
         to serve them is the wrong trade.
@@ -712,6 +717,7 @@ class Node(Base):
                 for materialization in self.current.materializations
                 if materialization.job == CUBE_MATERIALIZATION_JOB
                 and materialization.deactivated_at is None
+                and not materialization.is_cube_planner
             ),
             key=lambda materialization: materialization.name,
         )

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -4,6 +4,7 @@ import time
 from collections import Counter
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from datetime import UTC
 from typing import cast
 
 from sqlalchemy import func, or_, select, text
@@ -64,6 +65,7 @@ from datajunction_server.internal.impact import propagate_impact
 from datajunction_server.internal.materializations import (
     CubeMaterializationSwap,
     apply_cube_materialization_swap,
+    reconcile_declared_materialization,
     swap_cube_materializations,
 )
 from datajunction_server.internal.nodes import (
@@ -113,6 +115,7 @@ from datajunction_server.models.unit import (
     structured_to_legacy_unit,
 )
 from datajunction_server.sql.dag import get_metric_parents_map
+from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import (
     SEPARATOR,
     get_namespace_from_name,
@@ -481,7 +484,14 @@ class DeploymentOrchestrator:
                     self.deployment_spec.namespace,
                 ),
             )
-            if not needs_preagg_reconcile:
+            # Cube materializations still need reconciling too. A push that edits
+            # only a `materialization:` block leaves every cube comparing equal, so
+            # the plan this short-circuit is testing is exactly the one such a push
+            # produces.
+            declares_cube = any(
+                isinstance(spec, CubeSpec) for spec in self.deployment_spec.nodes
+            )
+            if not needs_preagg_reconcile and not declares_cube:
                 return DeploymentExecuteResult(
                     results=await self._handle_no_changes(),
                     downstream_impacts=[],
@@ -1748,6 +1758,12 @@ class DeploymentOrchestrator:
         with timer.phase("reconcile preaggregations"):
             await self._reconcile_preaggregations()
 
+        # Reconcile declared cube materializations. Runs unconditionally, for the
+        # same reason hierarchies do: a push that edits only a schedule deploys no
+        # nodes at all.
+        with timer.phase("reconcile cube materializations"):
+            await self._reconcile_cube_materializations(plan)
+
         # Run impact propagation before deletions so deleted nodes'
         # children are still reachable via NodeRelationship.
         changed_names = {
@@ -2347,6 +2363,323 @@ class DeploymentOrchestrator:
             and spec.materialization is None
             and "materialization" in spec.model_fields_set
         }
+
+    async def _reconcile_cube_materializations(self, plan: DeploymentPlan) -> None:
+        """
+        Bring every declared cube's materialization in line with its
+        `materialization:` block.
+
+        Driven off `deployment_spec.nodes` rather than the deploy's change list.
+        `materialization` is excluded from `CubeSpec.__eq__`, so a push that edits
+        only the schedule leaves the cube in the plan's skip list, and a reconciler
+        keyed on updated nodes would drop exactly the edit this exists to support.
+        Iterating every declared cube also corrects a materialization that was
+        changed outside YAML.
+
+        Only an explicit `materialization: null` removes anything. A cube that
+        declares no block but has one materialized keeps it and earns a warning:
+        the repo may simply not have caught up yet, and a live workflow must not be
+        torn down by omission.
+
+        Remote work is queued onto `self._cube_materialization_swaps` and handed to
+        the query service by `execute` after the commit, so a deploy that rolls back
+        -- every dry run -- has asked it to schedule nothing and stop nothing.
+        """
+        cube_names = [
+            spec.rendered_name
+            for spec in self.deployment_spec.nodes
+            if isinstance(spec, CubeSpec)
+        ]
+        if not cube_names:
+            return
+
+        declared = self._declared_materializations()
+        removing = self._cubes_declaring_no_materialization()
+
+        # What each cube's materialization looked like before this deploy, in the
+        # same declarative shape the block is written in. Taken from the plan rather
+        # than from the revision because a cube that got a new revision this deploy
+        # has already had its materialization rebuilt onto it by
+        # `_swap_cube_materializations`, and a dry run skips that rebuild entirely --
+        # reading the revision would make the two disagree.
+        persisted: dict[str, MaterializationSpec | None] = {
+            name: existing.materialization
+            for name in cube_names
+            if isinstance(existing := plan.existing_specs.get(name), CubeSpec)
+        }
+        # A cube that neither declares a block nor has one to tear down needs no
+        # revision loaded, which keeps a no-change push over a namespace full of
+        # cubes free of extra work.
+        revisions = await self._cube_revisions_to_reconcile(
+            [
+                name
+                for name in cube_names
+                if name in declared
+                or (name in removing and persisted.get(name) is not None)
+            ],
+        )
+        access_checker = (
+            AccessChecker(
+                await AuthContext.from_user(self.session, self.context.current_user),
+            )
+            if declared and not self.dry_run
+            else None
+        )
+        for name in cube_names:
+            revision = revisions.get(name)
+            if name in declared:
+                if revision is not None:  # pragma: no branch
+                    await self._declare_cube_materialization(
+                        revision,
+                        declared[name],
+                        persisted.get(name),
+                        access_checker,
+                    )
+            elif name in removing:
+                self._remove_cube_materialization(name, revision)
+            elif persisted.get(name) is not None:
+                self._warn_undeclared_materialization(name)
+
+    async def _cube_revisions_to_reconcile(
+        self,
+        cube_names: list[str],
+    ) -> dict[str, NodeRevision]:
+        """
+        The current revision of each named cube that exists, with everything a
+        rebuild reads eagerly loaded.
+
+        A cube absent from the registry never made it into the deployment -- it
+        failed validation, say -- and one whose revision was created moments ago has
+        nothing loaded on it, so the identity map is warmed in a single query rather
+        than lazy-loading per cube from async code.
+        """
+        revisions = {
+            name: node.current
+            for name in cube_names
+            if (node := self.registry.nodes.get(name)) is not None
+            and node.current is not None
+        }
+        if revisions:
+            await self.session.execute(
+                select(NodeRevision)
+                .where(NodeRevision.id.in_([rev.id for rev in revisions.values()]))
+                .options(*NodeRevision.cube_load_options()),
+            )
+        return revisions
+
+    async def _declare_cube_materialization(
+        self,
+        revision: NodeRevision,
+        block: MaterializationSpec,
+        persisted: MaterializationSpec | None,
+        access_checker: AccessChecker | None,
+    ) -> None:
+        """
+        Configure one cube's materialization from its declared block.
+
+        The reported operation compares the block against what the cube declared
+        before this deploy, so it says the same thing on a dry run as on the wet run
+        that follows. `reconcile_declared_materialization` decides separately whether
+        any DJ-side state actually moved, and only then is the query service asked to
+        schedule anything -- an unchanged re-declare, or a block a revision swap has
+        already built from, costs no remote call at all.
+        """
+        operation = (
+            DeploymentResult.Operation.CREATE
+            if persisted is None
+            else DeploymentResult.Operation.UPDATE
+            if persisted != block
+            else DeploymentResult.Operation.NOOP
+        )
+        if self.dry_run:
+            self.deployed_results.append(
+                DeploymentResult(
+                    name=revision.name,
+                    deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                    status=DeploymentResult.Status.SUCCESS,
+                    operation=operation,
+                    message=f"cube materialization on schedule {block.schedule}",
+                ),
+            )
+            return
+
+        # A declared block outside a dry run always comes with a checker; the assert
+        # narrows the Optional for mypy.
+        assert access_checker is not None
+        try:
+            materialization, changed = await reconcile_declared_materialization(
+                self.session,
+                revision,
+                block,
+                access_checker=access_checker,
+                current_user=self.context.current_user,
+            )
+        except DJException as exc:
+            # A cube whose measures queries sit at different grains cannot be
+            # materialized at all. That is this cube's failure, not the
+            # deployment's, so it is recorded and the remaining cubes go on.
+            message = f"Cube `{revision.name}`: {exc.message}"
+            self.errors.append(
+                DJError(
+                    code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
+                    message=message,
+                ),
+            )
+            self.deployed_results.append(
+                DeploymentResult(
+                    name=revision.name,
+                    deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                    status=DeploymentResult.Status.FAILED,
+                    operation=DeploymentResult.Operation.UNKNOWN,
+                    message=message,
+                ),
+            )
+            return
+
+        if changed:
+            # The block can be unchanged while the built config is not -- a cube
+            # materialized outside YAML, or one whose definition moved underneath an
+            # untouched schedule.
+            if operation == DeploymentResult.Operation.NOOP:
+                operation = DeploymentResult.Operation.UPDATE
+            self.session.add(
+                History(
+                    entity_type=EntityType.MATERIALIZATION,
+                    entity_name=materialization.name,
+                    node=revision.name,
+                    activity_type=(
+                        ActivityType.CREATE
+                        if operation == DeploymentResult.Operation.CREATE
+                        else ActivityType.UPDATE
+                    ),
+                    details={
+                        "materialization": materialization.name,
+                        "schedule": block.schedule,
+                        "strategy": block.strategy.value,
+                        "lookback_window": block.lookback_window,
+                    },
+                    user=self._history_user,
+                ),
+            )
+            # Nothing is superseded: the row was updated in place, so the workflow it
+            # names is replaced by scheduling it again rather than stopped.
+            self._cube_materialization_swaps.append(
+                CubeMaterializationSwap(
+                    cube_name=revision.name,
+                    previous_version=revision.version,
+                    new_revision_id=revision.id,
+                    new_version=revision.version,
+                    rebuilt_names=[materialization.name],
+                    superseded=[],
+                ),
+            )
+        self.deployed_results.append(
+            DeploymentResult(
+                name=revision.name,
+                deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                status=DeploymentResult.Status.SUCCESS,
+                operation=operation,
+                message=f"cube materialization on schedule {block.schedule}",
+            ),
+        )
+
+    def _remove_cube_materialization(
+        self,
+        name: str,
+        revision: NodeRevision | None,
+    ) -> None:
+        """
+        Tear down one cube's materialization because it declared
+        `materialization: null`.
+
+        A revision is only loaded for a cube that has something to tear down, so
+        `None` here is the cube that declared null and was never materialized.
+        Otherwise the rows are deactivated and their workflows stopped after the
+        commit, by the same drain that applies a revision swap -- a swap with nothing
+        rebuilt is exactly a teardown.
+        """
+        if revision is None:
+            self.deployed_results.append(
+                DeploymentResult(
+                    name=name,
+                    deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                    status=DeploymentResult.Status.SUCCESS,
+                    operation=DeploymentResult.Operation.NOOP,
+                    message="cube declares no materialization",
+                ),
+            )
+            return
+        self.deployed_results.append(
+            DeploymentResult(
+                name=name,
+                deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                status=DeploymentResult.Status.SUCCESS,
+                operation=DeploymentResult.Operation.DELETE,
+                message="cube materialization removed by `materialization: null`",
+            ),
+        )
+        if self.dry_run:
+            return
+        active = [mat for mat in revision.materializations if not mat.deactivated_at]
+        for materialization in active:
+            materialization.deactivated_at = UTCDatetime.now(UTC)  # type: ignore
+        self.session.add(
+            History(
+                entity_type=EntityType.MATERIALIZATION,
+                entity_name=revision.name,
+                node=revision.name,
+                activity_type=ActivityType.DELETE,
+                details={
+                    "message": (
+                        "Cube materialization removed by `materialization: null` and "
+                        "its workflows stopped."
+                    ),
+                    "deactivated_materializations": [mat.name for mat in active],
+                },
+                user=self._history_user,
+            ),
+        )
+        self._cube_materialization_swaps.append(
+            CubeMaterializationSwap(
+                cube_name=revision.name,
+                previous_version=revision.version,
+                new_revision_id=revision.id,
+                new_version=revision.version,
+                rebuilt_names=[],
+                superseded=active,
+            ),
+        )
+
+    def _warn_undeclared_materialization(self, name: str) -> None:
+        """
+        Flag a cube that is materialized but says nothing about it in YAML.
+
+        Left running on purpose. The materialization may predate the repo, or have
+        been configured through the UI, and a push that has not caught up yet must
+        not silently stop a live workflow -- so the warning names both ways out
+        instead.
+        """
+        message = (
+            f"Cube `{name}` is materialized but its spec declares no "
+            "`materialization:` block, so the existing materialization was left "
+            "running. Run `dj pull` to adopt it into YAML, or add "
+            "`materialization: null` to remove it."
+        )
+        self.warnings.append(
+            DJError(
+                code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
+                message=message,
+            ),
+        )
+        self.deployed_results.append(
+            DeploymentResult(
+                name=name,
+                deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                status=DeploymentResult.Status.WARNING,
+                operation=DeploymentResult.Operation.NOOP,
+                message=message,
+            ),
+        )
 
     async def _apply_cube_materialization_swaps(self) -> None:
         """

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -61,8 +61,14 @@ from datajunction_server.internal.deployment.validation import (
 )
 from datajunction_server.internal.history import EntityType
 from datajunction_server.internal.impact import propagate_impact
+from datajunction_server.internal.materializations import (
+    CubeMaterializationSwap,
+    apply_cube_materialization_swap,
+    swap_cube_materializations,
+)
 from datajunction_server.internal.nodes import (
     derive_frozen_measures_bulk,
+    is_non_trivial_cube_change,
 )
 from datajunction_server.models.access import ResourceAction
 from datajunction_server.models.base import labelize
@@ -342,6 +348,7 @@ class DeploymentOrchestrator:
         self.warnings: list[DJError] = []
         self.deployed_results: list[DeploymentResult] = []
         self._timer = DeploymentTimer()
+        self._cube_materialization_swaps: list[CubeMaterializationSwap] = []
 
     @property
     def _history_user(self) -> str:
@@ -371,6 +378,10 @@ class DeploymentOrchestrator:
         Returned ``results`` and ``downstream_impacts`` are populated inside
         the SAVEPOINT; Python references stay live after rollback, so dry-run
         callers still get the full impact analysis.
+
+        Cube materialization swaps are the one piece of remote work deferred past
+        the commit, so a deploy that rolls back has asked the query service to
+        neither schedule nor stop anything.
         """
         start_total = time.perf_counter()
         self._timer = DeploymentTimer()
@@ -392,6 +403,7 @@ class DeploymentOrchestrator:
             # `else` only fires when no _DryRunRollback was raised, which
             # implies wet-run — commit the outer transaction.
             await self.session.commit()
+            await self._apply_cube_materialization_swaps()
 
         # Warnings are only surfaced by the failure path (they ride along on
         # DJInvalidDeploymentConfig), so hand them back here too — otherwise a
@@ -2208,6 +2220,14 @@ class DeploymentOrchestrator:
             else:
                 validation_results = await self._bulk_validate_cubes(cubes_to_deploy)
 
+        # The superseded revision of every cube this deploy updates, captured before
+        # `node.current` is repointed below.
+        old_revisions = {
+            spec.rendered_name: existing.current
+            for spec in cubes_to_deploy
+            if (existing := self.registry.nodes.get(spec.rendered_name)) is not None
+        }
+
         with timer.phase("    cubes: create ORM objects"):
             (
                 nodes,
@@ -2226,6 +2246,9 @@ class DeploymentOrchestrator:
             node_obj.current = revision
         self.registry.add_nodes({n.name: n for n in nodes})
 
+        with timer.phase("    cubes: swap materializations"):
+            await self._swap_cube_materializations(old_revisions, revisions)
+
         elapsed_ms = (time.perf_counter() - start) * 1000
         logger.info(
             "Deployed %d cubes in %.3fs",
@@ -2241,6 +2264,67 @@ class DeploymentOrchestrator:
             len(nodes),
         )
         return deployment_results
+
+    async def _swap_cube_materializations(
+        self,
+        old_revisions: dict[str, NodeRevision],
+        new_revisions: list[NodeRevision],
+    ) -> None:
+        """
+        Rebuild each updated cube's materializations against its new revision and
+        retire the old ones.
+
+        Shares `swap_cube_materializations` with `PATCH /nodes/{name}/` so a cube
+        edited through a deploy and the same edit applied through the API land on
+        identical materialization state. Only the DJ-side half runs here; the query
+        service calls are queued and made by `execute` once the deployment is
+        committed. Skipped entirely during dry runs, which must schedule nothing and
+        stop nothing.
+        """
+        if self.dry_run:
+            return
+        swappable = [
+            (old_revision, new_revision)
+            for new_revision in new_revisions
+            if (old_revision := old_revisions.get(new_revision.name)) is not None
+        ]
+        if not swappable:
+            return
+        access_checker = AccessChecker(
+            await AuthContext.from_user(self.session, self.context.current_user),
+        )
+        for old_revision, new_revision in swappable:
+            swap = await swap_cube_materializations(
+                self.session,
+                old_revision,
+                new_revision,
+                access_checker=access_checker,
+                current_user=self.context.current_user,
+                previous_table_usable=not await is_non_trivial_cube_change(
+                    self.session,
+                    old_revision,
+                    new_revision,
+                ),
+            )
+            if swap:
+                self._cube_materialization_swaps.append(swap)
+
+    async def _apply_cube_materialization_swaps(self) -> None:
+        """
+        Hand the deployment's committed cube materialization swaps to the query
+        service. Called only after the outer transaction commits, so a deploy that
+        rolls back has told the query service nothing.
+        """
+        request_headers = (
+            dict(self.context.request.headers) if self.context.request else {}
+        )
+        for swap in self._cube_materialization_swaps:
+            await apply_cube_materialization_swap(
+                self.session,
+                swap,
+                self.context.query_service_client,
+                request_headers=request_headers,
+            )
 
     async def _bulk_validate_cubes(
         self,

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -82,6 +82,7 @@ from datajunction_server.models.deployment import (
     DimensionJoinLinkSpec,
     DimensionReferenceLinkSpec,
     LinkableNodeSpec,
+    MaterializationSpec,
     MetricSpec,
     NodeSpec,
     SourceSpec,
@@ -2280,6 +2281,10 @@ class DeploymentOrchestrator:
         service calls are queued and made by `execute` once the deployment is
         committed. Skipped entirely during dry runs, which must schedule nothing and
         stop nothing.
+
+        A cube that declares `materialization:` supplies it as the rebuild's source of
+        intent, so one push that edits both the definition and the schedule rebuilds
+        once, with the new schedule.
         """
         if self.dry_run:
             return
@@ -2293,6 +2298,7 @@ class DeploymentOrchestrator:
         access_checker = AccessChecker(
             await AuthContext.from_user(self.session, self.context.current_user),
         )
+        declared_specs = self._declared_materializations()
         for old_revision, new_revision in swappable:
             swap = await swap_cube_materializations(
                 self.session,
@@ -2305,9 +2311,42 @@ class DeploymentOrchestrator:
                     old_revision,
                     new_revision,
                 ),
+                declared=declared_specs.get(new_revision.name),
             )
             if swap:
                 self._cube_materialization_swaps.append(swap)
+
+    def _declared_materializations(self) -> dict[str, MaterializationSpec]:
+        """
+        The materialization block each declared cube carries, keyed by rendered name.
+
+        A cube that declares no block is absent from the mapping, which is distinct
+        from one that declares `materialization: null` -- see
+        `_cubes_declaring_no_materialization`. Absence means "not managed here, leave
+        whatever exists alone"; an explicit null means "this cube should not be
+        materialized".
+        """
+        return {
+            spec.rendered_name: spec.materialization
+            for spec in self.deployment_spec.nodes
+            if isinstance(spec, CubeSpec) and spec.materialization is not None
+        }
+
+    def _cubes_declaring_no_materialization(self) -> set[str]:
+        """
+        Rendered names of cubes that explicitly declared `materialization: null`.
+
+        Pydantic keeps the distinction between a field left out and one set to null in
+        `model_fields_set`, which is what lets an author say "tear this down" without
+        every cube that never mentions materialization meaning the same thing.
+        """
+        return {
+            spec.rendered_name
+            for spec in self.deployment_spec.nodes
+            if isinstance(spec, CubeSpec)
+            and spec.materialization is None
+            and "materialization" in spec.model_fields_set
+        }
 
     async def _apply_cube_materialization_swaps(self) -> None:
         """

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2527,6 +2527,12 @@ class DeploymentOrchestrator:
                     message=message,
                 ),
             )
+            # FAILED, not WARNING, even though every other node in the deployment
+            # still deploys and commits. `api/deployments.py` derives the aggregate
+            # status from these, so this is also what makes the deployment `failed`:
+            # a materialization the author asked for and did not get is exactly the
+            # silent gap this feature exists to close, and reporting `success` for it
+            # would reopen it.
             self.deployed_results.append(
                 DeploymentResult(
                     name=revision.name,

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2456,7 +2456,7 @@ class DeploymentOrchestrator:
                     active.get(name, []),
                 )
             elif name in active:
-                self._warn_undeclared_materialization(name)
+                self._warn_undeclared_materialization(name, active[name])
 
     async def _active_cube_materializations(
         self,
@@ -2660,6 +2660,11 @@ class DeploymentOrchestrator:
         a workflow running against the author's stated wish. No active rows -- and no
         revision, for a cube that never deployed -- is the only no-op.
 
+        A cube planner row comes down here too, though nothing else in the deployment
+        path touches one. Everywhere else the reason to leave it alone is that DJ
+        cannot rebuild what it stops; a teardown asks for nothing to be rebuilt, and
+        the row records the workflow names needed to stop it cleanly.
+
         The rows are deactivated and their workflows stopped after the commit, by the
         same drain that applies a revision swap: a swap with nothing rebuilt is
         exactly a teardown.
@@ -2715,20 +2720,35 @@ class DeploymentOrchestrator:
             ),
         )
 
-    def _warn_undeclared_materialization(self, name: str) -> None:
+    def _warn_undeclared_materialization(
+        self,
+        name: str,
+        active: list[Materialization],
+    ) -> None:
         """
         Flag a cube that is materialized but says nothing about it in YAML.
 
         Left running on purpose. The materialization may predate the repo, or have
         been configured through the UI, and a push that has not caught up yet must
-        not silently stop a live workflow -- so the warning names both ways out
-        instead.
+        not silently stop a live workflow -- so the warning names the ways out
+        instead. Which ways those are depends on the dialect: a cube materialized
+        only by the cube planner cannot be adopted into YAML at all, since a
+        `materialization:` block has no way to describe one.
         """
         message = (
-            f"Cube `{name}` is materialized but its spec declares no "
-            "`materialization:` block, so the existing materialization was left "
-            "running. Run `dj pull` to adopt it into YAML, or add "
-            "`materialization: none` to remove it."
+            (
+                f"Cube `{name}` is materialized but its spec declares no "
+                "`materialization:` block, so the existing materialization was left "
+                "running. Run `dj pull` to adopt it into YAML, or add "
+                "`materialization: none` to remove it."
+            )
+            if any(not materialization.is_cube_planner for materialization in active)
+            else (
+                f"Cube `{name}` is materialized by the cube planner, which a "
+                "`materialization:` block cannot describe, so the existing "
+                "materialization was left running. Add `materialization: none` to "
+                "remove it."
+            )
         )
         self.warnings.append(
             DJError(

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2493,94 +2493,83 @@ class DeploymentOrchestrator:
             if persisted != block
             else DeploymentResult.Operation.NOOP
         )
-        if self.dry_run:
-            self.deployed_results.append(
-                DeploymentResult(
-                    name=revision.name,
-                    deploy_type=DeploymentResult.Type.MATERIALIZATION,
-                    status=DeploymentResult.Status.SUCCESS,
-                    operation=operation,
-                    message=f"cube materialization on schedule {block.schedule}",
-                ),
-            )
-            return
-
-        # A declared block outside a dry run always comes with a checker; the assert
-        # narrows the Optional for mypy.
-        assert access_checker is not None
-        try:
-            materialization, changed = await reconcile_declared_materialization(
-                self.session,
-                revision,
-                block,
-                access_checker=access_checker,
-                current_user=self.context.current_user,
-            )
-        except DJException as exc:
-            # A cube whose measures queries sit at different grains cannot be
-            # materialized at all. That is this cube's failure, not the
-            # deployment's, so it is recorded and the remaining cubes go on.
-            message = f"Cube `{revision.name}`: {exc.message}"
-            self.errors.append(
-                DJError(
-                    code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
-                    message=message,
-                ),
-            )
-            # FAILED, not WARNING, even though every other node in the deployment
-            # still deploys and commits. `api/deployments.py` derives the aggregate
-            # status from these, so this is also what makes the deployment `failed`:
-            # a materialization the author asked for and did not get is exactly the
-            # silent gap this feature exists to close, and reporting `success` for it
-            # would reopen it.
-            self.deployed_results.append(
-                DeploymentResult(
-                    name=revision.name,
-                    deploy_type=DeploymentResult.Type.MATERIALIZATION,
-                    status=DeploymentResult.Status.FAILED,
-                    operation=DeploymentResult.Operation.UNKNOWN,
-                    message=message,
-                ),
-            )
-            return
-
-        if changed:
-            # The block can be unchanged while the built config is not -- a cube
-            # materialized outside YAML, or one whose definition moved underneath an
-            # untouched schedule.
-            if operation == DeploymentResult.Operation.NOOP:
-                operation = DeploymentResult.Operation.UPDATE
-            self.session.add(
-                History(
-                    entity_type=EntityType.MATERIALIZATION,
-                    entity_name=materialization.name,
-                    node=revision.name,
-                    activity_type=(
-                        ActivityType.CREATE
-                        if operation == DeploymentResult.Operation.CREATE
-                        else ActivityType.UPDATE
+        if not self.dry_run:
+            # A declared block outside a dry run always comes with a checker; the
+            # assert narrows the Optional for mypy.
+            assert access_checker is not None
+            try:
+                materialization, changed = await reconcile_declared_materialization(
+                    self.session,
+                    revision,
+                    block,
+                    access_checker=access_checker,
+                    current_user=self.context.current_user,
+                )
+            except DJException as exc:
+                # A cube whose measures queries sit at different grains cannot be
+                # materialized at all. That is this cube's failure, not the
+                # deployment's, so it is recorded and the remaining cubes go on.
+                message = f"Cube `{revision.name}`: {exc.message}"
+                self.errors.append(
+                    DJError(
+                        code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
+                        message=message,
                     ),
-                    details={
-                        "materialization": materialization.name,
-                        "schedule": block.schedule,
-                        "strategy": block.strategy.value,
-                        "lookback_window": block.lookback_window,
-                    },
-                    user=self._history_user,
-                ),
-            )
-            # Nothing is superseded: the row was updated in place, so the workflow it
-            # names is replaced by scheduling it again rather than stopped.
-            self._cube_materialization_swaps.append(
-                CubeMaterializationSwap(
-                    cube_name=revision.name,
-                    previous_version=revision.version,
-                    new_revision_id=revision.id,
-                    new_version=revision.version,
-                    rebuilt_names=[materialization.name],
-                    superseded=[],
-                ),
-            )
+                )
+                # FAILED, not WARNING, even though every other node in the deployment
+                # still deploys and commits. `api/deployments.py` derives the
+                # aggregate status from these, so this is also what makes the
+                # deployment `failed`: a materialization the author asked for and did
+                # not get is exactly the silent gap this feature exists to close, and
+                # reporting `success` for it would reopen it.
+                self.deployed_results.append(
+                    DeploymentResult(
+                        name=revision.name,
+                        deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                        status=DeploymentResult.Status.FAILED,
+                        operation=DeploymentResult.Operation.UNKNOWN,
+                        message=message,
+                    ),
+                )
+                return
+
+            if changed:
+                # The block can be unchanged while the built config is not -- a cube
+                # materialized outside YAML, or one whose definition moved underneath
+                # an untouched schedule.
+                if operation == DeploymentResult.Operation.NOOP:
+                    operation = DeploymentResult.Operation.UPDATE
+                self.session.add(
+                    History(
+                        entity_type=EntityType.MATERIALIZATION,
+                        entity_name=materialization.name,
+                        node=revision.name,
+                        activity_type=(
+                            ActivityType.CREATE
+                            if operation == DeploymentResult.Operation.CREATE
+                            else ActivityType.UPDATE
+                        ),
+                        details={
+                            "materialization": materialization.name,
+                            "schedule": block.schedule,
+                            "strategy": block.strategy.value,
+                            "lookback_window": block.lookback_window,
+                        },
+                        user=self._history_user,
+                    ),
+                )
+                # Nothing is superseded: the row was updated in place, so the workflow
+                # it names is replaced by scheduling it again rather than stopped.
+                self._cube_materialization_swaps.append(
+                    CubeMaterializationSwap(
+                        cube_name=revision.name,
+                        previous_version=revision.version,
+                        new_revision_id=revision.id,
+                        new_version=revision.version,
+                        rebuilt_names=[materialization.name],
+                        superseded=[],
+                    ),
+                )
         self.deployed_results.append(
             DeploymentResult(
                 name=revision.name,

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -26,6 +26,7 @@ from datajunction_server.database.column import Column, ColumnAttribute
 from datajunction_server.database.dimensionlink import DimensionLink, JoinType
 from datajunction_server.database.hierarchy import Hierarchy, HierarchyLevel
 from datajunction_server.database.history import History
+from datajunction_server.database.materialization import Materialization
 from datajunction_server.database.metricmetadata import MetricMetadata
 from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.node import MissingParent, NodeRelationship
@@ -2383,6 +2384,12 @@ class DeploymentOrchestrator:
         the repo may simply not have caught up yet, and a live workflow must not be
         torn down by omission.
 
+        What a cube has materialized is read from its rows, not from the declarative
+        projection of them. `to_spec` only projects the fused cube dialect, so a cube
+        materialized by any other job -- a legacy `druid_measures_cube`, say -- reads
+        there as unmaterialized, and both the teardown and the warning would then
+        answer for a workflow that is very much running.
+
         Remote work is queued onto `self._cube_materialization_swaps` and handed to
         the query service by `execute` after the commit, so a deploy that rolls back
         -- every dry run -- has asked it to schedule nothing and stop nothing.
@@ -2399,7 +2406,8 @@ class DeploymentOrchestrator:
         removing = self._cubes_declaring_no_materialization()
 
         # What each cube's materialization looked like before this deploy, in the
-        # same declarative shape the block is written in. Taken from the plan rather
+        # same declarative shape the block is written in. Only ever used to report
+        # the operation a declared block performs, and taken from the plan rather
         # than from the revision because a cube that got a new revision this deploy
         # has already had its materialization rebuilt onto it by
         # `_swap_cube_materializations`, and a dry run skips that rebuild entirely --
@@ -2409,16 +2417,20 @@ class DeploymentOrchestrator:
             for name in cube_names
             if isinstance(existing := plan.existing_specs.get(name), CubeSpec)
         }
-        # A cube that neither declares a block nor has one to tear down needs no
-        # revision loaded, which keeps a no-change push over a namespace full of
-        # cubes free of extra work.
-        revisions = await self._cube_revisions_to_reconcile(
-            [
-                name
-                for name in cube_names
-                if name in declared
-                or (name in removing and persisted.get(name) is not None)
-            ],
+        # A cube absent from the registry never made it into the deployment -- it
+        # failed validation, say.
+        revisions = {
+            name: node.current
+            for name in cube_names
+            if (node := self.registry.nodes.get(name)) is not None
+            and node.current is not None
+        }
+        active = await self._active_cube_materializations(revisions)
+        # Only a rebuild reads a revision's columns, partitions and cube elements, so
+        # only a declared cube pays for loading them. That keeps a no-change push over
+        # a namespace full of cubes free of extra work.
+        await self._load_cube_rebuild_state(
+            [revisions[name] for name in declared if name in revisions],
         )
         access_checker = (
             AccessChecker(
@@ -2438,36 +2450,65 @@ class DeploymentOrchestrator:
                         access_checker,
                     )
             elif name in removing:
-                self._remove_cube_materialization(name, revision)
-            elif persisted.get(name) is not None:
+                self._remove_cube_materialization(
+                    name,
+                    revision,
+                    active.get(name, []),
+                )
+            elif name in active:
                 self._warn_undeclared_materialization(name)
 
-    async def _cube_revisions_to_reconcile(
+    async def _active_cube_materializations(
         self,
-        cube_names: list[str],
-    ) -> dict[str, NodeRevision]:
+        revisions: dict[str, NodeRevision],
+    ) -> dict[str, list[Materialization]]:
         """
-        The current revision of each named cube that exists, with everything a
-        rebuild reads eagerly loaded.
+        The active materializations of each named cube that has any.
 
-        A cube absent from the registry never made it into the deployment -- it
-        failed validation, say -- and one whose revision was created moments ago has
-        nothing loaded on it, so the identity map is warmed in a single query rather
-        than lazy-loading per cube from async code.
+        One query for the whole deployment, and a cheap one: what the teardown and
+        the warning need to know is which rows exist, not what any revision they hang
+        off looks like.
         """
-        revisions = {
-            name: node.current
-            for name in cube_names
-            if (node := self.registry.nodes.get(name)) is not None
-            and node.current is not None
+        rows = (
+            (
+                await self.session.execute(
+                    select(Materialization).where(
+                        Materialization.node_revision_id.in_(
+                            [revision.id for revision in revisions.values()],
+                        ),
+                        Materialization.deactivated_at.is_(None),
+                    ),
+                )
+            )
+            .scalars()
+            .all()
+        )
+        by_revision: dict[int, list[Materialization]] = {}
+        for row in rows:
+            by_revision.setdefault(row.node_revision_id, []).append(row)
+        return {
+            name: by_revision[revision.id]
+            for name, revision in revisions.items()
+            if revision.id in by_revision
         }
+
+    async def _load_cube_rebuild_state(
+        self,
+        revisions: list[NodeRevision],
+    ) -> None:
+        """
+        Warm everything a materialization rebuild reads off the given revisions.
+
+        A revision created moments ago has nothing loaded on it, and a lazy load from
+        async code would fail, so the identity map is filled in a single query rather
+        than one per cube.
+        """
         if revisions:
             await self.session.execute(
                 select(NodeRevision)
-                .where(NodeRevision.id.in_([rev.id for rev in revisions.values()]))
+                .where(NodeRevision.id.in_([rev.id for rev in revisions]))
                 .options(*NodeRevision.cube_load_options()),
             )
-        return revisions
 
     async def _declare_cube_materialization(
         self,
@@ -2584,18 +2625,23 @@ class DeploymentOrchestrator:
         self,
         name: str,
         revision: NodeRevision | None,
+        active: list[Materialization],
     ) -> None:
         """
         Tear down one cube's materialization because it declared
         `materialization: none`.
 
-        A revision is only loaded for a cube that has something to tear down, so
-        `None` here is the cube that declared null and was never materialized.
-        Otherwise the rows are deactivated and their workflows stopped after the
-        commit, by the same drain that applies a revision swap -- a swap with nothing
-        rebuilt is exactly a teardown.
+        Whatever the cube has active is what comes down, whichever job wrote it: the
+        author asked for this cube not to be materialized, and answering that with a
+        no-op because the rows happen to be of a dialect YAML cannot describe leaves
+        a workflow running against the author's stated wish. No active rows -- and no
+        revision, for a cube that never deployed -- is the only no-op.
+
+        The rows are deactivated and their workflows stopped after the commit, by the
+        same drain that applies a revision swap: a swap with nothing rebuilt is
+        exactly a teardown.
         """
-        if revision is None:
+        if revision is None or not active:
             self.deployed_results.append(
                 DeploymentResult(
                     name=name,
@@ -2617,7 +2663,6 @@ class DeploymentOrchestrator:
         )
         if self.dry_run:
             return
-        active = [mat for mat in revision.materializations if not mat.deactivated_at]
         for materialization in active:
             materialization.deactivated_at = UTCDatetime.now(UTC)  # type: ignore
         self.session.add(

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2539,7 +2539,11 @@ class DeploymentOrchestrator:
             # assert narrows the Optional for mypy.
             assert access_checker is not None
             try:
-                materialization, changed = await reconcile_declared_materialization(
+                (
+                    materialization,
+                    changed,
+                    superseded,
+                ) = await reconcile_declared_materialization(
                     self.session,
                     revision,
                     block,
@@ -2595,12 +2599,31 @@ class DeploymentOrchestrator:
                             "schedule": block.schedule,
                             "strategy": block.strategy.value,
                             "lookback_window": block.lookback_window,
+                            "superseded_materializations": [
+                                mat.name for mat in superseded
+                            ],
                         },
                         user=self._history_user,
                     ),
                 )
-                # Nothing is superseded: the row was updated in place, so the workflow
-                # it names is replaced by scheduling it again rather than stopped.
+                if superseded:
+                    # Stopped before the declared materialization is scheduled, and as
+                    # its own unit of work, because both sit on the same cube version:
+                    # a superseded row with no workflow names of its own falls back to
+                    # the stop-by-cube-and-version endpoint, which would take the
+                    # replacement down with it if that had already been scheduled.
+                    self._cube_materialization_swaps.append(
+                        CubeMaterializationSwap(
+                            cube_name=revision.name,
+                            previous_version=revision.version,
+                            new_revision_id=revision.id,
+                            new_version=revision.version,
+                            rebuilt_names=[],
+                            superseded=superseded,
+                        ),
+                    )
+                # The row itself was updated in place, so the workflow it names is
+                # replaced by scheduling it again rather than stopped.
                 self._cube_materialization_swaps.append(
                     CubeMaterializationSwap(
                         cube_name=revision.name,

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -84,6 +84,7 @@ from datajunction_server.models.deployment import (
     DimensionJoinLinkSpec,
     DimensionReferenceLinkSpec,
     LinkableNodeSpec,
+    MaterializationAction,
     MaterializationSpec,
     MetricSpec,
     NodeSpec,
@@ -2337,31 +2338,32 @@ class DeploymentOrchestrator:
         The materialization block each declared cube carries, keyed by rendered name.
 
         A cube that declares no block is absent from the mapping, which is distinct
-        from one that declares `materialization: null` -- see
+        from one that declares `materialization: none` -- see
         `_cubes_declaring_no_materialization`. Absence means "not managed here, leave
-        whatever exists alone"; an explicit null means "this cube should not be
+        whatever exists alone"; the sentinel means "this cube should not be
         materialized".
         """
         return {
             spec.rendered_name: spec.materialization
             for spec in self.deployment_spec.nodes
-            if isinstance(spec, CubeSpec) and spec.materialization is not None
+            if isinstance(spec, CubeSpec)
+            and isinstance(spec.materialization, MaterializationSpec)
         }
 
     def _cubes_declaring_no_materialization(self) -> set[str]:
         """
-        Rendered names of cubes that explicitly declared `materialization: null`.
+        Rendered names of cubes that declared `materialization: none`.
 
-        Pydantic keeps the distinction between a field left out and one set to null in
-        `model_fields_set`, which is what lets an author say "tear this down" without
-        every cube that never mentions materialization meaning the same thing.
+        Teardown is keyed on that sentinel rather than on the `materialization` key
+        being present and null, so that it survives serialization: `model_dump` emits
+        every optional field explicitly, and a spec round-tripped through it would
+        otherwise read as every cube in the namespace asking to be torn down.
         """
         return {
             spec.rendered_name
             for spec in self.deployment_spec.nodes
             if isinstance(spec, CubeSpec)
-            and spec.materialization is None
-            and "materialization" in spec.model_fields_set
+            and spec.materialization is MaterializationAction.NONE
         }
 
     async def _reconcile_cube_materializations(self, plan: DeploymentPlan) -> None:
@@ -2376,7 +2378,7 @@ class DeploymentOrchestrator:
         Iterating every declared cube also corrects a materialization that was
         changed outside YAML.
 
-        Only an explicit `materialization: null` removes anything. A cube that
+        Only an explicit `materialization: none` removes anything. A cube that
         declares no block but has one materialized keeps it and earns a warning:
         the repo may simply not have caught up yet, and a live workflow must not be
         torn down by omission.
@@ -2402,7 +2404,7 @@ class DeploymentOrchestrator:
         # has already had its materialization rebuilt onto it by
         # `_swap_cube_materializations`, and a dry run skips that rebuild entirely --
         # reading the revision would make the two disagree.
-        persisted: dict[str, MaterializationSpec | None] = {
+        persisted: dict[str, MaterializationSpec | MaterializationAction | None] = {
             name: existing.materialization
             for name in cube_names
             if isinstance(existing := plan.existing_specs.get(name), CubeSpec)
@@ -2471,7 +2473,7 @@ class DeploymentOrchestrator:
         self,
         revision: NodeRevision,
         block: MaterializationSpec,
-        persisted: MaterializationSpec | None,
+        persisted: MaterializationSpec | MaterializationAction | None,
         access_checker: AccessChecker | None,
     ) -> None:
         """
@@ -2590,7 +2592,7 @@ class DeploymentOrchestrator:
     ) -> None:
         """
         Tear down one cube's materialization because it declared
-        `materialization: null`.
+        `materialization: none`.
 
         A revision is only loaded for a cube that has something to tear down, so
         `None` here is the cube that declared null and was never materialized.
@@ -2615,7 +2617,7 @@ class DeploymentOrchestrator:
                 deploy_type=DeploymentResult.Type.MATERIALIZATION,
                 status=DeploymentResult.Status.SUCCESS,
                 operation=DeploymentResult.Operation.DELETE,
-                message="cube materialization removed by `materialization: null`",
+                message="cube materialization removed by `materialization: none`",
             ),
         )
         if self.dry_run:
@@ -2631,7 +2633,7 @@ class DeploymentOrchestrator:
                 activity_type=ActivityType.DELETE,
                 details={
                     "message": (
-                        "Cube materialization removed by `materialization: null` and "
+                        "Cube materialization removed by `materialization: none` and "
                         "its workflows stopped."
                     ),
                     "deactivated_materializations": [mat.name for mat in active],
@@ -2663,7 +2665,7 @@ class DeploymentOrchestrator:
             f"Cube `{name}` is materialized but its spec declares no "
             "`materialization:` block, so the existing materialization was left "
             "running. Run `dj pull` to adopt it into YAML, or add "
-            "`materialization: null` to remove it."
+            "`materialization: none` to remove it."
         )
         self.warnings.append(
             DJError(

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -32,6 +32,7 @@ from datajunction_server.internal.sql import (
 from datajunction_server.materialization.jobs import MaterializationJob
 from datajunction_server.models.column import SemanticType
 from datajunction_server.models.cube_materialization import UpsertCubeMaterialization
+from datajunction_server.models.deployment import MaterializationSpec
 from datajunction_server.models.materialization import (
     DruidCubeConfigInput,
     DruidMeasuresCubeConfig,
@@ -381,6 +382,91 @@ class CubeMaterializationSwap:
     superseded: list[Materialization]
 
 
+def _apply_declared_spec(
+    upsert: UpsertCubeMaterialization | UpsertMaterialization,
+    declared: MaterializationSpec,
+) -> UpsertCubeMaterialization | UpsertMaterialization:
+    """
+    Let a cube's declared YAML block win over the intent recovered from the
+    persisted materialization.
+
+    A cube that declares `materialization:` has its config in the repo, so a rebuild
+    triggered by the same deploy must build what the YAML now says rather than what
+    the superseded revision happened to be built with -- otherwise editing a metric
+    and the schedule in one push would rebuild with the old schedule. Only cube
+    materializations can be declared; anything else keeps its recovered intent.
+    """
+    if isinstance(upsert, UpsertCubeMaterialization):
+        return upsert.model_copy(
+            update={
+                "schedule": declared.schedule,
+                "strategy": declared.strategy,
+                "lookback_window": declared.lookback_window,
+            },
+        )
+    return upsert  # pragma: no cover
+
+
+async def reconcile_declared_materialization(
+    session: AsyncSession,
+    revision: NodeRevision,
+    declared: MaterializationSpec,
+    *,
+    access_checker: AccessChecker,
+    current_user: User,
+) -> tuple[Materialization, bool]:
+    """
+    Bring a cube revision's materialization in line with its declared block.
+
+    Returns the materialization and whether anything actually changed, so a deploy
+    that re-declares what is already configured can skip the query service entirely.
+
+    Mirrors what `POST /nodes/{name}/materialization/` does -- build the config, then
+    update the row of the same name in place rather than inserting a second one,
+    since `(name, node_revision_id)` is unique -- with one deliberate difference. The
+    endpoint decides "unchanged" on `config` alone, but `schedule` and `strategy` are
+    columns rather than config keys, so by that test a schedule-only edit compares
+    equal and is silently dropped. Rescheduling is the whole point of a declared
+    block, so all three are compared here.
+    """
+    built = await create_new_materialization(
+        session,
+        revision,
+        UpsertCubeMaterialization(
+            job=MaterializationJobTypeEnum.DRUID_CUBE.value.name,  # type: ignore
+            strategy=declared.strategy,
+            schedule=declared.schedule,
+            lookback_window=declared.lookback_window,
+        ),
+        access_checker,
+        current_user=current_user,
+    )
+    existing = next(
+        (mat for mat in revision.materializations if mat.name == built.name),
+        None,
+    )
+    if existing is None:
+        session.add(built)
+        return built, True
+
+    # `create_new_materialization` sets the backref, which would insert a duplicate
+    # row alongside the one being updated.
+    built.node_revision = None  # type: ignore
+    unchanged = (
+        existing.config == built.config
+        and existing.schedule == built.schedule
+        and existing.strategy == built.strategy
+        and existing.deactivated_at is None
+    )
+    if unchanged:
+        return existing, False
+    existing.config = built.config
+    existing.schedule = built.schedule
+    existing.strategy = built.strategy
+    existing.deactivated_at = None
+    return existing, True
+
+
 async def swap_cube_materializations(
     session: AsyncSession,
     old_revision: NodeRevision,
@@ -389,6 +475,7 @@ async def swap_cube_materializations(
     access_checker: AccessChecker,
     current_user: User,
     previous_table_usable: bool,
+    declared: MaterializationSpec | None = None,
 ) -> CubeMaterializationSwap | None:
     """
     Rebuild a cube's materializations against a new revision and retire the old ones.
@@ -402,9 +489,11 @@ async def swap_cube_materializations(
 
     Rebuilt rather than copied: a stored config embeds the cube version plus combiner
     SQL and a Druid spec derived from the old definition, so the new revision goes
-    back through `create_new_materialization`. The old materialization is the source
-    of the user's intent because it is the only record of it -- a cube materialized
-    through the UI has no YAML to read it from.
+    back through `create_new_materialization`. The old materialization is the default
+    source of the user's intent because it is often the only record of it -- a cube
+    materialized through the UI has no YAML to read it from. A cube that does declare
+    `materialization:` passes it as `declared`, which wins, so a push that edits both
+    a metric and the schedule rebuilds with the new schedule rather than the old.
 
     `previous_table_usable` is the caller's answer to whether the superseded
     revision's materialized table is still valid (`is_non_trivial_cube_change`
@@ -436,10 +525,13 @@ async def swap_cube_materializations(
     rebuilt: list[Materialization] = []
     for materialization in superseded:
         try:
+            upsert = _upsert_from_materialization(materialization)
+            if declared:
+                upsert = _apply_declared_spec(upsert, declared)
             new_materialization = await create_new_materialization(
                 session,
                 new_revision,
-                _upsert_from_materialization(materialization),
+                upsert,
                 access_checker,
                 current_user=current_user,
             )

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -2,13 +2,21 @@
 
 import logging
 import zlib
+from dataclasses import dataclass
+from datetime import UTC
 
 from pydantic import ValidationError
+from sqlalchemy import select
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.construction.build import get_default_criteria
 from datajunction_server.construction.build_v2 import QueryBuilder
+from datajunction_server.database.history import (
+    ActivityType,
+    EntityType,
+    History,
+)
 from datajunction_server.database.materialization import Materialization
 from datajunction_server.database.node import NodeRevision
 from datajunction_server.database.user import User
@@ -25,6 +33,7 @@ from datajunction_server.materialization.jobs import MaterializationJob
 from datajunction_server.models.column import SemanticType
 from datajunction_server.models.cube_materialization import UpsertCubeMaterialization
 from datajunction_server.models.materialization import (
+    DruidCubeConfigInput,
     DruidMeasuresCubeConfig,
     DruidMetricsCubeConfig,
     GenericMaterializationConfig,
@@ -42,6 +51,7 @@ from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.ast import CompileContext
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from datajunction_server.sql.parsing.types import TimestampType
+from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import SEPARATOR, session_context
 
 MAX_COLUMN_NAME_LENGTH = 128
@@ -322,6 +332,210 @@ def _materialization_name(
         + (f"__{partition_names[0]}" if temporal_partitions else "")
         + ("__" if categorical_partitions else "")
         + ("__".join(partition_names[len(temporal_partitions) :]))
+    )
+
+
+def _upsert_from_materialization(
+    materialization: Materialization,
+) -> UpsertCubeMaterialization | UpsertMaterialization:
+    """
+    Recover the user's materialization intent from a persisted materialization.
+
+    Only the intent -- job type, strategy, schedule and lookback window -- is
+    carried over; everything else in a stored config is generated content derived
+    from the revision it was built against.
+    """
+    config = materialization.config if isinstance(materialization.config, dict) else {}
+    lookback_window = config.get("lookback_window")
+    job_type = MaterializationJobTypeEnum.find_match(materialization.job)
+    if job_type == MaterializationJobTypeEnum.DRUID_CUBE:
+        return UpsertCubeMaterialization(
+            job=job_type.value.name,  # type: ignore
+            strategy=materialization.strategy,
+            schedule=materialization.schedule,
+            lookback_window=lookback_window,
+        )
+    return UpsertMaterialization(
+        job=job_type.value.name,  # type: ignore
+        strategy=materialization.strategy,
+        schedule=materialization.schedule,
+        config=DruidCubeConfigInput(
+            spark=config.get("spark") or {},
+            lookback_window=lookback_window,
+        ),
+    )
+
+
+@dataclass
+class CubeMaterializationSwap:
+    """
+    The query service work a cube materialization swap still owes, once DJ's own
+    record of the swap is durable.
+    """
+
+    cube_name: str
+    previous_version: str
+    new_revision_id: int
+    new_version: str
+    rebuilt_names: list[str]
+    superseded: list[Materialization]
+
+
+async def swap_cube_materializations(
+    session: AsyncSession,
+    old_revision: NodeRevision,
+    new_revision: NodeRevision,
+    *,
+    access_checker: AccessChecker,
+    current_user: User,
+    previous_table_usable: bool,
+) -> CubeMaterializationSwap | None:
+    """
+    Rebuild a cube's materializations against a new revision and retire the old ones.
+
+    Materializations belong to a single `NodeRevision` and availability is scoped to
+    the revision encoded in the materialized table name, so without this a new cube
+    revision -- including a metadata-only one -- has neither: the cube silently falls
+    back to live queries while the superseded revision's workflow keeps posting
+    availability for a table built from the old definition. Every new revision
+    therefore swaps, no matter how insignificant the change was.
+
+    Rebuilt rather than copied: a stored config embeds the cube version plus combiner
+    SQL and a Druid spec derived from the old definition, so the new revision goes
+    back through `create_new_materialization`. The old materialization is the source
+    of the user's intent because it is the only record of it -- a cube materialized
+    through the UI has no YAML to read it from.
+
+    `previous_table_usable` is the caller's answer to whether the superseded
+    revision's materialized table is still valid (`is_non_trivial_cube_change`
+    inverted), recorded on the history event so an operator can tell whether the
+    rebuild can adopt the existing data or needs a fresh build and backfill.
+
+    Touches only DJ-side state, and returns the query service work still owed --
+    `None` when the cube had nothing materialized and there is no work at all. The
+    caller commits and then hands the result to `apply_cube_materialization_swap`, so
+    a query service that is slow or unreachable can neither hold the transaction open
+    nor leave DJ's record of what is active disagreeing with what was requested.
+    """
+    superseded = [
+        mat for mat in old_revision.materializations if not mat.deactivated_at
+    ]
+    if not superseded:
+        return None
+
+    # The rebuild reads the new revision's columns, partitions and cube elements.
+    # Neither caller is guaranteed to have those loaded -- the API path has just
+    # committed the revision -- and a lazy load from async code would fail, so pull
+    # them in up front.
+    await session.execute(
+        select(NodeRevision)
+        .where(NodeRevision.id == new_revision.id)
+        .options(*NodeRevision.cube_load_options()),
+    )
+
+    rebuilt: list[Materialization] = []
+    for materialization in superseded:
+        try:
+            new_materialization = await create_new_materialization(
+                session,
+                new_revision,
+                _upsert_from_materialization(materialization),
+                access_checker,
+                current_user=current_user,
+            )
+            # `create_new_materialization` only sets the backref, and `new_revision`
+            # is already persisted here, so nothing cascades the new row in for us.
+            session.add(new_materialization)
+            rebuilt.append(new_materialization)
+        except Exception as exc:
+            # A rebuild can become impossible -- e.g. the new revision no longer has
+            # the temporal partition a cube materialization needs. The superseded
+            # workflow still has to be stopped, and the cube edit that triggered the
+            # swap must not fail because its materialization could not be carried
+            # forward, so nothing here is allowed to propagate.
+            _logger.warning(
+                "Cannot rebuild materialization %s for cube=%s version=%s: %s",
+                materialization.name,
+                new_revision.name,
+                new_revision.version,
+                str(exc),
+            )
+    for materialization in superseded:
+        materialization.deactivated_at = UTCDatetime.now(UTC)  # type: ignore
+    session.add(
+        History(
+            entity_type=EntityType.MATERIALIZATION,
+            entity_name=old_revision.name,
+            node=old_revision.name,
+            activity_type=ActivityType.STATUS_CHANGE,
+            details={
+                "message": (
+                    f"Cube updated to {new_revision.version}. Materializations were "
+                    "rebuilt against the new version and the previous version's "
+                    "workflows were stopped."
+                ),
+                "previous_version": old_revision.version,
+                "new_version": new_revision.version,
+                "stopped_materializations": [mat.name for mat in superseded],
+                "rebuilt_materializations": [mat.name for mat in rebuilt],
+                "previous_table_usable": previous_table_usable,
+            },
+            user=current_user.username,
+        ),
+    )
+    await session.flush()
+    return CubeMaterializationSwap(
+        cube_name=old_revision.name,
+        previous_version=old_revision.version,
+        new_revision_id=new_revision.id,
+        new_version=new_revision.version,
+        rebuilt_names=[mat.name for mat in rebuilt],
+        superseded=superseded,
+    )
+
+
+async def apply_cube_materialization_swap(
+    session: AsyncSession,
+    swap: CubeMaterializationSwap,
+    query_service_client: QueryServiceClient | None,
+    request_headers: dict[str, str] | None = None,
+) -> None:
+    """
+    Hand a committed cube materialization swap to the query service.
+
+    The replacement is scheduled before the superseded workflow is stopped, so the
+    cube is never knowingly left with nothing running. The stop happens either way:
+    DJ has already recorded the superseded materializations as inactive, and leaving
+    their workflow running would keep posting availability for a table the current
+    revision cannot use.
+
+    Never raises. With no query service configured there is nothing to do at all.
+    """
+    if not query_service_client:
+        return
+    if swap.rebuilt_names:
+        try:
+            await schedule_materialization_jobs(
+                session,
+                node_revision_id=swap.new_revision_id,
+                materialization_names=swap.rebuilt_names,
+                query_service_client=query_service_client,
+                request_headers=request_headers,
+            )
+        except Exception as exc:
+            _logger.warning(
+                "Failed to schedule rebuilt materializations for cube=%s version=%s: "
+                "%s (continuing)",
+                swap.cube_name,
+                swap.new_version,
+                str(exc),
+            )
+    stop_cube_materialization_workflows(
+        query_service_client=query_service_client,
+        cube_name=swap.cube_name,
+        cube_version=swap.previous_version,
+        materializations=swap.superseded,
+        request_headers=request_headers,
     )
 
 

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -429,6 +429,10 @@ async def reconcile_declared_materialization(
     equal and is silently dropped. Rescheduling is the whole point of a declared
     block, so all three are compared here.
     """
+    # Snapshotted before the build, which sets the new materialization's backref and
+    # so appends it to this very collection -- searching afterwards would find the
+    # build itself, call it unchanged, and then detach it.
+    before = list(revision.materializations)
     built = await create_new_materialization(
         session,
         revision,
@@ -442,7 +446,7 @@ async def reconcile_declared_materialization(
         current_user=current_user,
     )
     existing = next(
-        (mat for mat in revision.materializations if mat.name == built.name),
+        (mat for mat in before if mat.name == built.name),
         None,
     )
     if existing is None:

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -382,31 +382,6 @@ class CubeMaterializationSwap:
     superseded: list[Materialization]
 
 
-def _apply_declared_spec(
-    upsert: UpsertCubeMaterialization | UpsertMaterialization,
-    declared: MaterializationSpec,
-) -> UpsertCubeMaterialization | UpsertMaterialization:
-    """
-    Let a cube's declared YAML block win over the intent recovered from the
-    persisted materialization.
-
-    A cube that declares `materialization:` has its config in the repo, so a rebuild
-    triggered by the same deploy must build what the YAML now says rather than what
-    the superseded revision happened to be built with -- otherwise editing a metric
-    and the schedule in one push would rebuild with the old schedule. Only cube
-    materializations can be declared; anything else keeps its recovered intent.
-    """
-    if isinstance(upsert, UpsertCubeMaterialization):
-        return upsert.model_copy(
-            update={
-                "schedule": declared.schedule,
-                "strategy": declared.strategy,
-                "lookback_window": declared.lookback_window,
-            },
-        )
-    return upsert  # pragma: no cover
-
-
 async def reconcile_declared_materialization(
     session: AsyncSession,
     revision: NodeRevision,
@@ -530,8 +505,19 @@ async def swap_cube_materializations(
     for materialization in superseded:
         try:
             upsert = _upsert_from_materialization(materialization)
-            if declared:
-                upsert = _apply_declared_spec(upsert, declared)
+            if declared and isinstance(upsert, UpsertCubeMaterialization):
+                # The declared block wins over the recovered intent: a cube that
+                # declares `materialization:` has its config in the repo, so a
+                # rebuild triggered by the same deploy must build what the YAML now
+                # says. Only cube materializations can be declared; anything else
+                # keeps what was recovered.
+                upsert = upsert.model_copy(
+                    update={
+                        "schedule": declared.schedule,
+                        "strategy": declared.strategy,
+                        "lookback_window": declared.lookback_window,
+                    },
+                )
             new_materialization = await create_new_materialization(
                 session,
                 new_revision,
@@ -548,13 +534,15 @@ async def swap_cube_materializations(
             # the temporal partition a cube materialization needs. The superseded
             # workflow still has to be stopped, and the cube edit that triggered the
             # swap must not fail because its materialization could not be carried
-            # forward, so nothing here is allowed to propagate.
+            # forward, so nothing here is allowed to propagate. Logged with the
+            # traceback, since this is also where a genuine bug would land silently.
             _logger.warning(
                 "Cannot rebuild materialization %s for cube=%s version=%s: %s",
                 materialization.name,
                 new_revision.name,
                 new_revision.version,
                 str(exc),
+                exc_info=True,
             )
     for materialization in superseded:
         materialization.deactivated_at = UTCDatetime.now(UTC)  # type: ignore
@@ -625,6 +613,7 @@ async def apply_cube_materialization_swap(
                 swap.cube_name,
                 swap.new_version,
                 str(exc),
+                exc_info=True,
             )
     stop_cube_materialization_workflows(
         query_service_client=query_service_client,

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -415,6 +415,10 @@ async def reconcile_declared_materialization(
     derived from job, strategy and partition, so declaring a strategy the cube was
     not already materialized with builds a differently named row, and without this
     the cube ends up with two live workflows deleting each other's data.
+
+    A cube planner row is the one thing left alone. It writes a datasource of its own
+    and DJ cannot rebuild it from a declared block, so superseding it would stop a
+    workflow nothing here can replace.
     """
     # Snapshotted before the build, which sets the new materialization's backref and
     # so appends it to this very collection -- searching afterwards would find the
@@ -437,7 +441,9 @@ async def reconcile_declared_materialization(
         None,
     )
     superseded = [
-        mat for mat in before if mat.name != built.name and not mat.deactivated_at
+        mat
+        for mat in before
+        if mat.name != built.name and not mat.deactivated_at and not mat.is_cube_planner
     ]
     for materialization in superseded:
         materialization.deactivated_at = UTCDatetime.now(UTC)  # type: ignore
@@ -503,8 +509,17 @@ async def swap_cube_materializations(
     a query service that is slow or unreachable can neither hold the transaction open
     nor leave DJ's record of what is active disagreeing with what was requested.
     """
+    # A cube planner row is not swapped. It is written by `POST
+    # /cubes/{name}/materialize` in a dialect this rebuild cannot produce -- and,
+    # since both dialects are stored under the same job class, feeding one through
+    # here recovers it as a fused materialization: the planner's workflow stopped, a
+    # fused one scheduled in its place, and a name that collides with the fused row
+    # of a cube that has both. Left where it is until the planner is asked to rebuild
+    # it, which is the only thing that can.
     superseded = [
-        mat for mat in old_revision.materializations if not mat.deactivated_at
+        mat
+        for mat in old_revision.materializations
+        if not mat.deactivated_at and not mat.is_cube_planner
     ]
     if not superseded:
         return None

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -389,12 +389,13 @@ async def reconcile_declared_materialization(
     *,
     access_checker: AccessChecker,
     current_user: User,
-) -> tuple[Materialization, bool]:
+) -> tuple[Materialization, bool, list[Materialization]]:
     """
     Bring a cube revision's materialization in line with its declared block.
 
-    Returns the materialization and whether anything actually changed, so a deploy
-    that re-declares what is already configured can skip the query service entirely.
+    Returns the materialization, whether anything actually changed -- so a deploy
+    that re-declares what is already configured can skip the query service entirely
+    -- and the materializations the block superseded.
 
     Mirrors what `POST /nodes/{name}/materialization/` does -- build the config, then
     update the row of the same name in place rather than inserting a second one,
@@ -403,6 +404,17 @@ async def reconcile_declared_materialization(
     columns rather than config keys, so by that test a schedule-only edit compares
     equal and is silently dropped. Rescheduling is the whole point of a declared
     block, so all three are compared here.
+
+    A declared block describes *the* materialization for its cube, so every other
+    active row on the revision is deactivated. The rule is "any active row whose name
+    the block did not build" rather than "any row of the same job type", because a
+    cube's materializations are all writing one Druid datasource and a full rebuild
+    replaces that datasource wholesale -- so a legacy `druid_measures_cube` row is
+    just as much a competing writer as a second `druid_cube` row, and matching on job
+    type would leave it running. The name is what carries the difference: it is
+    derived from job, strategy and partition, so declaring a strategy the cube was
+    not already materialized with builds a differently named row, and without this
+    the cube ends up with two live workflows deleting each other's data.
     """
     # Snapshotted before the build, which sets the new materialization's backref and
     # so appends it to this very collection -- searching afterwards would find the
@@ -424,9 +436,14 @@ async def reconcile_declared_materialization(
         (mat for mat in before if mat.name == built.name),
         None,
     )
+    superseded = [
+        mat for mat in before if mat.name != built.name and not mat.deactivated_at
+    ]
+    for materialization in superseded:
+        materialization.deactivated_at = UTCDatetime.now(UTC)  # type: ignore
     if existing is None:
         session.add(built)
-        return built, True
+        return built, True, superseded
 
     # `create_new_materialization` sets the backref, which would insert a duplicate
     # row alongside the one being updated.
@@ -436,14 +453,15 @@ async def reconcile_declared_materialization(
         and existing.schedule == built.schedule
         and existing.strategy == built.strategy
         and existing.deactivated_at is None
+        and not superseded
     )
     if unchanged:
-        return existing, False
+        return existing, False, superseded
     existing.config = built.config
     existing.schedule = built.schedule
     existing.strategy = built.strategy
     existing.deactivated_at = None
-    return existing, True
+    return existing, True, superseded
 
 
 async def swap_cube_materializations(
@@ -525,6 +543,14 @@ async def swap_cube_materializations(
                 access_checker,
                 current_user=current_user,
             )
+            if new_materialization.name in {mat.name for mat in rebuilt}:
+                # Two superseded rows can rebuild to one name -- a cube left with both
+                # a `full` and an `incremental_time` materialization, rebuilt under a
+                # declared block that names one strategy for both. `(name,
+                # node_revision_id)` is unique, so the second is dropped rather than
+                # failing the whole cube edit on an integrity error.
+                new_materialization.node_revision = None  # type: ignore
+                continue
             # `create_new_materialization` only sets the backref, and `new_revision`
             # is already persisted here, so nothing cascades the new row in for us.
             session.add(new_materialization)

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -255,6 +255,12 @@ async def create_new_materialization(
 ) -> Materialization:
     """
     Create a new materialization based on the input values.
+
+    Returns an unpersisted row whose `node_revision` backref is set but which is not
+    added to the session. Callers depend on both halves of that: they `session.add()`
+    the ones they mean to keep, and clear `node_revision` on the ones they do not, to
+    keep the backref from cascading in a row they are about to discard or fold into an
+    existing one. Adding the row here would insert those too.
     """
     generic_config = None
     try:
@@ -527,12 +533,21 @@ async def swap_cube_materializations(
     # The rebuild reads the new revision's columns, partitions and cube elements.
     # Neither caller is guaranteed to have those loaded -- the API path has just
     # committed the revision -- and a lazy load from async code would fail, so pull
-    # them in up front.
-    await session.execute(
-        select(NodeRevision)
-        .where(NodeRevision.id == new_revision.id)
-        .options(*NodeRevision.cube_load_options()),
+    # them in up front. The result is reassigned rather than discarded: the query
+    # would otherwise look dead, when what it is doing is populating the very
+    # instance the rest of this function walks.
+    loaded = (
+        (
+            await session.execute(
+                select(NodeRevision)
+                .where(NodeRevision.id == new_revision.id)
+                .options(*NodeRevision.cube_load_options()),
+            )
+        )
+        .unique()
+        .scalar_one_or_none()
     )
+    new_revision = loaded or new_revision
 
     rebuilt: list[Materialization] = []
     for materialization in superseded:

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -66,9 +66,10 @@ from datajunction_server.internal.access.authorization.context import AuthContex
 from datajunction_server.internal.caching.interface import Cache
 from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.internal.materializations import (
+    apply_cube_materialization_swap,
     create_new_materialization,
     schedule_materialization_jobs_bg,
-    stop_cube_materialization_workflows,
+    swap_cube_materializations,
 )
 from datajunction_server.internal.validation import (
     NodeValidator,
@@ -1685,6 +1686,13 @@ async def is_non_trivial_cube_change(
     asks whether the previously materialized table is still usable. The two can and
     do diverge -- reordering dimensions earns a minor bump but leaves the table
     valid, while a filters change is major and invalidates it.
+
+    It no longer decides whether the superseded revision's workflows are stopped:
+    `swap_cube_materializations` does that on every new revision, because a revision
+    that keeps neither its materialization nor its availability cannot be left
+    pointing at another revision's running workflow. What remains is the
+    adopt-or-backfill question -- whether the rebuilt materialization can reuse the
+    previous revision's data -- which the swap records on its history event.
     """
     if set(old_revision.cube_dimensions()) != set(new_revision.cube_dimensions()):
         return True
@@ -1844,74 +1852,36 @@ async def update_cube_node(
                     granularity=col.partition.granularity,
                 )
 
-        # Materializations are not migrated to the new revision. When the new
-        # revision is non-trivially different, the previous revision's workflows are
-        # also stopped: left running, they keep posting fresh availability for a
-        # table built from the old definition, and that stale-but-live availability
-        # record can then be used to route queries against the new revision,
-        # producing column-not-found errors.
-        #
-        # "default"-named materializations are included: they are legacy Druid
-        # materializations that post availability just like any other, so leaving
-        # them running reproduces exactly the failure we are preventing.
-        active_materializations = [
-            mat for mat in node_revision.materializations if not mat.deactivated_at
-        ]
-        materializations_to_stop = (
-            active_materializations
-            if active_materializations
-            and await is_non_trivial_cube_change(
-                session,
-                node_revision,
-                new_cube_revision,
-            )
-            else []
-        )
-        if materializations_to_stop:
-            for mat in materializations_to_stop:
-                mat.deactivated_at = UTCDatetime.now(UTC)  # type: ignore
-            await save_history(
-                event=History(
-                    entity_type=EntityType.MATERIALIZATION,
-                    entity_name=node_revision.name,
-                    node=node_revision.name,
-                    activity_type=ActivityType.STATUS_CHANGE,
-                    details={
-                        "message": (
-                            f"Cube updated to {new_cube_revision.version}. "
-                            "Materializations from the previous version were stopped "
-                            "because the cube changed non-trivially. Please set up "
-                            "materializations again if you want to continue "
-                            "materializing this cube."
-                        ),
-                        "previous_version": node_revision.version,
-                        "new_version": new_cube_revision.version,
-                        "stopped_materializations": [
-                            mat.name for mat in materializations_to_stop
-                        ],
-                    },
-                    user=current_user.username,
-                ),
-                session=session,
-            )
-
         session.add(new_cube_revision)
         session.add(new_cube_revision.node)
         await session.commit()
 
-    # Stop the remote workflows only once DJ's own state is committed, so a slow or
-    # failing query service can neither hold the transaction open nor leave DJ
-    # claiming the old materializations are still active. The call is batched rather
-    # than per-materialization: these are blocking HTTP requests, so a loop would
-    # stall the event loop once per materialization. The helper swallows query
-    # service errors: a stop that can't be delivered must not abort a legitimate
-    # cube edit, and the History event above records what we attempted.
-    if query_service_client and materializations_to_stop:
-        stop_cube_materialization_workflows(
-            query_service_client=query_service_client,
-            cube_name=node_revision.name,
-            cube_version=node_revision.version,
-            materializations=materializations_to_stop,
+    # Swap the materializations onto the new revision only once it is committed: the
+    # rebuild reads the new revision's columns and partitions back out of the DB.
+    swap = await swap_cube_materializations(
+        session,
+        node_revision,
+        new_cube_revision,
+        access_checker=access_checker,
+        current_user=current_user,
+        previous_table_usable=not await is_non_trivial_cube_change(
+            session,
+            node_revision,
+            new_cube_revision,
+        ),
+    )
+    if swap:
+        # Talk to the query service only once DJ's own record of the swap is
+        # committed, so a slow or failing query service can neither hold the
+        # transaction open nor leave DJ claiming the superseded materializations are
+        # still active. The call never raises: a stop or a schedule that cannot be
+        # delivered must not abort a legitimate cube edit, and the History event
+        # recorded above says what we attempted.
+        await session.commit()
+        await apply_cube_materialization_swap(
+            session,
+            swap,
+            query_service_client,
             request_headers=request_headers,
         )
 

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -670,6 +670,12 @@ class CubeMaterializationV2Input(BaseModel):
     )
 
 
+# The name every cube planner materialization row is stored under. The two cube
+# dialects share a job class, so this -- and the `version` discriminator on the
+# config below -- is what tells a planner row apart from a fused one.
+DRUID_CUBE_V3_MATERIALIZATION_NAME = "druid_cube_v3"
+
+
 class DruidCubeV3Config(BaseModel):
     """
     V3 Druid cube materialization config.

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -1345,6 +1345,7 @@ class DeploymentResult(BaseModel):
         TAG = "tag"
         NAMESPACE = "namespace"
         PREAGG = "preaggregation"
+        MATERIALIZATION = "materialization"
         GENERAL = "general"
 
     name: str

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -9,6 +9,7 @@ from pydantic import (
     Field,
     PrivateAttr,
     TypeAdapter,
+    field_validator,
     model_validator,
 )
 
@@ -257,6 +258,20 @@ class MaterializationSpec(BaseModel):
         if self.strategy != MaterializationStrategy.INCREMENTAL_TIME:
             self.lookback_window = None
         return self
+
+
+class MaterializationAction(str, Enum):
+    """
+    What a cube's `materialization:` block can say instead of naming a schedule.
+
+    `NONE` asks for whatever the cube has materialized to be torn down. It is a
+    value rather than an absent key on purpose: "not managed in YAML" and "should
+    not be materialized" have to stay distinguishable after a round trip through
+    `model_dump`, which emits every optional field explicitly and so cannot
+    preserve which keys an author actually wrote.
+    """
+
+    NONE = "none"
 
 
 class ColumnSpec(BaseModel):
@@ -948,7 +963,13 @@ class CubeSpec(NodeSpec):
     dimensions: list[str] = Field(default_factory=list)
     filters: list[str] | None = None
     columns: list[ColumnSpec] | None = None
-    materialization: MaterializationSpec | None = None
+    # Tri-state. A spec materializes the cube on the schedule it names; the `none`
+    # sentinel tears down whatever the cube has materialized; absent -- and null,
+    # which is what serializing an absent field produces -- means the cube's
+    # materialization is not managed here and whatever exists is left alone. Only a
+    # value can carry intent through serialization, so removal is spelled
+    # `materialization: none` rather than inferred from a key being present.
+    materialization: MaterializationSpec | MaterializationAction | None = None
 
     FIELD_CHANGE_TIERS: ClassVar[dict[str, ChangeTier]] = {
         # Adding or removing a metric or a dimension changes the cube's columns.
@@ -989,6 +1010,15 @@ class CubeSpec(NodeSpec):
         "filters": ChangeTier.NONE,
     }
 
+    @field_validator("materialization", mode="before")
+    @classmethod
+    def normalize_materialization_sentinel(cls, value: Any) -> Any:
+        """
+        Case-fold the sentinel, since `None` is what a Python author reaches for and
+        `NONE` what a YAML one does, and both mean `none`.
+        """
+        return value.lower() if isinstance(value, str) else value
+
     @model_validator(mode="after")
     def validate_materialization(self) -> "CubeSpec":
         """
@@ -999,7 +1029,7 @@ class CubeSpec(NodeSpec):
         carrying the same dimension in two roles can say which role partitions it.
         """
         if (
-            self.materialization
+            isinstance(self.materialization, MaterializationSpec)
             and self.materialization.strategy
             == MaterializationStrategy.INCREMENTAL_TIME
             and not any(

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -2751,10 +2751,28 @@ async def test_updating_cube_with_existing_cube_materialization(
     result = response.json()
     assert result["version"] == "v2.0"
 
-    # Check that there is no longer a materialization configured
+    # Both of the previous revision's materializations are rebuilt against v2.0.
     response = await client_with_repairs_cube.get(f"/cubes/{cube_name}/")
     data = response.json()
-    assert len(data["materializations"]) == 0
+    assert [
+        (mat["name"], mat["job"], mat["config"].get("cube"))
+        for mat in data["materializations"]
+    ] == [
+        (
+            "druid_cube__incremental_time__default.hard_hat.hire_date",
+            "DruidCubeMaterializationJob",
+            {
+                "name": cube_name,
+                "version": "v2.0",
+                "display_name": "Repairs Cube  Default Incremental 11",
+            },
+        ),
+        (
+            "druid_metrics_cube__incremental_time__default.hard_hat.hire_date",
+            "DruidMetricsCubeMaterializationJob",
+            None,
+        ),
+    ]
 
 
 @pytest.mark.asyncio
@@ -2812,10 +2830,20 @@ async def test_updating_cube_with_existing_materialization(
     result = response.json()
     assert result["version"] == "v2.0"
 
-    # Check that the cube was updated
+    # The materialization is rebuilt against the new revision, carrying the
+    # schedule and spark config the user set on the previous one.
     response = await client_with_repairs_cube.get("/cubes/default.repairs_cube_2/")
     data = response.json()
-    assert len(data["materializations"]) == 0
+    assert [
+        (mat["name"], mat["schedule"], mat["config"]["spark"])
+        for mat in data["materializations"]
+    ] == [
+        (
+            "druid_measures_cube__incremental_time__default.hard_hat.hire_date",
+            "@daily",
+            {"spark.executor.memory": "6g"},
+        ),
+    ]
     assert_updated_repairs_cube(data)
 
 
@@ -6266,10 +6294,14 @@ class TestCubeRefreshMaterialization:
 
 class TestStopStaleCubeMaterializationWorkflows:
     """
-    A non-trivial cube revision must stop the previous revision's materialization
-    workflows. Left running, they keep posting availability for a table built from
-    the old definition, and that stale-but-live availability is then used to route
-    queries against the new revision, producing column-not-found errors.
+    Every new cube revision swaps its materializations: they are rebuilt against the
+    new revision and the superseded revision's workflows are stopped.
+
+    Materializations belong to a single revision and availability is scoped to the
+    revision encoded in the materialized table name, so a new revision that is not
+    rebuilt has neither -- the cube silently falls back to live queries while the old
+    revision's workflow keeps posting availability for a table built from the old
+    definition, which is then used to route queries against the new revision.
     """
 
     METRICS = ["default.num_repair_orders", "default.avg_repair_price"]
@@ -6322,18 +6354,26 @@ class TestStopStaleCubeMaterializationWorkflows:
     async def _materialization_states(
         session: AsyncSession,
         cube_name: str,
-    ) -> list[tuple[str, bool]]:
+    ) -> list[tuple[str, str, bool]]:
         """
-        (materialization name, is deactivated) for every revision of the cube.
+        (revision version, materialization name, is deactivated) for every revision
+        of the cube.
         """
         statement = (
-            select(Materialization.name, Materialization.deactivated_at)
+            select(
+                NodeRevision.version,
+                Materialization.name,
+                Materialization.deactivated_at,
+            )
             .join(NodeRevision, NodeRevision.id == Materialization.node_revision_id)
             .where(NodeRevision.name == cube_name)
+            .order_by(NodeRevision.version, Materialization.name)
         )
         return [
-            (name, deactivated_at is not None)
-            for name, deactivated_at in (await session.execute(statement)).all()
+            (version, name, deactivated_at is not None)
+            for version, name, deactivated_at in (
+                await session.execute(statement)
+            ).all()
         ]
 
     @staticmethod
@@ -6361,8 +6401,10 @@ class TestStopStaleCubeMaterializationWorkflows:
         mocker,
     ):
         """
-        A swapped dimension is non-trivial: the previous revision's workflow is
-        stopped in the query service and marked deactivated in DJ.
+        A swapped dimension invalidates the previous materialized table: the
+        materialization is rebuilt against the new revision and the previous
+        revision's workflow is stopped in the query service and marked deactivated
+        in DJ.
         """
         cube_name = "default.stop_workflows_dimension_change"
         await self._make_materialized_cube(
@@ -6406,7 +6448,8 @@ class TestStopStaleCubeMaterializationWorkflows:
         mock_deactivate_workflows.assert_not_called()
 
         assert await self._materialization_states(module__session, cube_name) == [
-            (self.MATERIALIZATION_NAME, True),
+            ("v1.0", self.MATERIALIZATION_NAME, True),
+            ("v2.0", self.MATERIALIZATION_NAME, False),
         ]
         assert await self._materialization_history(
             client_with_repairs_cube,
@@ -6414,14 +6457,15 @@ class TestStopStaleCubeMaterializationWorkflows:
         ) == [
             {
                 "message": (
-                    "Cube updated to v2.0. Materializations from the previous "
-                    "version were stopped because the cube changed non-trivially. "
-                    "Please set up materializations again if you want to continue "
-                    "materializing this cube."
+                    "Cube updated to v2.0. Materializations were rebuilt against "
+                    "the new version and the previous version's workflows were "
+                    "stopped."
                 ),
                 "previous_version": "v1.0",
                 "new_version": "v2.0",
                 "stopped_materializations": [self.MATERIALIZATION_NAME],
+                "rebuilt_materializations": [self.MATERIALIZATION_NAME],
+                "previous_table_usable": False,
             },
         ]
 
@@ -6434,8 +6478,8 @@ class TestStopStaleCubeMaterializationWorkflows:
     ):
         """
         A filters-only change is a major version bump — it changes which rows the
-        cube contains — and for the same reason it is non-trivial, so the previous
-        version's workflows are stopped.
+        cube contains — so the previous version's workflows are stopped and the
+        materialization is rebuilt against the new revision.
         """
         cube_name = "default.stop_workflows_filters_change"
         await self._make_materialized_cube(
@@ -6465,21 +6509,29 @@ class TestStopStaleCubeMaterializationWorkflows:
             request_headers=mock.ANY,
         )
         assert await self._materialization_states(module__session, cube_name) == [
-            (self.MATERIALIZATION_NAME, True),
+            ("v1.0", self.MATERIALIZATION_NAME, True),
+            ("v2.0", self.MATERIALIZATION_NAME, False),
         ]
 
     @pytest.mark.asyncio
-    async def test_trivial_change_keeps_previous_workflows(
+    async def test_trivial_change_also_swaps_workflows(
         self,
         client_with_repairs_cube: AsyncClient,
         module__session: AsyncSession,
         mocker,
     ):
         """
-        A description-only change still creates a new revision, but the materialized
-        table stays valid, so the running workflow is left alone.
+        A description-only change earns only a minor bump and leaves the previously
+        materialized table valid, but it is still a new revision, and a revision
+        carries neither its predecessor's materialization nor its availability. So
+        the materialization is rebuilt against v1.1 and v1.0's workflow is stopped:
+        leaving v1.0's workflow running would mean the current revision has no
+        materialization at all while a superseded one keeps posting availability.
+
+        `previous_table_usable` records that this rebuild can adopt the existing
+        data rather than needing a fresh build.
         """
-        cube_name = "default.keep_workflows_trivial_change"
+        cube_name = "default.swap_workflows_trivial_change"
         await self._make_materialized_cube(client_with_repairs_cube, cube_name)
         qs_client = client_with_repairs_cube.app.dependency_overrides[
             get_query_service_client
@@ -6497,14 +6549,32 @@ class TestStopStaleCubeMaterializationWorkflows:
         assert response.status_code == 200, response.json()
         assert response.json()["version"] == "v1.1"
 
-        mock_deactivate_cube_workflow.assert_not_called()
-        assert await self._materialization_states(module__session, cube_name) == [
-            (self.MATERIALIZATION_NAME, False),
-        ]
-        assert (
-            await self._materialization_history(client_with_repairs_cube, cube_name)
-            == []
+        mock_deactivate_cube_workflow.assert_called_once_with(
+            cube_name,
+            version="v1.0",
+            request_headers=mock.ANY,
         )
+        assert await self._materialization_states(module__session, cube_name) == [
+            ("v1.0", self.MATERIALIZATION_NAME, True),
+            ("v1.1", self.MATERIALIZATION_NAME, False),
+        ]
+        assert await self._materialization_history(
+            client_with_repairs_cube,
+            cube_name,
+        ) == [
+            {
+                "message": (
+                    "Cube updated to v1.1. Materializations were rebuilt against "
+                    "the new version and the previous version's workflows were "
+                    "stopped."
+                ),
+                "previous_version": "v1.0",
+                "new_version": "v1.1",
+                "stopped_materializations": [self.MATERIALIZATION_NAME],
+                "rebuilt_materializations": [self.MATERIALIZATION_NAME],
+                "previous_table_usable": True,
+            },
+        ]
 
     @pytest.mark.asyncio
     async def test_metric_component_change_stops_previous_workflows(
@@ -6550,7 +6620,8 @@ class TestStopStaleCubeMaterializationWorkflows:
             request_headers=mock.ANY,
         )
         assert await self._materialization_states(module__session, cube_name) == [
-            (self.MATERIALIZATION_NAME, True),
+            ("v1.0", self.MATERIALIZATION_NAME, True),
+            ("v2.0", self.MATERIALIZATION_NAME, False),
         ]
 
     @pytest.mark.asyncio
@@ -6561,8 +6632,9 @@ class TestStopStaleCubeMaterializationWorkflows:
         mocker,
     ):
         """
-        Asking for a materialization refresh after a non-trivial update must not
-        re-activate the previous revision's stopped materializations.
+        Asking for a materialization refresh after a non-trivial update refreshes the
+        rebuilt materialization on the new revision, and must not re-activate the
+        previous revision's stopped ones.
         """
         cube_name = "default.stop_workflows_then_refresh"
         await self._make_materialized_cube(
@@ -6597,18 +6669,26 @@ class TestStopStaleCubeMaterializationWorkflows:
         )
         assert response.status_code == 200, response.json()
 
-        # The new revision has no materializations of its own, so there is nothing
-        # to refresh -- and nothing revived on the previous revision.
-        assert mock_refresh.call_args_list == [
-            mock.call(
-                cube_name=cube_name,
-                cube_version="v2.0",
-                materializations=[],
-                request_headers=mock.ANY,
+        # The refresh sees exactly the materialization rebuilt on v2.0, and nothing
+        # is revived on the previous revision.
+        assert mock_refresh.call_count == 1
+        _, kwargs = mock_refresh.call_args
+        assert kwargs["cube_name"] == cube_name
+        assert kwargs["cube_version"] == "v2.0"
+        assert [
+            (mat["name"], mat["job"], mat["strategy"], mat["cube"])
+            for mat in kwargs["materializations"]
+        ] == [
+            (
+                self.MATERIALIZATION_NAME,
+                "DruidMetricsCubeMaterializationJob",
+                "incremental_time",
+                {"name": cube_name, "version": "v2.0"},
             ),
         ]
         assert await self._materialization_states(module__session, cube_name) == [
-            (self.MATERIALIZATION_NAME, True),
+            ("v1.0", self.MATERIALIZATION_NAME, True),
+            ("v2.0", self.MATERIALIZATION_NAME, False),
         ]
 
     @pytest.mark.asyncio
@@ -6618,8 +6698,9 @@ class TestStopStaleCubeMaterializationWorkflows:
         module__session: AsyncSession,
     ):
         """
-        With no query service configured there is no workflow to stop remotely, but
-        DJ still stops treating the previous revision's materializations as active.
+        With no query service configured there is no workflow to stop or schedule
+        remotely, but DJ-side state still swaps: the materialization is rebuilt on the
+        new revision and the previous revision's is no longer active.
         """
         cube_name = "default.stop_workflows_without_query_service"
         await self._make_materialized_cube(
@@ -6640,5 +6721,113 @@ class TestStopStaleCubeMaterializationWorkflows:
         assert response.status_code == 200, response.json()
         assert response.json()["version"] == "v2.0"
         assert await self._materialization_states(module__session, cube_name) == [
-            (self.MATERIALIZATION_NAME, True),
+            ("v1.0", self.MATERIALIZATION_NAME, True),
+            ("v2.0", self.MATERIALIZATION_NAME, False),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_rebuild_that_cannot_be_built_still_stops_previous_workflows(
+        self,
+        client_with_repairs_cube: AsyncClient,
+        module__session: AsyncSession,
+        mocker,
+    ):
+        """
+        Dropping the only temporally partitioned dimension leaves a revision a cube
+        materialization cannot be built against at all. The edit still succeeds and
+        the superseded workflow is still stopped -- leaving it running would keep
+        posting availability for a table the new revision cannot use -- but there is
+        nothing to schedule in its place, and the history event says so.
+        """
+        cube_name = "default.stop_workflows_unbuildable_rebuild"
+        await self._make_materialized_cube(client_with_repairs_cube, cube_name)
+        qs_client = client_with_repairs_cube.app.dependency_overrides[
+            get_query_service_client
+        ]()
+        mock_materialize = mocker.patch.object(qs_client, "materialize")
+        mock_deactivate_cube_workflow = mocker.patch.object(
+            qs_client,
+            "deactivate_cube_workflow",
+            return_value={"status": "deactivated"},
+        )
+
+        response = await client_with_repairs_cube.patch(
+            f"/nodes/{cube_name}",
+            json={"dimensions": ["default.hard_hat.city"]},
+        )
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v2.0"
+
+        mock_materialize.assert_not_called()
+        mock_deactivate_cube_workflow.assert_called_once_with(
+            cube_name,
+            version="v1.0",
+            request_headers=mock.ANY,
+        )
+        assert await self._materialization_states(module__session, cube_name) == [
+            ("v1.0", self.MATERIALIZATION_NAME, True),
+        ]
+        assert await self._materialization_history(
+            client_with_repairs_cube,
+            cube_name,
+        ) == [
+            {
+                "message": (
+                    "Cube updated to v2.0. Materializations were rebuilt against "
+                    "the new version and the previous version's workflows were "
+                    "stopped."
+                ),
+                "previous_version": "v1.0",
+                "new_version": "v2.0",
+                "stopped_materializations": [self.MATERIALIZATION_NAME],
+                "rebuilt_materializations": [],
+                "previous_table_usable": False,
+            },
+        ]
+
+    @pytest.mark.asyncio
+    async def test_scheduling_failure_does_not_fail_the_edit(
+        self,
+        client_with_repairs_cube: AsyncClient,
+        module__session: AsyncSession,
+        mocker,
+    ):
+        """
+        A query service that cannot schedule the rebuilt materialization must not
+        abort the cube edit that triggered the swap. DJ keeps the rebuilt
+        materialization on the new revision -- that is what was asked for, and it is
+        what a later refresh will re-submit -- and still stops the old workflow.
+        """
+        cube_name = "default.stop_workflows_schedule_failure"
+        await self._make_materialized_cube(client_with_repairs_cube, cube_name)
+        qs_client = client_with_repairs_cube.app.dependency_overrides[
+            get_query_service_client
+        ]()
+        mock_materialize = mocker.patch.object(
+            qs_client,
+            "materialize",
+            side_effect=RuntimeError("query service unreachable"),
+        )
+        mock_deactivate_cube_workflow = mocker.patch.object(
+            qs_client,
+            "deactivate_cube_workflow",
+            return_value={"status": "deactivated"},
+        )
+
+        response = await client_with_repairs_cube.patch(
+            f"/nodes/{cube_name}",
+            json={"description": "Cube of repair metrics, revised"},
+        )
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v1.1"
+
+        assert mock_materialize.call_count == 1
+        mock_deactivate_cube_workflow.assert_called_once_with(
+            cube_name,
+            version="v1.0",
+            request_headers=mock.ANY,
+        )
+        assert await self._materialization_states(module__session, cube_name) == [
+            ("v1.0", self.MATERIALIZATION_NAME, True),
+            ("v1.1", self.MATERIALIZATION_NAME, False),
         ]

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -24,6 +24,10 @@ from datajunction_server.errors import (
     DJQueryServiceClientException,
 )
 from datajunction_server.models.cube import CubeElementMetadata
+from datajunction_server.models.materialization import (
+    MaterializationInfo,
+    MaterializationStrategy,
+)
 from datajunction_server.models.node import ColumnOutput
 from datajunction_server.models.query import ColumnMetadata, V3ColumnMetadata
 from datajunction_server.service_clients import QueryServiceClient
@@ -6831,3 +6835,118 @@ class TestStopStaleCubeMaterializationWorkflows:
             ("v1.0", self.MATERIALIZATION_NAME, True),
             ("v1.1", self.MATERIALIZATION_NAME, False),
         ]
+
+    @pytest.mark.asyncio
+    async def test_cube_planner_materialization_is_not_swapped(
+        self,
+        client_with_repairs_cube: AsyncClient,
+        module__session: AsyncSession,
+        mocker,
+    ):
+        """
+        A cube planner materialization is not carried onto the new revision.
+
+        The two cube dialects are indistinguishable by job -- `POST
+        /cubes/{name}/materialize` stores the same `DruidCubeMaterializationJob` the
+        fused path derives -- so a planner row read as intent to rebuild recovers as
+        a fused materialization. On a cube that has both, the two rebuilds derive one
+        name and the edit dies on `name_node_revision_uniq`, after the new revision
+        has already been committed. The planner's row is left where it is instead,
+        still active, and the fused one swaps as it always did.
+        """
+        cube_name = "default.stop_workflows_cube_planner"
+        response = await client_with_repairs_cube.post(
+            "/nodes/cube/",
+            json={
+                "metrics": list(self.METRICS),
+                "dimensions": list(self.DIMENSIONS),
+                "description": "Cube of repair metrics",
+                "mode": "published",
+                "name": cube_name,
+            },
+        )
+        assert response.status_code < 400, response.json()
+        response = await client_with_repairs_cube.post(
+            f"/nodes/{cube_name}/columns/default.hard_hat.hire_date/partition",
+            json={"type_": "temporal", "granularity": "day", "format": "yyyyMMdd"},
+        )
+        assert response.status_code < 400, response.json()
+
+        qs_client = client_with_repairs_cube.app.dependency_overrides[
+            get_query_service_client
+        ]()
+        mocker.patch.object(
+            qs_client,
+            "materialize_cube",
+            return_value=MaterializationInfo(
+                urls=["http://fake.url/job"],
+                output_tables=[],
+            ),
+        )
+        response = await client_with_repairs_cube.post(
+            f"/nodes/{cube_name}/materialization/",
+            json={
+                "job": "druid_cube",
+                "strategy": "incremental_time",
+                "schedule": "@daily",
+                "lookback_window": "1 DAY",
+            },
+        )
+        assert response.status_code < 400, response.json()
+
+        # The planner's row is written directly: its own endpoint needs pre-agg
+        # tables that this fixture's cube does not have.
+        revision_id = (
+            await module__session.execute(
+                select(NodeRevision.id).where(NodeRevision.name == cube_name),
+            )
+        ).scalar_one()
+        module__session.add(
+            Materialization(
+                node_revision_id=revision_id,
+                name="druid_cube_v3",
+                strategy=MaterializationStrategy.INCREMENTAL_TIME,
+                schedule="@daily",
+                config={"version": "v3", "workflow_names": ["planner-workflow"]},
+                job="DruidCubeMaterializationJob",
+            ),
+        )
+        await module__session.commit()
+
+        mock_deactivate_cube_workflow = mocker.patch.object(
+            qs_client,
+            "deactivate_cube_workflow",
+            return_value={"status": "deactivated"},
+        )
+        mock_deactivate_workflows = mocker.patch.object(
+            qs_client,
+            "deactivate_workflows",
+            return_value={"status": "deactivated"},
+        )
+
+        response = await client_with_repairs_cube.patch(
+            f"/nodes/{cube_name}",
+            json={
+                "dimensions": [
+                    "default.hard_hat.state",
+                    "default.hard_hat.hire_date",
+                ],
+            },
+        )
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v2.0"
+
+        fused_name = "druid_cube__incremental_time__default.hard_hat.hire_date"
+        assert await self._materialization_states(module__session, cube_name) == [
+            ("v1.0", fused_name, True),
+            ("v1.0", "druid_cube_v3", False),
+            ("v2.0", fused_name, False),
+        ]
+        # The planner's workflow is not among those stopped: only the fused row is
+        # superseded, and it carries no workflow names of its own.
+        assert mock_deactivate_workflows.call_args_list == []
+        mock_deactivate_cube_workflow.assert_called_once_with(
+            cube_name,
+            version="v1.0",
+            request_headers=mock.ANY,
+        )

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -7,13 +7,17 @@ from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy import select
 
+import datajunction_server.internal.materializations
 from datajunction_server.api.deployments import (
     InProcessExecutor,
     _normalize_repo_path,
 )
+from datajunction_server.database.materialization import Materialization
 from datajunction_server.database.node import Node, NodeRelationship
 from datajunction_server.database.tag import Tag
+from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.internal.git.github_service import GitHubServiceError
 from datajunction_server.models import access
 from datajunction_server.models.deployment import (
@@ -37,6 +41,10 @@ from datajunction_server.models.deployment import (
     TransformSpec,
 )
 from datajunction_server.models.dimensionlink import JoinType
+from datajunction_server.models.materialization import (
+    MaterializationInfo,
+    MaterializationStrategy,
+)
 from datajunction_server.models.node import (
     MetricDirection,
     MetricUnit,
@@ -1277,10 +1285,43 @@ def roads_nodes(
     ]
 
 
+def _mock_materializing_query_service() -> MagicMock:
+    """
+    A query service that accepts everything a cube materialization asks of it.
+
+    Plain `MagicMock` rather than a spec'd double so `method_calls` records the whole
+    sequence in order, which is what the materialization tests below compare against.
+    """
+    query_service = MagicMock()
+    query_service.materialize_cube.return_value = MaterializationInfo(
+        urls=["http://fake.url/job"],
+        output_tables=[],
+    )
+    return query_service
+
+
+def deployment_payload(deployment_spec: DeploymentSpec) -> dict:
+    """
+    The spec as `dj push` would send it, as far as `materialization:` is concerned.
+
+    `dj push` posts the YAML files as parsed, so a key nobody wrote is absent.
+    `model_dump` instead emits every optional field explicitly null, which would make
+    a cube that never mentioned `materialization:` indistinguishable from one that
+    set it to null and means "tear this down". Only that key is dropped: the rest of
+    the payload stays as-is, since several nested unions are discriminated on fields
+    that carry defaults and would vanish under a blanket `exclude_unset`.
+    """
+    payload = deployment_spec.model_dump()
+    for node_payload, node_spec in zip(payload["nodes"], deployment_spec.nodes):
+        if "materialization" not in node_spec.model_fields_set:
+            node_payload.pop("materialization", None)
+    return payload
+
+
 async def deploy_and_wait(client, deployment_spec: DeploymentSpec):
     response = await client.post(
         "/deployments",
-        json=deployment_spec.model_dump(),
+        json=deployment_payload(deployment_spec),
     )
     data = response.json()
     deployment_uuid = data["uuid"]
@@ -2902,7 +2943,9 @@ class TestDeployments:
             cube.description = "Cube for analyzing repair orders, revised"
             response = await client.post(
                 "/deployments/impact",
-                json=DeploymentSpec(namespace=namespace, nodes=nodes).model_dump(),
+                json=deployment_payload(
+                    DeploymentSpec(namespace=namespace, nodes=nodes),
+                ),
             )
             assert response.status_code == 200, response.json()
             assert mock_qs.method_calls == []
@@ -2928,12 +2971,13 @@ class TestDeployments:
         default_avg_length_of_employment,
     ):
         """
-        A cube can declare `materialization:` alongside its definition, and the block
-        survives the deploy/export round trip so a repo-managed cube keeps it.
+        A cube can declare `materialization:` alongside its definition, the block
+        survives the deploy/export round trip, and it is what gets scheduled.
 
-        Nothing is scheduled yet -- the reconciler that turns the block into a
-        workflow lands separately. This pins that the spec parses, deploys, and
-        exports, and that a schedule edit alone does not mint a new cube version.
+        The second push is the case the reconciler exists for and the one an
+        implementation keyed off the deploy's change list would drop: editing only
+        the schedule leaves the cube comparing equal, so it is skipped as a node --
+        and still rescheduled, without earning a version.
         """
         namespace = "cube_materialization"
         cube = CubeSpec(
@@ -2971,56 +3015,117 @@ class TestDeployments:
             default_avg_length_of_employment,
             cube,
         ]
-        data = await deploy_and_wait(
-            client,
-            DeploymentSpec(namespace=namespace, nodes=nodes_list),
-        )
-        assert data["status"] == "success"
+        cube_name = f"{namespace}.default.repairs_cube"
+        mock_qs = _mock_materializing_query_service()
+        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+        try:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes_list),
+            )
+            assert data["status"] == "success"
+            assert [
+                result for result in data["results"] if result["name"] == cube_name
+            ] == [
+                {
+                    "deploy_type": "node",
+                    "message": "Created cube (v1.0)",
+                    "name": cube_name,
+                    "operation": "create",
+                    "changed_fields": [],
+                    "status": "success",
+                },
+                {
+                    "deploy_type": "materialization",
+                    "message": "cube materialization on schedule 0 6 * * *",
+                    "name": cube_name,
+                    "operation": "create",
+                    "changed_fields": [],
+                    "status": "success",
+                },
+            ]
 
-        deployed = await Node.get_by_name(
-            session,
-            f"{namespace}.default.repairs_cube",
-            options=Node.cube_load_options(),
-        )
-        assert deployed.current.version == "v1.0"
+            session.expire_all()
+            deployed = await Node.get_by_name(
+                session,
+                cube_name,
+                options=Node.cube_load_options(),
+            )
+            assert deployed.current.version == "v1.0"
+            assert (await deployed.to_spec(session)).materialization == (
+                MaterializationSpec(
+                    schedule="0 6 * * *",
+                    strategy=MaterializationStrategy.INCREMENTAL_TIME,
+                    lookback_window="1 DAY",
+                )
+            )
 
-        # The block is accepted but not yet acted on, so nothing is scheduled.
-        assert (await deployed.to_spec(session)).materialization is None
+            # Editing only the schedule is not a definition change: the cube compares
+            # equal, is skipped rather than updated, and never earns a version. The
+            # reconciler runs off the spec rather than the change list, so the new
+            # schedule still reaches the query service.
+            mock_qs.reset_mock()
+            cube.materialization = MaterializationSpec(
+                schedule="0 3 * * *",
+                lookback_window="1 DAY",
+            )
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes_list),
+            )
+            assert data["status"] == "success"
+            assert [
+                result for result in data["results"] if result["name"] == cube_name
+            ] == [
+                {
+                    "deploy_type": "node",
+                    "message": "Unchanged",
+                    "name": cube_name,
+                    "operation": "noop",
+                    "changed_fields": [],
+                    "status": "skipped",
+                },
+                {
+                    "deploy_type": "materialization",
+                    "message": "cube materialization on schedule 0 3 * * *",
+                    "name": cube_name,
+                    "operation": "update",
+                    "changed_fields": [],
+                    "status": "success",
+                },
+            ]
 
-        # Editing only the schedule is not a definition change: the cube compares
-        # equal, is skipped rather than updated, and so is never given a version.
-        cube.materialization = MaterializationSpec(
-            schedule="0 3 * * *",
-            lookback_window="1 DAY",
-        )
-        data = await deploy_and_wait(
-            client,
-            DeploymentSpec(namespace=namespace, nodes=nodes_list),
-        )
-        assert data["status"] == "success"
-        cube_results = [
-            result
-            for result in data["results"]
-            if result["name"] == f"{namespace}.default.repairs_cube"
-        ]
-        assert cube_results == [
-            {
-                "deploy_type": "node",
-                "message": "Unchanged",
-                "name": f"{namespace}.default.repairs_cube",
-                "operation": "noop",
-                "changed_fields": [],
-                "status": "skipped",
-            },
-        ]
-
-        session.expire_all()
-        deployed = await Node.get_by_name(
-            session,
-            f"{namespace}.default.repairs_cube",
-            options=Node.cube_load_options(),
-        )
-        assert deployed.current.version == "v1.0"
+            session.expire_all()
+            deployed = await Node.get_by_name(
+                session,
+                cube_name,
+                options=Node.cube_load_options(),
+            )
+            assert deployed.current.version == "v1.0"
+            assert (await deployed.to_spec(session)).materialization == (
+                MaterializationSpec(
+                    schedule="0 3 * * *",
+                    strategy=MaterializationStrategy.INCREMENTAL_TIME,
+                    lookback_window="1 DAY",
+                )
+            )
+            assert mock_qs.materialize_cube.call_count == 1
+            assert mock_qs.deactivate_workflows.call_count == 0
+            assert mock_qs.deactivate_cube_workflow.call_count == 0
+            scheduled = mock_qs.materialize_cube.call_args.kwargs[
+                "materialization_input"
+            ]
+            assert (
+                scheduled.cube.name,
+                scheduled.cube.version,
+                scheduled.schedule,
+            ) == (
+                cube_name,
+                "v1.0",
+                "0 3 * * *",
+            )
+        finally:
+            del client.app.dependency_overrides[get_query_service_client]
 
     @pytest.mark.asyncio
     async def test_deploy_cube_with_custom_metadata(
@@ -4964,6 +5069,701 @@ async def test_print_roads_spec(roads_nodes):
     )
     print("Roads Spec:", json.dumps(spec.model_dump()))
     assert 1 == 2
+
+
+@pytest.mark.xdist_group(name="deployments")
+class TestDeclaredCubeMaterializations:
+    """
+    Reconciling a cube's `materialization:` block against what is materialized.
+    """
+
+    @staticmethod
+    def _cube(**overrides) -> CubeSpec:
+        """A partitioned cube, ready to declare a materialization."""
+        fields: dict = {
+            "name": "default.repairs_cube",
+            "display_name": "Repairs Cube",
+            "description": "Cube for analyzing repair orders",
+            "dimensions": [
+                "${prefix}default.hard_hat.state",
+                "${prefix}default.hard_hat.hire_date",
+            ],
+            "metrics": ["${prefix}default.avg_length_of_employment"],
+            "owners": ["dj"],
+            "columns": [
+                ColumnSpec(
+                    name="${prefix}default.hard_hat.hire_date",
+                    partition=PartitionSpec(
+                        type=PartitionType.TEMPORAL,
+                        granularity=Granularity.DAY,
+                        format="yyyyMMdd",
+                    ),
+                ),
+            ],
+        }
+        return CubeSpec(**{**fields, **overrides})
+
+    @staticmethod
+    def _materialization_results(data: dict) -> list[tuple]:
+        """The reconciler's own results, as (name, operation, status, message)."""
+        return [
+            (
+                result["name"],
+                result["operation"],
+                result["status"],
+                result["message"],
+            )
+            for result in data["results"]
+            if result["deploy_type"] == "materialization"
+        ]
+
+    @staticmethod
+    async def _persisted_materializations(client, cube_name: str) -> list[tuple]:
+        """The cube's materializations, as (name, schedule, strategy, active)."""
+        body = (await client.get(f"/nodes/{cube_name}/")).json()
+        return [
+            (
+                materialization["name"],
+                materialization["schedule"],
+                materialization["strategy"],
+                materialization["deactivated_at"] is None,
+            )
+            for materialization in body["materializations"]
+        ]
+
+    @pytest.mark.asyncio
+    async def test_unchanged_declaration_touches_nothing(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        Re-pushing an unchanged repo must not churn a live workflow: the second
+        deploy reports a no-op and makes no query service call at all.
+        """
+        namespace = "cube_mat_unchanged"
+        cube_name = f"{namespace}.default.repairs_cube"
+        cube = self._cube(
+            materialization=MaterializationSpec(
+                schedule="0 6 * * *",
+                lookback_window="1 DAY",
+            ),
+        )
+        nodes = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            cube,
+        ]
+        mock_qs = _mock_materializing_query_service()
+        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+        try:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes),
+            )
+            assert data["status"] == "success", data
+            assert mock_qs.materialize_cube.call_count == 1
+
+            mock_qs.reset_mock()
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes),
+            )
+            assert data["status"] == "success", data
+            assert self._materialization_results(data) == [
+                (
+                    cube_name,
+                    "noop",
+                    "success",
+                    "cube materialization on schedule 0 6 * * *",
+                ),
+            ]
+            assert mock_qs.method_calls == []
+            assert await self._persisted_materializations(client, cube_name) == [
+                (
+                    f"druid_cube__incremental_time__{namespace}"
+                    ".default.hard_hat.hire_date",
+                    "0 6 * * *",
+                    "incremental_time",
+                    True,
+                ),
+            ]
+        finally:
+            del client.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_definition_and_schedule_edit_rebuilds_once(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+        default_num_repair_orders,
+    ):
+        """
+        Editing the cube's metrics and its schedule in one push must rebuild once.
+
+        The new revision's swap already builds from the declared block, so the
+        reconciler that follows has to find the result matching and stand down --
+        otherwise the query service is asked to schedule the same cube twice.
+        """
+        namespace = "cube_mat_one_rebuild"
+        cube_name = f"{namespace}.default.repairs_cube"
+        cube = self._cube(
+            materialization=MaterializationSpec(
+                schedule="0 6 * * *",
+                lookback_window="1 DAY",
+            ),
+        )
+        nodes = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            default_num_repair_orders,
+            cube,
+        ]
+        mock_qs = _mock_materializing_query_service()
+        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+        try:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes),
+            )
+            assert data["status"] == "success", data
+
+            mock_qs.reset_mock()
+            cube.metrics = [
+                "${prefix}default.avg_length_of_employment",
+                "${prefix}default.num_repair_orders",
+            ]
+            cube.materialization = MaterializationSpec(
+                schedule="0 3 * * *",
+                lookback_window="1 DAY",
+            )
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes),
+            )
+            assert data["status"] == "success", data
+            assert self._materialization_results(data) == [
+                (
+                    cube_name,
+                    "update",
+                    "success",
+                    "cube materialization on schedule 0 3 * * *",
+                ),
+            ]
+
+            # One schedule call, for the new revision and the new schedule, and one
+            # stop for the superseded revision's workflow.
+            assert mock_qs.materialize_cube.call_count == 1
+            scheduled = mock_qs.materialize_cube.call_args.kwargs[
+                "materialization_input"
+            ]
+            assert (
+                scheduled.cube.name,
+                scheduled.cube.version,
+                scheduled.schedule,
+            ) == (cube_name, "v2.0", "0 3 * * *")
+            assert mock_qs.deactivate_cube_workflow.call_args_list == [
+                mock.call(cube_name, version="v1.0", request_headers=mock.ANY),
+            ]
+            assert await self._persisted_materializations(client, cube_name) == [
+                (
+                    f"druid_cube__incremental_time__{namespace}"
+                    ".default.hard_hat.hire_date",
+                    "0 3 * * *",
+                    "incremental_time",
+                    True,
+                ),
+            ]
+        finally:
+            del client.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_explicit_null_removes_the_materialization(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        `materialization: null` is the one thing that tears a materialization down:
+        the row is deactivated and its workflow stopped.
+        """
+        namespace = "cube_mat_removed"
+        cube_name = f"{namespace}.default.repairs_cube"
+        cube = self._cube(
+            materialization=MaterializationSpec(
+                schedule="0 6 * * *",
+                lookback_window="1 DAY",
+            ),
+        )
+        nodes = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            cube,
+        ]
+        mock_qs = _mock_materializing_query_service()
+        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+        try:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes),
+            )
+            assert data["status"] == "success", data
+
+            mock_qs.reset_mock()
+            cube.materialization = None
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes),
+            )
+            assert data["status"] == "success", data
+            assert self._materialization_results(data) == [
+                (
+                    cube_name,
+                    "delete",
+                    "success",
+                    "cube materialization removed by `materialization: null`",
+                ),
+            ]
+            assert mock_qs.materialize_cube.call_count == 0
+            assert mock_qs.deactivate_cube_workflow.call_args_list == [
+                mock.call(cube_name, version="v1.0", request_headers=mock.ANY),
+            ]
+            assert await self._persisted_materializations(client, cube_name) == [
+                (
+                    f"druid_cube__incremental_time__{namespace}"
+                    ".default.hard_hat.hire_date",
+                    "0 6 * * *",
+                    "incremental_time",
+                    False,
+                ),
+            ]
+        finally:
+            del client.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_explicit_null_without_a_materialization_is_a_noop(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        A cube that says `materialization: null` and never had one reports a no-op
+        and asks the query service to stop nothing.
+        """
+        namespace = "cube_mat_null_noop"
+        cube_name = f"{namespace}.default.repairs_cube"
+        nodes = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            self._cube(materialization=None),
+        ]
+        mock_qs = _mock_materializing_query_service()
+        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+        try:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes),
+            )
+            assert data["status"] == "success", data
+            assert self._materialization_results(data) == [
+                (
+                    cube_name,
+                    "noop",
+                    "success",
+                    "cube declares no materialization",
+                ),
+            ]
+            assert mock_qs.method_calls == []
+            assert await self._persisted_materializations(client, cube_name) == []
+        finally:
+            del client.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_undeclared_materialization_is_left_running(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        Omitting the block is not the same as removing it. A cube materialized
+        outside YAML keeps running, and the deploy says so and names both ways out.
+        """
+        namespace = "cube_mat_undeclared"
+        cube_name = f"{namespace}.default.repairs_cube"
+        nodes = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            self._cube(),
+        ]
+        mock_qs = _mock_materializing_query_service()
+        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+        try:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes),
+            )
+            assert data["status"] == "success", data
+            assert self._materialization_results(data) == []
+
+            response = await client.post(
+                f"/nodes/{cube_name}/materialization/",
+                json={
+                    "job": "druid_cube",
+                    "strategy": "incremental_time",
+                    "schedule": "@daily",
+                    "lookback_window": "1 DAY",
+                },
+            )
+            assert response.status_code == 200, response.json()
+
+            mock_qs.reset_mock()
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes),
+            )
+            assert data["status"] == "success", data
+            warning = (
+                f"Cube `{cube_name}` is materialized but its spec declares no "
+                "`materialization:` block, so the existing materialization was "
+                "left running. Run `dj pull` to adopt it into YAML, or add "
+                "`materialization: null` to remove it."
+            )
+            assert self._materialization_results(data) == [
+                (cube_name, "noop", "warning", warning),
+            ]
+            assert [item["message"] for item in data["warnings"]] == [warning]
+            assert mock_qs.method_calls == []
+            assert await self._persisted_materializations(client, cube_name) == [
+                (
+                    f"druid_cube__incremental_time__{namespace}"
+                    ".default.hard_hat.hire_date",
+                    "@daily",
+                    "incremental_time",
+                    True,
+                ),
+            ]
+        finally:
+            del client.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_config_drift_under_an_unchanged_block_is_corrected(
+        self,
+        session,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        The block is only three fields; the built config is much more. When the two
+        disagree -- something reconfigured the materialization outside YAML -- the
+        repo wins, even though the block itself did not change.
+        """
+        namespace = "cube_mat_drift"
+        cube_name = f"{namespace}.default.repairs_cube"
+        materialization_name = (
+            f"druid_cube__incremental_time__{namespace}.default.hard_hat.hire_date"
+        )
+        cube = self._cube(
+            materialization=MaterializationSpec(
+                schedule="0 6 * * *",
+                lookback_window="1 DAY",
+            ),
+        )
+        nodes = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            cube,
+        ]
+        mock_qs = _mock_materializing_query_service()
+        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+        try:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes),
+            )
+            assert data["status"] == "success", data
+
+            materialization = (
+                (
+                    await session.execute(
+                        select(Materialization).where(
+                            Materialization.name == materialization_name,
+                        ),
+                    )
+                )
+                .scalars()
+                .one()
+            )
+            materialization.config = {
+                **materialization.config,
+                "workflow_names": ["configured-elsewhere"],
+            }
+            await session.commit()
+
+            mock_qs.reset_mock()
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes),
+            )
+            assert data["status"] == "success", data
+            assert self._materialization_results(data) == [
+                (
+                    cube_name,
+                    "update",
+                    "success",
+                    "cube materialization on schedule 0 6 * * *",
+                ),
+            ]
+            assert mock_qs.materialize_cube.call_count == 1
+            # Read from the database rather than through `GET /nodes/{name}/`: the
+            # revision did not change, so that response is still cached.
+            session.expire_all()
+            assert [
+                (row.name, row.config.get("workflow_names"), row.deactivated_at)
+                for row in (
+                    (
+                        await session.execute(
+                            select(Materialization).where(
+                                Materialization.name == materialization_name,
+                            ),
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+            ] == [(materialization_name, None, None)]
+        finally:
+            del client.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_dry_run_plans_the_change_without_making_it(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        A dry run reports the operation the wet run would perform, and performs none
+        of it: nothing scheduled, nothing stopped, the persisted schedule untouched.
+        """
+        namespace = "cube_mat_dry_run"
+        cube_name = f"{namespace}.default.repairs_cube"
+        cube = self._cube(
+            materialization=MaterializationSpec(
+                schedule="0 6 * * *",
+                lookback_window="1 DAY",
+            ),
+        )
+        nodes = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            cube,
+        ]
+        mock_qs = _mock_materializing_query_service()
+        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+        try:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes),
+            )
+            assert data["status"] == "success", data
+
+            mock_qs.reset_mock()
+            cube.materialization = MaterializationSpec(
+                schedule="0 3 * * *",
+                lookback_window="1 DAY",
+            )
+            response = await client.post(
+                "/deployments/impact",
+                json=deployment_payload(
+                    DeploymentSpec(namespace=namespace, nodes=nodes),
+                ),
+            )
+            assert response.status_code == 200, response.json()
+            assert self._materialization_results(response.json()) == [
+                (
+                    cube_name,
+                    "update",
+                    "success",
+                    "cube materialization on schedule 0 3 * * *",
+                ),
+            ]
+            assert mock_qs.method_calls == []
+            assert await self._persisted_materializations(client, cube_name) == [
+                (
+                    f"druid_cube__incremental_time__{namespace}"
+                    ".default.hard_hat.hire_date",
+                    "0 6 * * *",
+                    "incremental_time",
+                    True,
+                ),
+            ]
+
+            # A planned teardown is reported and equally not carried out.
+            cube.materialization = None
+            response = await client.post(
+                "/deployments/impact",
+                json=deployment_payload(
+                    DeploymentSpec(namespace=namespace, nodes=nodes),
+                ),
+            )
+            assert response.status_code == 200, response.json()
+            assert self._materialization_results(response.json()) == [
+                (
+                    cube_name,
+                    "delete",
+                    "success",
+                    "cube materialization removed by `materialization: null`",
+                ),
+            ]
+            assert mock_qs.method_calls == []
+            assert await self._persisted_materializations(client, cube_name) == [
+                (
+                    f"druid_cube__incremental_time__{namespace}"
+                    ".default.hard_hat.hire_date",
+                    "0 6 * * *",
+                    "incremental_time",
+                    True,
+                ),
+            ]
+        finally:
+            del client.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_unmaterializable_cube_fails_alone(
+        self,
+        client,
+        mocker,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+        default_num_repair_orders,
+    ):
+        """
+        A cube DJ cannot build a materialization for -- measures queries at different
+        grains, say -- fails with an error naming it, and does not take the other
+        declared cube in the same push down with it.
+        """
+        namespace = "cube_mat_ungrainable"
+        broken_name = f"{namespace}.default.broken_cube"
+        working_name = f"{namespace}.default.repairs_cube"
+        grain_error = (
+            "DJ cannot manage materializations for cubes that have underlying "
+            "measures queries at different grains"
+        )
+        real_build = (
+            datajunction_server.internal.materializations.build_cube_materialization
+        )
+
+        async def build(*args, **kwargs):
+            if kwargs["current_revision"].name == broken_name:
+                raise DJInvalidInputException(grain_error)
+            return await real_build(*args, **kwargs)
+
+        mocker.patch(
+            "datajunction_server.internal.materializations.build_cube_materialization",
+            side_effect=build,
+        )
+        nodes = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            default_num_repair_orders,
+            self._cube(
+                materialization=MaterializationSpec(
+                    schedule="0 6 * * *",
+                    lookback_window="1 DAY",
+                ),
+            ),
+            self._cube(
+                name="default.broken_cube",
+                metrics=["${prefix}default.num_repair_orders"],
+                materialization=MaterializationSpec(
+                    schedule="0 7 * * *",
+                    lookback_window="1 DAY",
+                ),
+            ),
+        ]
+        mock_qs = _mock_materializing_query_service()
+        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+        try:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes),
+            )
+            assert self._materialization_results(data) == [
+                (
+                    working_name,
+                    "create",
+                    "success",
+                    "cube materialization on schedule 0 6 * * *",
+                ),
+                (
+                    broken_name,
+                    "unknown",
+                    "failed",
+                    f"Cube `{broken_name}`: {grain_error}",
+                ),
+            ]
+            assert mock_qs.materialize_cube.call_count == 1
+            scheduled = mock_qs.materialize_cube.call_args.kwargs[
+                "materialization_input"
+            ]
+            assert scheduled.cube.name == working_name
+            assert await self._persisted_materializations(client, broken_name) == []
+        finally:
+            del client.app.dependency_overrides[get_query_service_client]
 
 
 @pytest.mark.xdist_group(name="deployments")

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -2643,6 +2643,280 @@ class TestDeployments:
         assert await version_of(deploy_ns) == "v2.0"
 
     @pytest.mark.asyncio
+    async def test_patch_and_deployment_agree_on_materialization_state(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        The same edit, applied once through `PATCH /nodes/{name}` and once through a
+        deployment, must leave identical materialization state: the same active
+        materialization rebuilt on the new current revision, and the same query
+        service calls to schedule it and stop the superseded revision's workflow.
+
+        The materialization itself is set up through `POST
+        /nodes/{name}/materialization/` in both namespaces, because that is the only
+        place it can come from -- a cube materialized through the UI has no YAML. The
+        temporal partition it needs is declared on the spec so that a re-deploy keeps
+        it, the same way the patch path carries partitions onto a new revision.
+        """
+        upstreams = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+        ]
+
+        def build_cube(**overrides) -> CubeSpec:
+            fields: dict = {
+                "name": "default.repairs_cube",
+                "display_name": "Repairs Cube",
+                "description": "Cube for analyzing repair orders",
+                "dimensions": [
+                    "${prefix}default.hard_hat.state",
+                    "${prefix}default.hard_hat.hire_date",
+                ],
+                "metrics": ["${prefix}default.avg_length_of_employment"],
+                "owners": ["dj"],
+                "columns": [
+                    ColumnSpec(
+                        name="${prefix}default.hard_hat.hire_date",
+                        partition=PartitionSpec(
+                            type=PartitionType.TEMPORAL,
+                            granularity=Granularity.DAY,
+                            format="yyyyMMdd",
+                        ),
+                    ),
+                ],
+            }
+            return CubeSpec(**{**fields, **overrides})
+
+        async def deploy(namespace: str, cube: CubeSpec) -> None:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace=namespace,
+                    nodes=[spec.model_copy(deep=True) for spec in upstreams] + [cube],
+                ),
+            )
+            assert data["status"] == "success", data
+
+        async def materialization_state(namespace: str) -> tuple:
+            body = (
+                await client.get(f"/nodes/{namespace}.default.repairs_cube/")
+            ).json()
+            return (
+                body["version"],
+                [
+                    (
+                        mat["name"],
+                        mat["job"],
+                        mat["strategy"],
+                        mat["schedule"],
+                        mat["config"]["cube"]["version"],
+                        mat["config"]["lookback_window"],
+                        mat["deactivated_at"],
+                    )
+                    for mat in body["materializations"]
+                ],
+            )
+
+        def query_service_calls(namespace: str) -> list:
+            """
+            The materialization-related query service calls, with the namespace
+            stripped so the two paths' calls are directly comparable.
+            """
+            calls: list[tuple] = []
+            for name, args, kwargs in mock_qs.method_calls:
+                if name == "materialize_cube":
+                    materialization = kwargs["materialization_input"]
+                    calls.append(
+                        (
+                            name,
+                            materialization.name,
+                            materialization.cube.name.removeprefix(f"{namespace}."),
+                            materialization.cube.version,
+                        ),
+                    )
+                elif name in ("deactivate_cube_workflow", "deactivate_workflows"):
+                    calls.append(
+                        (
+                            name,
+                            args[0].removeprefix(f"{namespace}."),
+                            kwargs.get("version"),
+                        ),
+                    )
+            return calls
+
+        mock_qs = _mock_materializing_query_service()
+        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+        patch_ns, deploy_ns = "mat_equivalence_patch", "mat_equivalence_deploy"
+        try:
+            for namespace in (patch_ns, deploy_ns):
+                await deploy(namespace, build_cube())
+                cube_name = f"{namespace}.default.repairs_cube"
+                response = await client.post(
+                    f"/nodes/{cube_name}/materialization/",
+                    json={
+                        "job": "druid_cube",
+                        "strategy": "incremental_time",
+                        "schedule": "@daily",
+                        "lookback_window": "7 DAY",
+                    },
+                )
+                assert response.status_code == 200, response.json()
+
+            # The same metadata-only edit through each path.
+            revised = "Cube for analyzing repair orders, revised"
+            mock_qs.reset_mock()
+            response = await client.patch(
+                f"/nodes/{patch_ns}.default.repairs_cube/",
+                json={"description": revised},
+            )
+            assert response.status_code == 200, response.json()
+            patch_calls = query_service_calls(patch_ns)
+
+            mock_qs.reset_mock()
+            await deploy(deploy_ns, build_cube(description=revised))
+            deploy_calls = query_service_calls(deploy_ns)
+
+            expected = (
+                "v1.1",
+                [
+                    (
+                        "druid_cube__incremental_time__"
+                        f"{patch_ns}.default.hard_hat.hire_date",
+                        "DruidCubeMaterializationJob",
+                        "incremental_time",
+                        "@daily",
+                        "v1.1",
+                        "7 DAY",
+                        None,
+                    ),
+                ],
+            )
+            assert await materialization_state(patch_ns) == expected
+            assert await materialization_state(deploy_ns) == (
+                expected[0],
+                [
+                    (
+                        name.replace(patch_ns, deploy_ns),
+                        *rest,
+                    )
+                    for name, *rest in expected[1]
+                ],
+            )
+            assert patch_calls == [
+                (
+                    "materialize_cube",
+                    f"druid_cube__incremental_time__{patch_ns}"
+                    ".default.hard_hat.hire_date",
+                    "default.repairs_cube",
+                    "v1.1",
+                ),
+                ("deactivate_cube_workflow", "default.repairs_cube", "v1.0"),
+            ]
+            assert deploy_calls == [
+                (
+                    "materialize_cube",
+                    f"druid_cube__incremental_time__{deploy_ns}"
+                    ".default.hard_hat.hire_date",
+                    "default.repairs_cube",
+                    "v1.1",
+                ),
+                ("deactivate_cube_workflow", "default.repairs_cube", "v1.0"),
+            ]
+        finally:
+            del client.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_dry_run_deploy_does_not_swap_cube_materializations(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        A dry run must schedule nothing and stop nothing: the materialization stays on
+        the revision it was built for and no query service call is made.
+        """
+        namespace = "mat_dry_run"
+        cube = CubeSpec(
+            name="default.repairs_cube",
+            display_name="Repairs Cube",
+            description="Cube for analyzing repair orders",
+            dimensions=[
+                "${prefix}default.hard_hat.state",
+                "${prefix}default.hard_hat.hire_date",
+            ],
+            metrics=["${prefix}default.avg_length_of_employment"],
+            owners=["dj"],
+        )
+        nodes = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            cube,
+        ]
+        mock_qs = _mock_materializing_query_service()
+        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+        cube_name = f"{namespace}.default.repairs_cube"
+        try:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes),
+            )
+            assert data["status"] == "success", data
+            response = await client.post(
+                f"/nodes/{cube_name}/columns/"
+                f"{namespace}.default.hard_hat.hire_date/partition",
+                json={
+                    "type_": "temporal",
+                    "granularity": "day",
+                    "format": "yyyyMMdd",
+                },
+            )
+            assert response.status_code == 201, response.json()
+            response = await client.post(
+                f"/nodes/{cube_name}/materialization/",
+                json={
+                    "job": "druid_cube",
+                    "strategy": "incremental_time",
+                    "schedule": "@daily",
+                    "lookback_window": "1 DAY",
+                },
+            )
+            assert response.status_code == 200, response.json()
+
+            mock_qs.reset_mock()
+            cube.description = "Cube for analyzing repair orders, revised"
+            response = await client.post(
+                "/deployments/impact",
+                json=DeploymentSpec(namespace=namespace, nodes=nodes).model_dump(),
+            )
+            assert response.status_code == 200, response.json()
+            assert mock_qs.method_calls == []
+
+            body = (await client.get(f"/nodes/{cube_name}/")).json()
+            assert body["version"] == "v1.0"
+            assert [
+                (mat["config"]["cube"]["version"], mat["deactivated_at"])
+                for mat in body["materializations"]
+            ] == [("v1.0", None)]
+        finally:
+            del client.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
     async def test_deploy_cube_with_materialization_block(
         self,
         session,

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -5390,6 +5390,167 @@ class TestDeclaredCubeMaterializations:
         ]
 
     @pytest.mark.asyncio
+    async def test_declared_block_supersedes_a_competing_materialization(
+        self,
+        client,
+        upstreams,
+        mock_qs,
+    ):
+        """
+        A cube gets one materialization: the one it declares.
+
+        A materialization's name carries its strategy, so declaring a strategy the
+        cube was not already materialized with builds a differently named row -- and
+        leaving the old one active gives one Druid datasource two writers, where the
+        full rebuild deletes what the incremental run added. The competing row is
+        deactivated and its workflow stopped before the declared one is scheduled,
+        since both sit on the same cube version and the stop can only be addressed by
+        cube and version.
+        """
+        namespace = "cube_mat_supersede"
+        cube_name = f"{namespace}.default.repairs_cube"
+        full_name = f"druid_cube__full__{namespace}.default.hard_hat.hire_date"
+        nodes = [
+            *upstreams,
+            self._cube(),
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+
+        # `full` is what the node page's popover defaults to for this cube.
+        response = await client.post(
+            f"/nodes/{cube_name}/materialization/",
+            json={
+                "job": "druid_cube",
+                "strategy": "full",
+                "schedule": "@daily",
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        mock_qs.reset_mock()
+        nodes[-1] = self._cube(
+            materialization=MaterializationSpec(
+                schedule="0 6 * * *",
+                lookback_window="1 DAY",
+            ),
+        )
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "update",
+                "success",
+                "cube materialization on schedule 0 6 * * *",
+            ),
+        ]
+        assert [call[0] for call in mock_qs.method_calls] == [
+            "deactivate_cube_workflow",
+            "materialize_cube",
+        ]
+        assert mock_qs.deactivate_cube_workflow.call_args_list == [
+            mock.call(cube_name, version="v1.0", request_headers=mock.ANY),
+        ]
+        assert await self._persisted_materializations(client, cube_name) == [
+            (full_name, "@daily", "full", False),
+            (
+                self._materialization_name(namespace),
+                "0 6 * * *",
+                "incremental_time",
+                True,
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_competing_materializations_rebuild_to_one_row(
+        self,
+        client,
+        upstreams,
+        default_num_repair_orders,
+        mock_qs,
+    ):
+        """
+        The state a declared block prevents already exists on cubes materialized
+        before it did: a `full` and an `incremental_time` materialization on one cube.
+
+        Editing such a cube's definition rebuilds both against the new revision under
+        the strategy the block declares, so both derive the same name -- and `(name,
+        node_revision_id)` is unique. The cube lands on the one materialization it
+        declared instead of failing the deployment on an integrity error.
+        """
+        namespace = "cube_mat_two_writers"
+        cube_name = f"{namespace}.default.repairs_cube"
+        cube = self._cube()
+        nodes = [
+            *upstreams,
+            default_num_repair_orders,
+            cube,
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+
+        for strategy in ("full", "incremental_time"):
+            response = await client.post(
+                f"/nodes/{cube_name}/materialization/",
+                json={
+                    "job": "druid_cube",
+                    "strategy": strategy,
+                    "schedule": "@daily",
+                },
+            )
+            assert response.status_code == 200, response.json()
+
+        mock_qs.reset_mock()
+        nodes[-1] = self._cube(
+            metrics=[
+                "${prefix}default.avg_length_of_employment",
+                "${prefix}default.num_repair_orders",
+            ],
+            materialization=MaterializationSpec(
+                schedule="0 6 * * *",
+                lookback_window="1 DAY",
+            ),
+        )
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "update",
+                "success",
+                "cube materialization on schedule 0 6 * * *",
+            ),
+        ]
+        assert [call[0] for call in mock_qs.method_calls] == [
+            "materialize_cube",
+            "deactivate_cube_workflow",
+        ]
+        assert mock_qs.deactivate_cube_workflow.call_args_list == [
+            mock.call(cube_name, version="v1.0", request_headers=mock.ANY),
+        ]
+        assert await self._persisted_materializations(client, cube_name) == [
+            (
+                self._materialization_name(namespace),
+                "0 6 * * *",
+                "incremental_time",
+                True,
+            ),
+        ]
+
+    @pytest.mark.asyncio
     async def test_explicit_none_removes_a_materialization_of_any_job(
         self,
         client,

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 
 import datajunction_server.internal.materializations
 from datajunction_server.api.deployments import (
@@ -2681,6 +2682,56 @@ class TestDeployments:
         )
         assert await version_of(patch_ns) == "v2.0"
         assert await version_of(deploy_ns) == "v2.0"
+
+    @pytest.mark.asyncio
+    async def test_get_node_reads_past_a_stale_session_copy(
+        self,
+        client,
+        session,
+        default_hard_hats,
+    ):
+        """
+        `GET /nodes/{name}/` must answer from the database once a deployment has moved
+        the node on to a new revision in a session of its own.
+
+        The test client shares one session across requests, so a node an earlier
+        request left in that session's identity map is what the next request gets --
+        SQLAlchemy leaves an already-loaded relationship alone no matter what load
+        options the next query carries. That served a superseded revision, and where
+        the earlier request had no use for `parents` it served one that could not be
+        serialized at all. Holding the node here makes it deterministic; in CI it
+        depended on whether the earlier request's node had been collected yet.
+        """
+        namespace = "stale_session_copy"
+
+        async def deploy(**overrides) -> None:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace=namespace,
+                    nodes=[default_hard_hats.model_copy(deep=True, update=overrides)],
+                ),
+            )
+            assert data["status"] == "success", data
+
+        await deploy()
+        name = f"{namespace}.default.hard_hats"
+        assert (await client.get(f"/nodes/{name}/")).json()["version"] == "v1.0"
+
+        # An earlier request's view of the node, kept alive in the session with its
+        # revision loaded but not that revision's parents.
+        held = await Node.get_by_name(
+            session,
+            name,
+            options=[selectinload(Node.current)],
+        )
+        assert "parents" not in held.current.__dict__
+
+        await deploy(description="Hard hats, revised")
+        response = await client.get(f"/nodes/{name}/")
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v2.0"
+        assert response.json()["description"] == "Hard hats, revised"
 
     @pytest.mark.asyncio
     async def test_patch_and_deployment_agree_on_materialization_state(

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -31,6 +31,7 @@ from datajunction_server.models.deployment import (
     GitDeploymentSource,
     Granularity,
     LocalDeploymentSource,
+    MaterializationAction,
     MaterializationSpec,
     MetricSpec,
     PartitionSpec,
@@ -1302,20 +1303,14 @@ def _mock_materializing_query_service() -> MagicMock:
 
 def deployment_payload(deployment_spec: DeploymentSpec) -> dict:
     """
-    The spec as `dj push` would send it, as far as `materialization:` is concerned.
+    The spec as a serializing caller would send it.
 
-    `dj push` posts the YAML files as parsed, so a key nobody wrote is absent.
-    `model_dump` instead emits every optional field explicitly null, which would make
-    a cube that never mentioned `materialization:` indistinguishable from one that
-    set it to null and means "tear this down". Only that key is dropped: the rest of
-    the payload stays as-is, since several nested unions are discriminated on fields
-    that carry defaults and would vanish under a blanket `exclude_unset`.
+    Deliberately a plain `model_dump`, which emits every optional field explicitly
+    null. Nothing in the deployment path may read a key's mere presence as intent --
+    `materialization: none` is a value for exactly that reason -- so posting the
+    lossiest payload shape keeps every test below honest about it.
     """
-    payload = deployment_spec.model_dump()
-    for node_payload, node_spec in zip(payload["nodes"], deployment_spec.nodes):
-        if "materialization" not in node_spec.model_fields_set:
-            node_payload.pop("materialization", None)
-    return payload
+    return deployment_spec.model_dump()
 
 
 async def deploy_and_wait(client, deployment_spec: DeploymentSpec):
@@ -5292,7 +5287,7 @@ class TestDeclaredCubeMaterializations:
             del client.app.dependency_overrides[get_query_service_client]
 
     @pytest.mark.asyncio
-    async def test_explicit_null_removes_the_materialization(
+    async def test_explicit_none_removes_the_materialization(
         self,
         client,
         default_hard_hats,
@@ -5302,7 +5297,7 @@ class TestDeclaredCubeMaterializations:
         default_avg_length_of_employment,
     ):
         """
-        `materialization: null` is the one thing that tears a materialization down:
+        `materialization: none` is the one thing that tears a materialization down:
         the row is deactivated and its workflow stopped.
         """
         namespace = "cube_mat_removed"
@@ -5331,7 +5326,7 @@ class TestDeclaredCubeMaterializations:
             assert data["status"] == "success", data
 
             mock_qs.reset_mock()
-            cube.materialization = None
+            cube.materialization = MaterializationAction.NONE
             data = await deploy_and_wait(
                 client,
                 DeploymentSpec(namespace=namespace, nodes=nodes),
@@ -5342,7 +5337,7 @@ class TestDeclaredCubeMaterializations:
                     cube_name,
                     "delete",
                     "success",
-                    "cube materialization removed by `materialization: null`",
+                    "cube materialization removed by `materialization: none`",
                 ),
             ]
             assert mock_qs.materialize_cube.call_count == 0
@@ -5362,7 +5357,7 @@ class TestDeclaredCubeMaterializations:
             del client.app.dependency_overrides[get_query_service_client]
 
     @pytest.mark.asyncio
-    async def test_explicit_null_without_a_materialization_is_a_noop(
+    async def test_explicit_none_without_a_materialization_is_a_noop(
         self,
         client,
         default_hard_hats,
@@ -5372,7 +5367,7 @@ class TestDeclaredCubeMaterializations:
         default_avg_length_of_employment,
     ):
         """
-        A cube that says `materialization: null` and never had one reports a no-op
+        A cube that says `materialization: none` and never had one reports a no-op
         and asks the query service to stop nothing.
         """
         namespace = "cube_mat_null_noop"
@@ -5383,7 +5378,7 @@ class TestDeclaredCubeMaterializations:
             default_us_states,
             default_us_state,
             default_avg_length_of_employment,
-            self._cube(materialization=None),
+            self._cube(materialization=MaterializationAction.NONE),
         ]
         mock_qs = _mock_materializing_query_service()
         client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
@@ -5461,7 +5456,7 @@ class TestDeclaredCubeMaterializations:
                 f"Cube `{cube_name}` is materialized but its spec declares no "
                 "`materialization:` block, so the existing materialization was "
                 "left running. Run `dj pull` to adopt it into YAML, or add "
-                "`materialization: null` to remove it."
+                "`materialization: none` to remove it."
             )
             assert self._materialization_results(data) == [
                 (cube_name, "noop", "warning", warning),
@@ -5477,6 +5472,115 @@ class TestDeclaredCubeMaterializations:
                     True,
                 ),
             ]
+        finally:
+            del client.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_serialized_spec_tears_nothing_down(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        A caller that serializes a spec and re-posts it gets the deploy it asked for,
+        not a mass teardown.
+
+        `model_dump` emits every optional field explicitly, so a spec round-tripped
+        through it says `materialization: null` for every cube -- which, read as
+        "the author wrote that key", is a request to stop every workflow in the
+        namespace. Teardown is a value (`materialization: none`) so that a round trip
+        preserves what the cube actually declared, whether that is a schedule or
+        nothing at all.
+        """
+        namespace = "cube_mat_round_trip"
+        cube_name = f"{namespace}.default.repairs_cube"
+        block = MaterializationSpec(schedule="0 6 * * *", lookback_window="1 DAY")
+        nodes = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+        ]
+        materialized = [
+            (
+                f"druid_cube__incremental_time__{namespace}.default.hard_hat.hire_date",
+                "0 6 * * *",
+                "incremental_time",
+                True,
+            ),
+        ]
+        mock_qs = _mock_materializing_query_service()
+        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+        try:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace=namespace,
+                    nodes=[*nodes, self._cube(materialization=block)],
+                ),
+            )
+            assert data["status"] == "success", data
+            assert await self._persisted_materializations(client, cube_name) == (
+                materialized
+            )
+
+            # A re-declare that has been through `model_dump` and back is still a
+            # re-declare: the schedule stands, unchanged.
+            mock_qs.reset_mock()
+            declared = DeploymentSpec(
+                namespace=namespace,
+                nodes=[*nodes, self._cube(materialization=block)],
+            )
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec.model_validate(declared.model_dump()),
+            )
+            assert data["status"] == "success", data
+            assert self._materialization_results(data) == [
+                (
+                    cube_name,
+                    "noop",
+                    "success",
+                    "cube materialization on schedule 0 6 * * *",
+                ),
+            ]
+            assert mock_qs.method_calls == []
+            assert await self._persisted_materializations(client, cube_name) == (
+                materialized
+            )
+
+            # And a cube that never mentioned `materialization:` keeps its
+            # materialization once serialized, rather than losing it to the null the
+            # dump invents.
+            undeclared = DeploymentSpec(
+                namespace=namespace,
+                nodes=[*nodes, self._cube()],
+            )
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec.model_validate(undeclared.model_dump()),
+            )
+            assert data["status"] == "success", data
+            assert self._materialization_results(data) == [
+                (
+                    cube_name,
+                    "noop",
+                    "warning",
+                    f"Cube `{cube_name}` is materialized but its spec declares no "
+                    "`materialization:` block, so the existing materialization was "
+                    "left running. Run `dj pull` to adopt it into YAML, or add "
+                    "`materialization: none` to remove it.",
+                ),
+            ]
+            assert mock_qs.method_calls == []
+            assert await self._persisted_materializations(client, cube_name) == (
+                materialized
+            )
         finally:
             del client.app.dependency_overrides[get_query_service_client]
 
@@ -5647,7 +5751,7 @@ class TestDeclaredCubeMaterializations:
             ]
 
             # A planned teardown is reported and equally not carried out.
-            cube.materialization = None
+            cube.materialization = MaterializationAction.NONE
             response = await client.post(
                 "/deployments/impact",
                 json=deployment_payload(
@@ -5660,7 +5764,7 @@ class TestDeclaredCubeMaterializations:
                     cube_name,
                     "delete",
                     "success",
-                    "cube materialization removed by `materialization: null`",
+                    "cube materialization removed by `materialization: none`",
                 ),
             ]
             assert mock_qs.method_calls == []

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1286,9 +1286,11 @@ def roads_nodes(
     ]
 
 
-def _mock_materializing_query_service() -> MagicMock:
+@pytest.fixture
+def mock_qs(client):
     """
-    A query service that accepts everything a cube materialization asks of it.
+    A query service that accepts everything a cube materialization asks of it,
+    installed for the duration of the test.
 
     Plain `MagicMock` rather than a spec'd double so `method_calls` records the whole
     sequence in order, which is what the materialization tests below compare against.
@@ -1298,7 +1300,9 @@ def _mock_materializing_query_service() -> MagicMock:
         urls=["http://fake.url/job"],
         output_tables=[],
     )
-    return query_service
+    client.app.dependency_overrides[get_query_service_client] = lambda: query_service
+    yield query_service
+    del client.app.dependency_overrides[get_query_service_client]
 
 
 def deployment_payload(deployment_spec: DeploymentSpec) -> dict:
@@ -2687,6 +2691,7 @@ class TestDeployments:
         default_us_states,
         default_us_state,
         default_avg_length_of_employment,
+        mock_qs,
     ):
         """
         The same edit, applied once through `PATCH /nodes/{name}` and once through a
@@ -2789,86 +2794,79 @@ class TestDeployments:
                     )
             return calls
 
-        mock_qs = _mock_materializing_query_service()
-        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
         patch_ns, deploy_ns = "mat_equivalence_patch", "mat_equivalence_deploy"
-        try:
-            for namespace in (patch_ns, deploy_ns):
-                await deploy(namespace, build_cube())
-                cube_name = f"{namespace}.default.repairs_cube"
-                response = await client.post(
-                    f"/nodes/{cube_name}/materialization/",
-                    json={
-                        "job": "druid_cube",
-                        "strategy": "incremental_time",
-                        "schedule": "@daily",
-                        "lookback_window": "7 DAY",
-                    },
-                )
-                assert response.status_code == 200, response.json()
-
-            # The same metadata-only edit through each path.
-            revised = "Cube for analyzing repair orders, revised"
-            mock_qs.reset_mock()
-            response = await client.patch(
-                f"/nodes/{patch_ns}.default.repairs_cube/",
-                json={"description": revised},
+        for namespace in (patch_ns, deploy_ns):
+            await deploy(namespace, build_cube())
+            cube_name = f"{namespace}.default.repairs_cube"
+            response = await client.post(
+                f"/nodes/{cube_name}/materialization/",
+                json={
+                    "job": "druid_cube",
+                    "strategy": "incremental_time",
+                    "schedule": "@daily",
+                    "lookback_window": "7 DAY",
+                },
             )
             assert response.status_code == 200, response.json()
-            patch_calls = query_service_calls(patch_ns)
 
-            mock_qs.reset_mock()
-            await deploy(deploy_ns, build_cube(description=revised))
-            deploy_calls = query_service_calls(deploy_ns)
+        # The same metadata-only edit through each path.
+        revised = "Cube for analyzing repair orders, revised"
+        mock_qs.reset_mock()
+        response = await client.patch(
+            f"/nodes/{patch_ns}.default.repairs_cube/",
+            json={"description": revised},
+        )
+        assert response.status_code == 200, response.json()
+        patch_calls = query_service_calls(patch_ns)
 
-            expected = (
+        mock_qs.reset_mock()
+        await deploy(deploy_ns, build_cube(description=revised))
+        deploy_calls = query_service_calls(deploy_ns)
+
+        expected = (
+            "v1.1",
+            [
+                (
+                    "druid_cube__incremental_time__"
+                    f"{patch_ns}.default.hard_hat.hire_date",
+                    "DruidCubeMaterializationJob",
+                    "incremental_time",
+                    "@daily",
+                    "v1.1",
+                    "7 DAY",
+                    None,
+                ),
+            ],
+        )
+        assert await materialization_state(patch_ns) == expected
+        assert await materialization_state(deploy_ns) == (
+            expected[0],
+            [
+                (
+                    name.replace(patch_ns, deploy_ns),
+                    *rest,
+                )
+                for name, *rest in expected[1]
+            ],
+        )
+        assert patch_calls == [
+            (
+                "materialize_cube",
+                f"druid_cube__incremental_time__{patch_ns}.default.hard_hat.hire_date",
+                "default.repairs_cube",
                 "v1.1",
-                [
-                    (
-                        "druid_cube__incremental_time__"
-                        f"{patch_ns}.default.hard_hat.hire_date",
-                        "DruidCubeMaterializationJob",
-                        "incremental_time",
-                        "@daily",
-                        "v1.1",
-                        "7 DAY",
-                        None,
-                    ),
-                ],
-            )
-            assert await materialization_state(patch_ns) == expected
-            assert await materialization_state(deploy_ns) == (
-                expected[0],
-                [
-                    (
-                        name.replace(patch_ns, deploy_ns),
-                        *rest,
-                    )
-                    for name, *rest in expected[1]
-                ],
-            )
-            assert patch_calls == [
-                (
-                    "materialize_cube",
-                    f"druid_cube__incremental_time__{patch_ns}"
-                    ".default.hard_hat.hire_date",
-                    "default.repairs_cube",
-                    "v1.1",
-                ),
-                ("deactivate_cube_workflow", "default.repairs_cube", "v1.0"),
-            ]
-            assert deploy_calls == [
-                (
-                    "materialize_cube",
-                    f"druid_cube__incremental_time__{deploy_ns}"
-                    ".default.hard_hat.hire_date",
-                    "default.repairs_cube",
-                    "v1.1",
-                ),
-                ("deactivate_cube_workflow", "default.repairs_cube", "v1.0"),
-            ]
-        finally:
-            del client.app.dependency_overrides[get_query_service_client]
+            ),
+            ("deactivate_cube_workflow", "default.repairs_cube", "v1.0"),
+        ]
+        assert deploy_calls == [
+            (
+                "materialize_cube",
+                f"druid_cube__incremental_time__{deploy_ns}.default.hard_hat.hire_date",
+                "default.repairs_cube",
+                "v1.1",
+            ),
+            ("deactivate_cube_workflow", "default.repairs_cube", "v1.0"),
+        ]
 
     @pytest.mark.asyncio
     async def test_dry_run_deploy_does_not_swap_cube_materializations(
@@ -2879,6 +2877,7 @@ class TestDeployments:
         default_us_states,
         default_us_state,
         default_avg_length_of_employment,
+        mock_qs,
     ):
         """
         A dry run must schedule nothing and stop nothing: the materialization stays on
@@ -2904,55 +2903,50 @@ class TestDeployments:
             default_avg_length_of_employment,
             cube,
         ]
-        mock_qs = _mock_materializing_query_service()
-        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
         cube_name = f"{namespace}.default.repairs_cube"
-        try:
-            data = await deploy_and_wait(
-                client,
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        response = await client.post(
+            f"/nodes/{cube_name}/columns/"
+            f"{namespace}.default.hard_hat.hire_date/partition",
+            json={
+                "type_": "temporal",
+                "granularity": "day",
+                "format": "yyyyMMdd",
+            },
+        )
+        assert response.status_code == 201, response.json()
+        response = await client.post(
+            f"/nodes/{cube_name}/materialization/",
+            json={
+                "job": "druid_cube",
+                "strategy": "incremental_time",
+                "schedule": "@daily",
+                "lookback_window": "1 DAY",
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        mock_qs.reset_mock()
+        cube.description = "Cube for analyzing repair orders, revised"
+        response = await client.post(
+            "/deployments/impact",
+            json=deployment_payload(
                 DeploymentSpec(namespace=namespace, nodes=nodes),
-            )
-            assert data["status"] == "success", data
-            response = await client.post(
-                f"/nodes/{cube_name}/columns/"
-                f"{namespace}.default.hard_hat.hire_date/partition",
-                json={
-                    "type_": "temporal",
-                    "granularity": "day",
-                    "format": "yyyyMMdd",
-                },
-            )
-            assert response.status_code == 201, response.json()
-            response = await client.post(
-                f"/nodes/{cube_name}/materialization/",
-                json={
-                    "job": "druid_cube",
-                    "strategy": "incremental_time",
-                    "schedule": "@daily",
-                    "lookback_window": "1 DAY",
-                },
-            )
-            assert response.status_code == 200, response.json()
+            ),
+        )
+        assert response.status_code == 200, response.json()
+        assert mock_qs.method_calls == []
 
-            mock_qs.reset_mock()
-            cube.description = "Cube for analyzing repair orders, revised"
-            response = await client.post(
-                "/deployments/impact",
-                json=deployment_payload(
-                    DeploymentSpec(namespace=namespace, nodes=nodes),
-                ),
-            )
-            assert response.status_code == 200, response.json()
-            assert mock_qs.method_calls == []
-
-            body = (await client.get(f"/nodes/{cube_name}/")).json()
-            assert body["version"] == "v1.0"
-            assert [
-                (mat["config"]["cube"]["version"], mat["deactivated_at"])
-                for mat in body["materializations"]
-            ] == [("v1.0", None)]
-        finally:
-            del client.app.dependency_overrides[get_query_service_client]
+        body = (await client.get(f"/nodes/{cube_name}/")).json()
+        assert body["version"] == "v1.0"
+        assert [
+            (mat["config"]["cube"]["version"], mat["deactivated_at"])
+            for mat in body["materializations"]
+        ] == [("v1.0", None)]
 
     @pytest.mark.asyncio
     async def test_deploy_cube_with_materialization_block(
@@ -2964,6 +2958,7 @@ class TestDeployments:
         default_us_states,
         default_us_state,
         default_avg_length_of_employment,
+        mock_qs,
     ):
         """
         A cube can declare `materialization:` alongside its definition, the block
@@ -3011,116 +3006,109 @@ class TestDeployments:
             cube,
         ]
         cube_name = f"{namespace}.default.repairs_cube"
-        mock_qs = _mock_materializing_query_service()
-        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
-        try:
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(namespace=namespace, nodes=nodes_list),
-            )
-            assert data["status"] == "success"
-            assert [
-                result for result in data["results"] if result["name"] == cube_name
-            ] == [
-                {
-                    "deploy_type": "node",
-                    "message": "Created cube (v1.0)",
-                    "name": cube_name,
-                    "operation": "create",
-                    "changed_fields": [],
-                    "status": "success",
-                },
-                {
-                    "deploy_type": "materialization",
-                    "message": "cube materialization on schedule 0 6 * * *",
-                    "name": cube_name,
-                    "operation": "create",
-                    "changed_fields": [],
-                    "status": "success",
-                },
-            ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        assert [
+            result for result in data["results"] if result["name"] == cube_name
+        ] == [
+            {
+                "deploy_type": "node",
+                "message": "Created cube (v1.0)",
+                "name": cube_name,
+                "operation": "create",
+                "changed_fields": [],
+                "status": "success",
+            },
+            {
+                "deploy_type": "materialization",
+                "message": "cube materialization on schedule 0 6 * * *",
+                "name": cube_name,
+                "operation": "create",
+                "changed_fields": [],
+                "status": "success",
+            },
+        ]
 
-            session.expire_all()
-            deployed = await Node.get_by_name(
-                session,
-                cube_name,
-                options=Node.cube_load_options(),
-            )
-            assert deployed.current.version == "v1.0"
-            assert (await deployed.to_spec(session)).materialization == (
-                MaterializationSpec(
-                    schedule="0 6 * * *",
-                    strategy=MaterializationStrategy.INCREMENTAL_TIME,
-                    lookback_window="1 DAY",
-                )
-            )
-
-            # Editing only the schedule is not a definition change: the cube compares
-            # equal, is skipped rather than updated, and never earns a version. The
-            # reconciler runs off the spec rather than the change list, so the new
-            # schedule still reaches the query service.
-            mock_qs.reset_mock()
-            cube.materialization = MaterializationSpec(
-                schedule="0 3 * * *",
+        session.expire_all()
+        deployed = await Node.get_by_name(
+            session,
+            cube_name,
+            options=Node.cube_load_options(),
+        )
+        assert deployed.current.version == "v1.0"
+        assert (await deployed.to_spec(session)).materialization == (
+            MaterializationSpec(
+                schedule="0 6 * * *",
+                strategy=MaterializationStrategy.INCREMENTAL_TIME,
                 lookback_window="1 DAY",
             )
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(namespace=namespace, nodes=nodes_list),
-            )
-            assert data["status"] == "success"
-            assert [
-                result for result in data["results"] if result["name"] == cube_name
-            ] == [
-                {
-                    "deploy_type": "node",
-                    "message": "Unchanged",
-                    "name": cube_name,
-                    "operation": "noop",
-                    "changed_fields": [],
-                    "status": "skipped",
-                },
-                {
-                    "deploy_type": "materialization",
-                    "message": "cube materialization on schedule 0 3 * * *",
-                    "name": cube_name,
-                    "operation": "update",
-                    "changed_fields": [],
-                    "status": "success",
-                },
-            ]
+        )
 
-            session.expire_all()
-            deployed = await Node.get_by_name(
-                session,
-                cube_name,
-                options=Node.cube_load_options(),
+        # Editing only the schedule is not a definition change: the cube compares
+        # equal, is skipped rather than updated, and never earns a version. The
+        # reconciler runs off the spec rather than the change list, so the new
+        # schedule still reaches the query service.
+        mock_qs.reset_mock()
+        cube.materialization = MaterializationSpec(
+            schedule="0 3 * * *",
+            lookback_window="1 DAY",
+        )
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        assert [
+            result for result in data["results"] if result["name"] == cube_name
+        ] == [
+            {
+                "deploy_type": "node",
+                "message": "Unchanged",
+                "name": cube_name,
+                "operation": "noop",
+                "changed_fields": [],
+                "status": "skipped",
+            },
+            {
+                "deploy_type": "materialization",
+                "message": "cube materialization on schedule 0 3 * * *",
+                "name": cube_name,
+                "operation": "update",
+                "changed_fields": [],
+                "status": "success",
+            },
+        ]
+
+        session.expire_all()
+        deployed = await Node.get_by_name(
+            session,
+            cube_name,
+            options=Node.cube_load_options(),
+        )
+        assert deployed.current.version == "v1.0"
+        assert (await deployed.to_spec(session)).materialization == (
+            MaterializationSpec(
+                schedule="0 3 * * *",
+                strategy=MaterializationStrategy.INCREMENTAL_TIME,
+                lookback_window="1 DAY",
             )
-            assert deployed.current.version == "v1.0"
-            assert (await deployed.to_spec(session)).materialization == (
-                MaterializationSpec(
-                    schedule="0 3 * * *",
-                    strategy=MaterializationStrategy.INCREMENTAL_TIME,
-                    lookback_window="1 DAY",
-                )
-            )
-            assert mock_qs.materialize_cube.call_count == 1
-            assert mock_qs.deactivate_workflows.call_count == 0
-            assert mock_qs.deactivate_cube_workflow.call_count == 0
-            scheduled = mock_qs.materialize_cube.call_args.kwargs[
-                "materialization_input"
-            ]
-            assert (
-                scheduled.cube.name,
-                scheduled.cube.version,
-                scheduled.schedule,
-            ) == (
-                cube_name,
-                "v1.0",
-                "0 3 * * *",
-            )
-        finally:
-            del client.app.dependency_overrides[get_query_service_client]
+        )
+        assert mock_qs.materialize_cube.call_count == 1
+        assert mock_qs.deactivate_workflows.call_count == 0
+        assert mock_qs.deactivate_cube_workflow.call_count == 0
+        scheduled = mock_qs.materialize_cube.call_args.kwargs["materialization_input"]
+        assert (
+            scheduled.cube.name,
+            scheduled.cube.version,
+            scheduled.schedule,
+        ) == (
+            cube_name,
+            "v1.0",
+            "0 3 * * *",
+        )
 
     @pytest.mark.asyncio
     async def test_deploy_cube_with_custom_metadata(
@@ -5072,6 +5060,39 @@ class TestDeclaredCubeMaterializations:
     Reconciling a cube's `materialization:` block against what is materialized.
     """
 
+    @pytest.fixture
+    def upstreams(
+        self,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ) -> list:
+        """The sources, dimensions and metric every cube in this class is built on."""
+        return [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+        ]
+
+    @staticmethod
+    def _undeclared_warning(cube_name: str) -> str:
+        """The warning a materialized cube with no declared block earns."""
+        return (
+            f"Cube `{cube_name}` is materialized but its spec declares no "
+            "`materialization:` block, so the existing materialization was left "
+            "running. Run `dj pull` to adopt it into YAML, or add "
+            "`materialization: none` to remove it."
+        )
+
+    @staticmethod
+    def _materialization_name(namespace: str) -> str:
+        """The name `create_new_materialization` derives for this class's cube."""
+        return f"druid_cube__incremental_time__{namespace}.default.hard_hat.hire_date"
+
     @staticmethod
     def _cube(**overrides) -> CubeSpec:
         """A partitioned cube, ready to declare a materialization."""
@@ -5130,11 +5151,8 @@ class TestDeclaredCubeMaterializations:
     async def test_unchanged_declaration_touches_nothing(
         self,
         client,
-        default_hard_hats,
-        default_hard_hat,
-        default_us_states,
-        default_us_state,
-        default_avg_length_of_employment,
+        upstreams,
+        mock_qs,
     ):
         """
         Re-pushing an unchanged repo must not churn a live workflow: the second
@@ -5149,60 +5167,47 @@ class TestDeclaredCubeMaterializations:
             ),
         )
         nodes = [
-            default_hard_hats,
-            default_hard_hat,
-            default_us_states,
-            default_us_state,
-            default_avg_length_of_employment,
+            *upstreams,
             cube,
         ]
-        mock_qs = _mock_materializing_query_service()
-        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
-        try:
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(namespace=namespace, nodes=nodes),
-            )
-            assert data["status"] == "success", data
-            assert mock_qs.materialize_cube.call_count == 1
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert mock_qs.materialize_cube.call_count == 1
 
-            mock_qs.reset_mock()
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(namespace=namespace, nodes=nodes),
-            )
-            assert data["status"] == "success", data
-            assert self._materialization_results(data) == [
-                (
-                    cube_name,
-                    "noop",
-                    "success",
-                    "cube materialization on schedule 0 6 * * *",
-                ),
-            ]
-            assert mock_qs.method_calls == []
-            assert await self._persisted_materializations(client, cube_name) == [
-                (
-                    f"druid_cube__incremental_time__{namespace}"
-                    ".default.hard_hat.hire_date",
-                    "0 6 * * *",
-                    "incremental_time",
-                    True,
-                ),
-            ]
-        finally:
-            del client.app.dependency_overrides[get_query_service_client]
+        mock_qs.reset_mock()
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "noop",
+                "success",
+                "cube materialization on schedule 0 6 * * *",
+            ),
+        ]
+        assert mock_qs.method_calls == []
+        assert await self._persisted_materializations(client, cube_name) == [
+            (
+                self._materialization_name(namespace),
+                "0 6 * * *",
+                "incremental_time",
+                True,
+            ),
+        ]
 
     @pytest.mark.asyncio
     async def test_definition_and_schedule_edit_rebuilds_once(
         self,
         client,
-        default_hard_hats,
-        default_hard_hat,
-        default_us_states,
-        default_us_state,
-        default_avg_length_of_employment,
+        upstreams,
         default_num_repair_orders,
+        mock_qs,
     ):
         """
         Editing the cube's metrics and its schedule in one push must rebuild once.
@@ -5220,81 +5225,66 @@ class TestDeclaredCubeMaterializations:
             ),
         )
         nodes = [
-            default_hard_hats,
-            default_hard_hat,
-            default_us_states,
-            default_us_state,
-            default_avg_length_of_employment,
+            *upstreams,
             default_num_repair_orders,
             cube,
         ]
-        mock_qs = _mock_materializing_query_service()
-        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
-        try:
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(namespace=namespace, nodes=nodes),
-            )
-            assert data["status"] == "success", data
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
 
-            mock_qs.reset_mock()
-            cube.metrics = [
-                "${prefix}default.avg_length_of_employment",
-                "${prefix}default.num_repair_orders",
-            ]
-            cube.materialization = MaterializationSpec(
-                schedule="0 3 * * *",
-                lookback_window="1 DAY",
-            )
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(namespace=namespace, nodes=nodes),
-            )
-            assert data["status"] == "success", data
-            assert self._materialization_results(data) == [
-                (
-                    cube_name,
-                    "update",
-                    "success",
-                    "cube materialization on schedule 0 3 * * *",
-                ),
-            ]
+        mock_qs.reset_mock()
+        cube.metrics = [
+            "${prefix}default.avg_length_of_employment",
+            "${prefix}default.num_repair_orders",
+        ]
+        cube.materialization = MaterializationSpec(
+            schedule="0 3 * * *",
+            lookback_window="1 DAY",
+        )
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "update",
+                "success",
+                "cube materialization on schedule 0 3 * * *",
+            ),
+        ]
 
-            # One schedule call, for the new revision and the new schedule, and one
-            # stop for the superseded revision's workflow.
-            assert mock_qs.materialize_cube.call_count == 1
-            scheduled = mock_qs.materialize_cube.call_args.kwargs[
-                "materialization_input"
-            ]
-            assert (
-                scheduled.cube.name,
-                scheduled.cube.version,
-                scheduled.schedule,
-            ) == (cube_name, "v2.0", "0 3 * * *")
-            assert mock_qs.deactivate_cube_workflow.call_args_list == [
-                mock.call(cube_name, version="v1.0", request_headers=mock.ANY),
-            ]
-            assert await self._persisted_materializations(client, cube_name) == [
-                (
-                    f"druid_cube__incremental_time__{namespace}"
-                    ".default.hard_hat.hire_date",
-                    "0 3 * * *",
-                    "incremental_time",
-                    True,
-                ),
-            ]
-        finally:
-            del client.app.dependency_overrides[get_query_service_client]
+        # One schedule call, for the new revision and the new schedule, and one
+        # stop for the superseded revision's workflow.
+        assert mock_qs.materialize_cube.call_count == 1
+        scheduled = mock_qs.materialize_cube.call_args.kwargs["materialization_input"]
+        assert (
+            scheduled.cube.name,
+            scheduled.cube.version,
+            scheduled.schedule,
+        ) == (cube_name, "v2.0", "0 3 * * *")
+        assert mock_qs.deactivate_cube_workflow.call_args_list == [
+            mock.call(cube_name, version="v1.0", request_headers=mock.ANY),
+        ]
+        assert await self._persisted_materializations(client, cube_name) == [
+            (
+                self._materialization_name(namespace),
+                "0 3 * * *",
+                "incremental_time",
+                True,
+            ),
+        ]
 
     @pytest.mark.asyncio
     async def test_explicit_none_removes_the_materialization(
         self,
         client,
-        default_hard_hats,
-        default_hard_hat,
-        default_us_states,
-        default_us_state,
-        default_avg_length_of_employment,
+        upstreams,
+        mock_qs,
     ):
         """
         `materialization: none` is the one thing that tears a materialization down:
@@ -5309,62 +5299,49 @@ class TestDeclaredCubeMaterializations:
             ),
         )
         nodes = [
-            default_hard_hats,
-            default_hard_hat,
-            default_us_states,
-            default_us_state,
-            default_avg_length_of_employment,
+            *upstreams,
             cube,
         ]
-        mock_qs = _mock_materializing_query_service()
-        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
-        try:
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(namespace=namespace, nodes=nodes),
-            )
-            assert data["status"] == "success", data
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
 
-            mock_qs.reset_mock()
-            cube.materialization = MaterializationAction.NONE
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(namespace=namespace, nodes=nodes),
-            )
-            assert data["status"] == "success", data
-            assert self._materialization_results(data) == [
-                (
-                    cube_name,
-                    "delete",
-                    "success",
-                    "cube materialization removed by `materialization: none`",
-                ),
-            ]
-            assert mock_qs.materialize_cube.call_count == 0
-            assert mock_qs.deactivate_cube_workflow.call_args_list == [
-                mock.call(cube_name, version="v1.0", request_headers=mock.ANY),
-            ]
-            assert await self._persisted_materializations(client, cube_name) == [
-                (
-                    f"druid_cube__incremental_time__{namespace}"
-                    ".default.hard_hat.hire_date",
-                    "0 6 * * *",
-                    "incremental_time",
-                    False,
-                ),
-            ]
-        finally:
-            del client.app.dependency_overrides[get_query_service_client]
+        mock_qs.reset_mock()
+        cube.materialization = MaterializationAction.NONE
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "delete",
+                "success",
+                "cube materialization removed by `materialization: none`",
+            ),
+        ]
+        assert mock_qs.materialize_cube.call_count == 0
+        assert mock_qs.deactivate_cube_workflow.call_args_list == [
+            mock.call(cube_name, version="v1.0", request_headers=mock.ANY),
+        ]
+        assert await self._persisted_materializations(client, cube_name) == [
+            (
+                self._materialization_name(namespace),
+                "0 6 * * *",
+                "incremental_time",
+                False,
+            ),
+        ]
 
     @pytest.mark.asyncio
     async def test_explicit_none_without_a_materialization_is_a_noop(
         self,
         client,
-        default_hard_hats,
-        default_hard_hat,
-        default_us_states,
-        default_us_state,
-        default_avg_length_of_employment,
+        upstreams,
+        mock_qs,
     ):
         """
         A cube that says `materialization: none` and never had one reports a no-op
@@ -5373,43 +5350,31 @@ class TestDeclaredCubeMaterializations:
         namespace = "cube_mat_null_noop"
         cube_name = f"{namespace}.default.repairs_cube"
         nodes = [
-            default_hard_hats,
-            default_hard_hat,
-            default_us_states,
-            default_us_state,
-            default_avg_length_of_employment,
+            *upstreams,
             self._cube(materialization=MaterializationAction.NONE),
         ]
-        mock_qs = _mock_materializing_query_service()
-        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
-        try:
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(namespace=namespace, nodes=nodes),
-            )
-            assert data["status"] == "success", data
-            assert self._materialization_results(data) == [
-                (
-                    cube_name,
-                    "noop",
-                    "success",
-                    "cube declares no materialization",
-                ),
-            ]
-            assert mock_qs.method_calls == []
-            assert await self._persisted_materializations(client, cube_name) == []
-        finally:
-            del client.app.dependency_overrides[get_query_service_client]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "noop",
+                "success",
+                "cube declares no materialization",
+            ),
+        ]
+        assert mock_qs.method_calls == []
+        assert await self._persisted_materializations(client, cube_name) == []
 
     @pytest.mark.asyncio
     async def test_undeclared_materialization_is_left_running(
         self,
         client,
-        default_hard_hats,
-        default_hard_hat,
-        default_us_states,
-        default_us_state,
-        default_avg_length_of_employment,
+        upstreams,
+        mock_qs,
     ):
         """
         Omitting the block is not the same as removing it. A cube materialized
@@ -5418,72 +5383,54 @@ class TestDeclaredCubeMaterializations:
         namespace = "cube_mat_undeclared"
         cube_name = f"{namespace}.default.repairs_cube"
         nodes = [
-            default_hard_hats,
-            default_hard_hat,
-            default_us_states,
-            default_us_state,
-            default_avg_length_of_employment,
+            *upstreams,
             self._cube(),
         ]
-        mock_qs = _mock_materializing_query_service()
-        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
-        try:
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(namespace=namespace, nodes=nodes),
-            )
-            assert data["status"] == "success", data
-            assert self._materialization_results(data) == []
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == []
 
-            response = await client.post(
-                f"/nodes/{cube_name}/materialization/",
-                json={
-                    "job": "druid_cube",
-                    "strategy": "incremental_time",
-                    "schedule": "@daily",
-                    "lookback_window": "1 DAY",
-                },
-            )
-            assert response.status_code == 200, response.json()
+        response = await client.post(
+            f"/nodes/{cube_name}/materialization/",
+            json={
+                "job": "druid_cube",
+                "strategy": "incremental_time",
+                "schedule": "@daily",
+                "lookback_window": "1 DAY",
+            },
+        )
+        assert response.status_code == 200, response.json()
 
-            mock_qs.reset_mock()
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(namespace=namespace, nodes=nodes),
-            )
-            assert data["status"] == "success", data
-            warning = (
-                f"Cube `{cube_name}` is materialized but its spec declares no "
-                "`materialization:` block, so the existing materialization was "
-                "left running. Run `dj pull` to adopt it into YAML, or add "
-                "`materialization: none` to remove it."
-            )
-            assert self._materialization_results(data) == [
-                (cube_name, "noop", "warning", warning),
-            ]
-            assert [item["message"] for item in data["warnings"]] == [warning]
-            assert mock_qs.method_calls == []
-            assert await self._persisted_materializations(client, cube_name) == [
-                (
-                    f"druid_cube__incremental_time__{namespace}"
-                    ".default.hard_hat.hire_date",
-                    "@daily",
-                    "incremental_time",
-                    True,
-                ),
-            ]
-        finally:
-            del client.app.dependency_overrides[get_query_service_client]
+        mock_qs.reset_mock()
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        warning = self._undeclared_warning(cube_name)
+        assert self._materialization_results(data) == [
+            (cube_name, "noop", "warning", warning),
+        ]
+        assert [item["message"] for item in data["warnings"]] == [warning]
+        assert mock_qs.method_calls == []
+        assert await self._persisted_materializations(client, cube_name) == [
+            (
+                self._materialization_name(namespace),
+                "@daily",
+                "incremental_time",
+                True,
+            ),
+        ]
 
     @pytest.mark.asyncio
     async def test_serialized_spec_tears_nothing_down(
         self,
         client,
-        default_hard_hats,
-        default_hard_hat,
-        default_us_states,
-        default_us_state,
-        default_avg_length_of_employment,
+        upstreams,
+        mock_qs,
     ):
         """
         A caller that serializes a spec and re-posts it gets the deploy it asked for,
@@ -5500,100 +5447,85 @@ class TestDeclaredCubeMaterializations:
         cube_name = f"{namespace}.default.repairs_cube"
         block = MaterializationSpec(schedule="0 6 * * *", lookback_window="1 DAY")
         nodes = [
-            default_hard_hats,
-            default_hard_hat,
-            default_us_states,
-            default_us_state,
-            default_avg_length_of_employment,
+            *upstreams,
         ]
         materialized = [
             (
-                f"druid_cube__incremental_time__{namespace}.default.hard_hat.hire_date",
+                self._materialization_name(namespace),
                 "0 6 * * *",
                 "incremental_time",
                 True,
             ),
         ]
-        mock_qs = _mock_materializing_query_service()
-        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
-        try:
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(
-                    namespace=namespace,
-                    nodes=[*nodes, self._cube(materialization=block)],
-                ),
-            )
-            assert data["status"] == "success", data
-            assert await self._persisted_materializations(client, cube_name) == (
-                materialized
-            )
-
-            # A re-declare that has been through `model_dump` and back is still a
-            # re-declare: the schedule stands, unchanged.
-            mock_qs.reset_mock()
-            declared = DeploymentSpec(
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(
                 namespace=namespace,
                 nodes=[*nodes, self._cube(materialization=block)],
-            )
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec.model_validate(declared.model_dump()),
-            )
-            assert data["status"] == "success", data
-            assert self._materialization_results(data) == [
-                (
-                    cube_name,
-                    "noop",
-                    "success",
-                    "cube materialization on schedule 0 6 * * *",
-                ),
-            ]
-            assert mock_qs.method_calls == []
-            assert await self._persisted_materializations(client, cube_name) == (
-                materialized
-            )
+            ),
+        )
+        assert data["status"] == "success", data
+        assert await self._persisted_materializations(client, cube_name) == (
+            materialized
+        )
 
-            # And a cube that never mentioned `materialization:` keeps its
-            # materialization once serialized, rather than losing it to the null the
-            # dump invents.
-            undeclared = DeploymentSpec(
-                namespace=namespace,
-                nodes=[*nodes, self._cube()],
-            )
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec.model_validate(undeclared.model_dump()),
-            )
-            assert data["status"] == "success", data
-            assert self._materialization_results(data) == [
-                (
-                    cube_name,
-                    "noop",
-                    "warning",
-                    f"Cube `{cube_name}` is materialized but its spec declares no "
-                    "`materialization:` block, so the existing materialization was "
-                    "left running. Run `dj pull` to adopt it into YAML, or add "
-                    "`materialization: none` to remove it.",
-                ),
-            ]
-            assert mock_qs.method_calls == []
-            assert await self._persisted_materializations(client, cube_name) == (
-                materialized
-            )
-        finally:
-            del client.app.dependency_overrides[get_query_service_client]
+        # A re-declare that has been through `model_dump` and back is still a
+        # re-declare: the schedule stands, unchanged.
+        mock_qs.reset_mock()
+        declared = DeploymentSpec(
+            namespace=namespace,
+            nodes=[*nodes, self._cube(materialization=block)],
+        )
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec.model_validate(declared.model_dump()),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "noop",
+                "success",
+                "cube materialization on schedule 0 6 * * *",
+            ),
+        ]
+        assert mock_qs.method_calls == []
+        assert await self._persisted_materializations(client, cube_name) == (
+            materialized
+        )
+
+        # And a cube that never mentioned `materialization:` keeps its
+        # materialization once serialized, rather than losing it to the null the
+        # dump invents.
+        undeclared = DeploymentSpec(
+            namespace=namespace,
+            nodes=[*nodes, self._cube()],
+        )
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec.model_validate(undeclared.model_dump()),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "noop",
+                "warning",
+                self._undeclared_warning(cube_name),
+            ),
+        ]
+        assert mock_qs.method_calls == []
+        assert await self._persisted_materializations(client, cube_name) == (
+            materialized
+        )
 
     @pytest.mark.asyncio
     async def test_config_drift_under_an_unchanged_block_is_corrected(
         self,
         session,
         client,
-        default_hard_hats,
-        default_hard_hat,
-        default_us_states,
-        default_us_state,
-        default_avg_length_of_employment,
+        upstreams,
+        mock_qs,
     ):
         """
         The block is only three fields; the built config is much more. When the two
@@ -5602,9 +5534,7 @@ class TestDeclaredCubeMaterializations:
         """
         namespace = "cube_mat_drift"
         cube_name = f"{namespace}.default.repairs_cube"
-        materialization_name = (
-            f"druid_cube__incremental_time__{namespace}.default.hard_hat.hire_date"
-        )
+        materialization_name = self._materialization_name(namespace)
         cube = self._cube(
             materialization=MaterializationSpec(
                 schedule="0 6 * * *",
@@ -5612,23 +5542,53 @@ class TestDeclaredCubeMaterializations:
             ),
         )
         nodes = [
-            default_hard_hats,
-            default_hard_hat,
-            default_us_states,
-            default_us_state,
-            default_avg_length_of_employment,
+            *upstreams,
             cube,
         ]
-        mock_qs = _mock_materializing_query_service()
-        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
-        try:
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(namespace=namespace, nodes=nodes),
-            )
-            assert data["status"] == "success", data
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
 
-            materialization = (
+        materialization = (
+            (
+                await session.execute(
+                    select(Materialization).where(
+                        Materialization.name == materialization_name,
+                    ),
+                )
+            )
+            .scalars()
+            .one()
+        )
+        materialization.config = {
+            **materialization.config,
+            "workflow_names": ["configured-elsewhere"],
+        }
+        await session.commit()
+
+        mock_qs.reset_mock()
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "update",
+                "success",
+                "cube materialization on schedule 0 6 * * *",
+            ),
+        ]
+        assert mock_qs.materialize_cube.call_count == 1
+        # Read from the database rather than through `GET /nodes/{name}/`: the
+        # revision did not change, so that response is still cached.
+        session.expire_all()
+        assert [
+            (row.name, row.config.get("workflow_names"), row.deactivated_at)
+            for row in (
                 (
                     await session.execute(
                         select(Materialization).where(
@@ -5637,58 +5597,16 @@ class TestDeclaredCubeMaterializations:
                     )
                 )
                 .scalars()
-                .one()
+                .all()
             )
-            materialization.config = {
-                **materialization.config,
-                "workflow_names": ["configured-elsewhere"],
-            }
-            await session.commit()
-
-            mock_qs.reset_mock()
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(namespace=namespace, nodes=nodes),
-            )
-            assert data["status"] == "success", data
-            assert self._materialization_results(data) == [
-                (
-                    cube_name,
-                    "update",
-                    "success",
-                    "cube materialization on schedule 0 6 * * *",
-                ),
-            ]
-            assert mock_qs.materialize_cube.call_count == 1
-            # Read from the database rather than through `GET /nodes/{name}/`: the
-            # revision did not change, so that response is still cached.
-            session.expire_all()
-            assert [
-                (row.name, row.config.get("workflow_names"), row.deactivated_at)
-                for row in (
-                    (
-                        await session.execute(
-                            select(Materialization).where(
-                                Materialization.name == materialization_name,
-                            ),
-                        )
-                    )
-                    .scalars()
-                    .all()
-                )
-            ] == [(materialization_name, None, None)]
-        finally:
-            del client.app.dependency_overrides[get_query_service_client]
+        ] == [(materialization_name, None, None)]
 
     @pytest.mark.asyncio
     async def test_dry_run_plans_the_change_without_making_it(
         self,
         client,
-        default_hard_hats,
-        default_hard_hat,
-        default_us_states,
-        default_us_state,
-        default_avg_length_of_employment,
+        upstreams,
+        mock_qs,
     ):
         """
         A dry run reports the operation the wet run would perform, and performs none
@@ -5703,94 +5621,80 @@ class TestDeclaredCubeMaterializations:
             ),
         )
         nodes = [
-            default_hard_hats,
-            default_hard_hat,
-            default_us_states,
-            default_us_state,
-            default_avg_length_of_employment,
+            *upstreams,
             cube,
         ]
-        mock_qs = _mock_materializing_query_service()
-        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
-        try:
-            data = await deploy_and_wait(
-                client,
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+
+        mock_qs.reset_mock()
+        cube.materialization = MaterializationSpec(
+            schedule="0 3 * * *",
+            lookback_window="1 DAY",
+        )
+        response = await client.post(
+            "/deployments/impact",
+            json=deployment_payload(
                 DeploymentSpec(namespace=namespace, nodes=nodes),
-            )
-            assert data["status"] == "success", data
+            ),
+        )
+        assert response.status_code == 200, response.json()
+        assert self._materialization_results(response.json()) == [
+            (
+                cube_name,
+                "update",
+                "success",
+                "cube materialization on schedule 0 3 * * *",
+            ),
+        ]
+        assert mock_qs.method_calls == []
+        assert await self._persisted_materializations(client, cube_name) == [
+            (
+                self._materialization_name(namespace),
+                "0 6 * * *",
+                "incremental_time",
+                True,
+            ),
+        ]
 
-            mock_qs.reset_mock()
-            cube.materialization = MaterializationSpec(
-                schedule="0 3 * * *",
-                lookback_window="1 DAY",
-            )
-            response = await client.post(
-                "/deployments/impact",
-                json=deployment_payload(
-                    DeploymentSpec(namespace=namespace, nodes=nodes),
-                ),
-            )
-            assert response.status_code == 200, response.json()
-            assert self._materialization_results(response.json()) == [
-                (
-                    cube_name,
-                    "update",
-                    "success",
-                    "cube materialization on schedule 0 3 * * *",
-                ),
-            ]
-            assert mock_qs.method_calls == []
-            assert await self._persisted_materializations(client, cube_name) == [
-                (
-                    f"druid_cube__incremental_time__{namespace}"
-                    ".default.hard_hat.hire_date",
-                    "0 6 * * *",
-                    "incremental_time",
-                    True,
-                ),
-            ]
-
-            # A planned teardown is reported and equally not carried out.
-            cube.materialization = MaterializationAction.NONE
-            response = await client.post(
-                "/deployments/impact",
-                json=deployment_payload(
-                    DeploymentSpec(namespace=namespace, nodes=nodes),
-                ),
-            )
-            assert response.status_code == 200, response.json()
-            assert self._materialization_results(response.json()) == [
-                (
-                    cube_name,
-                    "delete",
-                    "success",
-                    "cube materialization removed by `materialization: none`",
-                ),
-            ]
-            assert mock_qs.method_calls == []
-            assert await self._persisted_materializations(client, cube_name) == [
-                (
-                    f"druid_cube__incremental_time__{namespace}"
-                    ".default.hard_hat.hire_date",
-                    "0 6 * * *",
-                    "incremental_time",
-                    True,
-                ),
-            ]
-        finally:
-            del client.app.dependency_overrides[get_query_service_client]
+        # A planned teardown is reported and equally not carried out.
+        cube.materialization = MaterializationAction.NONE
+        response = await client.post(
+            "/deployments/impact",
+            json=deployment_payload(
+                DeploymentSpec(namespace=namespace, nodes=nodes),
+            ),
+        )
+        assert response.status_code == 200, response.json()
+        assert self._materialization_results(response.json()) == [
+            (
+                cube_name,
+                "delete",
+                "success",
+                "cube materialization removed by `materialization: none`",
+            ),
+        ]
+        assert mock_qs.method_calls == []
+        assert await self._persisted_materializations(client, cube_name) == [
+            (
+                self._materialization_name(namespace),
+                "0 6 * * *",
+                "incremental_time",
+                True,
+            ),
+        ]
 
     @pytest.mark.asyncio
     async def test_unmaterializable_cube_fails_alone(
         self,
         client,
         mocker,
-        default_hard_hats,
-        default_hard_hat,
-        default_us_states,
-        default_us_state,
-        default_avg_length_of_employment,
+        upstreams,
         default_num_repair_orders,
+        mock_qs,
     ):
         """
         A cube DJ cannot build a materialization for -- measures queries at different
@@ -5818,11 +5722,7 @@ class TestDeclaredCubeMaterializations:
             side_effect=build,
         )
         nodes = [
-            default_hard_hats,
-            default_hard_hat,
-            default_us_states,
-            default_us_state,
-            default_avg_length_of_employment,
+            *upstreams,
             default_num_repair_orders,
             self._cube(
                 materialization=MaterializationSpec(
@@ -5839,35 +5739,28 @@ class TestDeclaredCubeMaterializations:
                 ),
             ),
         ]
-        mock_qs = _mock_materializing_query_service()
-        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
-        try:
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(namespace=namespace, nodes=nodes),
-            )
-            assert self._materialization_results(data) == [
-                (
-                    working_name,
-                    "create",
-                    "success",
-                    "cube materialization on schedule 0 6 * * *",
-                ),
-                (
-                    broken_name,
-                    "unknown",
-                    "failed",
-                    f"Cube `{broken_name}`: {grain_error}",
-                ),
-            ]
-            assert mock_qs.materialize_cube.call_count == 1
-            scheduled = mock_qs.materialize_cube.call_args.kwargs[
-                "materialization_input"
-            ]
-            assert scheduled.cube.name == working_name
-            assert await self._persisted_materializations(client, broken_name) == []
-        finally:
-            del client.app.dependency_overrides[get_query_service_client]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert self._materialization_results(data) == [
+            (
+                working_name,
+                "create",
+                "success",
+                "cube materialization on schedule 0 6 * * *",
+            ),
+            (
+                broken_name,
+                "unknown",
+                "failed",
+                f"Cube `{broken_name}`: {grain_error}",
+            ),
+        ]
+        assert mock_qs.materialize_cube.call_count == 1
+        scheduled = mock_qs.materialize_cube.call_args.kwargs["materialization_input"]
+        assert scheduled.cube.name == working_name
+        assert await self._persisted_materializations(client, broken_name) == []
 
 
 @pytest.mark.xdist_group(name="deployments")

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -5705,6 +5705,107 @@ class TestDeclaredCubeMaterializations:
         ]
 
     @pytest.mark.asyncio
+    async def test_cube_planner_materialization_is_left_alone(
+        self,
+        session,
+        client,
+        upstreams,
+        default_num_repair_orders,
+        mock_qs,
+    ):
+        """
+        A cube materialized by the cube planner is not adopted into the fused dialect.
+
+        The two dialects are indistinguishable by job -- `POST
+        /cubes/{name}/materialize` stores the same `DruidCubeMaterializationJob` the
+        fused path derives -- so a planner row read as intent to rebuild recovers as a
+        fused materialization: the planner's workflow stopped and a fused one
+        scheduled in its place. It is left exactly where it is instead, and the
+        warning the cube earns says something true about it.
+        """
+        namespace = "cube_mat_planner"
+        cube_name = f"{namespace}.default.repairs_cube"
+        nodes = [
+            *upstreams,
+            default_num_repair_orders,
+            self._cube(),
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+
+        cube = await Node.get_by_name(session, cube_name)
+        session.add(
+            Materialization(
+                node_revision_id=cube.current.id,
+                name="druid_cube_v3",
+                strategy=MaterializationStrategy.INCREMENTAL_TIME,
+                schedule="@daily",
+                config={"version": "v3", "workflow_names": ["planner-workflow"]},
+                job="DruidCubeMaterializationJob",
+            ),
+        )
+        await session.commit()
+        planner_row = ("druid_cube_v3", "@daily", "incremental_time", True)
+
+        # An unchanged push leaves it running, and says so in terms that apply to it:
+        # `dj pull` cannot write a block that describes a planner materialization.
+        mock_qs.reset_mock()
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        warning = (
+            f"Cube `{cube_name}` is materialized by the cube planner, which a "
+            "`materialization:` block cannot describe, so the existing "
+            "materialization was left running. Add `materialization: none` to "
+            "remove it."
+        )
+        assert self._materialization_results(data) == [
+            (cube_name, "noop", "warning", warning),
+        ]
+        assert [item["message"] for item in data["warnings"]] == [warning]
+        assert mock_qs.method_calls == []
+        assert await self._persisted_materializations(client, cube_name) == [
+            planner_row,
+        ]
+
+        # And so does a push that gives the cube a new revision, which would
+        # otherwise carry the planner's row over as a fused one.
+        nodes[-1] = self._cube(
+            metrics=[
+                "${prefix}default.avg_length_of_employment",
+                "${prefix}default.num_repair_orders",
+            ],
+        )
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == []
+        assert mock_qs.method_calls == []
+        assert await self._persisted_materializations(client, cube_name) == []
+        session.expire_all()
+        assert [
+            (row.name, row.deactivated_at)
+            for row in (
+                (
+                    await session.execute(
+                        select(Materialization).where(
+                            Materialization.name == "druid_cube_v3",
+                        ),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        ] == [("druid_cube_v3", None)]
+
+    @pytest.mark.asyncio
     async def test_serialized_spec_tears_nothing_down(
         self,
         client,

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1297,10 +1297,12 @@ def mock_qs(client):
     sequence in order, which is what the materialization tests below compare against.
     """
     query_service = MagicMock()
-    query_service.materialize_cube.return_value = MaterializationInfo(
+    materialized = MaterializationInfo(
         urls=["http://fake.url/job"],
         output_tables=[],
     )
+    query_service.materialize_cube.return_value = materialized
+    query_service.materialize.return_value = materialized
     client.app.dependency_overrides[get_query_service_client] = lambda: query_service
     yield query_service
     del client.app.dependency_overrides[get_query_service_client]
@@ -5385,6 +5387,71 @@ class TestDeclaredCubeMaterializations:
                 "incremental_time",
                 False,
             ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_explicit_none_removes_a_materialization_of_any_job(
+        self,
+        client,
+        upstreams,
+        mock_qs,
+    ):
+        """
+        A teardown takes down whatever the cube actually has, not only what a
+        `materialization:` block could have described.
+
+        Only the fused Druid cube job projects back into declarative form, so a cube
+        materialized by the older `druid_measures_cube` job reads there as
+        unmaterialized -- and answering `materialization: none` from that projection
+        reported a green no-op while the workflow kept running.
+        """
+        namespace = "cube_mat_legacy_removed"
+        cube_name = f"{namespace}.default.repairs_cube"
+        materialization_name = (
+            f"druid_measures_cube__incremental_time__"
+            f"{namespace}.default.hard_hat.hire_date"
+        )
+        nodes = [
+            *upstreams,
+            self._cube(),
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+
+        response = await client.post(
+            f"/nodes/{cube_name}/materialization/",
+            json={
+                "job": "druid_measures_cube",
+                "strategy": "incremental_time",
+                "schedule": "@daily",
+                "config": {"spark": {}, "lookback_window": "1 DAY"},
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        mock_qs.reset_mock()
+        nodes[-1] = self._cube(materialization=MaterializationAction.NONE)
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "delete",
+                "success",
+                "cube materialization removed by `materialization: none`",
+            ),
+        ]
+        assert mock_qs.deactivate_cube_workflow.call_args_list == [
+            mock.call(cube_name, version="v1.0", request_headers=mock.ANY),
+        ]
+        assert await self._persisted_materializations(client, cube_name) == [
+            (materialization_name, "@daily", "incremental_time", False),
         ]
 
     @pytest.mark.asyncio

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -1674,17 +1674,23 @@ async def test_getting_materializations_for_all_revisions(
         },
     )
 
+    materialization_name = (
+        "druid_measures_cube__incremental_time__default.repair_orders_fact.order_date"
+    )
     response = await client.get(
         f"/nodes/{cube_name}/materializations",
     )
-    assert len(response.json()) == 0
+    assert [mat["name"] for mat in response.json()] == [materialization_name]
 
     # Make sure both materializations show up when all materializations are requested
     response = await client.get(
         f"/nodes/{cube_name}/materializations"
         "?include_all_revisions=true&show_inactive=true",
     )
-    assert len(response.json()) == 1
+    assert [mat["name"] for mat in response.json()] == [
+        materialization_name,
+        materialization_name,
+    ]
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -10,6 +10,7 @@ from datajunction_server.models.deployment import (
     DimensionReferenceLinkSpec,
     DimensionSpec,
     Granularity,
+    MaterializationAction,
     MaterializationSpec,
     MetricSpec,
     NamespaceGitConfig,
@@ -997,3 +998,53 @@ def test_cube_spec_without_materialization_omits_it_from_export():
     spec = _partitioned_cube()
     assert spec.materialization is None
     assert "materialization" not in spec.model_dump(mode="json", exclude_none=True)
+
+
+def test_cube_spec_teardown_survives_serialization():
+    """
+    The two ways a cube can decline to be materialized have to stay distinguishable
+    after a round trip. `model_dump` emits every optional field explicitly, so a
+    teardown carried by a key's presence alone would be indistinguishable from every
+    cube that never mentioned `materialization:` -- and the round-tripped spec would
+    read as a request to tear down the whole namespace.
+    """
+    torn_down = CubeSpec.model_validate(
+        {**_partitioned_cube().model_dump(), "materialization": "none"},
+    )
+    assert torn_down.materialization == MaterializationAction.NONE
+    assert (
+        CubeSpec.model_validate(torn_down.model_dump()).materialization
+        == MaterializationAction.NONE
+    )
+
+    unmanaged = CubeSpec.model_validate(_partitioned_cube().model_dump())
+    assert unmanaged.materialization is None
+    assert CubeSpec.model_validate(unmanaged.model_dump()).materialization is None
+
+    # `rendered_spec` round-trips through JSON too, and preserved neither before.
+    assert torn_down.rendered_spec().materialization == MaterializationAction.NONE
+    assert unmanaged.rendered_spec().materialization is None
+
+
+def test_cube_spec_teardown_sentinel_is_case_insensitive():
+    """`None` is what a Python author writes and `NONE` what a YAML one does."""
+    for spelling in ("none", "None", "NONE"):
+        spec = CubeSpec.model_validate(
+            {**_partitioned_cube().model_dump(), "materialization": spelling},
+        )
+        assert spec.materialization == MaterializationAction.NONE
+
+
+def test_cube_spec_teardown_needs_no_temporal_partition():
+    """
+    The partition requirement is a property of an incremental block, so a cube being
+    torn down is exempt -- it may well be losing the partition in the same push.
+    """
+    spec = CubeSpec(
+        namespace="test",
+        name="my_cube",
+        metrics=["${prefix}num_orders"],
+        dimensions=["${prefix}date_dim.dateint"],
+        materialization=MaterializationAction.NONE,
+    )
+    assert spec.materialization == MaterializationAction.NONE


### PR DESCRIPTION
### Summary

#2400 enabled `CubeSpec` to handle a `materialization:` block, but it wasn't actually scheduling any materializations based off of the config yet. This is the follow-up PR that makes the deployment reconcile the YAML declaration against what the cube actually has.

Deploying a declared `materialization:` block schedules a `druid_cube` materialization (in line with how the current DJ UI's node materialization page creates materializations). If the declared YAML config is the same between deployments, this is a no-op that never reaches the query service. Changing the block will update the same materialization config row in-place, and the relevant workflows will be called from the query service to repush. However, if a change is more substantial (e.g., a different strategy), the old materialization row will be superseded, and its workflows will be stopped rather than left running alongside.

To explicitly remove an existing materialization, use `materialization: none`. (This is to distinguish from the unmanaged case, which is just an absent value for the `materialization:` block).

Additional Warnings:
* A materialized cube that does not have a corresponding `materialization: block` will get a warning upon deployment.
* A cube that cannot be materialized says why
* Remote swap calls are drained after `session.commit()` so that a query-service outage leaves the deployment committed rather than half-applied.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
