### PR TITLE
Cube validation should work for reference dimension links

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/dimension_reachability.py
+++ b/datajunction-server/datajunction_server/internal/deployment/dimension_reachability.py
@@ -1,9 +1,10 @@
 """
 Batched dimension reachability for cube validation and impact propagation.
 
-Uses a single BFS query (via find_join_paths_batch) to determine which
-dimensions are reachable from a set of source nodes through the dimension
-link graph.  All subsequent lookups are pure in-memory.
+Two batched queries determine which dimensions are reachable from a set of
+source nodes: a BFS over the dimension link graph (via find_join_paths_batch)
+and a lookup of column-level reference dimensions.  All subsequent lookups are
+pure in-memory.
 
 Used by:
   - Cube validation: are all requested dimensions reachable from every metric?
@@ -13,13 +14,42 @@ Used by:
 
 from __future__ import annotations
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.construction.build_v3.loaders import find_join_paths_batch
+from datajunction_server.database.column import Column
+from datajunction_server.database.node import Node
+
+
+async def find_reference_dimensions_batch(
+    session: AsyncSession,
+    source_revision_ids: set[int],
+    target_dimension_names: set[str],
+) -> dict[int, set[tuple[str, str]]]:
+    """Reference-linked dimensions per source revision, as (dim_name, role) pairs.
+
+    A reference link is not a graph edge — it lives on ``Column.dimension_id``
+    with the role inline in ``dimension_column`` — so the BFS cannot see it.
+    """
+    statement = (
+        select(Column.node_revision_id, Node.name, Column.dimension_column)
+        .join(Node, Node.id == Column.dimension_id)
+        .where(Column.node_revision_id.in_(source_revision_ids))
+        .where(Node.name.in_(target_dimension_names))
+    )
+    rows = (await session.execute(statement)).all()
+    reference_dims: dict[int, set[tuple[str, str]]] = {}
+    for rev_id, dim_name, dimension_column in rows:
+        role = ""
+        if dimension_column and "[" in dimension_column:
+            role = dimension_column.split("[", 1)[1].rstrip("]")
+        reference_dims.setdefault(rev_id, set()).add((dim_name, role))
+    return reference_dims
 
 
 class DimensionReachability:
-    """Batched dimension reachability — one BFS query, in-memory lookups.
+    """Batched dimension reachability — two batched queries, in-memory lookups.
 
     Tracks reachability node-level (role-agnostic, for impact propagation) and
     role-aware (for cube deploy validation). See `is_reachable_under_role` for
@@ -30,6 +60,7 @@ class DimensionReachability:
         self,
         paths: dict[tuple[int, str, str], list[int]],
         local_names: dict[int, str] | None = None,
+        reference_dims: dict[int, set[tuple[str, str]]] | None = None,
     ):
         self._paths = paths
         # Reachable (dimension, role) pairs for each source node; role is "" for
@@ -43,6 +74,10 @@ class DimensionReachability:
         # A node always reaches its own columns ("local dimensions"), role-less.
         for rev_id, node_name in (local_names or {}).items():
             self._reachable_roles.setdefault(rev_id, set()).add((node_name, ""))
+        # Reference-linked dimensions are local too — the column already holds the
+        # value — but they carry the role declared on the column.
+        for rev_id, dim_roles in (reference_dims or {}).items():
+            self._reachable_roles.setdefault(rev_id, set()).update(dim_roles)
         # Node-level (role-agnostic) view, derived once for O(1) lookups.
         self._reachable: dict[int, set[str]] = {
             sid: {name for name, _role in roles}
@@ -57,7 +92,7 @@ class DimensionReachability:
         target_dimension_names: set[str],
         local_names: dict[int, str] | None = None,
     ) -> DimensionReachability:
-        """One batched BFS query to build the reachability map.
+        """Batched queries (join-path BFS plus reference links) to build the map.
 
         Args:
             source_revision_ids: Revision IDs of the source nodes to BFS from.
@@ -72,7 +107,12 @@ class DimensionReachability:
             source_revision_ids,
             target_dimension_names,
         )
-        return cls(paths, local_names)
+        reference_dims = await find_reference_dimensions_batch(
+            session,
+            source_revision_ids,
+            target_dimension_names,
+        )
+        return cls(paths, local_names, reference_dims)
 
     def is_reachable(self, source_rev_id: int, dim_name: str) -> bool:
         """Node-level (role-agnostic) check: is the dimension reachable at all?"""

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -7778,6 +7778,103 @@ class TestCubeBareDimRoleAwareDeployment:
         assert response.json()["status"] == "valid"
 
 
+@pytest.mark.xdist_group(name="deployments")
+class TestCubeReferenceDimDeployment:
+    """Deploy-time cube validation must see reference dimension links.
+
+    A reference link writes no dimensionlink row — it lives on the column, as a
+    denormalized copy of the dimension attribute — so the join-path BFS cannot
+    find it. A cube sliced by such a dimension used to deploy INVALID ("not
+    reachable from parent node(s)") even though it builds correct SQL.
+    """
+
+    def _nodes(self):
+        """Orders reaches the customer dimension only via a reference link."""
+        return [
+            SourceSpec(
+                name="orders_raw",
+                description="Raw orders",
+                catalog="default",
+                schema="store",
+                table="orders_raw",
+                columns=[
+                    ColumnSpec(name="order_id", type="int"),
+                    ColumnSpec(name="customer_country", type="string"),
+                ],
+                owners=["dj"],
+            ),
+            SourceSpec(
+                name="customers_raw",
+                description="Raw customers",
+                catalog="default",
+                schema="store",
+                table="customers_raw",
+                columns=[
+                    ColumnSpec(name="customer_id", type="int"),
+                    ColumnSpec(name="country", type="string"),
+                ],
+                owners=["dj"],
+            ),
+            DimensionSpec(
+                name="customers_d",
+                description="Customer dimension",
+                query="SELECT customer_id, country FROM ${prefix}customers_raw",
+                primary_key=["customer_id"],
+                owners=["dj"],
+            ),
+            TransformSpec(
+                name="orders_f",
+                description="Orders fact carrying the customer country inline",
+                query="SELECT order_id, customer_country FROM ${prefix}orders_raw",
+                dimension_links=[
+                    DimensionReferenceLinkSpec(
+                        node_column="customer_country",
+                        dimension="${prefix}customers_d.country",
+                    ),
+                ],
+                owners=["dj"],
+            ),
+            MetricSpec(
+                name="order_count",
+                description="Order count",
+                query="SELECT COUNT(*) FROM ${prefix}orders_f",
+                owners=["dj"],
+            ),
+            MetricSpec(
+                name="customer_count",
+                description="Customer count",
+                query="SELECT COUNT(*) FROM ${prefix}customers_d",
+                owners=["dj"],
+            ),
+            CubeSpec(
+                name="orders_cube",
+                display_name="Orders Cube",
+                description="Cube sliced by a reference-linked dimension",
+                metrics=["${prefix}order_count", "${prefix}customer_count"],
+                dimensions=["${prefix}customers_d.country"],
+                owners=["dj"],
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_deploy_cube_on_reference_linked_dim(self, client):
+        """Repro: the reference-linked dimension is reachable, so the cube is valid."""
+        namespace = "cube_reference_dim"
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=self._nodes()),
+        )
+        assert data["status"] == DeploymentStatus.SUCCESS.value, data
+        cube_result = next(
+            r for r in data["results"] if r["name"] == f"{namespace}.orders_cube"
+        )
+        assert cube_result["status"] not in ("invalid", "failed"), cube_result
+
+        response = await client.get(f"/nodes/{namespace}.orders_cube/")
+        assert response.status_code == 200, response.json()
+        assert response.json()["status"] == "valid"
+
+
 def _hard_hat_deploy_nodes(default_hard_hats, default_us_states, default_us_state):
     """Fact + dimension + link + a COUNT measure metric, for pre-agg deploy tests."""
     hard_hat_facts = TransformSpec(

--- a/datajunction-server/tests/internal/deployment/test_dimension_reachability.py
+++ b/datajunction-server/tests/internal/deployment/test_dimension_reachability.py
@@ -2,12 +2,13 @@
 Tests for DimensionReachability — batched dimension reachability lookups.
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from datajunction_server.internal.deployment.dimension_reachability import (
     DimensionReachability,
+    find_reference_dimensions_batch,
 )
 
 
@@ -149,6 +150,67 @@ class TestDimensionReachabilityInMemory:
         assert r.shared_dimensions({10, 20}) == set()
 
 
+class TestReferenceDimensions:
+    """A reference-linked column makes its dimension reachable without a join."""
+
+    def test_reference_dimension_is_reachable(self):
+        r = DimensionReachability(
+            {},
+            local_names={10: "orders"},
+            reference_dims={10: {("dim.customer", "")}},
+        )
+        assert r.is_reachable(10, "dim.customer")
+        assert r.is_reachable_under_role(10, "dim.customer", None)
+        assert r.reachable_from(10) == {"orders", "dim.customer"}
+
+    def test_reference_dimension_role_matches_only_its_role(self):
+        r = DimensionReachability({}, reference_dims={10: {("dim.date", "ordered")}})
+        assert r.is_reachable_under_role(10, "dim.date", "ordered")
+        assert not r.is_reachable_under_role(10, "dim.date", "shipped")
+        # A bare reference does not match a role-only reference link.
+        assert not r.is_reachable_under_role(10, "dim.date", None)
+        # The node-level check stays role-agnostic.
+        assert r.is_reachable(10, "dim.date")
+
+    def test_reference_dimensions_do_not_disturb_join_paths(self):
+        paths = {(10, "dim.product", ""): [100], (10, "dim.date", "ordered"): [101]}
+        r = DimensionReachability(paths, reference_dims={10: {("dim.customer", "")}})
+        assert r.is_reachable_under_role(10, "dim.product", None)
+        assert r.is_reachable_under_role(10, "dim.date", "ordered")
+        assert not r.is_reachable_under_role(10, "dim.date", None)
+        assert r.unreachable_dimension_roles({10}, {("dim.customer", None)}) == {}
+
+    def test_reference_dimensions_participate_in_shared(self):
+        r = DimensionReachability(
+            {},
+            reference_dims={10: {("dim.customer", "")}, 20: {("dim.customer", "")}},
+        )
+        assert r.shared_dimensions({10, 20}) == {"dim.customer"}
+
+    @pytest.mark.asyncio
+    async def test_find_reference_dimensions_batch_parses_roles(self):
+        """The role travels inline on dimension_column: `column[role]`."""
+        session = AsyncMock()
+        session.execute.return_value = MagicMock(
+            all=MagicMock(
+                return_value=[
+                    (10, "dim.customer", "customer_id"),
+                    (10, "dim.date", "dateint[ordered]"),
+                    (20, "dim.product", None),
+                ],
+            ),
+        )
+        reference_dims = await find_reference_dimensions_batch(
+            session,
+            {10, 20},
+            {"dim.customer", "dim.date", "dim.product"},
+        )
+        assert reference_dims == {
+            10: {("dim.customer", ""), ("dim.date", "ordered")},
+            20: {("dim.product", "")},
+        }
+
+
 class TestDimensionReachabilityBuild:
     """Tests for the async build method using mocked find_join_paths_batch."""
 
@@ -167,11 +229,19 @@ class TestDimensionReachabilityBuild:
             (10, "dim.country", ""): [100],
             (20, "dim.country", ""): [200],
         }
-        with patch(
-            "datajunction_server.internal.deployment.dimension_reachability.find_join_paths_batch",
-            new_callable=AsyncMock,
-            return_value=mock_paths,
-        ) as mock_bfs:
+        with (
+            patch(
+                "datajunction_server.internal.deployment.dimension_reachability.find_join_paths_batch",
+                new_callable=AsyncMock,
+                return_value=mock_paths,
+            ) as mock_bfs,
+            patch(
+                "datajunction_server.internal.deployment.dimension_reachability."
+                "find_reference_dimensions_batch",
+                new_callable=AsyncMock,
+                return_value={20: {("dim.customer", "")}},
+            ) as mock_refs,
+        ):
             r = await DimensionReachability.build(
                 session=AsyncMock(),
                 source_revision_ids={10, 20},
@@ -179,10 +249,13 @@ class TestDimensionReachabilityBuild:
                 local_names={10: "node.fact"},
             )
             mock_bfs.assert_called_once()
+            mock_refs.assert_called_once()
 
         assert r.is_reachable(10, "dim.country")
         assert r.is_reachable(10, "node.fact")  # local
         assert r.is_reachable(20, "dim.country")
+        assert r.is_reachable(20, "dim.customer")  # reference link
+        assert not r.is_reachable(10, "dim.customer")
 
     @pytest.mark.asyncio
     async def test_build_with_local_names_no_targets(self):


### PR DESCRIPTION
### Summary

A cube sliced by a dimension that its metrics reach through a reference link would deploy with an invalid error: `not reachable from parent node(s)`, even though the same dimension builds and runs correctly through the sql/data path. This check was a false positive and cube validation during deployment should take into account reference links.

`DimensionReachability` was set up with two paths: the join-path BFS (which expands based on `dimensionlink`) and the local-dimensions map. A reference link is a leaf node on the graph -- we just need to include `Column.dimension_id` to include them.

### Test Plan

Added tests to cover the reachability logic (a reference-linked dimension is reachable, a role-qualified one matches only its role, a bare reference does not match a role-only link, join paths behave as before) plus an end-to-end deploy of a cube whose two metrics have different parents and whose only path to the sliced dimension is a reference link.

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
