### PR TITLE
Trim always-on context in DJ skill descriptions

### DIFF
--- a/datajunction-clients/python/datajunction/skills/datajunction-api/SKILL.md
+++ b/datajunction-clients/python/datajunction/skills/datajunction-api/SKILL.md
@@ -3,15 +3,12 @@ name: datajunction-api
 description: |
   Activate this skill when authoring DataJunction (DJ) nodes via the REST
   API directly (curl, HTTP clients) — typically for exploration, ad-hoc
-  prototyping, or namespaces that aren't repo-backed. For modeling
-  decisions and the decomposition workflow, invoke `datajunction-semantic-model`.
-  For repo-backed YAML authoring (the production path), invoke
-  `datajunction-repo`. For concepts, invoke `datajunction`.
+  prototyping, or namespaces that aren't repo-backed.
   Keywords:
   - DJ API, REST API, curl
   - POST nodes/metric, POST nodes/dimension
-  - create metric, create dimension, create cube
-  - API approach, direct API changes
+  - create a metric via the API, create a dimension via the API
+  - create a node with curl
   - prototyping, exploration
 user-invocable: false
 ---

--- a/datajunction-clients/python/datajunction/skills/datajunction-query/SKILL.md
+++ b/datajunction-clients/python/datajunction/skills/datajunction-query/SKILL.md
@@ -3,21 +3,16 @@ name: datajunction-query
 description: |
   Activate this skill for querying DataJunction (DJ) — finding nodes,
   generating SQL, fetching metric data, exploring lineage, visualizing
-  results — via the DJ UI, MCP tools, or REST/GraphQL APIs. For core DJ
-  concepts and vocabulary, invoke `datajunction`. For modeling decisions
-  (what shape something should take), invoke `datajunction-semantic-model`.
-  For authoring nodes, invoke `datajunction-repo` (YAML) or
-  `datajunction-api` (REST).
+  results — via the DJ UI, MCP tools, or REST/GraphQL APIs.
   Keywords:
   - query metric, query metrics
-  - generate SQL, build metric SQL
-  - get metric data, fetch metric
+  - generate SQL
   - available dimensions, common dimensions
   - search_nodes, get_node_details, get_node_lineage
   - get_common, build_metric_sql, get_metric_data
   - visualize metrics
-  - MCP tools, DJ API, GraphQL
-  - DJ UI, web UI, browse
+  - MCP tools, GraphQL
+  - DJ UI
 user-invocable: false
 ---
 

--- a/datajunction-clients/python/datajunction/skills/datajunction-repo/SKILL.md
+++ b/datajunction-clients/python/datajunction/skills/datajunction-repo/SKILL.md
@@ -5,16 +5,13 @@ description: |
   in a git repository — the repo-backed workflow. Covers YAML schemas per
   node type, branch-based development, temporal partitions on cubes,
   registering pre-aggregations / aggregate awareness, and the full
-  PR-driven deployment flow. For modeling decisions (how to
-  structure metrics, decomposition workflow), invoke `datajunction-semantic-model`.
-  For direct API authoring, invoke `datajunction-api`. For concepts,
-  invoke `datajunction`.
+  PR-driven deployment flow.
   Keywords:
   - YAML nodes, YAML definitions
   - repo-backed namespace, repo-backed workflow
   - git workflow, branch development, feature branch
   - cube YAML, metric YAML, dimension YAML, transform YAML
-  - create metric, create dimension, create cube, build cube
+  - add a metric YAML file, add a dimension YAML file, add a cube YAML file
   - temporal partition, partition pushdown
   - pre-commit, push.sh
   - pre-aggregation, pre-agg, preagg, kind: preagg

--- a/datajunction-clients/python/datajunction/skills/datajunction-semantic-model/SKILL.md
+++ b/datajunction-clients/python/datajunction/skills/datajunction-semantic-model/SKILL.md
@@ -5,15 +5,12 @@ description: |
   choosing the right node shape (fact, dimension, transform, metric, cube),
   turning a draft SQL query into well-designed nodes, and the cross-cutting
   conventions (ownership, naming, namespace organization). Format-agnostic
-  modeling guidance; for YAML schemas and the repo-backed authoring flow,
-  invoke `datajunction-repo`; for direct API examples, invoke
-  `datajunction-api`. For DJ concepts (node types, dim links), invoke
-  `datajunction`. For querying existing metrics, invoke
-  `datajunction-query`.
+  modeling guidance.
   Keywords:
   - semantic modeling
   - decompose query, model query, query to nodes
-  - create metric, create dimension, create node, create cube, build cube
+  - how should I model this metric, what shape should this node be
+  - design a cube, what belongs in this cube
   - ratio metric, derived metric, base metric
   - composable metrics
   - metric query constraints

--- a/datajunction-clients/python/datajunction/skills/datajunction/SKILL.md
+++ b/datajunction-clients/python/datajunction/skills/datajunction/SKILL.md
@@ -2,11 +2,7 @@
 name: datajunction
 description: |
   Activate this skill whenever working with DataJunction (DJ) semantic layer.
-  Core concepts and shared vocabulary used by every DJ workflow. For
-  querying metrics, invoke `datajunction-query`. For modeling decisions
-  (what shape something should take), invoke `datajunction-semantic-model`.
-  For authoring nodes, invoke `datajunction-repo` (YAML in a git repo) or
-  `datajunction-api` (REST API for exploration / prototyping).
+  Core concepts and shared vocabulary used by every DJ workflow.
   Keywords:
   - DataJunction, DJ
   - semantic layer
@@ -14,7 +10,6 @@ description: |
   - star schema
   - node types
   - source, transform, dimension, metric, cube
-  - metric, metrics
   - mode, status, valid, invalid, draft, published
   - namespace
 user-invocable: false

--- a/plugins/datajunction/skills/datajunction-api/SKILL.md
+++ b/plugins/datajunction/skills/datajunction-api/SKILL.md
@@ -3,15 +3,12 @@ name: datajunction-api
 description: |
   Activate this skill when authoring DataJunction (DJ) nodes via the REST
   API directly (curl, HTTP clients) — typically for exploration, ad-hoc
-  prototyping, or namespaces that aren't repo-backed. For modeling
-  decisions and the decomposition workflow, invoke `datajunction-semantic-model`.
-  For repo-backed YAML authoring (the production path), invoke
-  `datajunction-repo`. For concepts, invoke `datajunction`.
+  prototyping, or namespaces that aren't repo-backed.
   Keywords:
   - DJ API, REST API, curl
   - POST nodes/metric, POST nodes/dimension
-  - create metric, create dimension, create cube
-  - API approach, direct API changes
+  - create a metric via the API, create a dimension via the API
+  - create a node with curl
   - prototyping, exploration
 user-invocable: false
 ---

--- a/plugins/datajunction/skills/datajunction-query/SKILL.md
+++ b/plugins/datajunction/skills/datajunction-query/SKILL.md
@@ -3,21 +3,16 @@ name: datajunction-query
 description: |
   Activate this skill for querying DataJunction (DJ) — finding nodes,
   generating SQL, fetching metric data, exploring lineage, visualizing
-  results — via the DJ UI, MCP tools, or REST/GraphQL APIs. For core DJ
-  concepts and vocabulary, invoke `datajunction`. For modeling decisions
-  (what shape something should take), invoke `datajunction-semantic-model`.
-  For authoring nodes, invoke `datajunction-repo` (YAML) or
-  `datajunction-api` (REST).
+  results — via the DJ UI, MCP tools, or REST/GraphQL APIs.
   Keywords:
   - query metric, query metrics
-  - generate SQL, build metric SQL
-  - get metric data, fetch metric
+  - generate SQL
   - available dimensions, common dimensions
   - search_nodes, get_node_details, get_node_lineage
   - get_common, build_metric_sql, get_metric_data
   - visualize metrics
-  - MCP tools, DJ API, GraphQL
-  - DJ UI, web UI, browse
+  - MCP tools, GraphQL
+  - DJ UI
 user-invocable: false
 ---
 

--- a/plugins/datajunction/skills/datajunction-repo/SKILL.md
+++ b/plugins/datajunction/skills/datajunction-repo/SKILL.md
@@ -5,16 +5,13 @@ description: |
   in a git repository — the repo-backed workflow. Covers YAML schemas per
   node type, branch-based development, temporal partitions on cubes,
   registering pre-aggregations / aggregate awareness, and the full
-  PR-driven deployment flow. For modeling decisions (how to
-  structure metrics, decomposition workflow), invoke `datajunction-semantic-model`.
-  For direct API authoring, invoke `datajunction-api`. For concepts,
-  invoke `datajunction`.
+  PR-driven deployment flow.
   Keywords:
   - YAML nodes, YAML definitions
   - repo-backed namespace, repo-backed workflow
   - git workflow, branch development, feature branch
   - cube YAML, metric YAML, dimension YAML, transform YAML
-  - create metric, create dimension, create cube, build cube
+  - add a metric YAML file, add a dimension YAML file, add a cube YAML file
   - temporal partition, partition pushdown
   - pre-commit, push.sh
   - pre-aggregation, pre-agg, preagg, kind: preagg

--- a/plugins/datajunction/skills/datajunction-semantic-model/SKILL.md
+++ b/plugins/datajunction/skills/datajunction-semantic-model/SKILL.md
@@ -5,15 +5,12 @@ description: |
   choosing the right node shape (fact, dimension, transform, metric, cube),
   turning a draft SQL query into well-designed nodes, and the cross-cutting
   conventions (ownership, naming, namespace organization). Format-agnostic
-  modeling guidance; for YAML schemas and the repo-backed authoring flow,
-  invoke `datajunction-repo`; for direct API examples, invoke
-  `datajunction-api`. For DJ concepts (node types, dim links), invoke
-  `datajunction`. For querying existing metrics, invoke
-  `datajunction-query`.
+  modeling guidance.
   Keywords:
   - semantic modeling
   - decompose query, model query, query to nodes
-  - create metric, create dimension, create node, create cube, build cube
+  - how should I model this metric, what shape should this node be
+  - design a cube, what belongs in this cube
   - ratio metric, derived metric, base metric
   - composable metrics
   - metric query constraints

--- a/plugins/datajunction/skills/datajunction/SKILL.md
+++ b/plugins/datajunction/skills/datajunction/SKILL.md
@@ -2,11 +2,7 @@
 name: datajunction
 description: |
   Activate this skill whenever working with DataJunction (DJ) semantic layer.
-  Core concepts and shared vocabulary used by every DJ workflow. For
-  querying metrics, invoke `datajunction-query`. For modeling decisions
-  (what shape something should take), invoke `datajunction-semantic-model`.
-  For authoring nodes, invoke `datajunction-repo` (YAML in a git repo) or
-  `datajunction-api` (REST API for exploration / prototyping).
+  Core concepts and shared vocabulary used by every DJ workflow.
   Keywords:
   - DataJunction, DJ
   - semantic layer
@@ -14,7 +10,6 @@ description: |
   - star schema
   - node types
   - source, transform, dimension, metric, cube
-  - metric, metrics
   - mode, status, valid, invalid, draft, published
   - namespace
 user-invocable: false


### PR DESCRIPTION
### Summary

The frontmatter description of every skill is loaded into each session, so the five DJ skills were paying a lot in always-on tokens.

Each description routed to its siblings ("for modeling decisions, invoke datajunction-semantic-model"), which is redundant when all five descriptions are in context at once and the model can already see the whole menu.

The keyword blocks listed 'create metric', 'create dimension' and 'create cube' on `datajunction-api`, `datajunction-repo` and `datajunction-semantic-model`, so the most likely thing a user types matched three skills equally. Each skill now carries the form a user would actually type for that path -- via the API, as a YAML file, or as a modeling question. Keywords that restated the prose were dropped in favor of tool names, domain terms etc.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
