### PR TITLE
Fix two silent-corruption bugs in pre-aggregation registration

### DIFF
--- a/datajunction-server/datajunction_server/database/preaggregation.py
+++ b/datajunction-server/datajunction_server/database/preaggregation.py
@@ -442,12 +442,28 @@ class PreAggregation(Base):
         measure_identities: set[str],
     ) -> PreAggregation | None:
         """
-        Find an existing pre-agg that covers the requested measures.
+        Find the row this exact declaration already occupies, if any.
 
-        Looks up by grain_group_hash, then finds a candidate whose measures are a
-        superset of those required, compared by identity token. Comparing bare
-        expression hashes made SUM- and MAX-backed pre-aggs look like one row, so
-        registering either silently overwrote the other.
+        This is the upsert's identity check -- "is this the same declaration I am
+        about to write?" -- so it matches the uniqueness key exactly: same
+        revision and grain (via ``grain_group_hash``) and the SAME set of measure
+        identities, not merely a covering one.
+
+        Covering was wrong here, in two compounding ways. Callers replace the
+        matched row's contents wholesale, so a narrow declaration could match a
+        wider pre-agg and silently strip measures off it, breaking routing for
+        whatever metric depended on the dropped ones. And ``preagg_hash`` is
+        UNIQUE over exactly ``(node_revision_id, grain_columns,
+        measure_identities)`` and frozen at insert, so a covering match could
+        hand back a row whose stored hash no longer described its own contents.
+        A declaration that genuinely differs now gets its own row instead.
+
+        Identity tokens rather than bare expression hashes, because the latter
+        made SUM- and MAX-backed pre-aggs look like one row, so registering
+        either silently overwrote the other.
+
+        Contrast ``find_latest_for_node``, which asks the other question -- "what
+        did this declaration look like before?" -- and does want covering.
 
         Returns:
             Matching PreAggregation if found, None otherwise
@@ -456,7 +472,7 @@ class PreAggregation(Base):
         candidates = await cls.get_by_grain_group_hash(session, grain_group_hash)
 
         for candidate in candidates:
-            if measure_identities <= get_measure_identities(candidate.measures):
+            if measure_identities == get_measure_identities(candidate.measures):
                 return candidate
 
         return None
@@ -473,15 +489,23 @@ class PreAggregation(Base):
         Find the most recent pre-agg for the same declaration on ANY revision of
         the node, i.e. the predecessor of the one about to be inserted.
 
-        There are two lookups because there are two different questions.
-        ``find_matching`` is revision-scoped and asks "is this the same row?" --
-        it decides whether to update in place, so it keys on
-        ``grain_group_hash``, which embeds ``node_revision_id``. This one is
-        node-scoped and asks "what did this declaration look like before?" --
-        the answer has to survive a new revision, so it cannot use that hash at
-        all and instead joins through ``NodeRevision`` to ``Node`` to match on
-        node name. Matching is otherwise identical: same grain columns, and
-        measures that are a superset of the ones required.
+        There are two lookups because there are two different questions, and
+        they deliberately match differently.
+
+        ``find_matching`` is revision-scoped and asks "is this the same
+        declaration I am upserting?". It decides whether to overwrite a row, so
+        it has to be exact: same ``grain_group_hash`` (which embeds
+        ``node_revision_id``) and the same set of measure identities.
+
+        This one is node-scoped and asks "what did this declaration look like
+        before?". The answer has to survive a new revision, so it cannot use
+        that hash at all and instead joins through ``NodeRevision`` to ``Node``
+        to match on node name. It also wants COVERING rather than exact
+        measures: the point is to recognise the earlier incarnation of a
+        declaration whose measures may have shifted, and it only reads the
+        predecessor -- the caller re-checks the physical table coordinates
+        before inheriting anything, which is what keeps a merely-similar
+        pre-agg from being mistaken for the same one.
 
         Returns:
             The newest matching PreAggregation, or None

--- a/datajunction-server/datajunction_server/database/preaggregation.py
+++ b/datajunction-server/datajunction_server/database/preaggregation.py
@@ -461,6 +461,52 @@ class PreAggregation(Base):
 
         return None
 
+    @classmethod
+    async def find_latest_for_node(
+        cls,
+        session: AsyncSession,
+        node_name: str,
+        grain_columns: list[str],
+        measure_identities: set[str],
+    ) -> PreAggregation | None:
+        """
+        Find the most recent pre-agg for the same declaration on ANY revision of
+        the node, i.e. the predecessor of the one about to be inserted.
+
+        There are two lookups because there are two different questions.
+        ``find_matching`` is revision-scoped and asks "is this the same row?" --
+        it decides whether to update in place, so it keys on
+        ``grain_group_hash``, which embeds ``node_revision_id``. This one is
+        node-scoped and asks "what did this declaration look like before?" --
+        the answer has to survive a new revision, so it cannot use that hash at
+        all and instead joins through ``NodeRevision`` to ``Node`` to match on
+        node name. Matching is otherwise identical: same grain columns, and
+        measures that are a superset of the ones required.
+
+        Returns:
+            The newest matching PreAggregation, or None
+        """
+        from sqlalchemy.orm import joinedload
+
+        from datajunction_server.database.node import Node
+
+        statement = (
+            select(cls)
+            .join(NodeRevision, cls.node_revision_id == NodeRevision.id)
+            .join(Node, NodeRevision.node_id == Node.id)
+            .options(joinedload(cls.availability))
+            .where(Node.name == node_name)
+            .order_by(cls.id.desc())
+        )
+        result = await session.execute(statement)
+        wanted_grain = sorted(grain_columns)
+        for candidate in result.scalars().unique().all():
+            if sorted(candidate.grain_columns) != wanted_grain:
+                continue
+            if measure_identities <= get_measure_identities(candidate.measures):
+                return candidate
+        return None
+
     # TODO: Remove this once we have a way to test pre-aggregations
     def get_column_type(  # pragma: no cover
         self,

--- a/datajunction-server/datajunction_server/internal/preaggregations.py
+++ b/datajunction-server/datajunction_server/internal/preaggregations.py
@@ -115,6 +115,54 @@ def assert_dimension_refs_are_role_qualified(
             )
 
 
+async def _inherit_availability(
+    session: AsyncSession,
+    preagg: PreAggregation,
+    *,
+    node_name: str,
+    grain_columns: list[str],
+    grain_measures: list[PreAggMeasure],
+    table: ExternalPreAggTable,
+) -> None:
+    """
+    Carry a predecessor's availability onto a freshly inserted pre-agg.
+
+    A new revision of the parent node gives the same declaration a new
+    ``grain_group_hash``, so re-registration inserts rather than updates. The
+    physical table coordinates live only on the AvailabilityState row (see
+    ``PreAggregation.materialized_table_ref``), and the query planner only
+    considers pre-aggs that have one, so an insert that starts at NULL silently
+    drops the table out of routing -- queries fall back to the source tables
+    with no error anywhere.
+
+    The predecessor's availability is only inherited when it describes the same
+    physical table. A spec repointed at a different table is a genuinely
+    different table, and its freshness would be describing the old one.
+    """
+    predecessor = await PreAggregation.find_latest_for_node(
+        session,
+        node_name=node_name,
+        grain_columns=grain_columns,
+        measure_identities=get_measure_identities(grain_measures),
+    )
+    if predecessor is None or predecessor.availability is None:
+        return
+    previous = predecessor.availability
+    if (previous.catalog, previous.schema_, previous.table) != (
+        table.catalog,
+        table.schema_,
+        table.table,
+    ):
+        return
+    # Reuse the row rather than clone it. The FK has no ``ondelete`` and the
+    # relationship no ``cascade``, so deleting the superseded pre-agg (as deploy
+    # reconciliation does) cannot take the shared availability with it; sharing
+    # also stops every revision stranding an orphaned AvailabilityState; and a
+    # pipeline still posting freshness against the OLD pre-agg id lands on the
+    # very row the live pre-agg reads.
+    preagg.availability_id = predecessor.availability_id
+
+
 async def register_external_preaggregations(
     session: AsyncSession,
     query_service_client: QueryServiceClient,
@@ -226,7 +274,23 @@ async def register_external_preaggregations(
             ),
         )
 
-    # 4. For each grain group: verify measure coverage, bind source columns,
+    # 4. Every grain group in one registration points at the same physical
+    #    table, so they share one availability row -- built once here rather
+    #    than once (plus a flush) per grain group. Freshness is still only
+    #    recorded when the caller supplies it; otherwise the pre-agg stays
+    #    pending for the availability callback to report.
+    availability: AvailabilityState | None = None
+    if table.valid_through_ts is not None:
+        availability = AvailabilityState(
+            catalog=table.catalog,
+            schema_=table.schema_,
+            table=table.table,
+            valid_through_ts=table.valid_through_ts,
+        )
+        session.add(availability)
+        await session.flush()
+
+    # 5. For each grain group: verify measure coverage, bind source columns,
     #    and upsert the pre-aggregation.
     created_preaggs: list[PreAggregation] = []
     for grain_group in measures_result.grain_groups:
@@ -336,20 +400,21 @@ async def register_external_preaggregations(
                 strategy=MaterializationStrategy.EXTERNAL,
                 name=name,
             )
+            # Before adding it to the session: the lookup below autoflushes, and
+            # a pending row would come back as its own predecessor.
+            if availability is None:
+                await _inherit_availability(
+                    session,
+                    preagg,
+                    node_name=grain_group.parent_name,
+                    grain_columns=grain_columns,
+                    grain_measures=grain_measures,
+                    table=table,
+                )
             session.add(preagg)
         created_preaggs.append(preagg)
 
-        # 5. Set availability immediately when freshness is provided; otherwise
-        #    leave it pending for the availability callback to report.
-        if table.valid_through_ts is not None:
-            availability = AvailabilityState(
-                catalog=table.catalog,
-                schema_=table.schema_,
-                table=table.table,
-                valid_through_ts=table.valid_through_ts,
-            )
-            session.add(availability)
-            await session.flush()
+        if availability is not None:
             preagg.availability_id = availability.id
 
     await session.flush()

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -6287,9 +6287,22 @@ class TestCubeRefreshMaterialization:
         mat_names = [m["name"] for m in call_kwargs["materializations"]]
         assert "deactivated_mat" in mat_names
 
-        # Verify the materialization was re-activated in the DB
-        await module__session.refresh(deactivated_mat)
-        assert deactivated_mat.deactivated_at is None
+        # Verify the materialization was re-activated in the DB. Re-select it
+        # rather than refreshing the instance built above: the request cleared
+        # the identity map, as it does in production, so that instance is no
+        # longer attached to this session.
+        reactivated_mat = (
+            (
+                await module__session.execute(
+                    select(Materialization).where(
+                        Materialization.id == deactivated_mat.id,
+                    ),
+                )
+            )
+            .scalars()
+            .one()
+        )
+        assert reactivated_mat.deactivated_at is None
 
         # Verify version didn't change
         response = await client_with_repairs_cube.get(f"/nodes/{cube_name}/")

--- a/datajunction-server/tests/api/preaggregations_test.py
+++ b/datajunction-server/tests/api/preaggregations_test.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import joinedload
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.partition import Partition
 from datajunction_server.database.preaggregation import PreAggregation
+from datajunction_server.models.dialect import Dialect
 from datajunction_server.models.materialization import MaterializationStrategy
 from datajunction_server.models.partition import Granularity, PartitionType
 from datajunction_server.models.preaggregation import WorkflowUrl
@@ -2916,5 +2917,324 @@ class TestPreaggWriteEnforcement:
             )
             assert response.status_code == 403, response.text
             assert "Access denied" in response.json()["message"]
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+
+def _session_for(client: AsyncClient) -> AsyncSession:
+    """The very session the API handlers use, so registrations are visible."""
+    from datajunction_server.utils import get_session
+
+    return client.app.dependency_overrides[get_session]()
+
+
+async def _availability_id(session: AsyncSession, preagg_id: int) -> int | None:
+    """
+    Read a pre-agg's availability_id straight from the row, bypassing the
+    identity map so a value written by a request is not read back stale.
+    """
+    result = await session.execute(
+        select(PreAggregation.availability_id).where(PreAggregation.id == preagg_id),
+    )
+    return result.scalar_one()
+
+
+async def _count_availability_states(session: AsyncSession) -> int:
+    """How many AvailabilityState rows exist right now."""
+    from sqlalchemy import func
+
+    from datajunction_server.database.availabilitystate import AvailabilityState
+
+    result = await session.execute(select(func.count()).select_from(AvailabilityState))
+    return result.scalar_one()
+
+
+async def _register_aov(
+    client: AsyncClient,
+    table: str,
+    valid_through_ts: int | None = None,
+) -> dict:
+    """Register avg_order_value by category against ``table``."""
+    table_spec: dict = {
+        "catalog": "default",
+        "schema": "analytics",
+        "table": table,
+    }
+    if valid_through_ts is not None:
+        table_spec["valid_through_ts"] = valid_through_ts
+    response = await client.post(
+        "/preaggs/register",
+        json={
+            "metrics": ["v3.avg_order_value"],
+            "dimensions": ["v3.product.category"],
+            "table": table_spec,
+            "measure_columns": {
+                "v3.total_revenue": "revenue_total",
+                "v3.order_count": "order_cnt",
+            },
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["preaggs"][0]
+
+
+async def _revise_order_details(client: AsyncClient, description: str) -> None:
+    """Edit the parent transform, which gives it a fresh node revision."""
+    response = await client.patch(
+        "/nodes/v3.order_details/",
+        json={"description": description},
+    )
+    assert response.status_code == 200, response.text
+
+
+class TestRegisteredPreAggAvailabilityInheritance:
+    """
+    A registered pre-agg keeps its availability across a parent node revision.
+
+    A new revision re-keys the grain group, so re-registration inserts a new row
+    rather than updating one; starting that row at NULL availability drops the
+    external table out of routing with no error reported anywhere.
+    """
+
+    @pytest.mark.asyncio
+    async def test_availability_survives_parent_revision(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """
+        The row inserted for the new revision reuses the predecessor's
+        availability, and routes again.
+        """
+        _mock_query_service(
+            client_with_build_v3,
+            ["revenue_total", "order_cnt", "category"],
+        )
+        session = _session_for(client_with_build_v3)
+        try:
+            first = await _register_aov(
+                client_with_build_v3,
+                "inherit_agg",
+                valid_through_ts=1700000000,
+            )
+            availability_report = await client_with_build_v3.post(
+                f"/preaggs/{first['id']}/availability/",
+                json={
+                    "catalog": "default",
+                    "schema_": "analytics",
+                    "table": "inherit_agg",
+                    "valid_through_ts": 1700100000,
+                },
+            )
+            assert availability_report.status_code == 200, availability_report.text
+            inherited_id = await _availability_id(session, first["id"])
+
+            await _revise_order_details(client_with_build_v3, "revised for preaggs")
+
+            second = await _register_aov(client_with_build_v3, "inherit_agg")
+            assert second["id"] != first["id"]
+            assert await _availability_id(session, second["id"]) == inherited_id
+            assert second["status"] == "active"
+
+            measures = await build_measures_sql(
+                session=session,
+                metrics=["v3.avg_order_value"],
+                dimensions=["v3.product.category"],
+                dialect=Dialect.SPARK,
+                use_materialized=True,
+            )
+            routed = {
+                preagg.id
+                for candidates in measures.ctx.available_preaggs.values()
+                for preagg in candidates
+            }
+            assert routed == {second["id"]}
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_inheritance_skips_other_declarations_on_the_node(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """
+        The node-scoped lookup sees every pre-agg on the node, so it has to walk
+        past the ones at another grain and the ones that cover only some of the
+        required measures before it reaches the real predecessor.
+        """
+        _mock_query_service(
+            client_with_build_v3,
+            ["revenue_total", "order_cnt", "up_max", "category", "status"],
+        )
+        session = _session_for(client_with_build_v3)
+        try:
+            predecessor = await _register_aov(
+                client_with_build_v3,
+                "scan_target_agg",
+                valid_through_ts=1700000000,
+            )
+            inherited_id = await _availability_id(session, predecessor["id"])
+            assert inherited_id is not None
+
+            # Same node and grain, but none of the required measures.
+            other_measures = await client_with_build_v3.post(
+                "/preaggs/register",
+                json={
+                    "metrics": ["v3.max_unit_price"],
+                    "dimensions": ["v3.product.category"],
+                    "table": {
+                        "catalog": "default",
+                        "schema": "analytics",
+                        "table": "scan_other_measures_agg",
+                    },
+                    "measure_columns": {"v3.max_unit_price": "up_max"},
+                },
+            )
+            assert other_measures.status_code == 201, other_measures.text
+
+            # Same node, different grain.
+            other_grain = await client_with_build_v3.post(
+                "/preaggs/register",
+                json={
+                    "metrics": ["v3.total_revenue"],
+                    "dimensions": ["v3.order_details.status"],
+                    "table": {
+                        "catalog": "default",
+                        "schema": "analytics",
+                        "table": "scan_other_grain_agg",
+                    },
+                    "measure_columns": {"v3.total_revenue": "revenue_total"},
+                },
+            )
+            assert other_grain.status_code == 201, other_grain.text
+
+            await _revise_order_details(client_with_build_v3, "revised for scanning")
+
+            reregistered = await _register_aov(client_with_build_v3, "scan_target_agg")
+            assert reregistered["id"] != predecessor["id"]
+            assert await _availability_id(session, reregistered["id"]) == inherited_id
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_repointed_table_does_not_inherit(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """
+        Freshness describes one physical table, so a spec pointed at a different
+        table starts pending rather than borrowing it.
+        """
+        _mock_query_service(
+            client_with_build_v3,
+            ["revenue_total", "order_cnt", "category"],
+        )
+        session = _session_for(client_with_build_v3)
+        try:
+            first = await _register_aov(
+                client_with_build_v3,
+                "repoint_before",
+                valid_through_ts=1700000000,
+            )
+            assert await _availability_id(session, first["id"]) is not None
+
+            await _revise_order_details(client_with_build_v3, "revised for repointing")
+
+            second = await _register_aov(client_with_build_v3, "repoint_after")
+            assert second["id"] != first["id"]
+            assert await _availability_id(session, second["id"]) is None
+            assert second["status"] == "pending"
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_no_predecessor_stays_pending(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """A first registration with no freshness has nothing to inherit."""
+        _mock_query_service(
+            client_with_build_v3,
+            ["revenue_total", "order_cnt", "category"],
+        )
+        session = _session_for(client_with_build_v3)
+        try:
+            registered = await _register_aov(client_with_build_v3, "no_predecessor_agg")
+            assert await _availability_id(session, registered["id"]) is None
+            assert registered["status"] == "pending"
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_same_revision_reregistration_keeps_availability(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """
+        Without a revision in between, re-registration still updates the same row
+        and leaves its availability alone.
+        """
+        _mock_query_service(
+            client_with_build_v3,
+            ["revenue_total", "order_cnt", "category"],
+        )
+        session = _session_for(client_with_build_v3)
+        try:
+            first = await _register_aov(
+                client_with_build_v3,
+                "same_revision_agg",
+                valid_through_ts=1700000000,
+            )
+            original = await _availability_id(session, first["id"])
+            assert original is not None
+
+            second = await _register_aov(client_with_build_v3, "same_revision_agg")
+            assert second["id"] == first["id"]
+            assert await _availability_id(session, second["id"]) == original
+            assert second["status"] == "active"
+        finally:
+            del client_with_build_v3.app.dependency_overrides[get_query_service_client]
+
+    @pytest.mark.asyncio
+    async def test_one_availability_state_per_registration(
+        self,
+        client_with_build_v3: AsyncClient,
+    ):
+        """
+        Every grain group in a registration reads the same physical table, so they
+        share one AvailabilityState rather than getting one apiece.
+        """
+        _mock_query_service(
+            client_with_build_v3,
+            ["revenue_total", "view_cnt", "category"],
+        )
+        session = _session_for(client_with_build_v3)
+        try:
+            before = await _count_availability_states(session)
+            response = await client_with_build_v3.post(
+                "/preaggs/register",
+                json={
+                    "metrics": ["v3.total_revenue", "v3.page_view_count"],
+                    "dimensions": ["v3.product.category"],
+                    "table": {
+                        "catalog": "default",
+                        "schema": "analytics",
+                        "table": "cross_fact_agg",
+                        "valid_through_ts": 1700000000,
+                    },
+                    "measure_columns": {
+                        "v3.total_revenue": "revenue_total",
+                        "v3.page_view_count": "view_cnt",
+                    },
+                },
+            )
+            assert response.status_code == 201, response.text
+            preaggs = response.json()["preaggs"]
+            assert len(preaggs) == 2
+            assert {preagg["status"] for preagg in preaggs} == {"active"}
+            availability_ids = {
+                await _availability_id(session, preagg["id"]) for preagg in preaggs
+            }
+            assert len(availability_ids) == 1
+            assert await _count_availability_states(session) == before + 1
         finally:
             del client_with_build_v3.app.dependency_overrides[get_query_service_client]

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -1465,6 +1465,15 @@ async def module__client(
                     if asyncio.iscoroutine(result):
                         await result
                 module__background_tasks.clear()
+                # Empty the identity map between requests, the way production
+                # does by handing each request its own session. Sharing one
+                # session across a module leaves partially-loaded instances
+                # (from a `load_only` query) reachable by later requests, and
+                # touching a column they didn't load issues a lazy primary-key
+                # fetch. In a synchronous frame -- the v2 builder, for one --
+                # that raises MissingGreenlet, and which test it lands on
+                # depends on how xdist happened to pack modules onto workers.
+                module__session.expunge_all()
                 return response
 
             test_client.request = wrapped_request
@@ -1812,6 +1821,9 @@ async def module__clean_client(
                     if asyncio.iscoroutine(result):
                         await result
                 module__background_tasks.clear()
+                # See the note above: production gives each request its own
+                # session, so clear the identity map to match.
+                session.expunge_all()
                 return response
 
             test_client.request = wrapped_request

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -4369,3 +4369,137 @@ class TestPreAggJoinBack:
             GROUP BY order_details_0.customer_id, order_details_0.name_customer
             """,
         )
+
+
+class TestRegistrationUpsertIdentity:
+    """
+    Registration upserts on the EXACT declaration, never on a wider one.
+
+    The upsert replaces the matched row's measures, SQL and columns wholesale,
+    so matching a merely-covering row would strip measures off a pre-agg other
+    metrics route to -- and, for an external pre-agg, leave the rewritten row
+    still bound to the first registration's physical table.
+    """
+
+    @staticmethod
+    async def _list_by_table(client) -> dict[str, dict]:
+        """Every pre-agg on v3.order_details, keyed by its materialized table."""
+        listing = await client.get(
+            "/preaggs/",
+            params={"node_name": "v3.order_details"},
+        )
+        assert listing.status_code == 200, listing.text
+        return {row["materialized_table_ref"]: row for row in listing.json()["items"]}
+
+    @staticmethod
+    async def _register_wide(client, table="wide_by_status"):
+        """A pre-agg covering both revenue and quantity, at status grain."""
+        return await _register_external_preagg(
+            client,
+            metrics=["v3.total_revenue", "v3.total_quantity"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": table,
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={
+                "v3.total_revenue": "rev_sum",
+                "v3.total_quantity": "qty_sum",
+            },
+            table_columns={
+                "status": "string",
+                "rev_sum": "double",
+                "qty_sum": "double",
+            },
+        )
+
+    @staticmethod
+    async def _register_narrow(client, table="narrow_by_status"):
+        """A pre-agg covering only revenue, at the same grain."""
+        return await _register_external_preagg(
+            client,
+            metrics=["v3.total_revenue"],
+            dimensions=["v3.order_details.status"],
+            table_ref={
+                "catalog": "default",
+                "schema": "analytics",
+                "table": table,
+                "valid_through_ts": 20250101,
+            },
+            measure_columns={"v3.total_revenue": "rev_sum"},
+            table_columns={"status": "string", "rev_sum": "double"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_narrower_registration_gets_its_own_row(
+        self,
+        client_with_build_v3,
+    ):
+        """A narrower declaration inserts rather than cannibalising the wider
+        row, which keeps every measure it was registered with."""
+        wide = await self._register_wide(client_with_build_v3)
+        wide_id = wide.json()["preaggs"][0]["id"]
+        narrow = await self._register_narrow(client_with_build_v3)
+        narrow_id = narrow.json()["preaggs"][0]["id"]
+        assert narrow_id != wide_id
+
+        rows = await self._list_by_table(client_with_build_v3)
+        assert set(rows) == {
+            "default.analytics.wide_by_status",
+            "default.analytics.narrow_by_status",
+        }
+        assert {
+            measure["source_column"]
+            for measure in rows["default.analytics.wide_by_status"]["measures"]
+        } == {"rev_sum", "qty_sum"}
+        assert {
+            measure["source_column"]
+            for measure in rows["default.analytics.narrow_by_status"]["measures"]
+        } == {"rev_sum"}
+        # The row bound to the first table was never rewritten to serve the
+        # second one's measures.
+        assert rows["default.analytics.wide_by_status"]["id"] == wide_id
+        assert rows["default.analytics.narrow_by_status"]["id"] == narrow_id
+
+    @pytest.mark.asyncio
+    async def test_wider_preagg_still_routes_after_narrower_registration(
+        self,
+        client_with_build_v3,
+    ):
+        """The measure only the wider pre-agg covers still reads its table."""
+        await self._register_wide(client_with_build_v3)
+        await self._register_narrow(client_with_build_v3)
+
+        response = await client_with_build_v3.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": ["v3.total_quantity"],
+                "dimensions": ["v3.order_details.status"],
+            },
+        )
+        assert response.status_code == 200, response.text
+        assert_sql_equal(
+            get_first_grain_group(response.json())["sql"],
+            """
+            SELECT status, SUM(qty_sum) qty_sum
+            FROM default.analytics.wide_by_status
+            GROUP BY status
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_identical_registration_still_updates_in_place(
+        self,
+        client_with_build_v3,
+    ):
+        """Exact matching is still a match: the same declaration re-registered
+        against a new table moves that one row rather than adding another."""
+        first = await self._register_wide(client_with_build_v3)
+        first_id = first.json()["preaggs"][0]["id"]
+        again = await self._register_wide(client_with_build_v3, "wide_moved")
+        assert again.json()["preaggs"][0]["id"] == first_id
+
+        rows = await self._list_by_table(client_with_build_v3)
+        assert set(rows) == {"default.analytics.wide_moved"}

--- a/datajunction-server/tests/database/preaggregation_test.py
+++ b/datajunction-server/tests/database/preaggregation_test.py
@@ -555,12 +555,19 @@ class TestPreAggregationDBMethods:
         result = await PreAggregation.get_by_id(session, 999999)
         assert result is None
 
-    async def test_find_matching_with_superset(
+    async def test_find_matching_rejects_covering_row(
         self,
         session,
         minimal_node_revision,
     ):
-        """Test find_matching returns pre-agg with superset of measures."""
+        """
+        A wider pre-agg is NOT the row a narrower declaration upserts into.
+
+        Matching is exact because the caller replaces the matched row wholesale:
+        a covering match would strip the extra measures off a row other metrics
+        route to, and leave its frozen preagg_hash describing contents it no
+        longer has.
+        """
         grain_columns = ["test.dim.col"]
 
         measures = [
@@ -586,13 +593,25 @@ class TestPreAggregationDBMethods:
         session.add(preagg)
         await session.flush()
 
-        # Request subset - should match
+        # A subset of the stored measures is a different declaration.
         result = await PreAggregation.find_matching(
             session,
             node_revision_id=minimal_node_revision.id,
             grain_columns=grain_columns,
             measure_identities={
                 measure_identity_token(compute_expression_hash("price"), "SUM"),
+            },
+        )
+        assert result is None
+
+        # The full set is the same declaration, and matches.
+        result = await PreAggregation.find_matching(
+            session,
+            node_revision_id=minimal_node_revision.id,
+            grain_columns=grain_columns,
+            measure_identities={
+                measure_identity_token(compute_expression_hash("price"), "SUM"),
+                measure_identity_token(compute_expression_hash("1"), "COUNT"),
             },
         )
         assert result is not None
@@ -648,7 +667,7 @@ class TestPreAggregationDBMethods:
         assert result.preagg_hash == legacy_hash
 
     async def test_find_matching_no_match(self, session, minimal_node_revision):
-        """Test find_matching returns None when no candidate has superset."""
+        """Test find_matching returns None when no candidate matches."""
         grain_columns = ["test.dim.col"]
 
         measures = [make_measure("sum_price", "price")]


### PR DESCRIPTION
Two silent-corruption bugs in pre-aggregation registration, both in the same upsert. In each case the symptom is that a pre-agg quietly stops serving queries and nothing anywhere reports an error.

1. Availability is lost when the parent node revises
2. A narrower declaration cannibalises a wider pre-agg
