### PR TITLE
Set a retention window on cube materializations

### DIFF
--- a/datajunction-server/datajunction_server/api/cubes.py
+++ b/datajunction-server/datajunction_server/api/cubes.py
@@ -341,6 +341,7 @@ async def cube_materialization_info(
         strategy=upsert.strategy,
         schedule=upsert.schedule,
         job=upsert.job.name,  # type: ignore
+        retention=cube_config.retention,
         measures_materializations=cube_config.measures_materializations,
         combiners=cube_config.combiners,
     )

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -72,7 +72,10 @@ from datajunction_server.models.deployment import (
     SourceSpec,
     TransformSpec,
 )
-from datajunction_server.models.materialization import MaterializationJobTypeEnum
+from datajunction_server.models.materialization import (
+    DEFAULT_CUBE_RETENTION,
+    MaterializationJobTypeEnum,
+)
 from datajunction_server.models.node import (
     DEFAULT_DRAFT_VERSION,
     BuildCriteria,
@@ -689,7 +692,7 @@ class Node(Base):
         """
         Project this cube's persisted materialization back into the declarative form.
 
-        Only the three authored fields round-trip. Everything else on the stored
+        Only the authored fields round-trip. Everything else on the stored
         config -- measures queries, combiner SQL, the Druid spec, output tables --
         is derived by DJ on every build, so re-exporting it would put generated
         artifacts into a hand-edited file and make the YAML churn on each rebuild.
@@ -723,6 +726,9 @@ class Node(Base):
             schedule=materialization.schedule,
             strategy=materialization.strategy,
             lookback_window=config.get("lookback_window"),
+            # Configs persisted before `retention` existed will be built with the
+            # default on their next run, so that is what the export should show.
+            retention=config.get("retention", DEFAULT_CUBE_RETENTION),
         )
 
     @classmethod

--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -524,5 +524,6 @@ async def build_cube_materialization(
         measures_materializations=measures_materializations,
         combiners=combiners,
         lookback_window=upsert_input.lookback_window if incremental else None,
+        retention=upsert_input.retention,
     )
     return config

--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -156,6 +156,7 @@ class DruidCubeMaterializationJob(DruidMaterializationJob, MaterializationJob):
                 schedule=materialization.schedule,
                 job=materialization.job,
                 lookback_window=cube_config.lookback_window,
+                retention=cube_config.retention,
                 measures_materializations=cube_config.measures_materializations,
                 combiners=cube_config.combiners,
             ),

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -14,6 +14,7 @@ from datajunction_server.models.decompose import (
     MetricComponent,
 )
 from datajunction_server.models.materialization import (
+    DEFAULT_CUBE_RETENTION,
     DRUID_AGG_MAPPING,
     MaterializationJobTypeEnum,
     MaterializationStrategy,
@@ -274,6 +275,9 @@ class UpsertCubeMaterialization(BaseModel):
     # Lookback window, only relevant if materialization strategy is INCREMENTAL_TIME
     lookback_window: str | None = "1 DAY"
 
+    # How long the Druid datasource keeps ingested data. Applies under both strategies.
+    retention: str | None = DEFAULT_CUBE_RETENTION
+
     @field_validator("job")
     def validate_job(
         cls,
@@ -465,6 +469,10 @@ class DruidCubeConfig(BaseModel):
     # Lookback window, only relevant if materialization strategy is INCREMENTAL_TIME
     lookback_window: str | None = "1 DAY"
 
+    # How long the Druid datasource keeps ingested data. Applies under both strategies.
+    # Configs persisted before this field existed pick up the default on their next build.
+    retention: str | None = DEFAULT_CUBE_RETENTION
+
 
 class DruidCubeMaterializationInput(BaseModel):
     """
@@ -483,6 +491,10 @@ class DruidCubeMaterializationInput(BaseModel):
     schedule: str
     job: str
     lookback_window: str | None = "1 DAY"
+
+    # Retention for the target Druid datasource, applied by the query service through
+    # Druid's coordinator API.
+    retention: str | None = DEFAULT_CUBE_RETENTION
 
     # List of measures materializations
     measures_materializations: list[MeasuresMaterialization]

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -24,7 +24,10 @@ from datajunction_server.models.dimensionlink import (
     SparkJoinStrategy,
 )
 from datajunction_server.models.impact import DownstreamImpact
-from datajunction_server.models.materialization import MaterializationStrategy
+from datajunction_server.models.materialization import (
+    DEFAULT_CUBE_RETENTION,
+    MaterializationStrategy,
+)
 from datajunction_server.models.node import (
     MetricDirection,
     MetricUnit,
@@ -229,16 +232,20 @@ class MaterializationSpec(BaseModel):
     """
     Declarative materialization config for a cube.
 
-    Deliberately carries only what the author decides: when to build, how, and
-    how far back to look. The backend that runs it (and everything it derives --
-    the measures queries, combiner SQL, Druid spec, output tables) is DJ's
-    choice, so no `job` field is exposed here and the block stays portable if
-    that choice changes.
+    Deliberately carries only what the author decides: when to build, how, how
+    far back to look, and how long the result is kept. The backend that runs it
+    (and everything it derives -- the measures queries, combiner SQL, Druid spec,
+    output tables) is DJ's choice, so no `job` field is exposed here and the
+    block stays portable if that choice changes.
     """
 
     schedule: str
     strategy: MaterializationStrategy = MaterializationStrategy.INCREMENTAL_TIME
     lookback_window: str | None = "1 DAY"
+
+    # Unlike `lookback_window`, this is meaningful under both strategies: a full
+    # rebuild is exactly the case that loads the widest span of history.
+    retention: str | None = DEFAULT_CUBE_RETENTION
 
     @model_validator(mode="after")
     def clear_lookback_for_full(self) -> "MaterializationSpec":

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -52,6 +52,12 @@ DRUID_AGG_MAPPING = {
 # Aggregation types that need special handling (extra config parameters)
 DRUID_SKETCH_TYPES = {"HLLSketchMerge"}
 
+# How long ingested cube data is kept in Druid. Without an explicit rule a datasource
+# inherits the cluster default, which is unrelated to the span the cube holds, so an
+# ingest reaching further back fails at load time with a retention rule violation.
+# 400 days covers a full year of history plus room for late-arriving restatements.
+DEFAULT_CUBE_RETENTION = "400 DAYS"
+
 
 class MaterializationStrategy(StrEnum):
     """

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -812,6 +812,10 @@ async def test_druid_cube_incremental(
     )
     assert mat.job == "DruidCubeMaterializationJob"
     assert mat.lookback_window == "7 DAY"
+    # Retention was not authored, so the default has to reach the query service: a
+    # Druid datasource with no rule of its own inherits a cluster default unrelated
+    # to the span of data the cube holds.
+    assert mat.retention == "400 DAYS"
     assert mat.cube == NodeNameVersion(
         name="default.repairs_cube__default_incremental",
         version="v1.0",
@@ -973,6 +977,9 @@ async def test_druid_cube_full(
     _, kwargs = module__query_service_client.materialize_cube.call_args_list[-1]  # type: ignore
     mat = kwargs["materialization_input"]
     assert mat.job == "DruidCubeMaterializationJob"
+    # `lookback_window` is dropped for FULL, but retention is not -- a full rebuild
+    # is exactly the case that loads the widest span of history.
+    assert (mat.lookback_window, mat.retention) == (None, "400 DAYS")
     measures_query = mat.measures_materializations[0].query
     assert "DJ_LOGICAL_TIMESTAMP" not in measures_query
     assert "dj_logical_timestamp" not in measures_query.lower()
@@ -2012,7 +2019,7 @@ async def test_cube_materialization_round_trips_to_spec(
     A cube materialized through the API exports as a declarative `materialization:`
     block, so a repo-managed cube can be pulled and re-deployed without losing it.
 
-    Only the three authored fields come back. The stored config also holds the
+    Only the authored fields come back. The stored config also holds the
     measures queries, combiner SQL and Druid spec, all of which DJ regenerates on
     every build -- re-exporting those would drop generated artifacts into a
     hand-edited file.
@@ -2047,9 +2054,14 @@ async def test_cube_materialization_round_trips_to_spec(
             "strategy": "incremental_time",
             "schedule": "0 6 * * *",
             "lookback_window": "7 DAY",
+            "retention": "90 DAYS",
         },
     )
     assert response.status_code in (200, 201)
+
+    # An authored retention rides all the way to the query service.
+    _, kwargs = module__query_service_client.materialize_cube.call_args_list[-1]  # type: ignore
+    assert kwargs["materialization_input"].retention == "90 DAYS"
 
     module__session.expire_all()
     cube = await Node.get_by_name(
@@ -2063,6 +2075,7 @@ async def test_cube_materialization_round_trips_to_spec(
         schedule="0 6 * * *",
         strategy=MaterializationStrategy.INCREMENTAL_TIME,
         lookback_window="7 DAY",
+        retention="90 DAYS",
     )
 
     # The exported block is exactly the authored surface -- no derived config leaks.
@@ -2070,6 +2083,7 @@ async def test_cube_materialization_round_trips_to_spec(
         "schedule": "0 6 * * *",
         "strategy": "incremental_time",
         "lookback_window": "7 DAY",
+        "retention": "90 DAYS",
     }
 
     # The export path itself loads with `export_load_options`, which deliberately
@@ -2088,4 +2102,5 @@ async def test_cube_materialization_round_trips_to_spec(
         schedule="0 6 * * *",
         strategy=MaterializationStrategy.INCREMENTAL_TIME,
         lookback_window="7 DAY",
+        retention="90 DAYS",
     )

--- a/datajunction-server/tests/models/cube_materialization_test.py
+++ b/datajunction-server/tests/models/cube_materialization_test.py
@@ -73,6 +73,49 @@ def test_druid_cube_materialization_job_passes_lookback_window():
     assert materialization_input.lookback_window == "7 DAY"
 
 
+def test_druid_cube_materialization_job_defaults_retention():
+    """
+    A config with no retention -- including one persisted before the field existed --
+    still hands the query service the default, which is what keeps Druid from
+    rejecting an ingest that reaches further back than the cluster default allows.
+    """
+    cube = NodeNameVersion(name="default.repairs_cube", version="v1.0")
+    config = DruidCubeConfig(
+        cube=cube,
+        dimensions=[],
+        metrics=[],
+        measures_materializations=[],
+        combiners=[],
+    ).model_dump()
+    del config["retention"]
+    materialization = SimpleNamespace(
+        name="druid_cube__full",
+        config=config,
+        strategy=MaterializationStrategy.FULL,
+        schedule="@daily",
+        job="DruidCubeMaterializationJob",
+    )
+    query_service_client = Mock()
+
+    DruidCubeMaterializationJob().schedule(materialization, query_service_client)
+
+    assert query_service_client.materialize_cube.call_args.kwargs[
+        "materialization_input"
+    ] == DruidCubeMaterializationInput(
+        name="druid_cube__full",
+        cube=cube,
+        dimensions=[],
+        metrics=[],
+        strategy=MaterializationStrategy.FULL,
+        schedule="@daily",
+        job="DruidCubeMaterializationJob",
+        lookback_window="1 DAY",
+        retention="400 DAYS",
+        measures_materializations=[],
+        combiners=[],
+    )
+
+
 class TestDruidCubeV3ConfigDruidCubeConfigCompatibility:
     """Test DruidCubeConfig compatibility computed properties."""
 

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -872,6 +872,18 @@ def test_materialization_spec_defaults():
         "schedule": "0 6 * * *",
         "strategy": MaterializationStrategy.INCREMENTAL_TIME,
         "lookback_window": "1 DAY",
+        "retention": "400 DAYS",
+    }
+
+
+def test_materialization_spec_retention_override():
+    """An author can widen or narrow how long Druid keeps the ingested data."""
+    spec = MaterializationSpec(schedule="0 6 * * *", retention="30 DAYS")
+    assert spec.model_dump() == {
+        "schedule": "0 6 * * *",
+        "strategy": MaterializationStrategy.INCREMENTAL_TIME,
+        "lookback_window": "1 DAY",
+        "retention": "30 DAYS",
     }
 
 
@@ -879,6 +891,7 @@ def test_materialization_spec_full_strategy_drops_lookback():
     """
     ``lookback_window`` is meaningless for FULL, so it is normalized away -- otherwise
     two equivalent specs could compare unequal and churn a live workflow on deploy.
+    ``retention`` is not: a full rebuild loads the widest span of history there is.
     """
     declared = MaterializationSpec(
         schedule="0 6 * * *",
@@ -889,6 +902,7 @@ def test_materialization_spec_full_strategy_drops_lookback():
         "schedule": "0 6 * * *",
         "strategy": MaterializationStrategy.FULL,
         "lookback_window": None,
+        "retention": "400 DAYS",
     }
     assert declared == MaterializationSpec(
         schedule="0 6 * * *",


### PR DESCRIPTION
### Summary

A Druid datasource created for a cube had no default retention rule, so it just inherited the cluster default, which isn't based on the actual span of data that the cube is meant to have. An ingest reaching beyond the boundaries of the default will fail at load time with a retention rule violation.

Cube materializations now carry a `retention`, defaulting to 400 days and overridable by the author on the declarative block. The query service is responsible for applying it to Druid.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
