### PR TITLE
Refresh source nodes from warehouse table metadata w/ owners

### DIFF
--- a/datajunction-clients/python/tests/conftest.py
+++ b/datajunction-clients/python/tests/conftest.py
@@ -28,6 +28,7 @@ from datajunction_server.models.query import (
     QueryCreate,
     QueryWithResults,
 )
+from datajunction_server.models.table_metadata import TableMetadata
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.typing import QueryState
 from datajunction_server.utils import (
@@ -208,6 +209,32 @@ def module__query_service_client(
         qs_client,
         "get_columns_for_table",
         mock_get_columns_for_table,
+    )
+
+    async def mock_get_table_metadata(
+        catalog: str,
+        schema: str,
+        table: str,
+        request_headers: dict[str, str] | None = None,
+        engine: Engine | None = None,
+    ) -> TableMetadata:
+        # Resolved through get_columns_for_table above rather than duplicating the
+        # mapping, and stubbed at all so that refresh does not fall through to the
+        # HTTP implementation and issue a real request to the scheme-less test URI.
+        return TableMetadata(
+            columns=await qs_client.get_columns_for_table(
+                catalog,
+                schema,
+                table,
+                request_headers,
+                engine,
+            ),
+        )
+
+    module_mocker.patch.object(
+        qs_client,
+        "get_table_metadata",
+        mock_get_table_metadata,
     )
 
     async def mock_submit_query(

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -49,7 +49,7 @@ from datajunction_server.database.preaggregation import (
     compute_expression_hash,
     measure_identity_token,
 )
-from datajunction_server.database.user import User
+from datajunction_server.database.user import OAuthProvider, User
 from datajunction_server.errors import (
     DJDoesNotExistException,
     DJError,
@@ -118,6 +118,7 @@ from datajunction_server.models.node import (
 )
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.query import QueryCreate
+from datajunction_server.models.table_metadata import TableOwner
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.dag import (
     get_downstream_nodes,
@@ -1538,6 +1539,54 @@ async def update_owners(
         session=session,
     )
     await session.commit()
+
+
+async def apply_table_owner(
+    session: AsyncSession,
+    node: Node,
+    owner: TableOwner,
+    save_history: Callable,
+) -> bool:
+    """
+    Set the node's owners to exactly the table's owner.
+
+    Returns True when a change was made. Creates the user if absent -- usernames
+    are emails, so the owner's email is its username. Never clears owners: the
+    caller only invokes this with a resolved owner.
+
+    Owners live on ``Node`` rather than ``NodeRevision``, so this never forks a
+    revision. The caller is responsible for committing.
+    """
+    await session.refresh(node, ["owners"])
+    old_owners = [existing.username for existing in node.owners]
+    if old_owners == [owner.email]:
+        return False
+
+    user = await User.get_by_username(session, owner.email)
+    if user is None:
+        user = User(
+            username=owner.email,
+            email=owner.email,
+            name=owner.full_name or owner.email,
+            oauth_provider=OAuthProvider.BASIC,
+        )
+        session.add(user)
+        await session.flush()
+
+    node.owners = [user]
+    session.add(node)
+    await save_history(
+        event=History(
+            entity_type=EntityType.NODE,
+            entity_name=node.name,
+            node=node.name,
+            activity_type=ActivityType.UPDATE,
+            details={"old_owners": old_owners, "new_owners": [owner.email]},
+            user=owner.email,
+        ),
+        session=session,
+    )
+    return True
 
 
 def cube_changed_fields(
@@ -4104,10 +4153,11 @@ async def refresh_source(
         )
         new_query = current_revision.query
 
-    # Get the latest columns for the source node's table from the query service
+    # Get the latest columns and owner for the source node's table from the query service
+    table_metadata = None
     new_columns = []
     try:
-        new_columns = await query_service_client.get_columns_for_table(
+        table_metadata = await query_service_client.get_table_metadata(
             current_revision.catalog.name,
             current_revision.schema_,  # type: ignore
             current_revision.table,  # type: ignore
@@ -4116,9 +4166,22 @@ async def refresh_source(
             if len(current_revision.catalog.engines) >= 1
             else None,
         )
+        new_columns = table_metadata.columns
     except DJDoesNotExistException:
         # continue with the update, if the table was not found
         pass
+
+    # Apply the table's owner before the column comparison below, so that an
+    # ownership-only change still takes effect on the two short-circuit paths.
+    # ``owner is None`` means "no ownership information", never "no owner", so it
+    # leaves the node's existing owners alone.
+    if table_metadata is not None and table_metadata.owner is not None:
+        await apply_table_owner(
+            session,
+            source_node,  # type: ignore
+            table_metadata.owner,
+            save_history,
+        )
 
     refresh_details = {}
     if new_columns:
@@ -4131,6 +4194,8 @@ async def refresh_source(
         # if the columns haven't changed and the node has a table, we can skip the update
         if not column_changes:
             if not source_node.missing_table:  # type: ignore
+                # Commits any ownership change made above; a no-op otherwise
+                await session.commit()
                 return source_node  # type: ignore
             # if the columns haven't changed but the node has a missing table, we should fix it
             source_node.missing_table = False  # type: ignore
@@ -4139,6 +4204,7 @@ async def refresh_source(
         # since we don't see any columns, we assume the table is gone
         if source_node.missing_table:  # type: ignore
             # but if the node already has a missing table, we can skip the update
+            await session.commit()
             return source_node  # type: ignore
         source_node.missing_table = True  # type: ignore
         new_columns = current_revision.columns

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -49,7 +49,7 @@ from datajunction_server.database.preaggregation import (
     compute_expression_hash,
     measure_identity_token,
 )
-from datajunction_server.database.user import OAuthProvider, User
+from datajunction_server.database.user import OAuthProvider, PrincipalKind, User
 from datajunction_server.errors import (
     DJDoesNotExistException,
     DJError,
@@ -1572,6 +1572,7 @@ async def apply_table_owner(
             email=owner.email,
             name=owner.display_name or owner.username,
             oauth_provider=OAuthProvider.BASIC,
+            kind=PrincipalKind.GROUP if owner.is_group else PrincipalKind.USER,
         )
         session.add(user)
         await session.flush()

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -118,7 +118,7 @@ from datajunction_server.models.node import (
 )
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.query import QueryCreate
-from datajunction_server.models.table_metadata import TableOwner
+from datajunction_server.models.table_metadata import TableMetadata, TableOwner
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.dag import (
     get_downstream_nodes,
@@ -1550,24 +1550,26 @@ async def apply_table_owner(
     """
     Set the node's owners to exactly the table's owner.
 
-    Returns True when a change was made. Creates the user if absent -- usernames
-    are emails, so the owner's email is its username. Never clears owners: the
-    caller only invokes this with a resolved owner.
+    Returns True when a change was made. Creates the user if absent, keyed on
+    ``owner.username`` -- the query service is responsible for mapping its
+    catalog's identity to a DJ username, since DJ usernames are not universally
+    emails. Never clears owners: the caller only invokes this with a resolved
+    owner.
 
     Owners live on ``Node`` rather than ``NodeRevision``, so this never forks a
     revision. The caller is responsible for committing.
     """
     await session.refresh(node, ["owners"])
     old_owners = [existing.username for existing in node.owners]
-    if old_owners == [owner.email]:
+    if old_owners == [owner.username]:
         return False
 
-    user = await User.get_by_username(session, owner.email)
+    user = await User.get_by_username(session, owner.username)
     if user is None:
         user = User(
-            username=owner.email,
+            username=owner.username,
             email=owner.email,
-            name=owner.full_name or owner.email,
+            name=owner.display_name or owner.username,
             oauth_provider=OAuthProvider.BASIC,
         )
         session.add(user)
@@ -1581,12 +1583,49 @@ async def apply_table_owner(
             entity_name=node.name,
             node=node.name,
             activity_type=ActivityType.UPDATE,
-            details={"old_owners": old_owners, "new_owners": [owner.email]},
-            user=owner.email,
+            details={"old_owners": old_owners, "new_owners": [owner.username]},
+            user=owner.username,
         ),
         session=session,
     )
     return True
+
+
+def apply_table_descriptions(
+    session: AsyncSession,
+    revision: NodeRevision,
+    table_metadata: TableMetadata,
+) -> bool:
+    """
+    Fill in the node's and columns' descriptions from the warehouse table.
+
+    Fill-when-empty, never overwrite: a description is curated prose that
+    someone may have written in DJ, and the table's comment is not automatically
+    the better one. This only closes the gap where DJ has nothing.
+
+    Applied in place rather than by forking a revision -- a comment is not a
+    schema change, and the caller commits.
+    """
+    changed = False
+
+    if table_metadata.description and not revision.description:
+        revision.description = table_metadata.description
+        changed = True
+
+    incoming = {
+        column.name: column.description
+        for column in table_metadata.columns
+        if column.description
+    }
+    for column in revision.columns:
+        description = incoming.get(column.name)
+        if description and not column.description:
+            column.description = description
+            changed = True
+
+    if changed:
+        session.add(revision)
+    return changed
 
 
 def cube_changed_fields(
@@ -4182,6 +4221,9 @@ async def refresh_source(
             table_metadata.owner,
             save_history,
         )
+
+    if table_metadata is not None:
+        apply_table_descriptions(session, current_revision, table_metadata)
 
     refresh_details = {}
     if new_columns:

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1546,6 +1546,7 @@ async def apply_table_owner(
     node: Node,
     owner: TableOwner,
     save_history: Callable,
+    current_user: User,
 ) -> bool:
     """
     Set the node's owners to exactly the table's owner.
@@ -1584,11 +1585,56 @@ async def apply_table_owner(
             node=node.name,
             activity_type=ActivityType.UPDATE,
             details={"old_owners": old_owners, "new_owners": [owner.username]},
-            user=owner.username,
+            # The actor is whoever ran the refresh, not the new owner -- the new
+            # owner is the object of the change. `get_node_creator`-style callers
+            # read this field, so it has to name a real actor.
+            user=current_user.username,
         ),
         session=session,
     )
     return True
+
+
+def describe_column_changes(
+    existing: list[Column],
+    incoming: list[Column],
+) -> dict:
+    """
+    Describe how a table's columns changed, for the audit trail.
+
+    Returns the same keys ``revalidate`` already records -- ``type_changes``,
+    ``added_columns``, ``removed_columns`` -- so a version bump is explained the
+    same way however it was triggered. Empty when nothing changed, so the result
+    doubles as the "did anything change" test.
+
+    Type changes matter beyond documentation: a source column changing type can
+    change the value of a metric computed from it, so a refresh that silently
+    bumps a version leaves no way to explain a number that moved.
+    """
+    existing_by_name = {column.name: column for column in existing}
+    incoming_by_name = {column.name: column for column in incoming}
+
+    changes: dict = {}
+    type_changes = [
+        {
+            "column": name,
+            "from": str(existing_by_name[name].type),
+            "to": str(column.type),
+        }
+        for name, column in incoming_by_name.items()
+        if name in existing_by_name
+        and str(existing_by_name[name].type) != str(column.type)
+    ]
+    added = sorted(set(incoming_by_name) - set(existing_by_name))
+    removed = sorted(set(existing_by_name) - set(incoming_by_name))
+
+    if type_changes:
+        changes["type_changes"] = type_changes
+    if added:
+        changes["added_columns"] = added
+    if removed:
+        changes["removed_columns"] = removed
+    return changes
 
 
 def apply_table_descriptions(
@@ -4220,8 +4266,11 @@ async def refresh_source(
             source_node,  # type: ignore
             table_metadata.owner,
             save_history,
+            current_user,
         )
 
+    # Descriptions are deliberately not recorded in the audit trail: a comment is
+    # documentation, not something a reported number can turn on.
     if table_metadata is not None:
         apply_table_descriptions(session, current_revision, table_metadata)
 
@@ -4236,7 +4285,9 @@ async def refresh_source(
         # if the columns haven't changed and the node has a table, we can skip the update
         if not column_changes:
             if not source_node.missing_table:  # type: ignore
-                # Commits any ownership change made above; a no-op otherwise
+                # No revision to fork. An ownership change is already recorded by
+                # apply_table_owner above, and descriptions are deliberately not
+                # audited, so there is nothing further to record here.
                 await session.commit()
                 return source_node  # type: ignore
             # if the columns haven't changed but the node has a missing table, we should fix it
@@ -4303,6 +4354,12 @@ async def refresh_source(
     session.add(source_node)
 
     refresh_details["version"] = new_revision.version
+    # Explain the bump the same way `revalidate` does. A source column changing
+    # type can change a metric computed from it, so "which columns and how" is
+    # the part of a refresh worth auditing.
+    refresh_details.update(
+        describe_column_changes(current_revision.columns, new_columns),
+    )
     await save_history(
         event=History(
             entity_type=EntityType.NODE,

--- a/datajunction-server/datajunction_server/models/table_metadata.py
+++ b/datajunction-server/datajunction_server/models/table_metadata.py
@@ -6,10 +6,22 @@ from datajunction_server.database.column import Column
 
 
 class TableOwner(BaseModel):
-    """A resolved, current human owner of a warehouse table."""
+    """
+    The principal that owns a warehouse table.
 
-    email: str
-    full_name: str = ""
+    ``username`` is what DJ keys on, and the query service decides it: DJ
+    usernames are not universally emails (the GitHub auth path uses a login,
+    basic auth uses an arbitrary name), so the mapping from a warehouse
+    identity to a DJ username belongs to whichever query service knows its own
+    catalog's identity model.
+
+    Not necessarily a person -- a Snowflake owner is a role, and a BigQuery one
+    can be a group or a service account.
+    """
+
+    username: str
+    email: str | None = None
+    display_name: str = ""
 
 
 class TableMetadata(BaseModel):
@@ -27,5 +39,7 @@ class TableMetadata(BaseModel):
     columns: list[Column] = []
     owner: TableOwner | None = None
     partitions: list[str] = []
-    broken_ref: bool | None = None
-    valid_through: str | None = None
+    # The table's own comment/description. Every major catalog has one
+    # (Snowflake COMMENT, BigQuery description, Iceberg/Hive comment). Per-column
+    # descriptions ride along on ``columns``, which already has the field.
+    description: str | None = None

--- a/datajunction-server/datajunction_server/models/table_metadata.py
+++ b/datajunction-server/datajunction_server/models/table_metadata.py
@@ -1,0 +1,31 @@
+"""Generic table metadata returned by a query service client."""
+
+from pydantic import BaseModel
+
+from datajunction_server.database.column import Column
+
+
+class TableOwner(BaseModel):
+    """A resolved, current human owner of a warehouse table."""
+
+    email: str
+    full_name: str = ""
+
+
+class TableMetadata(BaseModel):
+    """
+    What a query service can tell us about a table.
+
+    ``owner`` is None whenever it cannot be determined -- no owner on the table,
+    a query client with no ownership source, or a query service too old to
+    report one. Callers must treat None as "no ownership information", never as
+    "no owner".
+    """
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    columns: list[Column] = []
+    owner: TableOwner | None = None
+    partitions: list[str] = []
+    broken_ref: bool | None = None
+    valid_through: str | None = None

--- a/datajunction-server/datajunction_server/models/table_metadata.py
+++ b/datajunction-server/datajunction_server/models/table_metadata.py
@@ -22,6 +22,10 @@ class TableOwner(BaseModel):
     username: str
     email: str | None = None
     display_name: str = ""
+    # True when the owner is a group rather than an individual. Some catalogs
+    # only name a group for a table, and a group owner outlives the people in
+    # it, so recording it as a person would be both wrong and fragile.
+    is_group: bool = False
 
 
 class TableMetadata(BaseModel):

--- a/datajunction-server/datajunction_server/query_clients/base.py
+++ b/datajunction-server/datajunction_server/query_clients/base.py
@@ -19,6 +19,7 @@ from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.partition import PartitionBackfill
 from datajunction_server.models.preaggregation import PreAggMaterializationInput
 from datajunction_server.models.query import QueryCreate, QueryWithResults
+from datajunction_server.models.table_metadata import TableMetadata
 
 if TYPE_CHECKING:
     from datajunction_server.database.engine import Engine
@@ -48,6 +49,30 @@ class BaseQueryServiceClient(ABC):
         engine: Engine | None = None,
     ) -> list[Column]:
         """Retrieves columns for a table."""
+
+    async def get_table_metadata(
+        self,
+        catalog: str,
+        schema: str,
+        table: str,
+        request_headers: dict[str, str] | None = None,
+        engine: Engine | None = None,
+    ) -> TableMetadata:
+        """
+        Retrieve columns plus any extra table metadata.
+
+        Default implementation: columns only. Clients with an ownership source
+        override this; the rest inherit correct behaviour with owner=None.
+        """
+        return TableMetadata(
+            columns=await self.get_columns_for_table(
+                catalog,
+                schema,
+                table,
+                request_headers,
+                engine,
+            ),
+        )
 
     async def get_columns_for_tables_batch(
         self,

--- a/datajunction-server/datajunction_server/query_clients/http.py
+++ b/datajunction-server/datajunction_server/query_clients/http.py
@@ -18,6 +18,7 @@ from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.partition import PartitionBackfill
 from datajunction_server.models.preaggregation import PreAggMaterializationInput
 from datajunction_server.models.query import QueryCreate, QueryWithResults
+from datajunction_server.models.table_metadata import TableMetadata
 from datajunction_server.query_clients.base import BaseQueryServiceClient
 from datajunction_server.service_clients import QueryServiceClient
 
@@ -58,6 +59,23 @@ class HttpQueryServiceClient(BaseQueryServiceClient):
     ) -> list[Column]:
         """Retrieves columns for a table via HTTP query service."""
         return await self._client.get_columns_for_table(
+            catalog=catalog,
+            schema=schema,
+            table=table,
+            request_headers=request_headers,
+            engine=engine,
+        )
+
+    async def get_table_metadata(
+        self,
+        catalog: str,
+        schema: str,
+        table: str,
+        request_headers: dict[str, str] | None = None,
+        engine: Engine | None = None,
+    ) -> TableMetadata:
+        """Retrieves columns plus the owner for a table via HTTP query service."""
+        return await self._client.get_table_metadata(
             catalog=catalog,
             schema=schema,
             table=table,

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -32,6 +32,7 @@ from datajunction_server.models.materialization import (
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.partition import PartitionBackfill
 from datajunction_server.models.query import QueryCreate, QueryWithResults
+from datajunction_server.models.table_metadata import TableMetadata, TableOwner
 from datajunction_server.sql.parsing.types import ColumnType
 
 if TYPE_CHECKING:
@@ -247,6 +248,63 @@ class QueryServiceClient:
             Column(name=column["name"], type=ColumnType(column["type"]), order=idx)
             for idx, column in enumerate(table_columns)
         ]
+
+    async def get_table_metadata(
+        self,
+        catalog: str,
+        schema: str,
+        table: str,
+        request_headers: dict[str, str] | None = None,
+        engine: Engine | None = None,
+    ) -> TableMetadata:
+        """
+        Retrieves columns plus any extra table metadata, including the owner.
+
+        Falls back to ``get_columns_for_table`` when the query service predates
+        the ``/metadata/`` endpoint, so refresh keeps working mid-rollout.
+        """
+        params = (
+            {"engine": engine.name, "engine_version": engine.version}
+            if engine
+            else None
+        )
+        # ``request_headers`` is intentionally not forwarded to DJQS — see
+        # ``get_columns_for_table`` for the reason.
+        response = await self._arequest(
+            "GET",
+            f"/table/{catalog}.{schema}.{table}/metadata/",
+            params=params,
+        )
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            # Either the query service has no such endpoint, or the table is
+            # genuinely missing. The columns call answers both: it returns
+            # columns for the former and raises DJDoesNotExistException for
+            # the latter, which is what the caller already expects.
+            return TableMetadata(
+                columns=await self.get_columns_for_table(
+                    catalog,
+                    schema,
+                    table,
+                    request_headers,
+                    engine,
+                ),
+            )
+        if response.status_code not in (200, 201):
+            raise DJQueryServiceClientException(
+                message=f"Error response from query service: {response.text}",
+            )
+        metadata = response.json()
+        owner = metadata.get("owner")
+        return TableMetadata(
+            columns=[
+                Column(name=column["name"], type=ColumnType(column["type"]), order=idx)
+                for idx, column in enumerate(metadata.get("columns") or [])
+            ],
+            owner=TableOwner(**owner) if owner else None,
+            partitions=metadata.get("partitions") or [],
+            broken_ref=metadata.get("broken_ref"),
+            valid_through=metadata.get("valid_through"),
+        )
 
     async def get_columns_for_tables_batch(
         self,

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -297,13 +297,17 @@ class QueryServiceClient:
         owner = metadata.get("owner")
         return TableMetadata(
             columns=[
-                Column(name=column["name"], type=ColumnType(column["type"]), order=idx)
+                Column(
+                    name=column["name"],
+                    type=ColumnType(column["type"]),
+                    order=idx,
+                    description=column.get("description"),
+                )
                 for idx, column in enumerate(metadata.get("columns") or [])
             ],
             owner=TableOwner(**owner) if owner else None,
             partitions=metadata.get("partitions") or [],
-            broken_ref=metadata.get("broken_ref"),
-            valid_through=metadata.get("valid_through"),
+            description=metadata.get("description"),
         )
 
     async def get_columns_for_tables_batch(

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -23,6 +23,7 @@ from datajunction_server.errors import DJDoesNotExistException
 from datajunction_server.internal.materializations import decompose_expression
 from datajunction_server.models.node import NodeStatus
 from datajunction_server.models.node_type import NodeType
+from datajunction_server.models.table_metadata import TableMetadata, TableOwner
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.dag import get_upstream_nodes
 from datajunction_server.sql.parsing import ast, types
@@ -2379,6 +2380,227 @@ class TestNodeCRUD:
             ("refresh", "node"),
             ("create", "node"),
         ]
+
+    @pytest.mark.asyncio
+    async def test_refresh_sets_owner_from_table(
+        self,
+        module__client_with_roads,
+        module__query_service_client: QueryServiceClient,
+        mocker: MockerFixture,
+    ):
+        """An owner reported by the query service becomes the node's only owner."""
+        columns = await module__query_service_client.get_columns_for_table(
+            "default",
+            "roads",
+            "repair_orders",
+            request_headers={},
+        )
+
+        async def _with_owner(*args, **kwargs):
+            return TableMetadata(
+                columns=columns,
+                owner=TableOwner(
+                    email="owner@example.com",
+                    full_name="Example Owner",
+                ),
+            )
+
+        mocker.patch.object(
+            module__query_service_client,
+            "get_table_metadata",
+            _with_owner,
+        )
+        before = (
+            await module__client_with_roads.get("/nodes/default.repair_orders/")
+        ).json()
+        response = await module__client_with_roads.post(
+            "/nodes/default.repair_orders/refresh/",
+        )
+        assert response.status_code in (200, 201)
+
+        after = (
+            await module__client_with_roads.get("/nodes/default.repair_orders/")
+        ).json()
+        assert after["owners"] == [{"username": "owner@example.com"}]
+        # The columns are unchanged, so this is an ownership-only refresh: owners
+        # live on Node rather than NodeRevision, so no revision may be forked.
+        assert after["version"] == before["version"]
+        assert after["node_revision_id"] == before["node_revision_id"]
+
+        # The change is recorded, naming both the old and the new owners
+        history = (
+            await module__client_with_roads.get(
+                "/history?node=default.repair_orders",
+            )
+        ).json()
+        assert history[0]["details"] == {
+            "old_owners": ["dj"],
+            "new_owners": ["owner@example.com"],
+        }
+        assert history[0]["activity_type"] == "update"
+
+    @pytest.mark.asyncio
+    async def test_refresh_with_no_owner_leaves_owners_untouched(
+        self,
+        module__client_with_roads,
+        module__query_service_client: QueryServiceClient,
+        mocker: MockerFixture,
+    ):
+        """owner=None must never clear an existing owner."""
+        columns = await module__query_service_client.get_columns_for_table(
+            "default",
+            "roads",
+            "repair_orders",
+            request_headers={},
+        )
+
+        async def _without_owner(*args, **kwargs):
+            return TableMetadata(columns=columns, owner=None)
+
+        mocker.patch.object(
+            module__query_service_client,
+            "get_table_metadata",
+            _without_owner,
+        )
+        before = (
+            await module__client_with_roads.get("/nodes/default.repair_orders/")
+        ).json()
+        assert before["owners"] == [{"username": "owner@example.com"}]
+
+        await module__client_with_roads.post(
+            "/nodes/default.repair_orders/refresh/",
+        )
+        after = (
+            await module__client_with_roads.get("/nodes/default.repair_orders/")
+        ).json()
+        assert after["owners"] == before["owners"]
+        assert after["version"] == before["version"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_repeating_the_same_owner_is_a_noop(
+        self,
+        module__client_with_roads,
+        module__query_service_client: QueryServiceClient,
+        mocker: MockerFixture,
+    ):
+        """Refreshing with the owner the node already has records no history."""
+        columns = await module__query_service_client.get_columns_for_table(
+            "default",
+            "roads",
+            "repair_orders",
+            request_headers={},
+        )
+
+        async def _same_owner(*args, **kwargs):
+            return TableMetadata(
+                columns=columns,
+                owner=TableOwner(email="owner@example.com", full_name="Example Owner"),
+            )
+
+        mocker.patch.object(
+            module__query_service_client,
+            "get_table_metadata",
+            _same_owner,
+        )
+        before = (
+            await module__client_with_roads.get(
+                "/history?node=default.repair_orders",
+            )
+        ).json()
+        await module__client_with_roads.post(
+            "/nodes/default.repair_orders/refresh/",
+        )
+        after = (
+            await module__client_with_roads.get(
+                "/history?node=default.repair_orders",
+            )
+        ).json()
+        assert len(after) == len(before)
+
+    @pytest.mark.asyncio
+    async def test_refresh_owner_change_with_column_changes(
+        self,
+        module__client_with_roads,
+        module__query_service_client: QueryServiceClient,
+        mocker: MockerFixture,
+    ):
+        """
+        An owner change lands alongside a column change, in the same refresh, and
+        the new user row is created on the fly since usernames are emails.
+        """
+        columns = await module__query_service_client.get_columns_for_table(
+            "default",
+            "roads",
+            "repair_orders",
+            request_headers={},
+        )
+
+        async def _new_owner_and_columns(*args, **kwargs):
+            return TableMetadata(
+                columns=[
+                    *columns,
+                    Column(name="reviewer", type=StringType(), order=len(columns)),
+                ],
+                owner=TableOwner(email="new.owner@example.com"),
+            )
+
+        mocker.patch.object(
+            module__query_service_client,
+            "get_table_metadata",
+            _new_owner_and_columns,
+        )
+        before = (
+            await module__client_with_roads.get("/nodes/default.repair_orders/")
+        ).json()
+        await module__client_with_roads.post(
+            "/nodes/default.repair_orders/refresh/",
+        )
+        after = (
+            await module__client_with_roads.get("/nodes/default.repair_orders/")
+        ).json()
+        assert after["owners"] == [{"username": "new.owner@example.com"}]
+        assert [col["name"] for col in after["columns"]] == [
+            *[col["name"] for col in before["columns"]],
+            "reviewer",
+        ]
+        assert after["version"] != before["version"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_reassigns_owner_to_an_existing_user(
+        self,
+        module__client_with_roads,
+        module__query_service_client: QueryServiceClient,
+        mocker: MockerFixture,
+    ):
+        """An owner who already has a DJ user row is reused, not recreated."""
+        columns = await module__query_service_client.get_columns_for_table(
+            "default",
+            "roads",
+            "repair_orders",
+            request_headers={},
+        )
+
+        async def _known_owner(*args, **kwargs):
+            return TableMetadata(
+                columns=[
+                    *columns,
+                    Column(name="reviewer", type=StringType(), order=len(columns)),
+                ],
+                owner=TableOwner(email="owner@example.com", full_name="Example Owner"),
+            )
+
+        mocker.patch.object(
+            module__query_service_client,
+            "get_table_metadata",
+            _known_owner,
+        )
+        await module__client_with_roads.post(
+            "/nodes/default.repair_orders/refresh/",
+        )
+        after = (
+            await module__client_with_roads.get("/nodes/default.repair_orders/")
+        ).json()
+        assert after["owners"] == [{"username": "owner@example.com"}]
 
     @pytest.mark.asyncio
     async def test_create_update_source_node(

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2668,6 +2668,54 @@ class TestNodeCRUD:
         assert described_columns["id"] == "described id"
 
     @pytest.mark.asyncio
+    async def test_refresh_sets_a_group_owner(
+        self,
+        module__client_with_roads: AsyncClient,
+        module__query_service_client: QueryServiceClient,
+        mocker: MockerFixture,
+    ):
+        """
+        A table owned by a group is applied as the node's owner.
+
+        Some catalogs only name a group for a table. Recording it as a USER would
+        both misstate what it is and collide with the group principal that group
+        membership sync creates under the same username.
+        """
+        columns = await module__query_service_client.get_columns_for_table(
+            "default",
+            "roads",
+            "repair_orders",
+            request_headers={},
+        )
+
+        async def _group_owner(*args, **kwargs):
+            return TableMetadata(
+                columns=columns,
+                owner=TableOwner(
+                    username="data-eng@example.com",
+                    email="data-eng@example.com",
+                    display_name="Data Engineering",
+                    is_group=True,
+                ),
+            )
+
+        mocker.patch.object(
+            module__query_service_client,
+            "get_table_metadata",
+            _group_owner,
+        )
+        await module__client_with_roads.post(
+            "/nodes/default.repair_orders/refresh/",
+        )
+        after = (
+            await module__client_with_roads.get("/nodes/default.repair_orders/")
+        ).json()
+        # The principal kind itself is asserted in
+        # tests/database/nodeowner_test.py, against the same session that writes
+        # it -- this fixture's session is a different container and cannot see it.
+        assert after["owners"] == [{"username": "data-eng@example.com"}]
+
+    @pytest.mark.asyncio
     async def test_refresh_records_column_type_changes(
         self,
         module__client_with_roads: AsyncClient,

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2400,7 +2400,7 @@ class TestNodeCRUD:
             return TableMetadata(
                 columns=columns,
                 owner=TableOwner(
-                    email="owner@example.com",
+                    username="owner@example.com",
                     full_name="Example Owner",
                 ),
             )
@@ -2494,7 +2494,10 @@ class TestNodeCRUD:
         async def _same_owner(*args, **kwargs):
             return TableMetadata(
                 columns=columns,
-                owner=TableOwner(email="owner@example.com", full_name="Example Owner"),
+                owner=TableOwner(
+                    username="owner@example.com",
+                    display_name="Example Owner",
+                ),
             )
 
         mocker.patch.object(
@@ -2541,7 +2544,7 @@ class TestNodeCRUD:
                     *columns,
                     Column(name="reviewer", type=StringType(), order=len(columns)),
                 ],
-                owner=TableOwner(email="new.owner@example.com"),
+                owner=TableOwner(username="new.owner@example.com"),
             )
 
         mocker.patch.object(
@@ -2586,7 +2589,10 @@ class TestNodeCRUD:
                     *columns,
                     Column(name="reviewer", type=StringType(), order=len(columns)),
                 ],
-                owner=TableOwner(email="owner@example.com", full_name="Example Owner"),
+                owner=TableOwner(
+                    username="owner@example.com",
+                    display_name="Example Owner",
+                ),
             )
 
         mocker.patch.object(
@@ -2601,6 +2607,97 @@ class TestNodeCRUD:
             await module__client_with_roads.get("/nodes/default.repair_orders/")
         ).json()
         assert after["owners"] == [{"username": "owner@example.com"}]
+
+    @pytest.mark.asyncio
+    async def test_refresh_fills_empty_descriptions_from_the_table(
+        self,
+        module__client_with_roads: AsyncClient,
+        module__query_service_client: QueryServiceClient,
+        mocker: MockerFixture,
+    ):
+        """A table comment fills a node description that DJ does not have."""
+        # A dedicated node with an empty description: the shared roads fixture
+        # already has one, and fill-when-empty would (correctly) decline.
+        response = await module__client_with_roads.post(
+            "/nodes/source/",
+            json={
+                "name": "default.undocumented_table",
+                "description": "",
+                "columns": [{"name": "id", "type": "int"}],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "roads",
+                "table": "undocumented_table",
+            },
+        )
+        assert response.status_code in (200, 201)
+
+        async def _with_descriptions(*args, **kwargs):
+            return TableMetadata(
+                columns=[
+                    Column(
+                        name="id",
+                        type=IntegerType(),
+                        order=0,
+                        description="described id",
+                    ),
+                ],
+                description="Table comment from the warehouse",
+            )
+
+        mocker.patch.object(
+            module__query_service_client,
+            "get_table_metadata",
+            _with_descriptions,
+        )
+        await module__client_with_roads.post(
+            "/nodes/default.undocumented_table/refresh/",
+        )
+        after = (
+            await module__client_with_roads.get("/nodes/default.undocumented_table/")
+        ).json()
+        assert after["description"] == "Table comment from the warehouse"
+        described_columns = {
+            column["name"]: column.get("description") for column in after["columns"]
+        }
+        assert described_columns["id"] == "described id"
+
+    @pytest.mark.asyncio
+    async def test_refresh_does_not_overwrite_existing_descriptions(
+        self,
+        module__client_with_roads: AsyncClient,
+        module__query_service_client: QueryServiceClient,
+        mocker: MockerFixture,
+    ):
+        """Curated prose in DJ wins over the warehouse comment."""
+        columns = await module__query_service_client.get_columns_for_table(
+            "default",
+            "roads",
+            "repair_orders",
+            request_headers={},
+        )
+
+        async def _with_descriptions(*args, **kwargs):
+            return TableMetadata(
+                columns=columns,
+                description="Should not replace what DJ already has",
+            )
+
+        mocker.patch.object(
+            module__query_service_client,
+            "get_table_metadata",
+            _with_descriptions,
+        )
+        before = (
+            await module__client_with_roads.get("/nodes/default.repair_orders/")
+        ).json()
+        await module__client_with_roads.post(
+            "/nodes/default.repair_orders/refresh/",
+        )
+        after = (
+            await module__client_with_roads.get("/nodes/default.repair_orders/")
+        ).json()
+        assert after["description"] == before["description"]
 
     @pytest.mark.asyncio
     async def test_create_update_source_node(

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -28,7 +28,12 @@ from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.dag import get_upstream_nodes
 from datajunction_server.sql.parsing import ast, types
 from datajunction_server.sql.parsing.backends.antlr4 import parse
-from datajunction_server.sql.parsing.types import IntegerType, StringType, TimestampType
+from datajunction_server.sql.parsing.types import (
+    DoubleType,
+    IntegerType,
+    StringType,
+    TimestampType,
+)
 from datajunction_server.models.access import ResourceAction
 from tests.authz import VALIDATOR_AUTH_SERVICE, deny
 from tests.sql.utils import compare_query_strings
@@ -2661,6 +2666,59 @@ class TestNodeCRUD:
             column["name"]: column.get("description") for column in after["columns"]
         }
         assert described_columns["id"] == "described id"
+
+    @pytest.mark.asyncio
+    async def test_refresh_records_column_type_changes(
+        self,
+        module__client_with_roads: AsyncClient,
+        module__query_service_client: QueryServiceClient,
+        mocker: MockerFixture,
+    ):
+        """
+        A column changing type is recorded in the refresh event.
+
+        This is the part of a refresh worth auditing: a source column changing
+        type can change the value of a metric computed from it, so a version bump
+        with no explanation leaves no way to account for a number that moved.
+        """
+        response = await module__client_with_roads.post(
+            "/nodes/source/",
+            json={
+                "name": "default.retyped_table",
+                "description": "A table whose column type changes",
+                "columns": [{"name": "amount", "type": "int"}],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "roads",
+                "table": "retyped_table",
+            },
+        )
+        assert response.status_code in (200, 201)
+
+        async def _retyped(*args, **kwargs):
+            return TableMetadata(
+                columns=[Column(name="amount", type=DoubleType(), order=0)],
+            )
+
+        mocker.patch.object(
+            module__query_service_client,
+            "get_table_metadata",
+            _retyped,
+        )
+        await module__client_with_roads.post(
+            "/nodes/default.retyped_table/refresh/",
+        )
+
+        history = (
+            await module__client_with_roads.get(
+                "/history?node=default.retyped_table",
+            )
+        ).json()
+        refreshes = [event for event in history if event["activity_type"] == "refresh"]
+        assert refreshes, "the refresh should be recorded"
+        assert refreshes[0]["details"]["type_changes"] == [
+            {"column": "amount", "from": "int", "to": "double"},
+        ]
 
     @pytest.mark.asyncio
     async def test_refresh_does_not_overwrite_existing_descriptions(

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -62,6 +62,7 @@ from datajunction_server.internal.access.authorization import (
 from datajunction_server.internal.seed import seed_default_catalogs
 from datajunction_server.models.materialization import MaterializationInfo
 from datajunction_server.models.query import QueryCreate, QueryWithResults
+from datajunction_server.models.table_metadata import TableMetadata
 from datajunction_server.models.user import OAuthProvider
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.typing import QueryState
@@ -710,6 +711,25 @@ def query_service_client(
             request_headers,
         )
 
+    async def mock_get_table_metadata_async(
+        catalog: str,
+        schema: str,
+        table: str,
+        request_headers: dict[str, str] | None = None,
+        engine: Engine | None = None,
+    ) -> TableMetadata:
+        # ``get_columns_for_table`` is resolved at call time so that tests which
+        # patch only the columns call still drive refresh through this method.
+        return TableMetadata(
+            columns=await qs_client.get_columns_for_table(
+                catalog,
+                schema,
+                table,
+                request_headers,
+                engine,
+            ),
+        )
+
     mocker.patch.object(
         qs_client,
         "get_columns_for_table",
@@ -719,6 +739,11 @@ def query_service_client(
         qs_client,
         "get_columns_for_table",
         mock_get_columns_for_table_async,
+    )
+    mocker.patch.object(
+        qs_client,
+        "get_table_metadata",
+        mock_get_table_metadata_async,
     )
 
     def mock_submit_query(
@@ -2219,6 +2244,25 @@ def module__query_service_client(
             request_headers,
         )
 
+    async def mock_get_table_metadata_async(
+        catalog: str,
+        schema: str,
+        table: str,
+        request_headers: dict[str, str] | None = None,
+        engine: Engine | None = None,
+    ) -> TableMetadata:
+        # ``get_columns_for_table`` is resolved at call time so that tests which
+        # patch only the columns call still drive refresh through this method.
+        return TableMetadata(
+            columns=await qs_client.get_columns_for_table(
+                catalog,
+                schema,
+                table,
+                request_headers,
+                engine,
+            ),
+        )
+
     module_mocker.patch.object(
         qs_client,
         "get_columns_for_table",
@@ -2228,6 +2272,11 @@ def module__query_service_client(
         qs_client,
         "get_columns_for_table",
         mock_get_columns_for_table_async,
+    )
+    module_mocker.patch.object(
+        qs_client,
+        "get_table_metadata",
+        mock_get_table_metadata_async,
     )
 
     def mock_submit_query(

--- a/datajunction-server/tests/database/nodeowner_test.py
+++ b/datajunction-server/tests/database/nodeowner_test.py
@@ -201,3 +201,43 @@ async def test_add_multiple_node_owners(
     # Confirm ownership types
     types = {assoc.ownership_type for assoc in transform_node.owner_associations}
     assert types == {"domain", "technical"}
+
+
+@pytest.mark.asyncio
+async def test_apply_table_owner_records_a_group_principal(
+    session: AsyncSession,
+    user: User,
+    transform_node: Node,
+):
+    """
+    A table owned by a group creates a GROUP principal, not a USER.
+
+    Some catalogs only name a group for a table. Recording it as a USER would
+    misstate what it is, and would collide with the group principal that group
+    membership sync creates under the same username.
+    """
+    from datajunction_server.database.user import PrincipalKind
+    from datajunction_server.internal.nodes import apply_table_owner
+    from datajunction_server.models.table_metadata import TableOwner
+
+    async def save_history(event, session):  # pylint: disable=redefined-outer-name
+        session.add(event)
+
+    changed = await apply_table_owner(
+        session,
+        transform_node,
+        TableOwner(
+            username="data-eng@example.com",
+            email="data-eng@example.com",
+            display_name="Data Engineering",
+            is_group=True,
+        ),
+        save_history,
+        user,
+    )
+    assert changed is True
+
+    owner = await User.get_by_username(session, "data-eng@example.com")
+    assert owner is not None
+    assert owner.kind == PrincipalKind.GROUP
+    assert owner.name == "Data Engineering"

--- a/datajunction-server/tests/query_clients/test_table_metadata.py
+++ b/datajunction-server/tests/query_clients/test_table_metadata.py
@@ -1,0 +1,52 @@
+"""Tests for TableMetadata and the query-client default."""
+
+import pytest
+
+from datajunction_server.database.column import Column
+from datajunction_server.models.table_metadata import TableMetadata, TableOwner
+from datajunction_server.sql.parsing.types import IntegerType
+
+
+class FakeClient:
+    """Exercises the base-class default without a real backend."""
+
+    def __init__(self, columns):
+        self._columns = columns
+
+    async def get_columns_for_table(
+        self,
+        catalog,
+        schema,
+        table,
+        request_headers=None,
+        engine=None,
+    ):
+        return self._columns
+
+
+@pytest.mark.asyncio
+async def test_base_default_returns_columns_and_no_owner():
+    """A client that cannot supply an owner returns columns with owner=None."""
+    from datajunction_server.query_clients.base import BaseQueryServiceClient
+
+    class Client(FakeClient, BaseQueryServiceClient):
+        """A minimal client relying on the inherited default."""
+
+    cols = [Column(name="id", type=IntegerType(), order=0)]
+    client = Client(cols)
+    result = await client.get_table_metadata("c", "s", "t")
+    assert result == TableMetadata(
+        columns=cols,
+        owner=None,
+        partitions=[],
+        broken_ref=None,
+        valid_through=None,
+    )
+
+
+def test_table_owner_defaults_full_name():
+    """``full_name`` is optional, since not every source reports one."""
+    assert TableOwner(email="someone@example.com") == TableOwner(
+        email="someone@example.com",
+        full_name="",
+    )

--- a/datajunction-server/tests/query_clients/test_table_metadata.py
+++ b/datajunction-server/tests/query_clients/test_table_metadata.py
@@ -66,16 +66,15 @@ async def test_base_default_returns_columns_and_no_owner():
         columns=cols,
         owner=None,
         partitions=[],
-        broken_ref=None,
-        valid_through=None,
     )
 
 
-def test_table_owner_defaults_full_name():
-    """``full_name`` is optional, since not every source reports one."""
-    assert TableOwner(email="someone@example.com") == TableOwner(
-        email="someone@example.com",
-        full_name="",
+def test_table_owner_defaults():
+    """Only ``username`` is required; not every catalog reports the rest."""
+    assert TableOwner(username="someone@example.com") == TableOwner(
+        username="someone@example.com",
+        email=None,
+        display_name="",
     )
 
 
@@ -95,9 +94,10 @@ async def test_query_service_client_returns_owner(mocker: MockerFixture):
                     {"name": "flavor", "type": "string"},
                 ],
                 "partitions": ["dateint"],
-                "broken_ref": False,
-                "valid_through": "20260808",
-                "owner": {"email": "owner@example.com", "full_name": "Example Owner"},
+                "owner": {
+                    "username": "owner@example.com",
+                    "display_name": "Example Owner",
+                },
             },
         ),
     )
@@ -115,10 +115,8 @@ async def test_query_service_client_returns_owner(mocker: MockerFixture):
     ]
     assert result.model_copy(update={"columns": []}) == TableMetadata(
         columns=[],
-        owner=TableOwner(email="owner@example.com", full_name="Example Owner"),
+        owner=TableOwner(username="owner@example.com", display_name="Example Owner"),
         partitions=["dateint"],
-        broken_ref=False,
-        valid_through="20260808",
     )
     request.assert_called_once_with(
         "GET",
@@ -150,8 +148,6 @@ async def test_query_service_client_metadata_without_owner(mocker: MockerFixture
         columns=[],
         owner=None,
         partitions=[],
-        broken_ref=None,
-        valid_through=None,
     )
     request.assert_called_once_with(
         "GET",
@@ -186,8 +182,6 @@ async def test_query_service_client_falls_back_on_404(mocker: MockerFixture):
         columns=columns,
         owner=None,
         partitions=[],
-        broken_ref=None,
-        valid_through=None,
     )
     fallback.assert_called_once_with(
         "hive",
@@ -235,7 +229,7 @@ async def test_http_query_client_delegates(mocker: MockerFixture):
     client = HttpQueryServiceClient(uri="http://queryservice:8001")
     expected = TableMetadata(
         columns=[Column(name="id", type=IntegerType(), order=0)],
-        owner=TableOwner(email="owner@example.com", full_name="Example Owner"),
+        owner=TableOwner(username="owner@example.com", display_name="Example Owner"),
     )
     delegate = mocker.patch.object(
         client._client,

--- a/datajunction-server/tests/query_clients/test_table_metadata.py
+++ b/datajunction-server/tests/query_clients/test_table_metadata.py
@@ -1,10 +1,37 @@
 """Tests for TableMetadata and the query-client default."""
 
+from dataclasses import dataclass, field
+from typing import Any
+
 import pytest
+from pytest_mock import MockerFixture
 
 from datajunction_server.database.column import Column
+from datajunction_server.database.engine import Engine
+from datajunction_server.errors import (
+    DJDoesNotExistException,
+    DJQueryServiceClientException,
+)
 from datajunction_server.models.table_metadata import TableMetadata, TableOwner
-from datajunction_server.sql.parsing.types import IntegerType
+from datajunction_server.query_clients.http import HttpQueryServiceClient
+from datajunction_server.service_clients import QueryServiceClient
+from datajunction_server.sql.parsing.types import IntegerType, StringType
+
+
+@dataclass
+class FakeResponse:
+    """
+    A stand-in for an ``httpx.Response``, typed so that a renamed attribute
+    fails loudly instead of being silently absorbed by a bare mock.
+    """
+
+    status_code: int
+    text: str = ""
+    payload: dict[str, Any] = field(default_factory=dict)
+
+    def json(self) -> dict[str, Any]:
+        """The decoded response body."""
+        return self.payload
 
 
 class FakeClient:
@@ -49,4 +76,185 @@ def test_table_owner_defaults_full_name():
     assert TableOwner(email="someone@example.com") == TableOwner(
         email="someone@example.com",
         full_name="",
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_service_client_returns_owner(mocker: MockerFixture):
+    """A metadata response with an owner is surfaced in full."""
+    client = QueryServiceClient(uri="http://queryservice:8001")
+    request = mocker.patch.object(
+        client,
+        "_arequest",
+        return_value=FakeResponse(
+            status_code=200,
+            payload={
+                "name": "hive.test.pies",
+                "columns": [
+                    {"name": "id", "type": "int"},
+                    {"name": "flavor", "type": "string"},
+                ],
+                "partitions": ["dateint"],
+                "broken_ref": False,
+                "valid_through": "20260808",
+                "owner": {"email": "owner@example.com", "full_name": "Example Owner"},
+            },
+        ),
+    )
+    result = await client.get_table_metadata(
+        "hive",
+        "test",
+        "pies",
+        engine=Engine(name="spark", version="2.4.4"),
+    )
+    # ``Column`` is a SQLAlchemy model without ``__eq__``, so compare the
+    # columns by value and everything else by whole-model equality.
+    assert [(col.name, col.type, col.order) for col in result.columns] == [
+        ("id", IntegerType(), 0),
+        ("flavor", StringType(), 1),
+    ]
+    assert result.model_copy(update={"columns": []}) == TableMetadata(
+        columns=[],
+        owner=TableOwner(email="owner@example.com", full_name="Example Owner"),
+        partitions=["dateint"],
+        broken_ref=False,
+        valid_through="20260808",
+    )
+    request.assert_called_once_with(
+        "GET",
+        "/table/hive.test.pies/metadata/",
+        params={"engine": "spark", "engine_version": "2.4.4"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_service_client_metadata_without_owner(mocker: MockerFixture):
+    """A table with no resolvable owner reports owner=None, not an error."""
+    client = QueryServiceClient(uri="http://queryservice:8001")
+    request = mocker.patch.object(
+        client,
+        "_arequest",
+        return_value=FakeResponse(
+            status_code=200,
+            payload={
+                "name": "hive.test.pies",
+                "columns": [{"name": "id", "type": "int"}],
+            },
+        ),
+    )
+    result = await client.get_table_metadata("hive", "test", "pies")
+    assert [(col.name, col.type, col.order) for col in result.columns] == [
+        ("id", IntegerType(), 0),
+    ]
+    assert result.model_copy(update={"columns": []}) == TableMetadata(
+        columns=[],
+        owner=None,
+        partitions=[],
+        broken_ref=None,
+        valid_through=None,
+    )
+    request.assert_called_once_with(
+        "GET",
+        "/table/hive.test.pies/metadata/",
+        params=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_service_client_falls_back_on_404(mocker: MockerFixture):
+    """An older query service without the endpoint yields columns and owner=None."""
+    client = QueryServiceClient(uri="http://queryservice:8001")
+    mocker.patch.object(
+        client,
+        "_arequest",
+        return_value=FakeResponse(status_code=404, text="Not Found"),
+    )
+    columns = [Column(name="id", type=IntegerType(), order=0)]
+    fallback = mocker.patch.object(
+        client,
+        "get_columns_for_table",
+        return_value=columns,
+    )
+    result = await client.get_table_metadata(
+        "hive",
+        "test",
+        "pies",
+        {"accept": "application/json"},
+        None,
+    )
+    assert result == TableMetadata(
+        columns=columns,
+        owner=None,
+        partitions=[],
+        broken_ref=None,
+        valid_through=None,
+    )
+    fallback.assert_called_once_with(
+        "hive",
+        "test",
+        "pies",
+        {"accept": "application/json"},
+        None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_service_client_missing_table_still_raises(mocker: MockerFixture):
+    """
+    A 404 for a genuinely missing table surfaces as DJDoesNotExistException,
+    because the fallback columns call raises it.
+    """
+    client = QueryServiceClient(uri="http://queryservice:8001")
+    mocker.patch.object(
+        client,
+        "_arequest",
+        return_value=FakeResponse(status_code=404, text="Table not found"),
+    )
+    with pytest.raises(DJDoesNotExistException) as exc_info:
+        await client.get_table_metadata("hive", "test", "nope")
+    assert "Table not found" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_query_service_client_metadata_error(mocker: MockerFixture):
+    """Any other non-success status is an error, not a silent fallback."""
+    client = QueryServiceClient(uri="http://queryservice:8001")
+    mocker.patch.object(
+        client,
+        "_arequest",
+        return_value=FakeResponse(status_code=500, text="boom"),
+    )
+    with pytest.raises(DJQueryServiceClientException) as exc_info:
+        await client.get_table_metadata("hive", "test", "pies")
+    assert str(exc_info.value) == "Error response from query service: boom"
+
+
+@pytest.mark.asyncio
+async def test_http_query_client_delegates(mocker: MockerFixture):
+    """The HTTP query client passes the call through to the service client."""
+    client = HttpQueryServiceClient(uri="http://queryservice:8001")
+    expected = TableMetadata(
+        columns=[Column(name="id", type=IntegerType(), order=0)],
+        owner=TableOwner(email="owner@example.com", full_name="Example Owner"),
+    )
+    delegate = mocker.patch.object(
+        client._client,
+        "get_table_metadata",
+        return_value=expected,
+    )
+    engine = Engine(name="spark", version="2.4.4")
+    result = await client.get_table_metadata(
+        "hive",
+        "test",
+        "pies",
+        {"accept": "application/json"},
+        engine,
+    )
+    assert result == expected
+    delegate.assert_called_once_with(
+        catalog="hive",
+        schema="test",
+        table="pies",
+        request_headers={"accept": "application/json"},
+        engine=engine,
     )


### PR DESCRIPTION
### Summary

`POST /nodes/{name}/refresh/` has been used to reconcile a source node against its warehouse table's metadata, but the current implementation only focuses on refreshing column metadata.

This PR adds a new query service shim for `get_table_metadata` that focuses on pulling all facets of table metadata (see `TableMetadata`), not just columns.

#### New Fields

- **Owner**: `apply_table_owner` sets the node's owners to exactly the table's owner, creating the DJ user if absent. Owners live on Node, not NodeRevision, so an ownership-only refresh doesn't bump the version.
- **Descriptions**: `apply_table_descriptions` fills the node's and columns' descriptions based on upstream metadata, but only where DJ has none.

#### Compatibility

- `get_table_metadata` defaults to `owner=None`. The Snowflake and BigQuery clients have no ownership source and are unchanged.
- The HTTP client falls back to `get_columns_for_table` on a 404, so refresh keeps working against a query service that predates this `/table/{table}/metadata/` endpoint.
- `get_columns_for_table` and `get_columns_for_tables_batch` keep their contracts.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
