### PR TITLE
feat: granular types for semantic layer API

### DIFF
--- a/datajunction-server/datajunction_server/api/semantic_layer.py
+++ b/datajunction-server/datajunction_server/api/semantic_layer.py
@@ -39,7 +39,7 @@ DEFAULT_ROW_LIMIT = 10000
 MAX_ROW_LIMIT = 100000
 
 DIMENSION_FALLBACK_ARROW_TYPE_NAME = "utf8"
-METRIC_FALLBACK_ARROW_TYPE_NAME = "float"
+METRIC_FALLBACK_ARROW_TYPE_NAME = "floating"
 
 DJ_TO_ARROW_TYPE_NAMES = {
     "array": "list",
@@ -49,8 +49,8 @@ DJ_TO_ARROW_TYPE_NAMES = {
     "char": "utf8",
     "date": "date",
     "decimal": "decimal",
-    "double": "float",
-    "float": "float",
+    "double": "floating",
+    "float": "floating",
     "int": "int",
     "integer": "int",
     "list": "list",

--- a/datajunction-server/datajunction_server/api/semantic_layer.py
+++ b/datajunction-server/datajunction_server/api/semantic_layer.py
@@ -38,7 +38,7 @@ DEFAULT_ROW_LIMIT = 10000
 # An explicit limit above this is rejected (400).
 MAX_ROW_LIMIT = 100000
 
-DEFAULT_ARROW_TYPE_NAME = "utf8"
+DIMENSION_FALLBACK_ARROW_TYPE_NAME = "utf8"
 METRIC_FALLBACK_ARROW_TYPE_NAME = "float"
 
 DJ_TO_ARROW_TYPE_NAMES = {
@@ -80,18 +80,18 @@ def _problem(status_code: int, detail: str) -> JSONResponse:
     )
 
 
-def _arrow_type_name(dj_type: Any, fallback: str = DEFAULT_ARROW_TYPE_NAME) -> str:
+def _arrow_type_name(dj_type: Any) -> str | None:
     """Map a DJ column type to the Arrow JSON type object's ``name`` value."""
     if not dj_type:
-        return fallback
+        return None
 
     type_name = str(dj_type).lower().split("(", maxsplit=1)[0].strip()
     type_name = type_name.split("<", maxsplit=1)[0].strip()
 
-    return DJ_TO_ARROW_TYPE_NAMES.get(type_name, fallback)
+    return DJ_TO_ARROW_TYPE_NAMES.get(type_name)
 
 
-def _cube_column_type_map(cube: NodeRevision) -> dict[str, str]:
+def _cube_column_type_map(cube: NodeRevision) -> dict[str, str | None]:
     """Return Arrow type names for the metric/dimension ids exposed by a cube."""
     return {
         column.cube_element_name: _arrow_type_name(column.type)
@@ -106,7 +106,7 @@ def _metrics_payload(cube: NodeRevision) -> list["MetricInfo"]:
         MetricInfo(
             id=metric_name,
             name=metric_name.split(".")[-1],
-            type=type_by_name.get(metric_name, METRIC_FALLBACK_ARROW_TYPE_NAME),
+            type=type_by_name.get(metric_name) or METRIC_FALLBACK_ARROW_TYPE_NAME,
             definition=metric_name,
             description=None,
             aggregation="OTHER",
@@ -122,7 +122,7 @@ def _dimensions_payload(cube: NodeRevision) -> list["DimensionInfo"]:
         DimensionInfo(
             id=dim_ref,
             name=dim_ref.split(".")[-1],
-            type=type_by_name.get(dim_ref, DEFAULT_ARROW_TYPE_NAME),
+            type=type_by_name.get(dim_ref) or DIMENSION_FALLBACK_ARROW_TYPE_NAME,
             definition=dim_ref,
             description=None,
             grain=None,

--- a/datajunction-server/datajunction_server/api/semantic_layer.py
+++ b/datajunction-server/datajunction_server/api/semantic_layer.py
@@ -38,6 +38,34 @@ DEFAULT_ROW_LIMIT = 10000
 # An explicit limit above this is rejected (400).
 MAX_ROW_LIMIT = 100000
 
+DEFAULT_ARROW_TYPE_NAME = "utf8"
+METRIC_FALLBACK_ARROW_TYPE_NAME = "float"
+
+DJ_TO_ARROW_TYPE_NAMES = {
+    "array": "list",
+    "bigint": "int",
+    "binary": "binary",
+    "boolean": "bool",
+    "char": "utf8",
+    "date": "date",
+    "decimal": "decimal",
+    "double": "float",
+    "float": "float",
+    "int": "int",
+    "integer": "int",
+    "list": "list",
+    "long": "int",
+    "map": "map",
+    "smallint": "int",
+    "string": "utf8",
+    "struct": "struct",
+    "time": "time",
+    "timestamp": "timestamp",
+    "timestamptz": "timestamp",
+    "tinyint": "int",
+    "varchar": "utf8",
+}
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -52,14 +80,33 @@ def _problem(status_code: int, detail: str) -> JSONResponse:
     )
 
 
+def _arrow_type_name(dj_type: Any, fallback: str = DEFAULT_ARROW_TYPE_NAME) -> str:
+    """Map a DJ column type to the Arrow JSON type object's ``name`` value."""
+    if not dj_type:
+        return fallback
+
+    type_name = str(dj_type).lower().split("(", maxsplit=1)[0].strip()
+    type_name = type_name.split("<", maxsplit=1)[0].strip()
+
+    return DJ_TO_ARROW_TYPE_NAMES.get(type_name, fallback)
+
+
+def _cube_column_type_map(cube: NodeRevision) -> dict[str, str]:
+    """Return Arrow type names for the metric/dimension ids exposed by a cube."""
+    return {
+        column.cube_element_name: _arrow_type_name(column.type)
+        for column in cube.columns
+    }
+
+
 def _metrics_payload(cube: NodeRevision) -> list["MetricInfo"]:
-    """Spec ``metrics`` list. type/aggregation are coarse defaults — real types
-    come through the query-result schema; ``definition`` is display-only."""
+    """Spec ``metrics`` list. ``definition`` is display-only."""
+    type_by_name = _cube_column_type_map(cube)
     return [
         MetricInfo(
             id=metric_name,
             name=metric_name.split(".")[-1],
-            type="double",
+            type=type_by_name.get(metric_name, METRIC_FALLBACK_ARROW_TYPE_NAME),
             definition=metric_name,
             description=None,
             aggregation="OTHER",
@@ -69,13 +116,13 @@ def _metrics_payload(cube: NodeRevision) -> list["MetricInfo"]:
 
 
 def _dimensions_payload(cube: NodeRevision) -> list["DimensionInfo"]:
-    """Spec ``dimensions`` list. type is a coarse default (real types come through
-    the query-result schema); grain detection is deferred."""
+    """Spec ``dimensions`` list. Grain detection is deferred."""
+    type_by_name = _cube_column_type_map(cube)
     return [
         DimensionInfo(
             id=dim_ref,
             name=dim_ref.split(".")[-1],
-            type="string",
+            type=type_by_name.get(dim_ref, DEFAULT_ARROW_TYPE_NAME),
             definition=dim_ref,
             description=None,
             grain=None,

--- a/datajunction-server/tests/api/semantic_layer_test.py
+++ b/datajunction-server/tests/api/semantic_layer_test.py
@@ -75,7 +75,7 @@ class TestSemanticViewPayloadTypes:
         assert _arrow_type_name("varchar(255)") == "utf8"
         assert _arrow_type_name("array<string>") == "list"
         assert _arrow_type_name("timestamp") == "timestamp"
-        assert _arrow_type_name(None) == "utf8"
+        assert _arrow_type_name(None) is None
 
     def test_metric_and_dimension_payloads_use_cube_column_types(self):
         cube = SimpleNamespace(
@@ -108,6 +108,41 @@ class TestSemanticViewPayloadTypes:
             "sem.region.region_id": "int",
             "sem.region.region_name[home]": "utf8",
         }
+
+    def test_metric_and_dimension_payloads_fallback_when_type_is_unknown(self):
+        cube = SimpleNamespace(
+            columns=[
+                SimpleNamespace(
+                    cube_element_name="sem.total_amount",
+                    type=None,
+                ),
+                SimpleNamespace(
+                    cube_element_name="sem.region.region_name",
+                    type="unknown_type",
+                ),
+            ],
+            cube_node_metrics=["sem.total_amount"],
+            cube_node_dimensions=["sem.region.region_name"],
+        )
+
+        metrics = _metrics_payload(cube)  # type: ignore[arg-type]
+        dimensions = _dimensions_payload(cube)  # type: ignore[arg-type]
+
+        assert metrics[0].type == "float"
+        assert dimensions[0].type == "utf8"
+
+    def test_metric_and_dimension_payloads_fallback_when_column_is_missing(self):
+        cube = SimpleNamespace(
+            columns=[],
+            cube_node_metrics=["sem.total_amount"],
+            cube_node_dimensions=["sem.region.region_name"],
+        )
+
+        metrics = _metrics_payload(cube)  # type: ignore[arg-type]
+        dimensions = _dimensions_payload(cube)  # type: ignore[arg-type]
+
+        assert metrics[0].type == "float"
+        assert dimensions[0].type == "utf8"
 
 
 # ---------------------------------------------------------------------------

--- a/datajunction-server/tests/api/semantic_layer_test.py
+++ b/datajunction-server/tests/api/semantic_layer_test.py
@@ -71,7 +71,7 @@ class TestQuoteValue:
 class TestSemanticViewPayloadTypes:
     def test_arrow_type_name_uses_standard_name_only(self):
         assert _arrow_type_name("bigint") == "int"
-        assert _arrow_type_name("double") == "float"
+        assert _arrow_type_name("double") == "floating"
         assert _arrow_type_name("varchar(255)") == "utf8"
         assert _arrow_type_name("array<string>") == "list"
         assert _arrow_type_name("timestamp") == "timestamp"
@@ -128,7 +128,7 @@ class TestSemanticViewPayloadTypes:
         metrics = _metrics_payload(cube)  # type: ignore[arg-type]
         dimensions = _dimensions_payload(cube)  # type: ignore[arg-type]
 
-        assert metrics[0].type == "float"
+        assert metrics[0].type == "floating"
         assert dimensions[0].type == "utf8"
 
     def test_metric_and_dimension_payloads_fallback_when_column_is_missing(self):
@@ -141,7 +141,7 @@ class TestSemanticViewPayloadTypes:
         metrics = _metrics_payload(cube)  # type: ignore[arg-type]
         dimensions = _dimensions_payload(cube)  # type: ignore[arg-type]
 
-        assert metrics[0].type == "float"
+        assert metrics[0].type == "floating"
         assert dimensions[0].type == "utf8"
 
 

--- a/datajunction-server/tests/api/semantic_layer_test.py
+++ b/datajunction-server/tests/api/semantic_layer_test.py
@@ -15,7 +15,10 @@ from httpx import AsyncClient
 from datajunction_server.api.semantic_layer import (
     MAX_ROW_LIMIT,
     FilterPayload,
+    _arrow_type_name,
+    _dimensions_payload,
     _filter_to_sql,
+    _metrics_payload,
     _quote_value,
 )
 from datajunction_server.errors import DJException
@@ -63,6 +66,48 @@ class TestQuoteValue:
         # would mis-lex into two adjacent strings. So the correct literal is
         # backslash-escaped.
         assert _quote_value("O'Brien") == "'O\\'Brien'"
+
+
+class TestSemanticViewPayloadTypes:
+    def test_arrow_type_name_uses_standard_name_only(self):
+        assert _arrow_type_name("bigint") == "int"
+        assert _arrow_type_name("double") == "float"
+        assert _arrow_type_name("varchar(255)") == "utf8"
+        assert _arrow_type_name("array<string>") == "list"
+        assert _arrow_type_name("timestamp") == "timestamp"
+        assert _arrow_type_name(None) == "utf8"
+
+    def test_metric_and_dimension_payloads_use_cube_column_types(self):
+        cube = SimpleNamespace(
+            columns=[
+                SimpleNamespace(
+                    cube_element_name="sem.total_amount",
+                    type="decimal(18,2)",
+                ),
+                SimpleNamespace(
+                    cube_element_name="sem.region.region_id",
+                    type="bigint",
+                ),
+                SimpleNamespace(
+                    cube_element_name="sem.region.region_name[home]",
+                    type="varchar(255)",
+                ),
+            ],
+            cube_node_metrics=["sem.total_amount"],
+            cube_node_dimensions=[
+                "sem.region.region_id",
+                "sem.region.region_name[home]",
+            ],
+        )
+
+        metrics = _metrics_payload(cube)  # type: ignore[arg-type]
+        dimensions = _dimensions_payload(cube)  # type: ignore[arg-type]
+
+        assert metrics[0].type == "decimal"
+        assert {dimension.id: dimension.type for dimension in dimensions} == {
+            "sem.region.region_id": "int",
+            "sem.region.region_name[home]": "utf8",
+        }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

<!-- What's this change about? -->

I chatted with @joellubi about the Apache Superset -> Quiver -> DJ integration, and we agreed it would be better to have more information about types in the metadata responses. Since Quiver uses Arrow, and Superset is moving towards Arrow, we decided to adopt the Arrow names in the response payload. This PR maps the DJ (Spark) types to Arrow types and returns them in `MetricInfo` and `DimensionInfo`.

For context: https://docs.google.com/document/d/1ho0FKy9ge0tUSRzebq1AFi28KR1H_utecQjHx4CNCEs/edit?tab=t.0#heading=h.ljxz9kmy8g4n

### Test Plan

<!-- How did you test your change? -->

Added unit tests.

### Deployment Plan

<!-- Any special instructions around deployment? -->
