### PR TITLE
Hydrate a source node's primary key from the table's metadata

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1597,6 +1597,55 @@ async def apply_table_owner(
     return True
 
 
+async def apply_table_primary_key(
+    session: AsyncSession,
+    node: Node,
+    primary_key: list[str],
+    current_user: User,
+    save_history: Callable,
+) -> bool:
+    """
+    Set the primary key attribute from the catalog's primary key.
+
+    Fill-when-empty: if the node already declares a primary key, leave it alone.
+    A primary key is structural -- dimension joins and cube grain depend on it --
+    so a hand-chosen one is a deliberate modelling decision and the catalog is
+    not automatically more right than the person who set it.
+
+    Goes through set_node_column_attributes so the attribute's uniqueness scopes
+    are validated the same way a manual change is, and so any other attribute
+    already on the column is preserved rather than replaced.
+    """
+    if not primary_key or node.current.primary_key():
+        return False
+
+    by_name = {column.name: column for column in node.current.columns}
+    changed = False
+    for column_name in primary_key:
+        column = by_name.get(column_name)
+        if column is None:
+            # The catalog named a column the node does not have; the column diff
+            # elsewhere in refresh is what reconciles that, not this.
+            continue
+        attributes = [
+            AttributeTypeIdentifier(name=attribute.attribute_type.name)
+            for attribute in column.attributes
+        ]
+        attributes.append(
+            AttributeTypeIdentifier(name=ColumnAttributes.PRIMARY_KEY.value),
+        )
+        await set_node_column_attributes(
+            session,
+            node,
+            column_name,
+            attributes,
+            current_user=current_user,
+            save_history=save_history,
+        )
+        changed = True
+    return changed
+
+
 def describe_column_changes(
     existing: list[Column],
     incoming: list[Column],
@@ -4244,6 +4293,13 @@ async def refresh_source(
     # documentation, not something a reported number can turn on.
     if table_metadata is not None:
         apply_table_descriptions(session, current_revision, table_metadata)
+        await apply_table_primary_key(
+            session,
+            source_node,  # type: ignore
+            table_metadata.primary_key,
+            current_user,
+            save_history,
+        )
 
     refresh_details = {}
     if new_columns:

--- a/datajunction-server/datajunction_server/models/table_metadata.py
+++ b/datajunction-server/datajunction_server/models/table_metadata.py
@@ -47,3 +47,6 @@ class TableMetadata(BaseModel):
     # (Snowflake COMMENT, BigQuery description, Iceberg/Hive comment). Per-column
     # descriptions ride along on ``columns``, which already has the field.
     description: str | None = None
+    # Column names the catalog reports as the table's primary key. DJ models this
+    # as a column attribute, set by hand today.
+    primary_key: list[str] = []

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -308,6 +308,7 @@ class QueryServiceClient:
             owner=TableOwner(**owner) if owner else None,
             partitions=metadata.get("partitions") or [],
             description=metadata.get("description"),
+            primary_key=metadata.get("primary_key") or [],
         )
 
     async def get_columns_for_tables_batch(

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2827,6 +2827,63 @@ class TestNodeCRUD:
         assert keyed == {"id": [], "other_id": ["primary_key"]}
 
     @pytest.mark.asyncio
+    async def test_refresh_skips_a_primary_key_column_the_node_lacks(
+        self,
+        module__client_with_roads: AsyncClient,
+        module__query_service_client: QueryServiceClient,
+        mocker: MockerFixture,
+    ):
+        """
+        A primary key naming a column the node does not have hydrates nothing.
+
+        The column diff is what reconciles a table that gained a column, so the
+        column arrives on the refreshed node but without the attribute -- the
+        catalog's primary key is only applied to columns the node already had.
+        """
+        response = await module__client_with_roads.post(
+            "/nodes/source/",
+            json={
+                "name": "default.late_key_table",
+                "description": "A table that gains its primary key column later",
+                "columns": [
+                    {"name": "amount", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "roads",
+                "table": "late_key_table",
+            },
+        )
+        assert response.status_code in (200, 201)
+
+        async def _with_unknown_pk(*args, **kwargs):
+            return TableMetadata(
+                columns=[
+                    Column(name="amount", type=IntegerType(), order=0),
+                    Column(name="id", type=IntegerType(), order=1),
+                ],
+                primary_key=["id"],
+            )
+
+        mocker.patch.object(
+            module__query_service_client,
+            "get_table_metadata",
+            _with_unknown_pk,
+        )
+        refreshed = await module__client_with_roads.post(
+            "/nodes/default.late_key_table/refresh/",
+        )
+        assert refreshed.status_code == 201
+        after = (
+            await module__client_with_roads.get("/nodes/default.late_key_table/")
+        ).json()
+        keyed = {
+            column["name"]: [a["attribute_type"]["name"] for a in column["attributes"]]
+            for column in after["columns"]
+        }
+        assert keyed == {"amount": [], "id": []}
+
+    @pytest.mark.asyncio
     async def test_refresh_records_column_type_changes(
         self,
         module__client_with_roads: AsyncClient,

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -2716,6 +2716,117 @@ class TestNodeCRUD:
         assert after["owners"] == [{"username": "data-eng@example.com"}]
 
     @pytest.mark.asyncio
+    async def test_refresh_hydrates_the_primary_key(
+        self,
+        module__client_with_roads: AsyncClient,
+        module__query_service_client: QueryServiceClient,
+        mocker: MockerFixture,
+    ):
+        """The catalog's primary key becomes the node's primary key attribute."""
+        response = await module__client_with_roads.post(
+            "/nodes/source/",
+            json={
+                "name": "default.keyless_table",
+                "description": "A table with no primary key set in DJ",
+                "columns": [
+                    {"name": "id", "type": "int"},
+                    {"name": "amount", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "roads",
+                "table": "keyless_table",
+            },
+        )
+        assert response.status_code in (200, 201)
+
+        async def _with_pk(*args, **kwargs):
+            return TableMetadata(
+                columns=[
+                    Column(name="id", type=IntegerType(), order=0),
+                    Column(name="amount", type=IntegerType(), order=1),
+                ],
+                primary_key=["id"],
+            )
+
+        mocker.patch.object(
+            module__query_service_client,
+            "get_table_metadata",
+            _with_pk,
+        )
+        await module__client_with_roads.post(
+            "/nodes/default.keyless_table/refresh/",
+        )
+        after = (
+            await module__client_with_roads.get("/nodes/default.keyless_table/")
+        ).json()
+        keyed = {
+            column["name"]: [a["attribute_type"]["name"] for a in column["attributes"]]
+            for column in after["columns"]
+        }
+        assert keyed == {"id": ["primary_key"], "amount": []}
+
+    @pytest.mark.asyncio
+    async def test_refresh_does_not_replace_an_existing_primary_key(
+        self,
+        module__client_with_roads: AsyncClient,
+        module__query_service_client: QueryServiceClient,
+        mocker: MockerFixture,
+    ):
+        """
+        A primary key already set in DJ wins over the catalog's.
+
+        A primary key is structural -- dimension joins and cube grain depend on
+        it -- so a hand-chosen one is a deliberate modelling decision.
+        """
+        response = await module__client_with_roads.post(
+            "/nodes/source/",
+            json={
+                "name": "default.keyed_table",
+                "description": "A table whose primary key DJ already declares",
+                "columns": [
+                    {"name": "id", "type": "int"},
+                    {"name": "other_id", "type": "int"},
+                ],
+                "mode": "published",
+                "catalog": "default",
+                "schema_": "roads",
+                "table": "keyed_table",
+            },
+        )
+        assert response.status_code in (200, 201)
+        await module__client_with_roads.post(
+            "/nodes/default.keyed_table/columns/other_id/attributes/",
+            json=[{"name": "primary_key"}],
+        )
+
+        async def _with_pk(*args, **kwargs):
+            return TableMetadata(
+                columns=[
+                    Column(name="id", type=IntegerType(), order=0),
+                    Column(name="other_id", type=IntegerType(), order=1),
+                ],
+                primary_key=["id"],
+            )
+
+        mocker.patch.object(
+            module__query_service_client,
+            "get_table_metadata",
+            _with_pk,
+        )
+        await module__client_with_roads.post(
+            "/nodes/default.keyed_table/refresh/",
+        )
+        after = (
+            await module__client_with_roads.get("/nodes/default.keyed_table/")
+        ).json()
+        keyed = {
+            column["name"]: [a["attribute_type"]["name"] for a in column["attributes"]]
+            for column in after["columns"]
+        }
+        assert keyed == {"id": [], "other_id": ["primary_key"]}
+
+    @pytest.mark.asyncio
     async def test_refresh_records_column_type_changes(
         self,
         module__client_with_roads: AsyncClient,


### PR DESCRIPTION
### Summary

DJ models a primary key as a column attribute and it is set by hand today, but for source nodes it could be hydrated from the table metadata directly. This can be done via the `get_table_metadata` call that the source node refresh endpoint already makes. We add `primary_key` to `TableMetadata` and `apply_table_primary_key` sets the attribute on those columns.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
