### PR TITLE
Stop the workflows behind materializations a delete erases

### DIFF
--- a/datajunction-server/datajunction_server/api/branches.py
+++ b/datajunction-server/datajunction_server/api/branches.py
@@ -11,7 +11,7 @@ import time
 from collections.abc import Callable
 from http import HTTPStatus
 
-from fastapi import Depends
+from fastapi import Depends, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import or_, select
@@ -46,7 +46,13 @@ from datajunction_server.internal.nodes import copy_nodes_to_namespace
 from datajunction_server.models.access import ResourceAction
 from datajunction_server.models.deployment import DeploymentResult
 from datajunction_server.models.namespace import BranchInfo
-from datajunction_server.utils import SEPARATOR, get_current_user, get_session
+from datajunction_server.service_clients import QueryServiceClient
+from datajunction_server.utils import (
+    SEPARATOR,
+    get_current_user,
+    get_query_service_client,
+    get_session,
+)
 
 _logger = logging.getLogger(__name__)
 router = SecureAPIRouter(tags=["branches"])
@@ -499,6 +505,8 @@ async def delete_branch(
     current_user: User = Depends(get_current_user),
     access_checker: AccessChecker = Depends(get_access_checker),
     save_history: Callable = Depends(get_save_history),
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
+    request: Request,
 ) -> JSONResponse:
     """
     Delete a branch namespace.
@@ -568,6 +576,8 @@ async def delete_branch(
         current_user=current_user,
         save_history=save_history,
         cascade=True,
+        query_service_client=query_service_client,
+        request_headers=dict(request.headers),
     )
     nodes_deleted = len(impact.deleted_nodes)
 
@@ -585,5 +595,10 @@ async def delete_branch(
             "message": f"Branch namespace '{branch_namespace}' deleted",
             "nodes_deleted": nodes_deleted,
             "git_branch_deleted": git_branch_deleted,
+            **(
+                {"materialization_failures": impact.materialization_failures}
+                if impact.materialization_failures
+                else {}
+            ),
         },
     )

--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -435,6 +435,8 @@ async def hard_delete_node_namespace(
     current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
     access_checker: AccessChecker = Depends(get_access_checker),
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
+    request: Request,
 ) -> JSONResponse:
     """
     Hard delete a namespace, which will completely remove the namespace. Additionally,
@@ -474,6 +476,8 @@ async def hard_delete_node_namespace(
         cascade=cascade,
         current_user=current_user,
         save_history=save_history,
+        query_service_client=query_service_client,
+        request_headers=dict(request.headers),
     )
     return JSONResponse(
         status_code=HTTPStatus.OK,

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -411,10 +411,12 @@ async def delete_node(
 @router.delete("/nodes/{name}/hard/", name="Hard Delete a DJ Node")
 async def hard_delete(
     name: str,
+    request: Request,
     session: AsyncSession = Depends(get_session),
     current_user: User = Depends(get_current_user),
     save_history: Callable = Depends(get_save_history),
     access_checker: AccessChecker = Depends(get_access_checker),
+    query_service_client: QueryServiceClient = Depends(get_query_service_client),
 ) -> JSONResponse:
     """
     Hard delete a node, destroying all links and invalidating all downstream nodes.
@@ -425,17 +427,26 @@ async def hard_delete(
     namespace = name.rsplit(".", 1)[0]
     await check_namespace_not_git_only(session, namespace)
 
-    impact = await hard_delete_node(
+    result = await hard_delete_node(
         name=name,
         session=session,
         current_user=current_user,
         save_history=save_history,
+        query_service_client=query_service_client,
+        request_headers=dict(request.headers),
     )
     return JSONResponse(
         status_code=HTTPStatus.OK,
         content={
             "message": f"The node `{name}` has been completely removed.",
-            "impact": impact,
+            "impact": result.impact,
+            # Reported only when there is something to report: the node is gone
+            # either way, and DJ no longer knows what the workflow was called.
+            **(
+                {"materialization_failures": result.materialization_failures}
+                if result.materialization_failures
+                else {}
+            ),
         },
     )
 

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -65,8 +65,11 @@ from datajunction_server.internal.history import EntityType
 from datajunction_server.internal.impact import propagate_impact
 from datajunction_server.internal.materializations import (
     CubeMaterializationSwap,
+    NodeMaterializationTeardown,
     apply_cube_materialization_swap,
+    collect_materialization_teardowns,
     reconcile_declared_materialization,
+    stop_materialization_workflows,
     swap_cube_materializations,
 )
 from datajunction_server.internal.nodes import (
@@ -355,6 +358,7 @@ class DeploymentOrchestrator:
         self.deployed_results: list[DeploymentResult] = []
         self._timer = DeploymentTimer()
         self._cube_materialization_swaps: list[CubeMaterializationSwap] = []
+        self._materialization_teardowns: list[NodeMaterializationTeardown] = []
 
     @property
     def _history_user(self) -> str:
@@ -410,6 +414,7 @@ class DeploymentOrchestrator:
             # implies wet-run — commit the outer transaction.
             await self.session.commit()
             await self._apply_cube_materialization_swaps()
+            result.results.extend(self._stop_deleted_node_materializations())
 
         # Warnings are only surfaced by the failure path (they ride along on
         # DJInvalidDeploymentConfig), so hand them back here too — otherwise a
@@ -2783,6 +2788,36 @@ class DeploymentOrchestrator:
                 request_headers=request_headers,
             )
 
+    def _stop_deleted_node_materializations(self) -> list[DeploymentResult]:
+        """
+        Stop the workflows behind materializations that deleted nodes took with
+        them, once the deletion has committed.
+
+        A node dropped from the spec is hard-deleted, which cascades away the rows
+        naming its workflows -- so unless they are stopped here, the query service
+        keeps running jobs DJ can no longer identify. Reported rather than only
+        logged: the deployment says the node is gone, and a workflow still firing
+        against its table is not something a log line is enough for.
+        """
+        request_headers = (
+            dict(self.context.request.headers) if self.context.request else {}
+        )
+        failures = stop_materialization_workflows(
+            self.context.query_service_client,
+            self._materialization_teardowns,
+            request_headers=request_headers,
+        )
+        return [
+            DeploymentResult(
+                name=self.deployment_spec.namespace,
+                deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                status=DeploymentResult.Status.WARNING,
+                operation=DeploymentResult.Operation.DELETE,
+                message=failure,
+            )
+            for failure in failures
+        ]
+
     async def _bulk_validate_cubes(
         self,
         cube_specs: list[CubeSpec],
@@ -3712,6 +3747,15 @@ class DeploymentOrchestrator:
             deleted_names = {row.name for row in id_rows}
             node_ids = [row.id for row in id_rows]
             if node_ids:
+                # Read the workflows these nodes still have running before the
+                # delete cascades away the rows that name them. They are stopped
+                # after the deployment commits.
+                self._materialization_teardowns.extend(
+                    await collect_materialization_teardowns(
+                        self.session,
+                        sorted(deleted_names),
+                    ),
+                )
                 await hard_delete_nodes(
                     self.session,
                     node_ids,

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -18,7 +18,7 @@ from datajunction_server.database.history import (
     History,
 )
 from datajunction_server.database.materialization import Materialization
-from datajunction_server.database.node import NodeRevision
+from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import User
 from datajunction_server.errors import DJException, DJInvalidInputException
 from datajunction_server.internal.access.authorization import AccessChecker
@@ -686,7 +686,7 @@ def stop_cube_materialization_workflows(
     cube_version: str,
     materializations: list[Materialization],
     request_headers: dict[str, str] | None = None,
-) -> None:
+) -> str | None:
     """
     Ask the query service to stop the workflows behind cube materializations.
 
@@ -697,6 +697,10 @@ def stop_cube_materialization_workflows(
 
     Never raises: a query service that is unreachable, or that has already forgotten
     the workflow, must not block the DJ-side operation that triggered the teardown.
+    Returns a message describing the failure instead, `None` when there was none, so
+    a caller with somewhere to report it does not have to settle for a log line: DJ
+    has already dropped its own record of the materialization, and a workflow left
+    running past that point is one nothing will ever clean up.
     """
     workflow_names: list[str] = []
     needs_legacy_stop = False
@@ -738,6 +742,158 @@ def stop_cube_materialization_workflows(
             cube_version,
             str(exc),
         )
+        names = ", ".join(f"`{mat.name}`" for mat in materializations)
+        return (
+            f"Cube `{cube_name}`: DJ retired the materialization {names} at version "
+            f"{cube_version}, but the query service did not stop its workflow: {exc}. "
+            f"The workflow may still be running."
+        )
+    return None
+
+
+@dataclass
+class NodeMaterializationTeardown:
+    """
+    The workflows one node revision still has running, and everything needed to
+    stop them once the rows recording them are gone.
+
+    ``materializations`` are detached copies, not rows: they outlive the delete.
+    """
+
+    node_name: str
+    node_version: str
+    node_type: NodeType
+    materializations: list[Materialization]
+
+
+async def collect_materialization_teardowns(
+    session: AsyncSession,
+    node_names: list[str],
+) -> list[NodeMaterializationTeardown]:
+    """
+    Read what the query service is still running for a set of nodes about to be
+    deleted, before deleting them takes the answer away.
+
+    Deleting a node cascades its materialization rows away, so the workflow names
+    they carry have to be read first: afterwards DJ no longer knows what to stop,
+    and the workflow keeps firing on schedule against a table nobody reads.
+
+    Every active materialization on every revision counts, not just the current
+    one. A superseded revision's rows are marked deactivated when their workflow is
+    stopped, so a row that is still active is a workflow that is still running.
+
+    Cube planner rows are included, unlike during a revision swap where DJ spares
+    them because it cannot rebuild what it stops. A deletion rebuilds nothing, and
+    the planner's row is the only place its workflow names are written down.
+
+    What comes back are copies holding just the name and config the teardown reads,
+    never rows attached to the session: the workflows are stopped after the commit
+    that deleted them, where a real row would either be expired and unable to answer
+    or gone from the database entirely.
+    """
+    if not node_names:
+        return []
+    rows = (
+        await session.execute(
+            select(
+                Materialization.name,
+                Materialization.config,
+                NodeRevision.name.label("node_name"),
+                NodeRevision.version,
+                Node.type,
+            )
+            .join(NodeRevision, Materialization.node_revision_id == NodeRevision.id)
+            .join(Node, Node.id == NodeRevision.node_id)
+            .where(
+                Node.name.in_(node_names),
+                Materialization.deactivated_at.is_(None),
+            )
+            .order_by(NodeRevision.name, NodeRevision.version, Materialization.name),
+        )
+    ).all()
+    teardowns: dict[tuple[str, str], NodeMaterializationTeardown] = {}
+    for row in rows:
+        teardown = teardowns.setdefault(
+            (row.node_name, row.version),
+            NodeMaterializationTeardown(
+                node_name=row.node_name,
+                node_version=row.version,
+                node_type=row.type,
+                materializations=[],
+            ),
+        )
+        teardown.materializations.append(
+            Materialization(name=row.name, config=row.config),
+        )
+    return list(teardowns.values())
+
+
+def stop_materialization_workflows(
+    query_service_client: QueryServiceClient | None,
+    teardowns: list[NodeMaterializationTeardown],
+    request_headers: dict[str, str] | None = None,
+) -> list[str]:
+    """
+    Stop the workflows behind materializations that a deletion has erased.
+
+    Call this only after the deletion has committed: the query service is a remote
+    call that must not hold the transaction open, and telling it to stop a workflow
+    for a deletion that then rolls back is worse than not telling it at all.
+
+    Cubes go through the cube teardown, which knows about persisted workflow names
+    and the cube-name fallback for rows written before them. Everything else is a
+    node-and-materialization-name deactivation, the same call node deactivation
+    makes.
+
+    Never raises: a query service that is unreachable must not turn a deletion the
+    user already asked for -- and that has already happened -- into an error.
+    Returns one message per failure for the caller to report.
+    """
+    if not query_service_client:
+        return []
+    failures: list[str] = []
+    for teardown in teardowns:
+        if teardown.node_type == NodeType.CUBE:
+            failure = stop_cube_materialization_workflows(
+                query_service_client=query_service_client,
+                cube_name=teardown.node_name,
+                cube_version=teardown.node_version,
+                materializations=teardown.materializations,
+                request_headers=request_headers,
+            )
+            if failure:
+                failures.append(failure)
+            continue
+        for materialization in teardown.materializations:
+            try:
+                query_service_client.deactivate_materialization(
+                    teardown.node_name,
+                    materialization.name,
+                    node_version=teardown.node_version,
+                    request_headers=request_headers,
+                )
+                _logger.info(
+                    "Deactivated materialization %s for node=%s version=%s",
+                    materialization.name,
+                    teardown.node_name,
+                    teardown.node_version,
+                )
+            except Exception as exc:
+                _logger.warning(
+                    "Failed to deactivate materialization %s for node=%s version=%s: "
+                    "%s (continuing)",
+                    materialization.name,
+                    teardown.node_name,
+                    teardown.node_version,
+                    str(exc),
+                )
+                failures.append(
+                    f"Node `{teardown.node_name}`: DJ deleted the materialization "
+                    f"`{materialization.name}` at version {teardown.node_version}, "
+                    f"but the query service did not stop its workflow: {exc}. The "
+                    f"workflow may still be running.",
+                )
+    return failures
 
 
 async def schedule_materialization_jobs(

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -32,6 +32,10 @@ from datajunction_server.errors import (
     DJInvalidInputException,
 )
 from datajunction_server.internal.history import ActivityType, EntityType
+from datajunction_server.internal.materializations import (
+    collect_materialization_teardowns,
+    stop_materialization_workflows,
+)
 from datajunction_server.internal.nodes import get_single_cube_revision_metadata
 from datajunction_server.models.deployment import (
     CubeSpec,
@@ -53,6 +57,7 @@ from datajunction_server.models.namespace import (
 )
 from datajunction_server.models.node import NodeMinimumDetail
 from datajunction_server.models.node_type import NodeType
+from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.dag import topological_sort
 from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import SEPARATOR
@@ -637,9 +642,16 @@ async def hard_delete_namespace(
     current_user: User,
     save_history: Callable,
     cascade: bool = False,
+    query_service_client: QueryServiceClient | None = None,
+    request_headers: dict[str, str] | None = None,
 ) -> HardDeleteResponse:
     """
     Hard delete a node namespace.
+
+    Materializations under the namespace are read before the delete and their
+    workflows stopped after the commit: the rows naming those workflows go away with
+    the nodes, so a namespace deleted without this leaves the query service running
+    jobs no one can find again, let alone stop.
     """
     node_rows = (
         await session.execute(
@@ -665,6 +677,7 @@ async def hard_delete_namespace(
                 " this action cannot be undone."
             ),
         )
+    teardowns = await collect_materialization_teardowns(session, node_names)
     impacted = await hard_delete_nodes(session, node_ids, current_user)
 
     # Delete namespaces in the same transaction so the whole operation is
@@ -688,10 +701,17 @@ async def hard_delete_namespace(
 
     await session.commit()
 
+    materialization_failures = stop_materialization_workflows(
+        query_service_client,
+        teardowns,
+        request_headers=request_headers,
+    )
+
     return HardDeleteResponse(
         deleted_namespaces=deleted_namespaces,
         deleted_nodes=node_names,
         impacted=impacted,
+        materialization_failures=materialization_failures,
     )
 
 

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -3,9 +3,10 @@
 import logging
 from collections import defaultdict
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from http import HTTPStatus
-from typing import cast
+from typing import Any, cast
 
 from fastapi import BackgroundTasks, Request
 from fastapi.responses import JSONResponse
@@ -67,8 +68,10 @@ from datajunction_server.internal.caching.interface import Cache
 from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.internal.materializations import (
     apply_cube_materialization_swap,
+    collect_materialization_teardowns,
     create_new_materialization,
     schedule_materialization_jobs_bg,
+    stop_materialization_workflows,
     swap_cube_materializations,
 )
 from datajunction_server.internal.validation import (
@@ -3619,6 +3622,13 @@ async def deactivate_node(
 ):
     """
     Deactivates a node and propagates to all downstreams.
+
+    A deactivated node stops materializing. Restoring it does not reschedule
+    anything, so leaving its workflows running would keep writing a table whose node
+    is not readable -- which is why this path has always asked the query service to
+    stop them. It just could not stop a cube's: those workflows are named in the
+    materialization config, not derivable from the node and materialization name, so
+    the teardown goes through the shared helper that knows both dialects.
     """
     node = await Node.get_by_name(session, name, raise_if_not_exists=True)
 
@@ -3634,14 +3644,15 @@ async def deactivate_node(
         save_history=save_history,
     )
 
-    # If the node has materializations, deactivate them
-    for materialization in (
-        node.current.materializations if node and node.current else []
-    ):
+    # If the node has materializations, stop the workflows behind them. Collected
+    # here, before the deactivation, and handed to a background task as detached
+    # copies so the query service call happens off the request path.
+    teardowns = await collect_materialization_teardowns(session, [name])
+    if teardowns:
         background_tasks.add_task(
-            query_service_client.deactivate_materialization,
-            node_name=name,
-            materialization_name=materialization.name,
+            stop_materialization_workflows,
+            query_service_client,
+            teardowns,
             request_headers=request_headers,
         )
 
@@ -4104,15 +4115,33 @@ async def revalidate_node(
     return node_validator
 
 
+@dataclass
+class HardDeleteNodeResult:
+    """
+    What a hard delete did: its downstream impact, plus any materialization
+    workflow the query service would not stop on the way out.
+    """
+
+    impact: list[dict[str, Any]]
+    materialization_failures: list[str]
+
+
 async def hard_delete_node(
     name: str,
     session: AsyncSession,
     current_user: User,
     save_history: Callable,
-):
+    query_service_client: QueryServiceClient | None = None,
+    request_headers: dict[str, str] | None = None,
+) -> HardDeleteNodeResult:
     """
     Hard delete a node, destroying all links and invalidating all downstream nodes.
     This should be used with caution, deactivating a node is preferred.
+
+    The node's materializations are read before it is deleted and their workflows
+    stopped once the delete has committed. Deleting the node cascades away the rows
+    naming those workflows, so a delete that skips this leaves the query service
+    firing jobs on schedule that DJ can no longer even name, let alone stop.
     """
     node = await Node.get_by_name(
         session,
@@ -4140,8 +4169,20 @@ async def hard_delete_node(
             common_dimensions=[node],  # type: ignore
         )
 
+    teardowns = await collect_materialization_teardowns(session, [name])
+
     await session.delete(node)
     await session.commit()
+
+    # Straight after the commit that made the deletion durable, and before the
+    # downstream revalidation below, which is DB work that could fail and must not
+    # be what decides whether the workflows get stopped.
+    materialization_failures = stop_materialization_workflows(
+        query_service_client,
+        teardowns,
+        request_headers=request_headers,
+    )
+
     impact = []  # Aggregate all impact of this deletion to include in response
 
     # Revalidate all downstream nodes in topological order so that parents are
@@ -4218,7 +4259,10 @@ async def hard_delete_node(
     await delete_orphaned_missing_parents(session)
     await session.commit()
 
-    return impact
+    return HardDeleteNodeResult(
+        impact=impact,
+        materialization_failures=materialization_failures,
+    )
 
 
 async def refresh_source(

--- a/datajunction-server/datajunction_server/models/namespace.py
+++ b/datajunction-server/datajunction_server/models/namespace.py
@@ -33,6 +33,12 @@ class HardDeleteResponse(BaseModel):
     deleted_namespaces: list[str]
     impacted: ImpactedNodes
 
+    # Materialization workflows the query service refused to stop. The nodes are
+    # gone either way -- an unreachable query service does not undo a delete -- but
+    # DJ no longer holds what those workflows are named, so a failure here is the
+    # last chance anyone has to hear about it.
+    materialization_failures: list[str] = []
+
 
 class NamespaceWriteStatus(StrEnum):
     """What a create-or-reactivate namespace request ended up doing."""

--- a/datajunction-server/tests/api/materializations_test.py
+++ b/datajunction-server/tests/api/materializations_test.py
@@ -1759,6 +1759,181 @@ async def test_deleting_node_with_materialization(
 
 
 @pytest.mark.asyncio
+async def test_hard_deleting_cube_stops_its_materialization_workflows(
+    module__client_with_roads: AsyncClient,
+    module__query_service_client: QueryServiceClient,
+    set_temporal_column: Callable,
+    mocker,
+):
+    """
+    Hard deleting a materialized cube must ask the query service to stop the
+    workflows behind it. The delete cascades away the materialization rows, so a
+    workflow left running is one nothing can ever find or stop again.
+    """
+    client = module__client_with_roads
+    cube_name = "default.repairs_hard_delete_cube"
+    await create_cube_with_materialization(
+        client,
+        set_temporal_column,
+        cube_name=cube_name,
+        strategy="full",
+        schedule="@daily",
+    )
+    deactivate_cube_workflow = mocker.patch.object(
+        module__query_service_client,
+        "deactivate_cube_workflow",
+        return_value={"status": "deactivated"},
+    )
+    deactivate_workflows = mocker.patch.object(
+        module__query_service_client,
+        "deactivate_workflows",
+        return_value={"status": "deactivated"},
+    )
+
+    response = await client.delete(f"/nodes/{cube_name}/hard/")
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": f"The node `{cube_name}` has been completely removed.",
+        "impact": [],
+    }
+    assert deactivate_cube_workflow.call_args_list == [
+        mocker.call(cube_name, version="v1.0", request_headers=mocker.ANY),
+    ]
+    assert deactivate_workflows.call_args_list == []
+
+
+@pytest.mark.asyncio
+async def test_hard_deleting_unmaterialized_node_calls_no_query_service(
+    module__client_with_roads: AsyncClient,
+    module__query_service_client: QueryServiceClient,
+    mocker,
+):
+    """
+    A node with no materializations has no workflows to stop, so the delete must
+    not talk to the query service at all.
+    """
+    client = module__client_with_roads
+    node_name = "default.unmaterialized_teardown_probe"
+    response = await client.post(
+        "/nodes/transform/",
+        json={
+            "description": "A transform nobody materialized",
+            "query": "SELECT repair_order_id FROM default.repair_orders",
+            "mode": "published",
+            "name": node_name,
+        },
+    )
+    assert response.status_code == 201, response.json()
+    deactivate_cube_workflow = mocker.patch.object(
+        module__query_service_client,
+        "deactivate_cube_workflow",
+    )
+    deactivate_workflows = mocker.patch.object(
+        module__query_service_client,
+        "deactivate_workflows",
+    )
+    deactivate_materialization = mocker.patch.object(
+        module__query_service_client,
+        "deactivate_materialization",
+    )
+
+    response = await client.delete(f"/nodes/{node_name}/hard/")
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": f"The node `{node_name}` has been completely removed.",
+        "impact": [],
+    }
+    assert deactivate_cube_workflow.call_args_list == []
+    assert deactivate_workflows.call_args_list == []
+    assert deactivate_materialization.call_args_list == []
+
+
+@pytest.mark.asyncio
+async def test_hard_deleting_cube_completes_when_query_service_fails(
+    module__client_with_roads: AsyncClient,
+    module__query_service_client: QueryServiceClient,
+    set_temporal_column: Callable,
+    mocker,
+):
+    """
+    A query service that cannot be reached must not stop the deletion the user
+    asked for -- but the failure is reported, since DJ has just thrown away the
+    only record of what that workflow was called.
+    """
+    client = module__client_with_roads
+    cube_name = "default.repairs_hard_delete_failure_cube"
+    await create_cube_with_materialization(
+        client,
+        set_temporal_column,
+        cube_name=cube_name,
+        strategy="full",
+        schedule="@daily",
+    )
+    mocker.patch.object(
+        module__query_service_client,
+        "deactivate_cube_workflow",
+        side_effect=Exception("query service unreachable"),
+    )
+    materialization_name = (
+        "druid_measures_cube__full__default.repair_orders_fact.order_date"
+    )
+
+    response = await client.delete(f"/nodes/{cube_name}/hard/")
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": f"The node `{cube_name}` has been completely removed.",
+        "impact": [],
+        "materialization_failures": [
+            f"Cube `{cube_name}`: DJ retired the materialization "
+            f"`{materialization_name}` at version v1.0, but the query service did "
+            "not stop its workflow: query service unreachable. The workflow may "
+            "still be running.",
+        ],
+    }
+
+    # The node really is gone
+    response = await client.get(f"/nodes/{cube_name}/")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_deactivating_cube_stops_its_materialization_workflows(
+    module__client_with_roads: AsyncClient,
+    module__query_service_client: QueryServiceClient,
+    set_temporal_column: Callable,
+    mocker,
+):
+    """
+    Deactivating a cube stops its workflows too. Restoring the node does not
+    reschedule anything, so a workflow left running writes a table whose node
+    nobody can read.
+    """
+    client = module__client_with_roads
+    cube_name = "default.repairs_deactivate_cube"
+    await create_cube_with_materialization(
+        client,
+        set_temporal_column,
+        cube_name=cube_name,
+        strategy="full",
+        schedule="@daily",
+    )
+    deactivate_cube_workflow = mocker.patch.object(
+        module__query_service_client,
+        "deactivate_cube_workflow",
+        return_value={"status": "deactivated"},
+    )
+
+    response = await client.delete(f"/nodes/{cube_name}")
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": f"Node `{cube_name}` has been successfully deleted.",
+    }
+    assert deactivate_cube_workflow.call_args_list == [
+        mocker.call(cube_name, version="v1.0", request_headers=mocker.ANY),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_list_node_availability_states_across_versions(
     module__client_with_roads: AsyncClient,
 ) -> None:

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -697,6 +697,162 @@ async def test_hard_delete_namespace_with_backfills(
     )
 
 
+async def _create_materialized_cube(client: AsyncClient, cube_name: str) -> str:
+    """
+    Create a cube with a Druid materialization, returning its materialization name.
+    """
+    response = await client.post(
+        "/nodes/default.repair_orders_fact/columns/order_date/attributes/",
+        json=[{"name": "dimension"}],
+    )
+    assert response.status_code in (200, 201), response.json()
+    response = await client.post(
+        "/nodes/cube/",
+        json={
+            "metrics": ["default.num_repair_orders", "default.total_repair_cost"],
+            "dimensions": [
+                "default.repair_orders_fact.order_date",
+                "default.hard_hat.state",
+            ],
+            "description": "Cube of various metrics related to repairs",
+            "mode": "published",
+            "name": cube_name,
+        },
+    )
+    assert response.status_code == 201, response.json()
+    response = await client.post(
+        f"/nodes/{cube_name}/columns/default.repair_orders_fact.order_date/partition",
+        json={"type_": "temporal", "granularity": "day", "format": "yyyyMMdd"},
+    )
+    assert response.status_code in (200, 201), response.json()
+    response = await client.post(
+        f"/nodes/{cube_name}/materialization/",
+        json={"job": "druid_measures_cube", "strategy": "full", "schedule": "@daily"},
+    )
+    assert response.status_code in (200, 201), response.json()
+    return "druid_measures_cube__full__default.repair_orders_fact.order_date"
+
+
+@pytest.mark.asyncio
+async def test_hard_delete_namespace_stops_materialization_workflows(
+    client_example_loader,
+    query_service_client,
+    mocker,
+):
+    """
+    Cascade-deleting a namespace must stop the workflows behind every
+    materialization it takes with it.
+
+    This is the leak that matters most in practice: a branch-namespace reaper
+    hard-deletes namespaces after PRs merge, so every branch deploy that
+    materialized used to leave a daily-firing workflow behind.
+    """
+    client = await client_example_loader(["ROADS"])
+    client.app.dependency_overrides[get_query_service_client] = lambda: (
+        query_service_client
+    )
+    await _create_materialized_cube(client, "default.first_reaped_cube")
+    await _create_materialized_cube(client, "default.second_reaped_cube")
+
+    # A materialized dimension node, whose workflows are named by the node and
+    # materialization name rather than by a cube config
+    response = await client.post(
+        "/nodes/default.hard_hat/columns/birth_date/partition",
+        json={"type_": "temporal", "granularity": "day", "format": "yyyyMMdd"},
+    )
+    assert response.status_code < 400, response.json()
+    response = await client.post(
+        "/nodes/default.hard_hat/materialization/",
+        json={
+            "job": "spark_sql",
+            "strategy": "full",
+            "config": {},
+            "schedule": "@daily",
+        },
+    )
+    assert response.status_code < 400, response.json()
+
+    deactivate_cube_workflow = mocker.patch.object(
+        query_service_client,
+        "deactivate_cube_workflow",
+        return_value={"status": "deactivated"},
+    )
+    deactivate_workflows = mocker.patch.object(
+        query_service_client,
+        "deactivate_workflows",
+        return_value={"status": "deactivated"},
+    )
+    deactivate_materialization = mocker.patch.object(
+        query_service_client,
+        "deactivate_materialization",
+    )
+
+    response = await client.delete("/namespaces/default/hard/?cascade=true")
+    assert response.status_code == 200, response.json()
+    assert response.json()["impact"]["materialization_failures"] == []
+    assert deactivate_cube_workflow.call_args_list == [
+        mocker.call(
+            "default.first_reaped_cube",
+            version="v1.0",
+            request_headers=mocker.ANY,
+        ),
+        mocker.call(
+            "default.second_reaped_cube",
+            version="v1.0",
+            request_headers=mocker.ANY,
+        ),
+    ]
+    assert deactivate_workflows.call_args_list == []
+    assert deactivate_materialization.call_args_list == [
+        mocker.call(
+            "default.hard_hat",
+            "spark_sql__full__birth_date",
+            node_version="v1.1",
+            request_headers=mocker.ANY,
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_hard_delete_namespace_completes_when_query_service_fails(
+    client_example_loader,
+    query_service_client,
+    mocker,
+):
+    """
+    An unreachable query service must not block a namespace deletion, but the
+    failure is reported rather than swallowed into a log line.
+    """
+    client = await client_example_loader(["ROADS"])
+    client.app.dependency_overrides[get_query_service_client] = lambda: (
+        query_service_client
+    )
+    materialization_name = await _create_materialized_cube(
+        client,
+        "default.unstoppable_cube",
+    )
+    mocker.patch.object(
+        query_service_client,
+        "deactivate_cube_workflow",
+        side_effect=Exception("query service unreachable"),
+    )
+
+    response = await client.delete("/namespaces/default/hard/?cascade=true")
+    assert response.status_code == 200, response.json()
+    result = response.json()
+    assert result["message"] == "The namespace `default` has been completely removed."
+    assert result["impact"]["materialization_failures"] == [
+        "Cube `default.unstoppable_cube`: DJ retired the materialization "
+        f"`{materialization_name}` at version v1.0, but the query service did not "
+        "stop its workflow: query service unreachable. The workflow may still be "
+        "running.",
+    ]
+
+    # The namespace really is gone
+    response = await client.get("/namespaces/default/")
+    assert response.status_code == 404
+
+
 @pytest.mark.asyncio
 async def test_create_namespace(client_with_service_setup: AsyncClient):
     """

--- a/datajunction-server/tests/internal/materializations_test.py
+++ b/datajunction-server/tests/internal/materializations_test.py
@@ -6,8 +6,11 @@ from unittest import mock
 
 from datajunction_server.database.materialization import Materialization
 from datajunction_server.internal.materializations import (
+    NodeMaterializationTeardown,
     stop_cube_materialization_workflows,
+    stop_materialization_workflows,
 )
+from datajunction_server.models.node_type import NodeType
 
 
 def test_stop_cube_workflows_prefers_stored_workflow_names():
@@ -117,3 +120,110 @@ def test_stop_cube_workflows_without_a_config():
         mock.call("default.a_cube", version="v2.0", request_headers=None),
     ]
     assert query_service_client.deactivate_workflows.call_args_list == []
+
+
+def test_stop_materialization_workflows_without_a_query_service():
+    """
+    With no query service configured there is nothing to stop and nobody to tell.
+    """
+    assert (
+        stop_materialization_workflows(
+            None,
+            [
+                NodeMaterializationTeardown(
+                    node_name="default.a_cube",
+                    node_version="v1.0",
+                    node_type=NodeType.CUBE,
+                    materializations=[Materialization(name="druid_cube_v3", config={})],
+                ),
+            ],
+        )
+        == []
+    )
+
+
+def test_stop_materialization_workflows_for_a_non_cube_node():
+    """
+    A materialized transform's workflows are stopped by node and materialization
+    name -- the same call node deactivation makes -- since only cubes record
+    workflow names on their config.
+    """
+    query_service_client = mock.MagicMock()
+
+    failures = stop_materialization_workflows(
+        query_service_client,
+        [
+            NodeMaterializationTeardown(
+                node_name="default.a_transform",
+                node_version="v1.1",
+                node_type=NodeType.TRANSFORM,
+                materializations=[
+                    Materialization(name="spark_sql__full__birth_date", config={}),
+                    Materialization(name="spark_sql__full__hire_date", config={}),
+                ],
+            ),
+        ],
+        request_headers={"cookie": "a-cookie"},
+    )
+
+    assert failures == []
+    assert query_service_client.deactivate_materialization.call_args_list == [
+        mock.call(
+            "default.a_transform",
+            "spark_sql__full__birth_date",
+            node_version="v1.1",
+            request_headers={"cookie": "a-cookie"},
+        ),
+        mock.call(
+            "default.a_transform",
+            "spark_sql__full__hire_date",
+            node_version="v1.1",
+            request_headers={"cookie": "a-cookie"},
+        ),
+    ]
+    assert query_service_client.deactivate_workflows.call_args_list == []
+    assert query_service_client.deactivate_cube_workflow.call_args_list == []
+
+
+def test_stop_materialization_workflows_reports_every_failure():
+    """
+    A query service that refuses is reported, not raised: the nodes are already
+    deleted. Each node that failed gets its own message, and one failure does not
+    stop the rest from being tried.
+    """
+    query_service_client = mock.MagicMock()
+    query_service_client.deactivate_materialization.side_effect = Exception(
+        "unreachable",
+    )
+    query_service_client.deactivate_cube_workflow.side_effect = Exception(
+        "unreachable",
+    )
+
+    failures = stop_materialization_workflows(
+        query_service_client,
+        [
+            NodeMaterializationTeardown(
+                node_name="default.a_transform",
+                node_version="v1.1",
+                node_type=NodeType.TRANSFORM,
+                materializations=[
+                    Materialization(name="spark_sql__full__birth_date", config={}),
+                ],
+            ),
+            NodeMaterializationTeardown(
+                node_name="default.a_cube",
+                node_version="v1.0",
+                node_type=NodeType.CUBE,
+                materializations=[Materialization(name="druid_cube_v3", config={})],
+            ),
+        ],
+    )
+
+    assert failures == [
+        "Node `default.a_transform`: DJ deleted the materialization "
+        "`spark_sql__full__birth_date` at version v1.1, but the query service did "
+        "not stop its workflow: unreachable. The workflow may still be running.",
+        "Cube `default.a_cube`: DJ retired the materialization `druid_cube_v3` at "
+        "version v1.0, but the query service did not stop its workflow: unreachable. "
+        "The workflow may still be running.",
+    ]


### PR DESCRIPTION
### Summary

Deleting a node dropped DJ's record of its materializations without telling the query service to remove any actual workflows, so the workflow behind a materialized cube kept firing on schedule. This means that every branch deploy that materialized has leaked a daily-firing workflow, even after it's deleted.

Deletion now reads what a node still has running before the rows go away and stops it after the commit. This applies to the single-node hard delete, the namespace cascade, and the deployment's own node deletion. Cubes go through the existing cube teardown, which knows both the persisted workflow names and the cube-name fallback; everything else goes through the same node-and-materialization-name deactivation that node deactivation makes.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
