### PR TITLE
Require `join_on` on join links and reject `node_column` there

### DIFF
--- a/datajunction-clients/python/tests/examples/deploy0/roads/contractor.yaml
+++ b/datajunction-clients/python/tests/examples/deploy0/roads/contractor.yaml
@@ -17,7 +17,6 @@ primary_key:
   - contractor_id
 dimension_links:
   - type: join
-    node_column: state
     dimension_node: ${prefix}roads.us_state
     join_on: ${prefix}roads.us_state.state_abbr = ${prefix}roads.contractor.state
   - type: reference

--- a/datajunction-clients/python/tests/examples/project1/roads/hard_hat.dimension.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/hard_hat.dimension.yaml
@@ -19,11 +19,9 @@ primary_key:
   - hard_hat_id
 dimension_links:
   - type: join
-    node_column: state
     dimension_node: ${prefix}roads.us_state
     join_on: ${prefix}roads.us_state.state_abbr = ${prefix}roads.hard_hat.state
   - type: join
-    node_column: birth_date
     dimension_node: ${prefix}roads.date_dim
     join_on: ${prefix}roads.date_dim.dateint = ${prefix}roads.hard_hat.birth_date
     role: birth_date

--- a/datajunction-clients/python/tests/examples/project1/roads/local_hard_hats.dimension.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/local_hard_hats.dimension.yaml
@@ -23,8 +23,8 @@ primary_key:
   - hard_hat_id
 dimension_links:
   - type: join
-    node_column: state_id
     dimension_node: ${prefix}roads.us_state
+    join_on: ${prefix}roads.local_hard_hats.state_id = ${prefix}roads.us_state.state_id
   - type: reference
     node_column: birth_date
     dimension: ${prefix}roads.date_dim.dateint

--- a/datajunction-clients/python/tests/examples/project1/roads/regional_level_agg.transform.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/regional_level_agg.transform.yaml
@@ -48,8 +48,8 @@ query: |
       EXTRACT(DAY FROM ro.order_date)
 dimension_links:
   - type: join
-    node_column: state_name
     dimension_node: ${prefix}roads.us_state
+    join_on: ${prefix}roads.regional_level_agg.state_name = ${prefix}roads.us_state.state_name
 columns:
 - name: location_hierarchy
   display_name: Location (Hierarchy)

--- a/datajunction-clients/python/tests/examples/project1/roads/repair_order.dimension.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/repair_order.dimension.yaml
@@ -10,12 +10,12 @@ primary_key:
   - repair_order_id
 dimension_links:
   - type: join
-    node_column: dispatcher_id
     dimension_node: ${prefix}roads.dispatcher
+    join_on: ${prefix}roads.repair_order.dispatcher_id = ${prefix}roads.dispatcher.dispatcher_id
   - type: join
-    node_column: hard_hat_id
     dimension_node: ${prefix}roads.hard_hat
+    join_on: ${prefix}roads.repair_order.hard_hat_id = ${prefix}roads.hard_hat.hard_hat_id
   - type: join
-    node_column: municipality_id
     dimension_node: ${prefix}roads.municipality_dim
+    join_on: ${prefix}roads.repair_order.municipality_id = ${prefix}roads.municipality_dim.municipality_id
 display_name: Repair Order Dim

--- a/datajunction-clients/python/tests/examples/project1/roads/repair_order_details.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/repair_order_details.source.yaml
@@ -13,6 +13,6 @@ columns:
     type: float
 dimension_links:
   - type: join
-    node_column: repair_order_id
     dimension_node: ${prefix}roads.repair_order
+    join_on: ${prefix}roads.repair_order_details.repair_order_id = ${prefix}roads.repair_order.repair_order_id
 display_name: default.roads.repair_order_details

--- a/datajunction-clients/python/tests/examples/project1/roads/repair_orders.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/repair_orders.source.yaml
@@ -17,6 +17,6 @@ columns:
     type: int
 dimension_links:
   - type: join
-    node_column: repair_order_id
     dimension_node: ${prefix}roads.repair_order
+    join_on: ${prefix}roads.repair_orders.repair_order_id = ${prefix}roads.repair_order.repair_order_id
 display_name: default.roads.repair_orders

--- a/datajunction-clients/python/tests/examples/project1/roads/repair_type.source.yaml
+++ b/datajunction-clients/python/tests/examples/project1/roads/repair_type.source.yaml
@@ -9,6 +9,6 @@ columns:
     type: int
 dimension_links:
   - type: join
-    node_column: contractor_id
     dimension_node: ${prefix}roads.contractor
+    join_on: ${prefix}roads.repair_type.contractor_id = ${prefix}roads.contractor.contractor_id
 display_name: default.roads.repair_type

--- a/datajunction-clients/python/tests/examples/project9/roads/contractor.dimension.yaml
+++ b/datajunction-clients/python/tests/examples/project9/roads/contractor.dimension.yaml
@@ -15,8 +15,8 @@ primary_key:
   - contractor_id
 dimension_links:
   - type: join
-    node_column: state
     dimension_node: ${prefix}roads.us_state
+    join_on: ${prefix}roads.contractor.state = ${prefix}roads.us_state.state_abbr
   - type: reference
     node_column: company_name
     dimension: ${prefix}roads.companies_dim.name

--- a/datajunction-server/datajunction_server/internal/deployment/validation.py
+++ b/datajunction-server/datajunction_server/internal/deployment/validation.py
@@ -27,6 +27,7 @@ from datajunction_server.models.deployment import (
     LinkableNodeSpec,
     NodeSpec,
 )
+from datajunction_server.models.dimensionlink import JoinType
 from datajunction_server.models.node import NodeStatus, NodeType
 from datajunction_server.sql.dag import get_dimensions
 from datajunction_server.sql.parsing.ast import fast_parse_mode
@@ -200,6 +201,37 @@ class NodeSpecBulkValidator:
                             link,
                             node_name,
                             inferred_col_names,
+                        )
+                    if link.node_column:
+                        # Only reference links use node_column; on a join link it is
+                        # silently ignored, so accepting it invites a wrong mental model.
+                        result.status = NodeStatus.INVALID
+                        result.errors.append(
+                            DJError(
+                                code=ErrorCode.INVALID_COLUMN,
+                                message=(
+                                    f"Dimension link from {node_name} to "
+                                    f"{link.rendered_dimension_node} sets node_column, "
+                                    "which only applies to reference links. Express the "
+                                    "join in join_on instead."
+                                ),
+                            ),
+                        )
+                    if not link.rendered_join_on and link.join_type != JoinType.CROSS:
+                        # Without a clause the link is stored with no ON condition,
+                        # which builds a cross join and silently multiplies rows.
+                        result.status = NodeStatus.INVALID
+                        result.errors.append(
+                            DJError(
+                                code=ErrorCode.INVALID_COLUMN,
+                                message=(
+                                    f"Dimension link from {node_name} to "
+                                    f"{link.rendered_dimension_node} has no join_on "
+                                    "clause. Set join_on to the equality between this "
+                                    "node's foreign key column(s) and the dimension's "
+                                    "primary key."
+                                ),
+                            ),
                         )
                 else:
                     self._validate_reference_link(

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -421,8 +421,11 @@ class DimensionJoinLinkSpec(DimensionLinkSpec):
     """
     Specification for a dimension join link
 
-    If a custom `join_on` clause is not specified, DJ will automatically set
-    this clause to be on the selected column and the dimension node's primary key
+    `join_on` is required for every join type except CROSS, and carries the whole
+    join. A spec says nothing about which of this node's columns is the foreign
+    key, so the clause cannot be derived the way `link_dimension` derives it from
+    a column the caller names explicitly. `node_column` applies only to reference
+    links and is rejected here.
     """
 
     dimension_node: str

--- a/datajunction-server/tests/internal/deployment/validation_test.py
+++ b/datajunction-server/tests/internal/deployment/validation_test.py
@@ -29,6 +29,7 @@ from datajunction_server.models.deployment import (
     SourceSpec,
     TransformSpec,
 )
+from datajunction_server.models.dimensionlink import JoinType
 from datajunction_server.models.node import (
     DimensionAttributeOutput,
     NodeStatus,
@@ -1382,8 +1383,9 @@ class TestDimLinkValidation:
         assert result.status == NodeStatus.VALID
         assert result.errors == []
 
-    def test_join_link_with_no_join_on_is_skipped(self, session: AsyncSession):
-        """A DimensionJoinLinkSpec with no join_on is silently skipped."""
+    def test_join_link_with_no_join_on_is_invalid(self, session: AsyncSession):
+        """A join link must carry join_on: a spec says nothing about which column is
+        the foreign key, so an absent clause would build a cross join."""
         validator = _make_validator(session)
         spec = SourceSpec(
             name="facts",
@@ -1402,8 +1404,65 @@ class TestDimLinkValidation:
             dependencies=[],
         )
         validator._validate_dimension_link_specs([result])
+        assert result.status == NodeStatus.INVALID
+        assert "has no join_on clause" in result.errors[0].message
+
+    def test_cross_join_link_with_no_join_on_is_valid(self, session: AsyncSession):
+        """A CROSS join has no ON clause by definition, so join_on stays optional."""
+        validator = _make_validator(session)
+        spec = SourceSpec(
+            name="facts",
+            catalog="default",
+            schema_="s",
+            table="t",
+            columns=[ColumnSpec(name="id", type="int")],
+            dimension_links=[
+                DimensionJoinLinkSpec(
+                    dimension_node="test.dim",
+                    join_type=JoinType.CROSS,
+                ),
+            ],
+        )
+        spec.namespace = "test"
+        result = NodeValidationResult(
+            spec=spec,
+            status=NodeStatus.VALID,
+            inferred_columns=[ColumnSpec(name="id", type="int")],
+            errors=[],
+            dependencies=[],
+        )
+        validator._validate_dimension_link_specs([result])
         assert result.status == NodeStatus.VALID
         assert result.errors == []
+
+    def test_join_link_with_node_column_is_invalid(self, session: AsyncSession):
+        """node_column belongs to reference links; on a join link nothing reads it."""
+        validator = _make_validator(session)
+        spec = SourceSpec(
+            name="facts",
+            catalog="default",
+            schema_="s",
+            table="t",
+            columns=[ColumnSpec(name="dim_id", type="int")],
+            dimension_links=[
+                DimensionJoinLinkSpec(
+                    dimension_node="test.dim",
+                    node_column="dim_id",
+                    join_on="test.facts.dim_id = test.dim.id",
+                ),
+            ],
+        )
+        spec.namespace = "test"
+        result = NodeValidationResult(
+            spec=spec,
+            status=NodeStatus.VALID,
+            inferred_columns=[ColumnSpec(name="dim_id", type="int")],
+            errors=[],
+            dependencies=[],
+        )
+        validator._validate_dimension_link_specs([result])
+        assert result.status == NodeStatus.INVALID
+        assert "only applies to reference links" in result.errors[0].message
 
     def test_reference_link_is_skipped(self, session: AsyncSession):
         """A DimensionReferenceLinkSpec is silently skipped (no join_on to validate)."""

--- a/docs/content/0.1.0/docs/data-modeling/yaml.md
+++ b/docs/content/0.1.0/docs/data-modeling/yaml.md
@@ -148,8 +148,8 @@ query: ...
 primary_key: ...
 dimension_links:
   - type: join
-    node_column: state_id
     dimension_node: ${prefix}roads.us_state
+    join_on: ${prefix}roads.local_hard_hats.state_id = ${prefix}roads.us_state.state_id
     default_value: Unknown  # Optional: fallback for NULL values from LEFT JOIN
   - type: reference
     node_column: birth_date
@@ -161,8 +161,7 @@ dimension_links:
 | ---- | ---- | ---- | ---- |
 | `type` | Yes  | Must be `join` |
 | `dimension_node` | Yes | The dimension node being linked to |
-| `node_column` | No  | The column on this node that is being linked from |
-| `join_on` | No | A custom join on SQL clause |
+| `join_on` | Yes, unless `join_type` is `cross` | The join condition, equating this node's foreign key column(s) to the dimension's primary key. There is no inference: a spec says nothing about which column is the foreign key, so the clause must be written out. |
 | `join_type` | No | The type of join (one of `left`, `right`, `inner`, `full`, `cross`). Defaults to `left`. |
 | `role` | No | The role this dimension represents |
 | `default_value` | No | A fallback value for NULL results from LEFT/RIGHT joins. When set, dimension columns are wrapped in `COALESCE(column, 'default_value')`. |


### PR DESCRIPTION
### Summary

We should require `join_on` be specified when users create dimension join links via YAML. This PR makes it so that `join_on` is now required for every join type except CROSS (which has no ON clause by definition), and `node_column` on a join link is rejected rather than ignored (accepting a field that does nothing is misleading).

### Test Plan

The example fixtures and docsite use `node_column`, but this doesn't actually work, so we updated both.

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
