### PR TITLE
Tighten the external pre-aggregation spec to two maps 

### DIFF
--- a/datajunction-clients/python/datajunction/skills/datajunction-repo/SKILL.md
+++ b/datajunction-clients/python/datajunction/skills/datajunction-repo/SKILL.md
@@ -580,15 +580,15 @@ read, falling back to the fact table when no aggregate can answer correctly.
 
 **The rules live in the docs, not here** — see
 [Query Routing & Aggregate Awareness](https://datajunction.io/docs/0.1.0/dj-concepts/query-routing-aggregate-awareness/)
-for the `kind: preagg` schema, `measure_columns` / `dimension_columns`, what makes a
-metric mappable, role-qualified dimension references, freshness reporting, and the
-current limitations. Read it before registering anything; the rules that decide
+for the `kind: preagg` schema (`metrics` and `dimensions` are maps from each
+reference to the physical column holding it), what makes a metric mappable,
+role-qualified dimension references, freshness reporting, and the current limitations. Read it before registering anything; the rules that decide
 whether your table actually gets used are not guessable.
 
 ### The one thing to get right before you author metrics
 
-`measure_columns` maps a **metric to one column**, so a metric decomposing into more
-than one component can never be bound to an aggregate — and its components are
+A pre-agg's `metrics` map binds a **metric to one column**, so a metric decomposing
+into more than one component can never be bound to an aggregate — and its components are
 auto-named with a hash suffix that YAML cannot address. `SUM(revenue) /
 COUNT(DISTINCT view_id)` as a single node is unmappable forever; fixing it means
 refactoring a node other teams may already query.

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -182,105 +182,110 @@ class PreAggSpec(NamespacedSpec):
     use ``${prefix}`` or be fully qualified; they are rendered against the
     deployment namespace.
 
-    A metric or dimension and the physical column it is stored in are declared
-    together, as a map from the reference to the column::
+    Every metric and every dimension is declared together with the physical
+    column of the external table that holds it, as a map::
 
         metrics:
           ${prefix}paid_members: paid_members_sum
         dimensions:
           ${prefix}country_dim.country_iso: country
-          ${prefix}date_dim.utc_date:
+          ${prefix}date_dim.utc_date: utc_date
 
-    A dimension whose value is left empty (YAML ``null``) has no explicit binding
-    and falls back to its DJ column name, which is what the physical table is
-    assumed to have called it. A metric may not be left empty: a measure's DJ-side
-    name is auto-generated with an expression-hash suffix, so there is no stable
-    name to fall back on and the column must be spelled out.
+    Both maps require a value for every key -- including a dimension whose
+    physical column happens to match its DJ column name, which is written out
+    rather than left empty. An optional value would make the map not really a
+    mapping, a trailing colon is easy to write by accident, and spelling the
+    physical name out documents the table in the file that declares it.
 
-    The older four-field form -- ``metrics``/``dimensions`` as lists alongside
-    separate ``measure_columns``/``dimension_columns`` maps -- is still accepted
-    and normalizes to exactly the same fields, so the two forms compare equal.
-    Mixing the two (a map-form ``metrics`` together with a ``measure_columns``
-    block) is rejected rather than silently resolved one way.
+    What goes under ``metrics`` are the measures the table stores. A derived
+    metric (a ratio of two others, say) is not listed and cannot be: it has no
+    column of its own. It is covered anyway, because both registration and
+    query-time matching work on decomposed measure identities rather than metric
+    names, so any metric that decomposes into the stored measures resolves to
+    this table.
+
+    The earlier four-field form -- ``metrics``/``dimensions`` as lists alongside
+    separate ``measure_columns``/``dimension_columns`` maps -- is no longer
+    accepted, and a spec still using it is rejected with a message describing
+    what to write instead.
     """
 
-    metrics: list[str] = Field(default_factory=list)
-    dimensions: list[str] = Field(default_factory=list)
+    # Metric/dimension reference -> the physical column of the external table
+    # holding it. The `rendered_*` properties below split these back into the
+    # references-plus-bindings shape the registration internals take.
+    metrics: dict[str, str] = Field(default_factory=dict)
+    dimensions: dict[str, str] = Field(default_factory=dict)
     catalog: str
     schema_: str = Field(alias="schema")
     table: str
     valid_through_ts: int | None = None
-    measure_columns: dict[str, str] = Field(default_factory=dict)
-    # Physical-column binding for dimensions, keyed by dimension reference.
-    # Unmapped dimensions default to their DJ column name.
-    dimension_columns: dict[str, str] = Field(default_factory=dict)
 
     model_config = ConfigDict(populate_by_name=True)
 
+    # Each removed field and the map that replaced it.
+    _REPLACED_FIELDS: ClassVar[dict[str, str]] = {
+        "measure_columns": "metrics",
+        "dimension_columns": "dimensions",
+    }
+
+    # Why a missing column can't be defaulted, per axis.
+    _UNBOUND_REASONS: ClassVar[dict[str, str]] = {
+        "metrics": (
+            "A measure's DJ-side name is auto-generated with an expression-hash "
+            "suffix, so there is no name to fall back on."
+        ),
+        "dimensions": (
+            "Write the column out even when it matches the DJ column name, so "
+            "the file says what the table actually holds."
+        ),
+    }
+
     @model_validator(mode="before")
     @classmethod
-    def split_inline_column_bindings(cls, data: Any) -> Any:
+    def require_column_bindings(cls, data: Any) -> Any:
         """
-        Normalize the two-map form onto the list-plus-map fields the rest of the
-        codebase reads, so only the parser knows there are two spellings.
-
-        Everything downstream -- the `rendered_*` properties, the orchestrator,
-        `register_external_preaggregations` -- keeps seeing a list of references
-        and a separate binding map, and equality between the two forms falls out
-        of them normalizing to identical field values.
+        Hold the author to the map form: every metric and dimension names the
+        physical column that holds it, and the fields that used to carry those
+        bindings separately are gone.
         """
         if not isinstance(data, dict):
             return data
 
-        metrics, dimensions = data.get("metrics"), data.get("dimensions")
-        if not isinstance(metrics, dict) and not isinstance(dimensions, dict):
-            return data
-
         name = data.get("name")
-        data = dict(data)
-        if isinstance(metrics, dict):
-            if "measure_columns" in data:
+        for removed, replacement in cls._REPLACED_FIELDS.items():
+            if removed in data:
                 raise DJInvalidDeploymentConfig(
                     message=(
-                        f"Pre-aggregation '{name}' mixes two forms: `metrics` is "
-                        "already a map of metric to physical column, so a separate "
-                        "`measure_columns` block cannot also apply. Drop "
-                        "`measure_columns`, or write `metrics` as a plain list."
+                        f"Pre-aggregation '{name}' declares `{removed}`, which is no "
+                        f"longer a pre-aggregation field. Declare the physical column "
+                        f"alongside what it holds instead, as `{replacement}: "
+                        f"{{<reference>: <column>}}`, and drop the `{removed}` block."
                     ),
                 )
-            unbound = [metric for metric, column in metrics.items() if column is None]
+
+        for field, reason in cls._UNBOUND_REASONS.items():
+            value = data.get(field)
+            if value is None:
+                continue
+            if not isinstance(value, dict):
+                raise DJInvalidDeploymentConfig(
+                    message=(
+                        f"Pre-aggregation '{name}' declares `{field}` as a "
+                        f"{type(value).__name__}. `{field}` is a map from each "
+                        f"reference to the physical column of the external table "
+                        f"that holds it, e.g. `{field}: {{<reference>: <column>}}`."
+                    ),
+                )
+            unbound = [
+                reference for reference, column in value.items() if column is None
+            ]
             if unbound:
                 raise DJInvalidDeploymentConfig(
                     message=(
                         f"Pre-aggregation '{name}' leaves the physical column empty "
-                        f"for {unbound}. A measure always needs an explicit column: "
-                        "its DJ-side name is auto-generated with an expression-hash "
-                        "suffix, so there is no name to fall back on. Only "
-                        "dimensions may be left empty."
+                        f"under `{field}` for {unbound}. {reason}"
                     ),
                 )
-            data["metrics"] = list(metrics)
-            data["measure_columns"] = dict(metrics)
-
-        if isinstance(dimensions, dict):
-            if "dimension_columns" in data:
-                raise DJInvalidDeploymentConfig(
-                    message=(
-                        f"Pre-aggregation '{name}' mixes two forms: `dimensions` is "
-                        "already a map of dimension to physical column, so a separate "
-                        "`dimension_columns` block cannot also apply. Drop "
-                        "`dimension_columns`, or write `dimensions` as a plain list."
-                    ),
-                )
-            data["dimensions"] = list(dimensions)
-            # An empty value means "no explicit binding": leaving it out of the
-            # map is exactly how the list form spells the same thing, and the
-            # dimension falls back to its DJ column name downstream.
-            data["dimension_columns"] = {
-                dimension: column
-                for dimension, column in dimensions.items()
-                if column is not None
-            }
         return data
 
     @property
@@ -295,14 +300,14 @@ class PreAggSpec(NamespacedSpec):
     def rendered_measure_columns(self) -> dict[str, str]:
         return {
             render_prefixes(metric, self.namespace): column
-            for metric, column in self.measure_columns.items()
+            for metric, column in self.metrics.items()
         }
 
     @property
     def rendered_dimension_columns(self) -> dict[str, str]:
         return {
             render_prefixes(dimension, self.namespace): column
-            for dimension, column in self.dimension_columns.items()
+            for dimension, column in self.dimensions.items()
         }
 
 

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -181,6 +181,27 @@ class PreAggSpec(NamespacedSpec):
     for reconciliation and availability callbacks. Metric/dimension references may
     use ``${prefix}`` or be fully qualified; they are rendered against the
     deployment namespace.
+
+    A metric or dimension and the physical column it is stored in are declared
+    together, as a map from the reference to the column::
+
+        metrics:
+          ${prefix}paid_members: paid_members_sum
+        dimensions:
+          ${prefix}country_dim.country_iso: country
+          ${prefix}date_dim.utc_date:
+
+    A dimension whose value is left empty (YAML ``null``) has no explicit binding
+    and falls back to its DJ column name, which is what the physical table is
+    assumed to have called it. A metric may not be left empty: a measure's DJ-side
+    name is auto-generated with an expression-hash suffix, so there is no stable
+    name to fall back on and the column must be spelled out.
+
+    The older four-field form -- ``metrics``/``dimensions`` as lists alongside
+    separate ``measure_columns``/``dimension_columns`` maps -- is still accepted
+    and normalizes to exactly the same fields, so the two forms compare equal.
+    Mixing the two (a map-form ``metrics`` together with a ``measure_columns``
+    block) is rejected rather than silently resolved one way.
     """
 
     metrics: list[str] = Field(default_factory=list)
@@ -195,6 +216,72 @@ class PreAggSpec(NamespacedSpec):
     dimension_columns: dict[str, str] = Field(default_factory=dict)
 
     model_config = ConfigDict(populate_by_name=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def split_inline_column_bindings(cls, data: Any) -> Any:
+        """
+        Normalize the two-map form onto the list-plus-map fields the rest of the
+        codebase reads, so only the parser knows there are two spellings.
+
+        Everything downstream -- the `rendered_*` properties, the orchestrator,
+        `register_external_preaggregations` -- keeps seeing a list of references
+        and a separate binding map, and equality between the two forms falls out
+        of them normalizing to identical field values.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        metrics, dimensions = data.get("metrics"), data.get("dimensions")
+        if not isinstance(metrics, dict) and not isinstance(dimensions, dict):
+            return data
+
+        name = data.get("name")
+        data = dict(data)
+        if isinstance(metrics, dict):
+            if "measure_columns" in data:
+                raise DJInvalidDeploymentConfig(
+                    message=(
+                        f"Pre-aggregation '{name}' mixes two forms: `metrics` is "
+                        "already a map of metric to physical column, so a separate "
+                        "`measure_columns` block cannot also apply. Drop "
+                        "`measure_columns`, or write `metrics` as a plain list."
+                    ),
+                )
+            unbound = [metric for metric, column in metrics.items() if column is None]
+            if unbound:
+                raise DJInvalidDeploymentConfig(
+                    message=(
+                        f"Pre-aggregation '{name}' leaves the physical column empty "
+                        f"for {unbound}. A measure always needs an explicit column: "
+                        "its DJ-side name is auto-generated with an expression-hash "
+                        "suffix, so there is no name to fall back on. Only "
+                        "dimensions may be left empty."
+                    ),
+                )
+            data["metrics"] = list(metrics)
+            data["measure_columns"] = dict(metrics)
+
+        if isinstance(dimensions, dict):
+            if "dimension_columns" in data:
+                raise DJInvalidDeploymentConfig(
+                    message=(
+                        f"Pre-aggregation '{name}' mixes two forms: `dimensions` is "
+                        "already a map of dimension to physical column, so a separate "
+                        "`dimension_columns` block cannot also apply. Drop "
+                        "`dimension_columns`, or write `dimensions` as a plain list."
+                    ),
+                )
+            data["dimensions"] = list(dimensions)
+            # An empty value means "no explicit binding": leaving it out of the
+            # map is exactly how the list form spells the same thing, and the
+            # dimension falls back to its DJ column name downstream.
+            data["dimension_columns"] = {
+                dimension: column
+                for dimension, column in dimensions.items()
+                if column is not None
+            }
+        return data
 
     @property
     def rendered_metrics(self) -> list[str]:

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -6287,9 +6287,22 @@ class TestCubeRefreshMaterialization:
         mat_names = [m["name"] for m in call_kwargs["materializations"]]
         assert "deactivated_mat" in mat_names
 
-        # Verify the materialization was re-activated in the DB
-        await module__session.refresh(deactivated_mat)
-        assert deactivated_mat.deactivated_at is None
+        # Verify the materialization was re-activated in the DB. Re-select it
+        # rather than refreshing the instance built above: the request cleared
+        # the identity map, as it does in production, so that instance is no
+        # longer attached to this session.
+        reactivated_mat = (
+            (
+                await module__session.execute(
+                    select(Materialization).where(
+                        Materialization.id == deactivated_mat.id,
+                    ),
+                )
+            )
+            .scalars()
+            .one()
+        )
+        assert reactivated_mat.deactivated_at is None
 
         # Verify version didn't change
         response = await client_with_repairs_cube.get(f"/nodes/{cube_name}/")

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1900,6 +1900,109 @@ class TestDeployments:
             del client.app.dependency_overrides[get_query_service_client]
 
     @pytest.mark.asyncio
+    async def test_deploy_preagg_two_map_form(
+        self,
+        client,
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+    ):
+        """
+        The two-map form of a pre-agg spec -- each metric and dimension declared
+        with its physical column inline -- deploys to exactly the pre-aggregation
+        the four-field form registers in
+        ``test_deploy_reconciles_external_preaggregation``, including a dimension
+        left unbound (``state_name:`` with no value), which falls back to its DJ
+        column name.
+        """
+        hard_hat_facts = TransformSpec(
+            name="default.hard_hat_facts",
+            node_type=NodeType.TRANSFORM,
+            query="SELECT hard_hat_id, state FROM ${prefix}default.hard_hats",
+            dimension_links=[
+                DimensionJoinLinkSpec(
+                    dimension_node="${prefix}default.us_state",
+                    join_type="inner",
+                    join_on=(
+                        "${prefix}default.hard_hat_facts.state = "
+                        "${prefix}default.us_state.state_short"
+                    ),
+                ),
+            ],
+            owners=["dj"],
+        )
+        count_hard_hats = MetricSpec(
+            name="default.count_hard_hats",
+            node_type=NodeType.METRIC,
+            query="SELECT COUNT(*) FROM ${prefix}default.hard_hat_facts",
+            owners=["dj"],
+        )
+
+        async def _fake_columns(*args, **kwargs):
+            return [
+                SimpleNamespace(name="hard_hat_count", type="bigint"),
+                SimpleNamespace(name="state_name", type="string"),
+            ]
+
+        mock_qs = MagicMock()
+        mock_qs.get_columns_for_table = _fake_columns
+        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
+        try:
+            preagg_spec = PreAggSpec.model_validate(
+                {
+                    "name": "hard_hats_by_state",
+                    "metrics": {
+                        "${prefix}default.count_hard_hats": "hard_hat_count",
+                    },
+                    "dimensions": {"${prefix}default.us_state.state_name": None},
+                    "catalog": "default",
+                    "schema": "analytics",
+                    "table": "hard_hats_agg",
+                    "valid_through_ts": 1700000000,
+                },
+            )
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace="preagg_map",
+                    nodes=[
+                        default_hard_hats,
+                        default_us_states,
+                        default_us_state,
+                        hard_hat_facts,
+                        count_hard_hats,
+                    ],
+                    preaggregations=[preagg_spec],
+                ),
+            )
+            assert data["status"] == "success", data["results"]
+
+            listing = await client.get(
+                "/preaggs/",
+                params={"node_name": "preagg_map.default.hard_hat_facts"},
+            )
+            assert listing.status_code == 200, listing.text
+            items = listing.json()["items"]
+            assert len(items) == 1
+            preagg = items[0]
+            assert preagg["name"] == "preagg_map.hard_hats_by_state"
+            assert preagg["strategy"] == "external"
+            assert [measure["source_column"] for measure in preagg["measures"]] == [
+                "hard_hat_count",
+            ]
+            # The unbound dimension carries no physical binding, which is how
+            # "the column is named after the DJ dimension" is recorded.
+            dimension_columns = [
+                col
+                for col in preagg["columns"]
+                if col.get("semantic_type") == "dimension"
+            ]
+            assert [col["name"] for col in dimension_columns] == ["state_name"]
+            assert [col.get("source_column") for col in dimension_columns] == [None]
+        finally:
+            del client.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
     async def test_deploy_preagg_applies_dimension_columns(
         self,
         client,

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1850,15 +1850,12 @@ class TestDeployments:
         try:
             preagg_spec = PreAggSpec(
                 name="hard_hats_by_state",
-                metrics=["${prefix}default.count_hard_hats"],
-                dimensions=["${prefix}default.us_state.state_name"],
+                metrics={"${prefix}default.count_hard_hats": "hard_hat_count"},
+                dimensions={"${prefix}default.us_state.state_name": "state_name"},
                 catalog="default",
                 schema="analytics",
                 table="hard_hats_agg",
                 valid_through_ts=1700000000,
-                measure_columns={
-                    "${prefix}default.count_hard_hats": "hard_hat_count",
-                },
             )
             data = await deploy_and_wait(
                 client,
@@ -1896,109 +1893,6 @@ class TestDeployments:
             assert data["status"] == "success", data["results"]
             listing = await client.get("/preaggs/", params={"node_name": fact_node})
             assert listing.json()["items"] == []
-        finally:
-            del client.app.dependency_overrides[get_query_service_client]
-
-    @pytest.mark.asyncio
-    async def test_deploy_preagg_two_map_form(
-        self,
-        client,
-        default_hard_hats,
-        default_us_states,
-        default_us_state,
-    ):
-        """
-        The two-map form of a pre-agg spec -- each metric and dimension declared
-        with its physical column inline -- deploys to exactly the pre-aggregation
-        the four-field form registers in
-        ``test_deploy_reconciles_external_preaggregation``, including a dimension
-        left unbound (``state_name:`` with no value), which falls back to its DJ
-        column name.
-        """
-        hard_hat_facts = TransformSpec(
-            name="default.hard_hat_facts",
-            node_type=NodeType.TRANSFORM,
-            query="SELECT hard_hat_id, state FROM ${prefix}default.hard_hats",
-            dimension_links=[
-                DimensionJoinLinkSpec(
-                    dimension_node="${prefix}default.us_state",
-                    join_type="inner",
-                    join_on=(
-                        "${prefix}default.hard_hat_facts.state = "
-                        "${prefix}default.us_state.state_short"
-                    ),
-                ),
-            ],
-            owners=["dj"],
-        )
-        count_hard_hats = MetricSpec(
-            name="default.count_hard_hats",
-            node_type=NodeType.METRIC,
-            query="SELECT COUNT(*) FROM ${prefix}default.hard_hat_facts",
-            owners=["dj"],
-        )
-
-        async def _fake_columns(*args, **kwargs):
-            return [
-                SimpleNamespace(name="hard_hat_count", type="bigint"),
-                SimpleNamespace(name="state_name", type="string"),
-            ]
-
-        mock_qs = MagicMock()
-        mock_qs.get_columns_for_table = _fake_columns
-        client.app.dependency_overrides[get_query_service_client] = lambda: mock_qs
-        try:
-            preagg_spec = PreAggSpec.model_validate(
-                {
-                    "name": "hard_hats_by_state",
-                    "metrics": {
-                        "${prefix}default.count_hard_hats": "hard_hat_count",
-                    },
-                    "dimensions": {"${prefix}default.us_state.state_name": None},
-                    "catalog": "default",
-                    "schema": "analytics",
-                    "table": "hard_hats_agg",
-                    "valid_through_ts": 1700000000,
-                },
-            )
-            data = await deploy_and_wait(
-                client,
-                DeploymentSpec(
-                    namespace="preagg_map",
-                    nodes=[
-                        default_hard_hats,
-                        default_us_states,
-                        default_us_state,
-                        hard_hat_facts,
-                        count_hard_hats,
-                    ],
-                    preaggregations=[preagg_spec],
-                ),
-            )
-            assert data["status"] == "success", data["results"]
-
-            listing = await client.get(
-                "/preaggs/",
-                params={"node_name": "preagg_map.default.hard_hat_facts"},
-            )
-            assert listing.status_code == 200, listing.text
-            items = listing.json()["items"]
-            assert len(items) == 1
-            preagg = items[0]
-            assert preagg["name"] == "preagg_map.hard_hats_by_state"
-            assert preagg["strategy"] == "external"
-            assert [measure["source_column"] for measure in preagg["measures"]] == [
-                "hard_hat_count",
-            ]
-            # The unbound dimension carries no physical binding, which is how
-            # "the column is named after the DJ dimension" is recorded.
-            dimension_columns = [
-                col
-                for col in preagg["columns"]
-                if col.get("semantic_type") == "dimension"
-            ]
-            assert [col["name"] for col in dimension_columns] == ["state_name"]
-            assert [col.get("source_column") for col in dimension_columns] == [None]
         finally:
             del client.app.dependency_overrides[get_query_service_client]
 
@@ -2060,20 +1954,15 @@ class TestDeployments:
         try:
             preagg = PreAggSpec(
                 name="dimcol_agg",
-                metrics=["${prefix}default.dimcol_count"],
-                dimensions=[
-                    "${prefix}default.us_state.state_short",
-                    "${prefix}default.dimcol_facts.hard_hat_id",
-                ],
+                metrics={"${prefix}default.dimcol_count": "cnt"},
+                dimensions={
+                    "${prefix}default.us_state.state_short": "st_code",
+                    "${prefix}default.dimcol_facts.hard_hat_id": "hh_id_col",
+                },
                 catalog="default",
                 schema="analytics",
                 table="dimcol_agg_tbl",
                 valid_through_ts=1700000000,
-                measure_columns={"${prefix}default.dimcol_count": "cnt"},
-                dimension_columns={
-                    "${prefix}default.us_state.state_short": "st_code",
-                    "${prefix}default.dimcol_facts.hard_hat_id": "hh_id_col",
-                },
             )
             data = await deploy_and_wait(
                 client,
@@ -7772,17 +7661,15 @@ def _clear_query_service(client):
     client.app.dependency_overrides.pop(get_query_service_client, None)
 
 
-def _preagg_spec(name, table, measure_columns, dimensions=None, dimension_columns=None):
+def _preagg_spec(name, table, metrics, dimensions=None):
     return PreAggSpec(
         name=name,
-        metrics=["${prefix}default.count_hard_hats"],
-        dimensions=dimensions or ["${prefix}default.us_state.state_name"],
+        metrics=metrics,
+        dimensions=dimensions or {"${prefix}default.us_state.state_name": "state_name"},
         catalog="default",
         schema="analytics",
         table=table,
         valid_through_ts=1700000000,
-        measure_columns=measure_columns,
-        dimension_columns=dimension_columns or {},
     )
 
 
@@ -7799,7 +7686,10 @@ class TestExternalPreAggDeploy:
     ):
         """A pre-agg whose measure_columns key is not a valid measure fails the
         whole deploy and rolls it back -- no nodes or pre-aggs are left behind."""
-        _override_query_service(client, ["hard_hat_count", "state_name"])
+        _override_query_service(
+            client,
+            {"hard_hat_count": "bigint", "state_name": "string"},
+        )
         try:
             bad = _preagg_spec(
                 "bad_preagg",
@@ -7876,7 +7766,10 @@ class TestExternalPreAggDeploy:
         default_us_state,
     ):
         """A dry-run reports the planned pre-agg register without persisting it."""
-        _override_query_service(client, ["hard_hat_count", "state_name"])
+        _override_query_service(
+            client,
+            {"hard_hat_count": "bigint", "state_name": "string"},
+        )
         try:
             nodes = _hard_hat_deploy_nodes(
                 default_hard_hats,
@@ -7959,7 +7852,10 @@ class TestExternalPreAggDeploy:
         default_us_state,
     ):
         """A deploy to one namespace does not remove pre-aggs in another."""
-        _override_query_service(client, ["hard_hat_count", "state_name"])
+        _override_query_service(
+            client,
+            {"hard_hat_count": "bigint", "state_name": "string"},
+        )
         try:
             nodes = _hard_hat_deploy_nodes(
                 default_hard_hats,
@@ -8012,7 +7908,10 @@ class TestExternalPreAggDeploy:
             default_us_state,
         )
         try:
-            _override_query_service(client, ["hh_count_v1", "state_name"])
+            _override_query_service(
+                client,
+                {"hh_count_v1": "bigint", "state_name": "string"},
+            )
             data = await deploy_and_wait(
                 client,
                 DeploymentSpec(
@@ -8029,7 +7928,10 @@ class TestExternalPreAggDeploy:
             )
             assert data["status"] == "success", data["results"]
 
-            _override_query_service(client, ["hh_count_v2", "state_name"])
+            _override_query_service(
+                client,
+                {"hh_count_v2": "bigint", "state_name": "string"},
+            )
             data = await deploy_and_wait(
                 client,
                 DeploymentSpec(
@@ -8067,7 +7969,10 @@ class TestExternalPreAggDeploy:
     ):
         """A content-ful deploy that declares no pre-aggs leaves existing
         external pre-aggs intact; allow_empty is required to deregister them."""
-        _override_query_service(client, ["hard_hat_count", "state_name"])
+        _override_query_service(
+            client,
+            {"hard_hat_count": "bigint", "state_name": "string"},
+        )
         try:
             nodes = _hard_hat_deploy_nodes(
                 default_hard_hats,
@@ -8127,7 +8032,10 @@ class TestExternalPreAggDeploy:
         """The "left intact" warning is reported by the successful deploy that
         skipped the deregistration -- both as a top-level warning and as a
         per-item pre-aggregation result."""
-        _override_query_service(client, ["hard_hat_count", "state_name"])
+        _override_query_service(
+            client,
+            {"hard_hat_count": "bigint", "state_name": "string"},
+        )
         try:
             nodes = _hard_hat_deploy_nodes(
                 default_hard_hats,
@@ -8224,7 +8132,7 @@ class TestExternalPreAggDeploy:
                             "hh_by_state",
                             "hh_by_state_agg",
                             {"${prefix}default.count_hard_hats": "hard_hat_count"},
-                            dimension_columns={
+                            dimensions={
                                 "${prefix}default.us_state.state_name": "hh_state",
                             },
                         ),

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -1465,6 +1465,15 @@ async def module__client(
                     if asyncio.iscoroutine(result):
                         await result
                 module__background_tasks.clear()
+                # Empty the identity map between requests, the way production
+                # does by handing each request its own session. Sharing one
+                # session across a module leaves partially-loaded instances
+                # (from a `load_only` query) reachable by later requests, and
+                # touching a column they didn't load issues a lazy primary-key
+                # fetch. In a synchronous frame -- the v2 builder, for one --
+                # that raises MissingGreenlet, and which test it lands on
+                # depends on how xdist happened to pack modules onto workers.
+                module__session.expunge_all()
                 return response
 
             test_client.request = wrapped_request
@@ -1812,6 +1821,9 @@ async def module__clean_client(
                     if asyncio.iscoroutine(result):
                         await result
                 module__background_tasks.clear()
+                # See the note above: production gives each request its own
+                # session, so clear the identity map to match.
+                session.expunge_all()
                 return response
 
             test_client.request = wrapped_request

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -225,6 +225,72 @@ class TestExternalPreAggRouting:
         assert "default.analytics.orders_by_status" not in sql
 
     @pytest.mark.asyncio
+    async def test_external_preagg_serves_unregistered_derived_metric(
+        self,
+        client_with_build_v3,
+    ):
+        """
+        A derived metric is served by a table registered against its underlying
+        measures, without ever being named at registration.
+
+        This is what makes the pre-agg spec workable now that every declared
+        metric must name a physical column: a ratio has no column of its own, so
+        it cannot be declared -- but registration and matching both work on
+        decomposed measure identities rather than metric names, so declaring the
+        measures is enough. Here `avg_items_per_order` is
+        `total_quantity / order_count`, and neither the registration call nor the
+        stored pre-agg mentions it.
+        """
+        response = await _register_external_preagg(
+            client_with_build_v3,
+            metrics=["v3.total_quantity", "v3.order_count"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": "qty_orders_by_status",
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={
+                "v3.total_quantity": "qty_sum",
+                "v3.order_count": "order_id_col",
+            },
+            table_columns={
+                "status": "string",
+                "qty_sum": "double",
+                "order_id_col": "int",
+            },
+        )
+        # The two measures land in one pre-agg at the finer grain the distinct
+        # count needs -- the same grain group the derived metric decomposes to.
+        assert len(response.json()["preaggs"]) == 1
+
+        metrics_response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "metrics": ["v3.avg_items_per_order"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert metrics_response.status_code == 200, metrics_response.text
+        assert_sql_equal(
+            metrics_response.json()["sql"],
+            """
+            WITH order_details_0 AS (
+                SELECT status, SUM(qty_sum) qty_sum, order_id_col
+                FROM default.analytics.qty_orders_by_status
+                GROUP BY status, order_id_col
+            )
+            SELECT order_details_0.status AS status,
+                   SUM(order_details_0.qty_sum)
+                     / NULLIF(COUNT(DISTINCT order_details_0.order_id_col), 0)
+                     AS avg_items_per_order
+            FROM order_details_0
+            GROUP BY order_details_0.status
+            """,
+        )
+
+    @pytest.mark.asyncio
     async def test_external_preagg_not_used_for_incompatible_aggregation(
         self,
         client_with_build_v3,

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 
 from datajunction_server.errors import DJInvalidDeploymentConfig
 from datajunction_server.models.deployment import (
@@ -654,6 +655,154 @@ def test_preagg_spec_renders_dimension_columns():
     )
     assert spec.rendered_dimension_columns == {"ns.d.attr": "phys_attr"}
     assert spec.rendered_measure_columns == {"ns.count": "cnt"}
+
+
+def _preagg_two_map_form() -> dict:
+    """The two-map form: each metric/dimension carries its physical column."""
+    return {
+        "name": "p",
+        "namespace": "ns",
+        "metrics": {"${prefix}count": "cnt"},
+        "dimensions": {
+            "${prefix}d.attr": "phys_attr",
+            # No explicit column: falls back to the DJ column name.
+            "${prefix}d.unmapped": None,
+        },
+        "catalog": "c",
+        "schema": "s",
+        "table": "t",
+        "valid_through_ts": 1700000000,
+    }
+
+
+def _preagg_four_field_form() -> dict:
+    """The older form, saying exactly the same thing as `_preagg_two_map_form`."""
+    return {
+        "name": "p",
+        "namespace": "ns",
+        "metrics": ["${prefix}count"],
+        "dimensions": ["${prefix}d.attr", "${prefix}d.unmapped"],
+        "catalog": "c",
+        "schema": "s",
+        "table": "t",
+        "valid_through_ts": 1700000000,
+        "measure_columns": {"${prefix}count": "cnt"},
+        "dimension_columns": {"${prefix}d.attr": "phys_attr"},
+    }
+
+
+def test_preagg_spec_two_map_form_matches_four_field_form():
+    """
+    The two-map form and the older list-plus-map form normalize to the same
+    fields, so everything downstream (the `rendered_*` properties the deploy
+    path reads) sees identical values and the two specs compare equal.
+    """
+    two_map = PreAggSpec.model_validate(_preagg_two_map_form())
+    four_field = PreAggSpec.model_validate(_preagg_four_field_form())
+
+    assert two_map.rendered_metrics == ["ns.count"]
+    assert two_map.rendered_dimensions == ["ns.d.attr", "ns.d.unmapped"]
+    assert two_map.rendered_measure_columns == {"ns.count": "cnt"}
+    # `ns.d.unmapped` is absent, which is how "no explicit binding" is spelled
+    # downstream: registration falls back to the DJ column name for it.
+    assert two_map.rendered_dimension_columns == {"ns.d.attr": "phys_attr"}
+
+    assert two_map.rendered_metrics == four_field.rendered_metrics
+    assert two_map.rendered_dimensions == four_field.rendered_dimensions
+    assert two_map.rendered_measure_columns == four_field.rendered_measure_columns
+    assert two_map.rendered_dimension_columns == four_field.rendered_dimension_columns
+    assert two_map == four_field
+    assert two_map.model_dump() == four_field.model_dump()
+
+
+def test_preagg_spec_two_map_form_round_trips_through_model_dump():
+    """
+    A dumped spec is the list-plus-map form, which is what crosses the wire from
+    the client, so re-validating a dump has to land on an equal spec.
+    """
+    two_map = PreAggSpec.model_validate(_preagg_two_map_form())
+    # `namespace` is excluded from the dump (the deployment re-injects it), so
+    # the comparison is on the dumped fields.
+    assert PreAggSpec.model_validate(two_map.model_dump()).model_dump() == (
+        two_map.model_dump()
+    )
+
+
+def test_preagg_spec_allows_one_axis_at_a_time():
+    """
+    The two axes are independent: a file may declare its metrics inline while
+    still listing dimensions the old way, and vice versa. Only restating the
+    same axis twice is a conflict.
+    """
+    expected = PreAggSpec.model_validate(_preagg_four_field_form())
+
+    map_metrics = _preagg_four_field_form()
+    map_metrics["metrics"] = {"${prefix}count": "cnt"}
+    del map_metrics["measure_columns"]
+    assert PreAggSpec.model_validate(map_metrics) == expected
+
+    map_dimensions = _preagg_four_field_form()
+    map_dimensions["dimensions"] = {
+        "${prefix}d.attr": "phys_attr",
+        "${prefix}d.unmapped": None,
+    }
+    del map_dimensions["dimension_columns"]
+    assert PreAggSpec.model_validate(map_dimensions) == expected
+
+
+def test_preagg_spec_rejects_mixed_metric_forms():
+    """A map-form `metrics` plus a `measure_columns` block says it twice."""
+    spec = _preagg_two_map_form()
+    spec["measure_columns"] = {"${prefix}count": "other_cnt"}
+    with pytest.raises(DJInvalidDeploymentConfig) as exc_info:
+        PreAggSpec.model_validate(spec)
+    assert exc_info.value.message == (
+        "Pre-aggregation 'p' mixes two forms: `metrics` is already a map of "
+        "metric to physical column, so a separate `measure_columns` block "
+        "cannot also apply. Drop `measure_columns`, or write `metrics` as a "
+        "plain list."
+    )
+
+
+def test_preagg_spec_rejects_mixed_dimension_forms():
+    """Same for a map-form `dimensions` plus a `dimension_columns` block."""
+    spec = _preagg_two_map_form()
+    spec["dimension_columns"] = {"${prefix}d.attr": "other_attr"}
+    with pytest.raises(DJInvalidDeploymentConfig) as exc_info:
+        PreAggSpec.model_validate(spec)
+    assert exc_info.value.message == (
+        "Pre-aggregation 'p' mixes two forms: `dimensions` is already a map of "
+        "dimension to physical column, so a separate `dimension_columns` block "
+        "cannot also apply. Drop `dimension_columns`, or write `dimensions` as "
+        "a plain list."
+    )
+
+
+def test_preagg_spec_rejects_metric_without_column():
+    """
+    A dimension may be left unbound, but a measure may not: its DJ-side name
+    carries an expression-hash suffix, so there is nothing to fall back on.
+    """
+    spec = _preagg_two_map_form()
+    spec["metrics"] = {"${prefix}count": None, "${prefix}total": "total_sum"}
+    with pytest.raises(DJInvalidDeploymentConfig) as exc_info:
+        PreAggSpec.model_validate(spec)
+    assert exc_info.value.message == (
+        "Pre-aggregation 'p' leaves the physical column empty for "
+        "['${prefix}count']. A measure always needs an explicit column: its "
+        "DJ-side name is auto-generated with an expression-hash suffix, so "
+        "there is no name to fall back on. Only dimensions may be left empty."
+    )
+
+
+def test_preagg_spec_rejects_non_mapping_input():
+    """
+    Input that isn't a mapping at all falls through the form normalization and
+    gets pydantic's own error, rather than blowing up inside the validator.
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        PreAggSpec.model_validate(["not", "a", "spec"])
+    assert exc_info.value.errors()[0]["type"] == "model_type"
 
 
 def test_tag_spec_metadata_aliases():

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -624,14 +624,12 @@ def test_deployment_spec_preserves_explicit_preagg_namespace():
                 catalog="c",
                 schema="s",
                 table="t",
-                measure_columns={},
             ),
             PreAggSpec(
                 name="unscoped",
                 catalog="c",
                 schema="s",
                 table="t",
-                measure_columns={},
             ),
         ],
     )
@@ -639,34 +637,16 @@ def test_deployment_spec_preserves_explicit_preagg_namespace():
     assert spec.preaggregations[1].namespace == "ns"
 
 
-def test_preagg_spec_renders_dimension_columns():
-    """dimension_columns keys are prefix-rendered against the namespace, like
-    measure_columns; values (physical columns) are left as-is."""
-    spec = PreAggSpec(
-        name="p",
-        namespace="ns",
-        metrics=["${prefix}count"],
-        dimensions=["${prefix}d.attr"],
-        catalog="c",
-        schema="s",
-        table="t",
-        measure_columns={"${prefix}count": "cnt"},
-        dimension_columns={"${prefix}d.attr": "phys_attr"},
-    )
-    assert spec.rendered_dimension_columns == {"ns.d.attr": "phys_attr"}
-    assert spec.rendered_measure_columns == {"ns.count": "cnt"}
-
-
-def _preagg_two_map_form() -> dict:
-    """The two-map form: each metric/dimension carries its physical column."""
+def _preagg_spec_dict() -> dict:
+    """Each metric and dimension declared with the column that holds it."""
     return {
         "name": "p",
         "namespace": "ns",
         "metrics": {"${prefix}count": "cnt"},
         "dimensions": {
             "${prefix}d.attr": "phys_attr",
-            # No explicit column: falls back to the DJ column name.
-            "${prefix}d.unmapped": None,
+            # The physical column matches the DJ column name, and says so anyway.
+            "${prefix}d.same": "same",
         },
         "catalog": "c",
         "schema": "s",
@@ -675,130 +655,128 @@ def _preagg_two_map_form() -> dict:
     }
 
 
-def _preagg_four_field_form() -> dict:
-    """The older form, saying exactly the same thing as `_preagg_two_map_form`."""
-    return {
-        "name": "p",
-        "namespace": "ns",
-        "metrics": ["${prefix}count"],
-        "dimensions": ["${prefix}d.attr", "${prefix}d.unmapped"],
-        "catalog": "c",
-        "schema": "s",
-        "table": "t",
-        "valid_through_ts": 1700000000,
-        "measure_columns": {"${prefix}count": "cnt"},
-        "dimension_columns": {"${prefix}d.attr": "phys_attr"},
+def test_preagg_spec_renders_column_bindings():
+    """
+    The maps are split back into the references-plus-bindings shape the
+    registration internals take, with every reference prefix-rendered against
+    the namespace and the physical columns left as-is.
+    """
+    spec = PreAggSpec.model_validate(_preagg_spec_dict())
+    assert spec.rendered_metrics == ["ns.count"]
+    assert spec.rendered_dimensions == ["ns.d.attr", "ns.d.same"]
+    assert spec.rendered_measure_columns == {"ns.count": "cnt"}
+    assert spec.rendered_dimension_columns == {
+        "ns.d.attr": "phys_attr",
+        "ns.d.same": "same",
     }
 
 
-def test_preagg_spec_two_map_form_matches_four_field_form():
+def test_preagg_spec_round_trips_through_model_dump():
     """
-    The two-map form and the older list-plus-map form normalize to the same
-    fields, so everything downstream (the `rendered_*` properties the deploy
-    path reads) sees identical values and the two specs compare equal.
+    A dumped spec is what crosses the wire from the client, so re-validating a
+    dump has to land on an equal spec.
     """
-    two_map = PreAggSpec.model_validate(_preagg_two_map_form())
-    four_field = PreAggSpec.model_validate(_preagg_four_field_form())
-
-    assert two_map.rendered_metrics == ["ns.count"]
-    assert two_map.rendered_dimensions == ["ns.d.attr", "ns.d.unmapped"]
-    assert two_map.rendered_measure_columns == {"ns.count": "cnt"}
-    # `ns.d.unmapped` is absent, which is how "no explicit binding" is spelled
-    # downstream: registration falls back to the DJ column name for it.
-    assert two_map.rendered_dimension_columns == {"ns.d.attr": "phys_attr"}
-
-    assert two_map.rendered_metrics == four_field.rendered_metrics
-    assert two_map.rendered_dimensions == four_field.rendered_dimensions
-    assert two_map.rendered_measure_columns == four_field.rendered_measure_columns
-    assert two_map.rendered_dimension_columns == four_field.rendered_dimension_columns
-    assert two_map == four_field
-    assert two_map.model_dump() == four_field.model_dump()
-
-
-def test_preagg_spec_two_map_form_round_trips_through_model_dump():
-    """
-    A dumped spec is the list-plus-map form, which is what crosses the wire from
-    the client, so re-validating a dump has to land on an equal spec.
-    """
-    two_map = PreAggSpec.model_validate(_preagg_two_map_form())
+    spec = PreAggSpec.model_validate(_preagg_spec_dict())
     # `namespace` is excluded from the dump (the deployment re-injects it), so
     # the comparison is on the dumped fields.
-    assert PreAggSpec.model_validate(two_map.model_dump()).model_dump() == (
-        two_map.model_dump()
+    assert (
+        PreAggSpec.model_validate(spec.model_dump()).model_dump() == spec.model_dump()
     )
-
-
-def test_preagg_spec_allows_one_axis_at_a_time():
-    """
-    The two axes are independent: a file may declare its metrics inline while
-    still listing dimensions the old way, and vice versa. Only restating the
-    same axis twice is a conflict.
-    """
-    expected = PreAggSpec.model_validate(_preagg_four_field_form())
-
-    map_metrics = _preagg_four_field_form()
-    map_metrics["metrics"] = {"${prefix}count": "cnt"}
-    del map_metrics["measure_columns"]
-    assert PreAggSpec.model_validate(map_metrics) == expected
-
-    map_dimensions = _preagg_four_field_form()
-    map_dimensions["dimensions"] = {
-        "${prefix}d.attr": "phys_attr",
-        "${prefix}d.unmapped": None,
+    assert spec.model_dump() == {
+        "name": "p",
+        "metrics": {"${prefix}count": "cnt"},
+        "dimensions": {"${prefix}d.attr": "phys_attr", "${prefix}d.same": "same"},
+        "catalog": "c",
+        "schema_": "s",
+        "table": "t",
+        "valid_through_ts": 1700000000,
     }
-    del map_dimensions["dimension_columns"]
-    assert PreAggSpec.model_validate(map_dimensions) == expected
 
 
-def test_preagg_spec_rejects_mixed_metric_forms():
-    """A map-form `metrics` plus a `measure_columns` block says it twice."""
-    spec = _preagg_two_map_form()
-    spec["measure_columns"] = {"${prefix}count": "other_cnt"}
+def test_preagg_spec_rejects_measure_columns_block():
+    """
+    The four-field form is gone: `measure_columns` would otherwise be ignored as
+    an unknown key, silently dropping every binding it declared.
+    """
+    spec = _preagg_spec_dict()
+    spec["metrics"] = ["${prefix}count"]
+    spec["measure_columns"] = {"${prefix}count": "cnt"}
     with pytest.raises(DJInvalidDeploymentConfig) as exc_info:
         PreAggSpec.model_validate(spec)
     assert exc_info.value.message == (
-        "Pre-aggregation 'p' mixes two forms: `metrics` is already a map of "
-        "metric to physical column, so a separate `measure_columns` block "
-        "cannot also apply. Drop `measure_columns`, or write `metrics` as a "
-        "plain list."
+        "Pre-aggregation 'p' declares `measure_columns`, which is no longer a "
+        "pre-aggregation field. Declare the physical column alongside what it "
+        "holds instead, as `metrics: {<reference>: <column>}`, and drop the "
+        "`measure_columns` block."
     )
 
 
-def test_preagg_spec_rejects_mixed_dimension_forms():
-    """Same for a map-form `dimensions` plus a `dimension_columns` block."""
-    spec = _preagg_two_map_form()
-    spec["dimension_columns"] = {"${prefix}d.attr": "other_attr"}
+def test_preagg_spec_rejects_dimension_columns_block():
+    """Same for `dimension_columns`, the other half of the retired form."""
+    spec = _preagg_spec_dict()
+    spec["dimensions"] = ["${prefix}d.attr"]
+    spec["dimension_columns"] = {"${prefix}d.attr": "phys_attr"}
     with pytest.raises(DJInvalidDeploymentConfig) as exc_info:
         PreAggSpec.model_validate(spec)
     assert exc_info.value.message == (
-        "Pre-aggregation 'p' mixes two forms: `dimensions` is already a map of "
-        "dimension to physical column, so a separate `dimension_columns` block "
-        "cannot also apply. Drop `dimension_columns`, or write `dimensions` as "
-        "a plain list."
+        "Pre-aggregation 'p' declares `dimension_columns`, which is no longer a "
+        "pre-aggregation field. Declare the physical column alongside what it "
+        "holds instead, as `dimensions: {<reference>: <column>}`, and drop the "
+        "`dimension_columns` block."
+    )
+
+
+def test_preagg_spec_rejects_list_of_references():
+    """
+    A bare list of references carries no bindings at all, so it is refused with
+    the shape to write instead rather than a pydantic type error.
+    """
+    spec = _preagg_spec_dict()
+    spec["metrics"] = ["${prefix}count"]
+    with pytest.raises(DJInvalidDeploymentConfig) as exc_info:
+        PreAggSpec.model_validate(spec)
+    assert exc_info.value.message == (
+        "Pre-aggregation 'p' declares `metrics` as a list. `metrics` is a map "
+        "from each reference to the physical column of the external table that "
+        "holds it, e.g. `metrics: {<reference>: <column>}`."
     )
 
 
 def test_preagg_spec_rejects_metric_without_column():
-    """
-    A dimension may be left unbound, but a measure may not: its DJ-side name
-    carries an expression-hash suffix, so there is nothing to fall back on.
-    """
-    spec = _preagg_two_map_form()
+    """A measure's DJ-side name is hashed, so there is nothing to default to."""
+    spec = _preagg_spec_dict()
     spec["metrics"] = {"${prefix}count": None, "${prefix}total": "total_sum"}
     with pytest.raises(DJInvalidDeploymentConfig) as exc_info:
         PreAggSpec.model_validate(spec)
     assert exc_info.value.message == (
-        "Pre-aggregation 'p' leaves the physical column empty for "
-        "['${prefix}count']. A measure always needs an explicit column: its "
-        "DJ-side name is auto-generated with an expression-hash suffix, so "
-        "there is no name to fall back on. Only dimensions may be left empty."
+        "Pre-aggregation 'p' leaves the physical column empty under `metrics` "
+        "for ['${prefix}count']. A measure's DJ-side name is auto-generated "
+        "with an expression-hash suffix, so there is no name to fall back on."
+    )
+
+
+def test_preagg_spec_rejects_dimension_without_column():
+    """
+    A dimension is held to the same rule, even though its DJ column name would
+    be a plausible default: a trailing colon is too easy to write by accident,
+    and the written-out name documents the table.
+    """
+    spec = _preagg_spec_dict()
+    spec["dimensions"] = {"${prefix}d.attr": "phys_attr", "${prefix}d.same": None}
+    with pytest.raises(DJInvalidDeploymentConfig) as exc_info:
+        PreAggSpec.model_validate(spec)
+    assert exc_info.value.message == (
+        "Pre-aggregation 'p' leaves the physical column empty under "
+        "`dimensions` for ['${prefix}d.same']. Write the column out even when "
+        "it matches the DJ column name, so the file says what the table "
+        "actually holds."
     )
 
 
 def test_preagg_spec_rejects_non_mapping_input():
     """
-    Input that isn't a mapping at all falls through the form normalization and
-    gets pydantic's own error, rather than blowing up inside the validator.
+    Input that isn't a mapping at all falls through the binding checks and gets
+    pydantic's own error, rather than blowing up inside the validator.
     """
     with pytest.raises(ValidationError) as exc_info:
         PreAggSpec.model_validate(["not", "a", "spec"])

--- a/docs/content/0.1.0/docs/dj-concepts/aggregate-awareness.md
+++ b/docs/content/0.1.0/docs/dj-concepts/aggregate-awareness.md
@@ -324,31 +324,32 @@ metrics:
   ${prefix}session_count: session_cnt
 dimensions:
   ${prefix}page_d.page_id: page
-  ${prefix}geo_country_d.country_iso_code:
+  ${prefix}geo_country_d.country_iso_code: country_iso_code
 ```
 
-Each metric and each dimension is written together with the physical column that holds it, so the
-reference and its binding never drift apart. What you list under `metrics` are the *measures* the table
-stores — `view_rate` doesn't appear at all, and doesn't need to: DJ resolves its dependency on
-`view_secs` and `session_count`, sees both are covered, and considers `view_rate` covered as a result.
-A measure always needs an explicit column, because its DJ-side name is generated with an
-expression-hash suffix and so is not something the table can be assumed to have matched.
+Every metric and every dimension is written together with the physical column that holds it, so a
+reference and its binding can never drift apart, and reading the file tells you what the table looks
+like. Both maps require a value for every key. `page_d.page_id` is stored as `page`, so it says so;
+`geo_country_d.country_iso_code` happens to be stored under the same name DJ uses, and it says that
+too rather than leaving the value off. That is deliberate — a trailing colon is easy to write by
+accident, and an optional value would make the map not really a mapping. Each binding is validated
+the same way — the column must exist and be type-compatible — and only changes how the table is read,
+not how it's matched. A bound dimension can even be a joined attribute the table has denormalized (say
+it stores `country` directly rather than an account key you'd otherwise join through), which DJ then
+reads straight from the table with no join.
 
-Dimensions are more forgiving. `page_d.page_id` is stored in the table as `page`, so it says so, while
-`geo_country_d.country_iso_code` is left empty — that's how you say the table already calls the column
-by DJ's own name, and it is what the majority of grain columns will look like. A binding is validated
-the same way a measure's is — the column must exist and be type-compatible — and only changes how the
-table is read, not how it's matched. A bound dimension can even be a joined attribute the table has
-denormalized (say it stores `country` directly rather than an account key you'd otherwise join
-through), which DJ then reads straight from the table with no join.
+Notice that `view_rate` doesn't appear in the file at all. What you declare under `metrics` are the
+*measures* the table physically stores, and a derived metric has no column of its own to name, so it
+can't be listed. It doesn't need to be: both registration and query-time routing work on decomposed
+measures rather than metric names, so any metric that resolves to `view_secs` and `session_count` — the
+ratio `view_rate` among them — is served by this table automatically. Declare the measures and the
+metrics built on them follow.
 
-If you have existing pre-aggregation files, note that the older four-field form — `metrics` and
-`dimensions` as plain lists, with the columns declared separately under `measure_columns` and
-`dimension_columns` — still parses exactly as it always did, and is still the way to name a derived
-metric like `view_rate` in the spec itself. There is no migration to do; the two forms mean the same
-thing to DJ. What you can't do is mix them within one file, since a map-form `metrics` alongside a
-`measure_columns` block would be declaring the same bindings twice, and DJ rejects that rather than
-guess which one you meant.
+The earlier form of this file, where `metrics` and `dimensions` were plain lists and the columns lived
+in separate `measure_columns` and `dimension_columns` blocks, is no longer accepted; a file still using
+it is rejected with a message describing what to write instead. If you have one, move each column up
+next to the reference it belongs to, and write out the columns for any dimensions that were previously
+left unmapped and relied on DJ's column name.
 
 On deploy, DJ registers any pre-aggregation specs it finds. Because deployments are the source of truth,
 it also removes a previously-registered pre-aggregation once you drop its spec from a deploy that still

--- a/docs/content/0.1.0/docs/dj-concepts/aggregate-awareness.md
+++ b/docs/content/0.1.0/docs/dj-concepts/aggregate-awareness.md
@@ -316,34 +316,39 @@ like this:
 # views_by_page.yaml
 kind: preagg
 name: views_by_page
-metrics:
-  - ${prefix}view_rate
-dimensions:
-  - ${prefix}page_d.page_id
-  - ${prefix}geo_country_d.country_iso_code
 catalog: warehouse
 schema: analytics
 table: views_by_page_daily
-measure_columns:
+metrics:
   ${prefix}view_secs: view_secs_sum
   ${prefix}session_count: session_cnt
-dimension_columns:
+dimensions:
   ${prefix}page_d.page_id: page
-  ${prefix}geo_country_d.country_iso_code: country
+  ${prefix}geo_country_d.country_iso_code:
 ```
 
-`view_rate` is listed as the metric you care about querying, but the column mapping is still declared
-against its underlying measures — DJ resolves `view_rate`'s dependency on `view_secs` and
-`session_count`, sees both are covered by columns in `measure_columns`, and considers `view_rate`
-covered as a result.
+Each metric and each dimension is written together with the physical column that holds it, so the
+reference and its binding never drift apart. What you list under `metrics` are the *measures* the table
+stores — `view_rate` doesn't appear at all, and doesn't need to: DJ resolves its dependency on
+`view_secs` and `session_count`, sees both are covered, and considers `view_rate` covered as a result.
+A measure always needs an explicit column, because its DJ-side name is generated with an
+expression-hash suffix and so is not something the table can be assumed to have matched.
 
-Grain columns are mapped the same way: the optional `dimension_columns` map binds each dimension
-reference to the physical column holding it (here `page_d.page_id` is stored as `page` and the country
-as `country`), and unmapped dimensions are read under DJ's own name. It's validated like `measure_columns` — the column must exist
-and be type-compatible — and only changes how the table is read, not how it's matched. A mapped
-dimension can even be a joined attribute the table has denormalized (say it stores `country` directly
-rather than an account key you'd otherwise join through), which DJ then reads straight from the table
-with no join.
+Dimensions are more forgiving. `page_d.page_id` is stored in the table as `page`, so it says so, while
+`geo_country_d.country_iso_code` is left empty — that's how you say the table already calls the column
+by DJ's own name, and it is what the majority of grain columns will look like. A binding is validated
+the same way a measure's is — the column must exist and be type-compatible — and only changes how the
+table is read, not how it's matched. A bound dimension can even be a joined attribute the table has
+denormalized (say it stores `country` directly rather than an account key you'd otherwise join
+through), which DJ then reads straight from the table with no join.
+
+If you have existing pre-aggregation files, note that the older four-field form — `metrics` and
+`dimensions` as plain lists, with the columns declared separately under `measure_columns` and
+`dimension_columns` — still parses exactly as it always did, and is still the way to name a derived
+metric like `view_rate` in the spec itself. There is no migration to do; the two forms mean the same
+thing to DJ. What you can't do is mix them within one file, since a map-form `metrics` alongside a
+`measure_columns` block would be declaring the same bindings twice, and DJ rejects that rather than
+guess which one you meant.
 
 On deploy, DJ registers any pre-aggregation specs it finds. Because deployments are the source of truth,
 it also removes a previously-registered pre-aggregation once you drop its spec from a deploy that still

--- a/plugins/datajunction/skills/datajunction-repo/SKILL.md
+++ b/plugins/datajunction/skills/datajunction-repo/SKILL.md
@@ -580,15 +580,15 @@ read, falling back to the fact table when no aggregate can answer correctly.
 
 **The rules live in the docs, not here** — see
 [Query Routing & Aggregate Awareness](https://datajunction.io/docs/0.1.0/dj-concepts/query-routing-aggregate-awareness/)
-for the `kind: preagg` schema, `measure_columns` / `dimension_columns`, what makes a
-metric mappable, role-qualified dimension references, freshness reporting, and the
-current limitations. Read it before registering anything; the rules that decide
+for the `kind: preagg` schema (`metrics` and `dimensions` are maps from each
+reference to the physical column holding it), what makes a metric mappable,
+role-qualified dimension references, freshness reporting, and the current limitations. Read it before registering anything; the rules that decide
 whether your table actually gets used are not guessable.
 
 ### The one thing to get right before you author metrics
 
-`measure_columns` maps a **metric to one column**, so a metric decomposing into more
-than one component can never be bound to an aggregate — and its components are
+A pre-agg's `metrics` map binds a **metric to one column**, so a metric decomposing
+into more than one component can never be bound to an aggregate — and its components are
 auto-named with a hash suffix that YAML cannot address. `SUM(revenue) /
 COUNT(DISTINCT view_id)` as a single node is unmappable forever; fixing it means
 refactoring a node other teams may already query.


### PR DESCRIPTION
### Summary

Registering an externally-built pre-aggregation currently means naming each metric and dimension twice, once in a list, and again as a key in a separate column map:
```yaml
  metrics: [${prefix}total_revenue]
  dimensions: [${prefix}date_dim.dateint]
  measure_columns:
    ${prefix}total_revenue: revenue_sum
  dimension_columns:
    ${prefix}date_dim.dateint: order_date
```

We validate dimension_columns against dimensions, but there's no equivalent check on measure_columns, so an entry for a metric that isn't in metrics is silently ignored and at best shows up later as a coverage error.

This changes the spec so each metric and dimension carries its own column binding:
```yaml
  metrics:
    ${prefix}total_revenue: revenue_sum
  dimensions:
    ${prefix}date_dim.dateint: order_date
```

Changes include:
  - metrics and dimensions are now maps of reference to physical column
  - `measure_columns` and `dimension_columns` are no longer accepted, and a spec that uses them gets an error showing the new form
  - Every dimension needs an explicit column. Previously an unmapped dimension fell back to its DJ column name, but now a dimension whose physical column matches is written out as `default.date_dim.dateint: dateint`

### Test Plan

Added unit tests for both the new form and the rejection of the old one. Ran a deploy locally.

- [ ] PR has an associated issue: #
- [x] make check passes
- [x] make test shows 100% unit test coverage

### Deployment Plan

This is a breaking change to the kind: preagg spec. Normally we'd keep the old form working as an alias, but external registration went out less than a week ago and there are only a couple of spec files using it, so this is the cheapest time to make the change.