### PR TITLE
Compare SQL aliases without depending on the AS keyword

### DIFF
--- a/datajunction-server/tests/construction/build_v3/__init__.py
+++ b/datajunction-server/tests/construction/build_v3/__init__.py
@@ -1,6 +1,25 @@
 import re
 
+from datajunction_server.sql.parsing.ast import Aliasable, Node
 from datajunction_server.sql.parsing.backends.antlr4 import parse as parse_sql
+
+
+def _normalize_alias_keyword(node: Node) -> Node:
+    """
+    Spell every alias with AS, since the keyword is optional in SQL.
+
+    The parser records whether AS was written and renders it back, so otherwise
+    ``COALESCE(a, b) AS x`` and ``COALESCE(a, b) x`` compare unequal despite
+    being the same query -- which made these assertions depend on how the SQL
+    generator happens to format aliases rather than on what it means.
+    """
+
+    def spell_out_as(child: Node) -> None:
+        if isinstance(child, Aliasable) and child.alias is not None:
+            child.set_as(True)
+
+    node.apply(spell_out_as)
+    return node
 
 
 def assert_sql_equal(
@@ -12,7 +31,8 @@ def assert_sql_equal(
     Assert that two SQL strings are semantically equal.
 
     Uses the DJ SQL parser to normalize both strings before comparison.
-    This handles whitespace differences, keyword casing, etc.
+    This handles whitespace differences, keyword casing, the optional AS keyword
+    on aliases, etc.
 
     Args:
         actual_sql: The actual SQL generated
@@ -26,8 +46,8 @@ def assert_sql_equal(
         expected_sql = re.sub(hash_pattern, "_HASH", expected_sql)
 
     actual_sql = actual_sql.replace("${dj_logical_timestamp}", "DJ_LOGICAL_TIMESTAMP()")
-    actual_parsed = str(parse_sql(actual_sql))
-    expected_parsed = str(parse_sql(expected_sql))
+    actual_parsed = str(_normalize_alias_keyword(parse_sql(actual_sql)))
+    expected_parsed = str(_normalize_alias_keyword(parse_sql(expected_sql)))
 
     assert actual_parsed == expected_parsed, (
         f"\n\nActual SQL:\n{actual_parsed}\n\nExpected SQL:\n{expected_parsed}"


### PR DESCRIPTION
Five `TestBuildCombinerSql` cases are failing on `main` (and therefore on every open PR that merges it). No combiner code changed — the generated SQL now spells COALESCE aliases with `AS`, while the expectations omit it:

```
Actual:   COALESCE(gg1.date_id, gg2.date_id) AS date_id
Expected: COALESCE(gg1.date_id, gg2.date_id) date_id
```

`assert_sql_equal` promises semantic comparison, but the parser records whether `AS` was written and renders it back, so those two compare unequal despite being the same query. The assertion depended on how the SQL generator happens to spell aliases.

Rather than restate the new spelling in five expectations, this normalizes the optional keyword on both sides, so the same class of failure cannot return the next time alias formatting shifts. The change only loosens comparison over syntax that carries no meaning — an alias whose name differs, or is missing entirely, still fails.

---

Verification:

```
tests/construction/build_v3/combiners_test.py     -> 60 passed (was 5 failed)
tests/construction/ + tests/sql/decompose_test.py -> 1050 passed, 2 skipped, 1 xfailed
```

The helper is shared, so I also ran the API-side consumers: `sql_test.py`, `djql_test.py`, `cubes_test.py`, `dimension_links_test.py`, `query_params_test.py` — 142 passed, 6 skipped.

I confirmed the failures are pre-existing by running the same tests on a clean `upstream/main` worktree with no other changes: identical 5 failures.

Made with [Cursor](https://cursor.com)