### PR TITLE
Propagate upstream changes into downstream cubes

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -386,6 +386,10 @@ class DeploymentOrchestrator:
         # Cubes rebuilt onto a new, empty datasource.
         self._rebuilt_cubes: set[str] = set()
         self._branch_deploy: bool | None = None
+        # Cube name -> the changed upstreams that pulled it into this deploy.
+        self._cubes_bumped_by_upstream: dict[str, list[str]] = {}
+        # Node name -> the tier its change earned, for those cubes to inherit.
+        self._change_tiers: dict[str, ChangeTier] = {}
 
     @property
     def _history_user(self) -> str:
@@ -2374,10 +2378,15 @@ class DeploymentOrchestrator:
                 new_revision,
                 access_checker=access_checker,
                 current_user=self.context.current_user,
-                previous_table_usable=not await is_non_trivial_cube_change(
-                    self.session,
-                    old_revision,
-                    new_revision,
+                # An upstream change can leave the cube's shape identical while
+                # every row it serves differs, so the old table is not adoptable.
+                previous_table_usable=(
+                    new_revision.name not in self._cubes_bumped_by_upstream
+                    and not await is_non_trivial_cube_change(
+                        self.session,
+                        old_revision,
+                        new_revision,
+                    )
                 ),
                 declared=declared,
             )
@@ -3715,6 +3724,12 @@ class DeploymentOrchestrator:
             changelog, changed_fields, change_tier = await self._generate_changelog(
                 result,
             )
+            # A cube dragged in by an upstream change has an identical spec, so its
+            # own diff earns nothing; the upstream's tier is the whole bump.
+            change_tier = max(
+                change_tier,
+                self._inherited_change_tier(cube_spec.rendered_name),
+            )
             if existing:
                 new_node = existing
                 new_node.current_version = self._deployed_version(
@@ -4216,6 +4231,12 @@ class DeploymentOrchestrator:
         -- `change_tier` decides that and `_deployed_version` turns it into a
         version. So `force` and the INVALID re-deploy below can re-process a node
         without that implying anything about what changed.
+
+        A cube whose own spec is unchanged is still processed when something
+        upstream of it is changing, matching what `_propagate_update_downstream`
+        does for a `PATCH`: the cube names the same metrics and dimensions, but
+        they now resolve against new upstream revisions, so its materialized table
+        was computed against a definition that no longer exists.
         """
         to_create: list[NodeSpec] = []
         to_update: list[NodeSpec] = []
@@ -4240,6 +4261,23 @@ class DeploymentOrchestrator:
                 else:
                     to_skip.append(node_spec)
 
+        changed_names = {spec.rendered_name for spec in to_create + to_update}
+        self._cubes_bumped_by_upstream = self._cubes_below_changed_nodes(
+            to_skip,
+            changed_names,
+        )
+        if self._cubes_bumped_by_upstream:
+            to_update.extend(
+                spec
+                for spec in to_skip
+                if spec.rendered_name in self._cubes_bumped_by_upstream
+            )
+            to_skip = [
+                spec
+                for spec in to_skip
+                if spec.rendered_name not in self._cubes_bumped_by_upstream
+            ]
+
         desired_node_names = {n.rendered_name for n in self.deployment_spec.nodes}
         to_delete = [
             existing
@@ -4248,6 +4286,61 @@ class DeploymentOrchestrator:
         ]
 
         return to_create + to_update, to_skip, to_delete
+
+    def _cubes_below_changed_nodes(
+        self,
+        candidates: list[NodeSpec],
+        changed_names: set[str],
+    ) -> dict[str, list[str]]:
+        """Which unchanged cubes sit above a node this deploy is changing.
+
+        Maps each such cube to the changed nodes above it, which is what
+        `_inherited_change_tier` reads to give the cube a bump as significant as
+        the change that caused it.
+
+        The walk uses the parents already loaded with the namespace's nodes, so it
+        costs no queries and no parsing. It is transitive: a transform three levels
+        under a cube still reaches it, and no node between them has to have changed
+        for that to count -- an unchanged metric over an edited transform serves
+        different rows all the same.
+        """
+        parents = {
+            name: [parent.name for parent in node.current.parents]
+            for name, node in self.registry.nodes.items()
+            if node.current
+        }
+        bumped: dict[str, list[str]] = {}
+        for spec in candidates:
+            if not isinstance(spec, CubeSpec):
+                continue
+            causes, seen = [], set()
+            queue = list(parents.get(spec.rendered_name, []))
+            while queue:
+                ancestor = queue.pop()
+                if ancestor in seen:
+                    continue
+                seen.add(ancestor)
+                if ancestor in changed_names:
+                    causes.append(ancestor)
+                queue.extend(parents.get(ancestor, []))
+            if causes:
+                bumped[spec.rendered_name] = sorted(causes)
+        return bumped
+
+    def _inherited_change_tier(self, cube_name: str) -> ChangeTier:
+        """The tier a cube inherits from the upstream changes that pulled it in.
+
+        The most significant of them: over-rebuilding a cube costs compute, while
+        under-rebuilding serves wrong numbers. An upstream that turned out not to
+        change anything contributes nothing.
+        """
+        return max(
+            (
+                self._change_tiers.get(upstream, ChangeTier.NONE)
+                for upstream in self._cubes_bumped_by_upstream.get(cube_name, [])
+            ),
+            default=ChangeTier.NONE,
+        )
 
     def _guard_against_accidental_wipe(self, plan: "DeploymentPlan") -> None:
         """Refuse to wipe a populated namespace from a *fully empty* spec.
@@ -4735,6 +4828,9 @@ class DeploymentOrchestrator:
             else DeploymentResult.Operation.CREATE
         )
         changelog, changed_fields, change_tier = await self._generate_changelog(result)
+        # Read back by `_inherited_change_tier` when the cubes above this node are
+        # deployed, which happens after every non-cube node.
+        self._change_tiers[result.spec.rendered_name] = change_tier
         new_node = self._create_or_update_node(result.spec, existing, change_tier)
         new_revision = await self._create_node_revision(
             new_node,

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -100,6 +100,7 @@ from datajunction_server.models.deployment import (
     CubeSpec,
     DeploymentResult,
     bump_version,
+    version_change_tier,
 )
 from datajunction_server.models.dimensionlink import (
     JoinLinkInput,
@@ -128,6 +129,7 @@ from datajunction_server.models.query import QueryCreate
 from datajunction_server.models.table_metadata import TableMetadata, TableOwner
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.dag import (
+    _node_output_options,
     get_downstream_nodes,
     get_nodes_with_common_dimensions,
     topological_sort,
@@ -1528,6 +1530,12 @@ async def update_node_with_query(
         current_user=current_user,
         save_history=save_history,
         cache=cache,
+        # Downstream cubes inherit this node's tier: a cube's own shape can be
+        # identical across an upstream change that nonetheless changes every row it
+        # serves, so how significant the change was is only answerable here.
+        change_tier=version_change_tier(old_revision.version, node.current_version),  # type: ignore
+        query_service_client=query_service_client,
+        request_headers=request_headers,
     )
     await session.refresh(node, ["current"])
     await session.refresh(node.current, ["materializations"])  # type: ignore
@@ -2025,6 +2033,49 @@ async def update_cube_node(
             )
         return None
 
+    return await save_new_cube_revision(
+        session,
+        node_revision,
+        create_cube,
+        change_tier,
+        request_headers=request_headers,
+        query_service_client=query_service_client,
+        current_user=current_user,
+        access_checker=access_checker,
+        save_history=save_history,
+    )
+
+
+async def save_new_cube_revision(
+    session: AsyncSession,
+    node_revision: NodeRevision,
+    create_cube: CreateCubeNode,
+    change_tier: ChangeTier,
+    *,
+    request_headers: dict[str, str] | None,
+    query_service_client: QueryServiceClient | None,
+    current_user: User,
+    access_checker: AccessChecker,
+    save_history: Callable,
+    extra_history_details: dict | None = None,
+) -> NodeRevision:
+    """
+    Commit `create_cube` as the cube's next revision, at the version `change_tier`
+    earns, and move its materializations onto it.
+
+    Everything a new cube revision needs beyond deciding *that* there should be one:
+    resolving the cube against the current metrics and dimensions, the version bump,
+    carrying partition columns forward, the audit event, and the materialization
+    swap. Both writers of a cube revision go through here -- a user editing the cube
+    (`update_cube_node`) and an upstream change propagating into it -- so the two
+    cannot produce differently-shaped revisions.
+
+    `extra_history_details` is merged into the UPDATE event's details, which is how
+    the propagation path records the upstream node and version that caused the bump.
+    """
+    old_metrics = [m.name for m in node_revision.cube_metrics()]
+    old_dimensions = node_revision.cube_dimensions()
+
     # Disable autoflush to prevent partial state from being persisted if an error
     # occurs during revision creation. This ensures that node.current_version and
     # the new NodeRevision are committed atomically - either both succeed or both
@@ -2049,6 +2100,7 @@ async def update_cube_node(
                 activity_type=ActivityType.UPDATE,
                 details={
                     "version": new_cube_revision.version,  # type: ignore
+                    **(extra_history_details or {}),
                 },
                 pre={
                     "metrics": old_metrics,
@@ -2121,9 +2173,16 @@ async def propagate_update_downstream(
     current_user: User,
     save_history: Callable,
     cache: Cache | None = None,
+    change_tier: ChangeTier = ChangeTier.MAJOR,
+    query_service_client: QueryServiceClient | None = None,
+    request_headers: dict[str, str] | None = None,
 ):
     """
     Background task to propagate the updated node's changes to all of its downstream children.
+
+    `change_tier` is how significant the change to `node` itself was, which is what
+    downstream cubes inherit as their own bump. It defaults to MAJOR because
+    over-rebuilding a cube costs compute while under-rebuilding serves wrong numbers.
     """
     try:
         async with session_context() as session:
@@ -2133,6 +2192,9 @@ async def propagate_update_downstream(
                 current_user=current_user,
                 save_history=save_history,
                 cache=cache,
+                change_tier=change_tier,
+                query_service_client=query_service_client,
+                request_headers=request_headers,
             )
     except Exception:
         _logger.exception(
@@ -2141,12 +2203,110 @@ async def propagate_update_downstream(
         )
 
 
+async def _reload_nodes_in_order(
+    session: AsyncSession,
+    names: list[str],
+) -> list[Node]:
+    """
+    Reload the named nodes in one query, preserving the order they were given in.
+
+    Used to recover the tail of a propagation walk after a rollback has expired the
+    instances it was holding. A node that has disappeared meanwhile is dropped
+    rather than resurrected, and an empty list of names is a select that matches
+    nothing rather than a case to special-case.
+    """
+    reloaded = (
+        (
+            await session.execute(
+                select(Node)
+                .where(Node.name.in_(names))
+                .options(*_node_output_options()),
+            )
+        )
+        .unique()
+        .scalars()
+        .all()
+    )
+    position = {name: index for index, name in enumerate(names)}
+    return sorted(reloaded, key=lambda reloaded_node: position[reloaded_node.name])
+
+
+async def _rebuild_downstream_cube(
+    session: AsyncSession,
+    cube: Node,
+    upstream: Node,
+    change_tier: ChangeTier,
+    *,
+    current_user: User,
+    save_history: Callable,
+    query_service_client: QueryServiceClient | None,
+    request_headers: dict[str, str] | None,
+) -> None:
+    """
+    Bump a cube because something upstream of it changed.
+
+    Nobody edited the cube, so there is no payload to reconstruct it from: the new
+    revision is resolved from the cube's *own* current metrics and dimensions, which
+    is exactly what `update_cube_node` falls back to for every field a PATCH omits.
+    Re-resolving them is the point -- the metrics and dimensions are the same names,
+    but they now resolve against new upstream revisions, so the cube's columns,
+    elements and parents recompile against what the upstream became.
+
+    The cube inherits the upstream's tier rather than being classified on its own
+    shape. `is_non_trivial_cube_change` asks whether the *cube's* definition moved,
+    which is the wrong question here: widening a transform's WHERE clause changes no
+    metric, no dimension and no component identity, yet every row in the cube's
+    materialized table was computed under the old filter. Over-rebuilding costs
+    compute; under-rebuilding serves wrong numbers.
+    """
+    cube_node = await Node.get_cube_by_name(session, cube.name)
+    node_revision = cube_node.current  # type: ignore
+    create_cube = CreateCubeNode(
+        name=node_revision.name,
+        display_name=node_revision.display_name,
+        description=node_revision.description,
+        metrics=[metric.name for metric in node_revision.cube_metrics()],
+        dimensions=node_revision.cube_dimensions(),
+        mode=node_revision.mode,
+        filters=node_revision.cube_filters or [],
+        custom_metadata=node_revision.custom_metadata,
+    )
+    # Propagation runs after the response has returned, outside the request's
+    # AccessChecker, so the materialization rebuild gets a fresh one built from the
+    # updating user. It is not used to gate the bump: like the revalidation path
+    # above, propagation into a cube whose owner pointed it at this upstream is not
+    # the updater's call to make.
+    access_checker = AccessChecker(await AuthContext.from_user(session, current_user))
+    await save_new_cube_revision(
+        session,
+        node_revision,
+        create_cube,
+        change_tier,
+        request_headers=request_headers,
+        query_service_client=query_service_client,
+        current_user=current_user,
+        access_checker=access_checker,
+        save_history=save_history,
+        extra_history_details={
+            "upstream": {
+                "node": upstream.name,
+                "version": upstream.current_version,
+            },
+            "reason": f"Caused by update of `{upstream.name}` to "
+            f"{upstream.current_version}",
+        },
+    )
+
+
 async def _propagate_update_downstream(
     session: AsyncSession,
     node: Node,
     current_user: User,
     save_history: Callable,
     cache: Cache | None = None,
+    change_tier: ChangeTier = ChangeTier.MAJOR,
+    query_service_client: QueryServiceClient | None = None,
+    request_headers: dict[str, str] | None = None,
 ):
     """
     Propagate the updated node's changes to all of its downstream children.
@@ -2164,15 +2324,25 @@ async def _propagate_update_downstream(
     graph asserting VALID for nodes that are now broken -- silently, since the
     caller above swallows exceptions. Pinned by
     tests/internal/nodes/background_authz_test.py.
+
+    Cubes are included. They used to be filtered out, which meant a cube kept
+    serving a materialized table built against a definition that no longer existed
+    -- the only way to recompile it was a no-op edit to the cube itself. They also
+    can't go through `revalidate_node`, whose cube branch only refreshes status; a
+    cube's next revision comes from `save_new_cube_revision`, which is what
+    `_rebuild_downstream_cube` calls.
     """
     _logger.info("Propagating update of node %s downstream", node.name)
     downstreams = await get_downstream_nodes(
         session,
         node.name,
         include_deactivated=False,
-        include_cubes=False,
     )
     downstreams = topological_sort(downstreams)
+    # Names in topological order, kept separately because a rollback below expires
+    # every instance in the session and reading `.name` back off one would be a
+    # lazy load, which async SQLAlchemy cannot do.
+    downstream_names = [downstream.name for downstream in downstreams]
     _logger.info(
         "Node %s updated — revalidating %s downstreams",
         node.name,
@@ -2192,18 +2362,10 @@ async def _propagate_update_downstream(
             downstream.name,
             node.name,
         )
-        node_validator = await revalidate_node(
-            downstream.name,
-            session,
-            current_user=current_user,
-            save_history=save_history,
-            # propagate_update_downstream writes its own richer history event
-            # below (with upstream context); skip the inner one to avoid
-            # duplicate audit rows for the same revision bump.
-            record_revision_bump_event=False,
-        )
 
-        # Reset the upstreams DAG cache of any downstream nodes
+        # Reset the upstreams DAG cache of any downstream nodes. Done before the
+        # per-type work so a cube -- which returns early below -- has its cache
+        # invalidated too.
         if cache:
             upstream_cache_key = downstream.upstream_cache_key()
             results = cache.get(upstream_cache_key)
@@ -2215,6 +2377,51 @@ async def _propagate_update_downstream(
                     upstream_cache_key,
                 )
                 cache.delete(upstream_cache_key)
+
+        if downstream.type == NodeType.CUBE:
+            # A cube bump can trigger a materialization rebuild, so one cube that
+            # cannot be rebuilt -- an unresolvable metric, a query service that
+            # rejects the new workflow -- must not cost the remaining downstreams
+            # their propagation.
+            if change_tier is not ChangeTier.NONE:
+                try:
+                    await _rebuild_downstream_cube(
+                        session,
+                        downstream,
+                        node,
+                        change_tier,
+                        current_user=current_user,
+                        save_history=save_history,
+                        query_service_client=query_service_client,
+                        request_headers=request_headers,
+                    )
+                except Exception:
+                    _logger.exception(
+                        "Error rebuilding downstream cube %s after update of node %s",
+                        downstream.name,
+                        node.name,
+                    )
+                    # Discard the failed rebuild's partial writes, then reload what
+                    # is left of the walk: a rollback expires every instance in the
+                    # session, and the loop would otherwise touch an expired
+                    # attribute on the next downstream and lazy-load from async
+                    # code. One query, and only on the failure path.
+                    await session.rollback()
+                    downstreams[idx + 1 :] = await _reload_nodes_in_order(
+                        session,
+                        downstream_names[idx + 1 :],
+                    )
+            continue
+        node_validator = await revalidate_node(
+            downstream.name,
+            session,
+            current_user=current_user,
+            save_history=save_history,
+            # propagate_update_downstream writes its own richer history event
+            # below (with upstream context); skip the inner one to avoid
+            # duplicate audit rows for the same revision bump.
+            record_revision_bump_event=False,
+        )
 
         # Record history event
         if (

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -4235,32 +4235,40 @@ async def revalidate_node(
     # columns remain a faithful snapshot of what was committed at that
     # version. Track *why* the validator decided a column changed so the
     # history event can explain the bump.
-    type_changes: list[dict] = []
-    order_fixed: list[str] = []
-    added_columns: list[str] = []
-    for col in node_validator.columns:
-        existing_col = existing_columns.get(col.name)
-        if existing_col is None:
-            added_columns.append(col.name)
-            continue
-        if existing_col.type != col.type:
-            type_changes.append(
-                {
-                    "column": col.name,
-                    "from": str(existing_col.type),
-                    "to": str(col.type),
-                },
-            )
-        if existing_col.order is None:
-            order_fixed.append(col.name)
+    #
+    # `describe_column_changes` is the shared comparison, so a bump is explained
+    # the same way however it was triggered -- and so removals are seen at all.
+    # Walking the validator's columns and looking each one up, which is what this
+    # did, can only ever find what the validator produced: a column the revision
+    # still stores but the query no longer selects was never visited, so it earned
+    # no bump and rode along on the next revision advertising a value the node
+    # cannot supply.
+    column_changes = describe_column_changes(
+        node.current.columns,  # type: ignore
+        node_validator.columns,
+    )
+    type_changes: list[dict] = column_changes.get("type_changes", [])
+    added_columns: list[str] = column_changes.get("added_columns", [])
+    removed_columns: list[str] = column_changes.get("removed_columns", [])
+    # Not a column change, and so not part of the shared comparison: `order` is
+    # DJ's own bookkeeping rather than anything the query says.
+    order_fixed: list[str] = [
+        col.name
+        for col in node_validator.columns
+        if col.name in existing_columns and existing_columns[col.name].order is None
+    ]
     # How significant the validator's findings are, as a tier rather than a version,
     # so downstream propagation can hand the same value to `bump_version` for cubes.
     #
     # A type change is major: anything selecting the column may now be reading a
     # different type, and a cube materialized on it holds a table whose schema no
-    # longer matches. An added column is minor -- nothing downstream can reference a
-    # column that did not exist when it was written, so an additive change breaks
-    # nobody, and treating it as major rebuilds every downstream cube for free.
+    # longer matches. A removal is major for the same reason and more bluntly --
+    # anything that referenced the column is now broken. An added column is minor:
+    # nothing downstream can reference a column that did not exist when it was
+    # written, so an additive change breaks nobody, and treating it as major
+    # rebuilds every downstream cube for free. The asymmetry is deliberate --
+    # removals are rare and additions are constant, so occasionally rebuilding a
+    # cube that never used the dropped column is a cost worth paying.
     #
     # `order_fixed` is deliberately not a tier at all. It fires when a stored column
     # has no `order` and DJ fills in the projection index -- its own bookkeeping on
@@ -4270,7 +4278,7 @@ async def revalidate_node(
     # applied to the current revision in place instead, below.
     change_tier = fold_change_tiers(
         [
-            ChangeTier.MAJOR if type_changes else ChangeTier.NONE,
+            ChangeTier.MAJOR if (type_changes or removed_columns) else ChangeTier.NONE,
             ChangeTier.MINOR if added_columns else ChangeTier.NONE,
         ],
     )
@@ -4278,7 +4286,7 @@ async def revalidate_node(
 
     _logger.info(
         "Columns updated: %s (tier %s) for node %s (current version: %s) — "
-        "type_changes=%s, order_fixed=%s, added_columns=%s",
+        "type_changes=%s, order_fixed=%s, added_columns=%s, removed_columns=%s",
         updated_columns,
         change_tier.name,
         node.name,
@@ -4286,6 +4294,7 @@ async def revalidate_node(
         type_changes,
         order_fixed,
         added_columns,
+        removed_columns,
     )
     # Only create a new revision if the columns have been updated
     if updated_columns:  # type: ignore
@@ -4359,19 +4368,16 @@ async def revalidate_node(
         # Record the revision bump so the audit trail reflects revalidate-
         # driven version changes, not just deploy-driven ones, and explains
         # *which* validator-detected differences triggered it (type changes,
-        # missing column orders, new columns). Skip when the caller will
-        # write its own (richer) event for the same bump.
+        # new columns, dropped columns, missing column orders). Skip when the
+        # caller will write its own (richer) event for the same bump.
         if record_revision_bump_event:
             history_details: dict = {
                 "version": new_revision.version,
                 "reason": "revalidate",
+                **column_changes,
             }
-            if type_changes:
-                history_details["type_changes"] = type_changes
             if order_fixed:
                 history_details["order_fixed"] = order_fixed
-            if added_columns:
-                history_details["added_columns"] = added_columns
             await save_history(
                 event=History(
                     entity_type=EntityType.NODE,

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -4257,11 +4257,11 @@ async def revalidate_node(
     # A tier rather than a version, so propagation can hand the same value to
     # `bump_version` for downstream cubes.
     #
-    # Type changes and removals are major: both break anything referencing the
-    # column. An addition is minor -- nothing could already reference a column that
-    # did not exist. The asymmetry is deliberate: removals are rare and additions
-    # constant, so occasionally rebuilding a cube that never used a dropped column
-    # is cheaper than rebuilding every cube on every addition.
+    # Any column change is major. An addition looks harmless -- nothing could
+    # already reference a column that did not exist -- but the query produced it,
+    # and a query edit can move a filter or a join while leaving the rest of the
+    # projection identical. Demoting additions to MINOR buys nothing anyway: the
+    # cube rebuild below skips only NONE, so a minor bump rebuilds all the same.
     #
     # `order_fixed` earns no tier. DJ filling in a missing projection index is its
     # own bookkeeping, not a change to the node, so a revision would describe
@@ -4269,8 +4269,9 @@ async def revalidate_node(
     # to the current revision in place instead, below.
     change_tier = fold_change_tiers(
         [
-            ChangeTier.MAJOR if (type_changes or removed_columns) else ChangeTier.NONE,
-            ChangeTier.MINOR if added_columns else ChangeTier.NONE,
+            ChangeTier.MAJOR
+            if (type_changes or removed_columns or added_columns)
+            else ChangeTier.NONE,
         ],
     )
     updated_columns = change_tier is not ChangeTier.NONE

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -1531,9 +1531,8 @@ async def update_node_with_query(
         current_user=current_user,
         save_history=save_history,
         cache=cache,
-        # Downstream cubes inherit this node's tier: a cube's own shape can be
-        # identical across an upstream change that nonetheless changes every row it
-        # serves, so how significant the change was is only answerable here.
+        # Downstream cubes inherit this tier: a cube's own shape can be identical
+        # across an upstream change that alters every row it serves.
         change_tier=version_change_tier(old_revision.version, node.current_version),  # type: ignore
         query_service_client=query_service_client,
         request_headers=request_headers,
@@ -2272,11 +2271,9 @@ async def _rebuild_downstream_cube(
         filters=node_revision.cube_filters or [],
         custom_metadata=node_revision.custom_metadata,
     )
-    # Propagation runs after the response has returned, outside the request's
-    # AccessChecker, so the materialization rebuild gets a fresh one built from the
-    # updating user. It is not used to gate the bump: like the revalidation path
-    # above, propagation into a cube whose owner pointed it at this upstream is not
-    # the updater's call to make.
+    # Propagation runs after the response returned, outside the request's
+    # AccessChecker, so the rebuild gets a fresh one. It does not gate the bump:
+    # a cube whose owner pointed it at this upstream is not the updater's call.
     access_checker = AccessChecker(await AuthContext.from_user(session, current_user))
     await save_new_cube_revision(
         session,
@@ -2340,9 +2337,8 @@ async def _propagate_update_downstream(
         include_deactivated=False,
     )
     downstreams = topological_sort(downstreams)
-    # Names in topological order, kept separately because a rollback below expires
-    # every instance in the session and reading `.name` back off one would be a
-    # lazy load, which async SQLAlchemy cannot do.
+    # Kept separately because the rollback below expires every instance, and
+    # reading `.name` back off one would lazy-load from async code.
     downstream_names = [downstream.name for downstream in downstreams]
     _logger.info(
         "Node %s updated — revalidating %s downstreams",
@@ -2364,8 +2360,7 @@ async def _propagate_update_downstream(
             node.name,
         )
 
-        # Reset the upstreams DAG cache of any downstream nodes. Done before the
-        # per-type work so a cube -- which returns early below -- has its cache
+        # Before the per-type work, so a cube -- which returns early -- is
         # invalidated too.
         if cache:
             upstream_cache_key = downstream.upstream_cache_key()
@@ -2380,30 +2375,16 @@ async def _propagate_update_downstream(
                 cache.delete(upstream_cache_key)
 
         if downstream.type == NodeType.CUBE:
-            # Any tier at all rebuilds, and that churn is deliberate -- please do
-            # not "fix" it. Editing a transform's query is always a major bump
-            # (`create_new_revision_from_existing` asks only whether the query text
-            # differs), so every upstream query edit rebuilds every cube below it,
-            # including edits that turn out to have changed nothing that matters.
+            # Any tier rebuilds, and the churn is deliberate. Narrowing this by
+            # comparing the upstream's resolved columns was rejected: a query edit
+            # can move a filter, a join or a CASE threshold while leaving every
+            # column and type identical, and each changes every row the cube serves.
+            # Nothing short of reading the SQL tells those apart, so a changed query
+            # makes anything built from it suspect. Only NONE is skipped, the one
+            # case where DJ knows nothing material happened.
             #
-            # Narrowing this by comparing the upstream's resolved output columns was
-            # considered and rejected: a query edit can move a filter, a join or a
-            # CASE threshold while leaving the column set and every type identical,
-            # and each of those changes every row the cube serves. Nothing short of
-            # understanding the SQL separates a cosmetic edit from a material one,
-            # so "the query changed, therefore anything built from it is suspect" is
-            # the only rule that cannot be wrong. Rebuilding costs compute; the
-            # alternative is serving numbers computed from a definition that no
-            # longer exists, and not knowing it.
-            #
-            # NONE is the one tier that is skipped, because it is the one case where
-            # DJ knows nothing material happened -- see the column-order backfill in
-            # `revalidate_node`, which is the only thing that produces it.
-            #
-            # A cube bump can trigger a materialization rebuild, so one cube that
-            # cannot be rebuilt -- an unresolvable metric, a query service that
-            # rejects the new workflow -- must not cost the remaining downstreams
-            # their propagation.
+            # A rebuild can fail, and one cube's failure must not cost the remaining
+            # downstreams theirs.
             if change_tier is not ChangeTier.NONE:
                 try:
                     await _rebuild_downstream_cube(
@@ -2422,11 +2403,9 @@ async def _propagate_update_downstream(
                         downstream.name,
                         node.name,
                     )
-                    # Discard the failed rebuild's partial writes, then reload what
-                    # is left of the walk: a rollback expires every instance in the
-                    # session, and the loop would otherwise touch an expired
-                    # attribute on the next downstream and lazy-load from async
-                    # code. One query, and only on the failure path.
+                    # Discard partial writes, then reload the rest of the walk:
+                    # the rollback expires every instance, so the next iteration
+                    # would lazy-load from async code. Failure path only.
                     await session.rollback()
                     downstreams[idx + 1 :] = await _reload_nodes_in_order(
                         session,
@@ -4236,13 +4215,9 @@ async def revalidate_node(
     # version. Track *why* the validator decided a column changed so the
     # history event can explain the bump.
     #
-    # `describe_column_changes` is the shared comparison, so a bump is explained
-    # the same way however it was triggered -- and so removals are seen at all.
-    # Walking the validator's columns and looking each one up, which is what this
-    # did, can only ever find what the validator produced: a column the revision
-    # still stores but the query no longer selects was never visited, so it earned
-    # no bump and rode along on the next revision advertising a value the node
-    # cannot supply.
+    # Uses the shared comparison so removals are seen at all: walking the
+    # validator's columns can only find what the validator produced, so a column
+    # the revision still stores but the query no longer selects went unnoticed.
     column_changes = describe_column_changes(
         node.current.columns,  # type: ignore
         node_validator.columns,
@@ -4257,25 +4232,19 @@ async def revalidate_node(
         for col in node_validator.columns
         if col.name in existing_columns and existing_columns[col.name].order is None
     ]
-    # How significant the validator's findings are, as a tier rather than a version,
-    # so downstream propagation can hand the same value to `bump_version` for cubes.
+    # A tier rather than a version, so propagation can hand the same value to
+    # `bump_version` for downstream cubes.
     #
-    # A type change is major: anything selecting the column may now be reading a
-    # different type, and a cube materialized on it holds a table whose schema no
-    # longer matches. A removal is major for the same reason and more bluntly --
-    # anything that referenced the column is now broken. An added column is minor:
-    # nothing downstream can reference a column that did not exist when it was
-    # written, so an additive change breaks nobody, and treating it as major
-    # rebuilds every downstream cube for free. The asymmetry is deliberate --
-    # removals are rare and additions are constant, so occasionally rebuilding a
-    # cube that never used the dropped column is a cost worth paying.
+    # Type changes and removals are major: both break anything referencing the
+    # column. An addition is minor -- nothing could already reference a column that
+    # did not exist. The asymmetry is deliberate: removals are rare and additions
+    # constant, so occasionally rebuilding a cube that never used a dropped column
+    # is cheaper than rebuilding every cube on every addition.
     #
-    # `order_fixed` is deliberately not a tier at all. It fires when a stored column
-    # has no `order` and DJ fills in the projection index -- its own bookkeeping on
-    # a row written before the field existed. No query changed and no name, type or
-    # value moved, so there is nothing for a new revision to describe, and any tier
-    # above NONE would rebuild every downstream cube for a metadata backfill. It is
-    # applied to the current revision in place instead, below.
+    # `order_fixed` earns no tier. DJ filling in a missing projection index is its
+    # own bookkeeping, not a change to the node, so a revision would describe
+    # nothing and any tier above NONE would rebuild every cube below. It is applied
+    # to the current revision in place instead, below.
     change_tier = fold_change_tiers(
         [
             ChangeTier.MAJOR if (type_changes or removed_columns) else ChangeTier.NONE,
@@ -4391,15 +4360,9 @@ async def revalidate_node(
             )
     elif order_fixed:
         # No new revision was earned, so the backfill lands on the current one.
-        # Leaving it unset is not free: every reader sorts columns by `order` with
-        # None ordered last, so an unordered column drifts to the end of the
-        # projection and `Node.to_spec` logs the node as unordered on every read.
-        # Writing the projection index onto the stored row misrepresents nothing --
-        # the rows were inserted in projection order to begin with, so this records
-        # the position they already had.
-        #
-        # Only missing values are filled, matching what the new-revision path above
-        # does, so an order someone set deliberately is never overwritten.
+        # Leaving it unset is not free: readers sort by `order` with None last, so
+        # an unordered column drifts to the end of the projection. Only missing
+        # values are filled, so an order set deliberately is never overwritten.
         for idx, validator_col in enumerate(node_validator.columns):
             stored_col = existing_columns[validator_col.name]
             if stored_col.order is None:

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -100,6 +100,7 @@ from datajunction_server.models.deployment import (
     CubeSpec,
     DeploymentResult,
     bump_version,
+    fold_change_tiers,
     version_change_tier,
 )
 from datajunction_server.models.dimensionlink import (
@@ -4232,12 +4233,30 @@ async def revalidate_node(
             )
         if existing_col.order is None:
             order_fixed.append(col.name)
-    updated_columns = bool(type_changes or order_fixed or added_columns)
+    # How significant the validator's findings are, as a tier rather than a version,
+    # so downstream propagation can hand the same value to `bump_version` for cubes.
+    #
+    # A type change is major: anything selecting the column may now be reading a
+    # different type, and a cube materialized on it holds a table whose schema no
+    # longer matches. An added column is minor -- nothing downstream can reference a
+    # column that did not exist when it was written, so an additive change breaks
+    # nobody, and treating it as major rebuilds every downstream cube for free.
+    # `order_fixed` is DJ backfilling a missing `order` onto stored columns to match
+    # the query's projection; it changes no name, no type and no value, so it earns
+    # the same minor bump as an addition rather than a major one.
+    change_tier = fold_change_tiers(
+        [
+            ChangeTier.MAJOR if type_changes else ChangeTier.NONE,
+            ChangeTier.MINOR if (order_fixed or added_columns) else ChangeTier.NONE,
+        ],
+    )
+    updated_columns = change_tier is not ChangeTier.NONE
 
     _logger.info(
-        "Columns updated: %s for node %s (current version: %s) — "
+        "Columns updated: %s (tier %s) for node %s (current version: %s) — "
         "type_changes=%s, order_fixed=%s, added_columns=%s",
         updated_columns,
+        change_tier.name,
         node.name,
         node.current.version,
         type_changes,
@@ -4247,9 +4266,7 @@ async def revalidate_node(
     # Only create a new revision if the columns have been updated
     if updated_columns:  # type: ignore
         new_revision = copy_existing_node_revision(node.current, current_user)  # type: ignore
-        new_revision.version = str(
-            Version.parse(node.current.version).next_major_version(),  # type: ignore
-        )
+        new_revision.version = bump_version(node.current.version, change_tier)  # type: ignore
 
         new_revision.status = node_validator.status
         # Snapshot pending m2m state before compile — autoflush during

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -2058,6 +2058,7 @@ async def save_new_cube_revision(
     access_checker: AccessChecker,
     save_history: Callable,
     extra_history_details: dict | None = None,
+    previous_table_usable: bool | None = None,
 ) -> NodeRevision:
     """
     Commit `create_cube` as the cube's next revision, at the version `change_tier`
@@ -2066,12 +2067,21 @@ async def save_new_cube_revision(
     Everything a new cube revision needs beyond deciding *that* there should be one:
     resolving the cube against the current metrics and dimensions, the version bump,
     carrying partition columns forward, the audit event, and the materialization
-    swap. Both writers of a cube revision go through here -- a user editing the cube
-    (`update_cube_node`) and an upstream change propagating into it -- so the two
-    cannot produce differently-shaped revisions.
+    swap. Both writers that start from a cube's *own* definition go through here --
+    a user editing the cube (`update_cube_node`) and an upstream change propagating
+    into it -- so the two cannot produce differently-shaped revisions. Deploy builds
+    cube revisions on its own path and swaps them itself
+    (`orchestrator._swap_cube_materializations`).
 
     `extra_history_details` is merged into the UPDATE event's details, which is how
     the propagation path records the upstream node and version that caused the bump.
+
+    `previous_table_usable` is recorded on the swap's history event for an operator
+    deciding whether the rebuild can adopt the old table or needs a backfill. Left
+    unset it is derived from `is_non_trivial_cube_change`, which compares the cube's
+    own shape -- correct when the cube itself changed. An upstream change must pass
+    False: the shapes can be identical while every row differs, which is the same
+    reason propagation does not use that predicate to decide whether to rebuild.
     """
     old_metrics = [m.name for m in node_revision.cube_metrics()]
     old_dimensions = node_revision.cube_dimensions()
@@ -2141,10 +2151,14 @@ async def save_new_cube_revision(
         new_cube_revision,
         access_checker=access_checker,
         current_user=current_user,
-        previous_table_usable=not await is_non_trivial_cube_change(
-            session,
-            node_revision,
-            new_cube_revision,
+        previous_table_usable=(
+            previous_table_usable
+            if previous_table_usable is not None
+            else not await is_non_trivial_cube_change(
+                session,
+                node_revision,
+                new_cube_revision,
+            )
         ),
     )
     if swap:
@@ -2293,6 +2307,9 @@ async def _rebuild_downstream_cube(
             "reason": f"Caused by update of `{upstream.name}` to "
             f"{upstream.current_version}",
         },
+        # The cube's own shape can be identical across an upstream change that
+        # altered every row, so the old table cannot be assumed adoptable.
+        previous_table_usable=False,
     )
 
 
@@ -2406,6 +2423,11 @@ async def _propagate_update_downstream(
                     # Discard partial writes, then reload the rest of the walk:
                     # the rollback expires every instance, so the next iteration
                     # would lazy-load from async code. Failure path only.
+                    #
+                    # `node` and `current_user` survive it because they belong to
+                    # the request's session, not this one, so the rollback never
+                    # touches them and reading `.name` below needs no IO. Load
+                    # either one in this session and that stops being true.
                     await session.rollback()
                     downstreams[idx + 1 :] = await _reload_nodes_in_order(
                         session,

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -2380,6 +2380,26 @@ async def _propagate_update_downstream(
                 cache.delete(upstream_cache_key)
 
         if downstream.type == NodeType.CUBE:
+            # Any tier at all rebuilds, and that churn is deliberate -- please do
+            # not "fix" it. Editing a transform's query is always a major bump
+            # (`create_new_revision_from_existing` asks only whether the query text
+            # differs), so every upstream query edit rebuilds every cube below it,
+            # including edits that turn out to have changed nothing that matters.
+            #
+            # Narrowing this by comparing the upstream's resolved output columns was
+            # considered and rejected: a query edit can move a filter, a join or a
+            # CASE threshold while leaving the column set and every type identical,
+            # and each of those changes every row the cube serves. Nothing short of
+            # understanding the SQL separates a cosmetic edit from a material one,
+            # so "the query changed, therefore anything built from it is suspect" is
+            # the only rule that cannot be wrong. Rebuilding costs compute; the
+            # alternative is serving numbers computed from a definition that no
+            # longer exists, and not knowing it.
+            #
+            # NONE is the one tier that is skipped, because it is the one case where
+            # DJ knows nothing material happened -- see the column-order backfill in
+            # `revalidate_node`, which is the only thing that produces it.
+            #
             # A cube bump can trigger a materialization rebuild, so one cube that
             # cannot be rebuilt -- an unresolvable metric, a query service that
             # rejects the new workflow -- must not cost the remaining downstreams
@@ -4241,13 +4261,17 @@ async def revalidate_node(
     # longer matches. An added column is minor -- nothing downstream can reference a
     # column that did not exist when it was written, so an additive change breaks
     # nobody, and treating it as major rebuilds every downstream cube for free.
-    # `order_fixed` is DJ backfilling a missing `order` onto stored columns to match
-    # the query's projection; it changes no name, no type and no value, so it earns
-    # the same minor bump as an addition rather than a major one.
+    #
+    # `order_fixed` is deliberately not a tier at all. It fires when a stored column
+    # has no `order` and DJ fills in the projection index -- its own bookkeeping on
+    # a row written before the field existed. No query changed and no name, type or
+    # value moved, so there is nothing for a new revision to describe, and any tier
+    # above NONE would rebuild every downstream cube for a metadata backfill. It is
+    # applied to the current revision in place instead, below.
     change_tier = fold_change_tiers(
         [
             ChangeTier.MAJOR if type_changes else ChangeTier.NONE,
-            ChangeTier.MINOR if (order_fixed or added_columns) else ChangeTier.NONE,
+            ChangeTier.MINOR if added_columns else ChangeTier.NONE,
         ],
     )
     updated_columns = change_tier is not ChangeTier.NONE
@@ -4359,6 +4383,44 @@ async def revalidate_node(
                 ),
                 session=session,
             )
+    elif order_fixed:
+        # No new revision was earned, so the backfill lands on the current one.
+        # Leaving it unset is not free: every reader sorts columns by `order` with
+        # None ordered last, so an unordered column drifts to the end of the
+        # projection and `Node.to_spec` logs the node as unordered on every read.
+        # Writing the projection index onto the stored row misrepresents nothing --
+        # the rows were inserted in projection order to begin with, so this records
+        # the position they already had.
+        #
+        # Only missing values are filled, matching what the new-revision path above
+        # does, so an order someone set deliberately is never overwritten.
+        for idx, validator_col in enumerate(node_validator.columns):
+            stored_col = existing_columns[validator_col.name]
+            if stored_col.order is None:
+                stored_col.order = idx
+        session.add(node.current)  # type: ignore
+
+        # The audit trail records that DJ touched the row even though the node's
+        # definition did not change, so a column that changes position has an
+        # explanation. Not gated on ``record_revision_bump_event``: this is not a
+        # revision bump, and no caller writes a richer event in its place.
+        await save_history(
+            event=History(
+                entity_type=EntityType.NODE,
+                entity_name=node.name,  # type: ignore
+                node=node.name,  # type: ignore
+                activity_type=ActivityType.UPDATE,
+                details={
+                    # The version the node still has -- this event explains a
+                    # metadata fix, not a bump.
+                    "version": node.current.version,  # type: ignore
+                    "reason": "column order backfill",
+                    "order_fixed": order_fixed,
+                },
+                user=current_user.username,
+            ),
+            session=session,
+        )
     await session.commit()
     await session.refresh(node.current)  # type: ignore
     await session.refresh(node, ["current"])

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -90,6 +90,26 @@ def bump_version(version: str, tier: ChangeTier) -> str:
     return str(parsed)
 
 
+def version_change_tier(old_version: str, new_version: str) -> ChangeTier:
+    """
+    The tier that turned `old_version` into `new_version` -- `bump_version` read
+    backwards.
+
+    Callers that only see the two version strings, notably downstream propagation
+    (which runs after the upstream revision has already been committed and so never
+    sees the classifier's answer), recover the tier here rather than plumbing it
+    through every update path. A major bump reads as MAJOR even when the minor part
+    also moved, since a major bump resets the minor to zero.
+    """
+    old = Version.parse(old_version)
+    new = Version.parse(new_version)
+    if new.major != old.major:
+        return ChangeTier.MAJOR
+    if new.minor != old.minor:
+        return ChangeTier.MINOR
+    return ChangeTier.NONE
+
+
 class DeploymentStatus(str, Enum):
     PENDING = "pending"
     RUNNING = "running"

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -2764,6 +2764,79 @@ class TestDeployments:
         )
 
     @pytest.mark.asyncio
+    async def test_deployment_bumps_a_cube_over_a_changed_source(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        A cube bumps for a change anywhere above it, not just in its own parents.
+
+        Here the edited node is the source two levels down: neither the metric nor
+        the dimension the cube names changes, so nothing the cube points at directly
+        moved, and only walking the whole way up finds the edit. The cube lands on
+        the tier the source earned rather than one of its own.
+        """
+        cube = CubeSpec(
+            name="default.repairs_cube",
+            display_name="Repairs Cube",
+            description="Cube for analyzing repair orders",
+            dimensions=["${prefix}default.hard_hat.state"],
+            metrics=["${prefix}default.avg_length_of_employment"],
+            owners=["dj"],
+        )
+
+        async def deploy(source: SourceSpec) -> None:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace="upstream_source_deploy",
+                    nodes=[
+                        spec.model_copy(deep=True)
+                        for spec in (
+                            source,
+                            default_hard_hat,
+                            default_us_states,
+                            default_us_state,
+                            default_avg_length_of_employment,
+                            cube,
+                        )
+                    ],
+                ),
+            )
+            assert data["status"] == "success", data
+
+        async def version_of(node: str) -> str:
+            response = await client.get(
+                f"/nodes/upstream_source_deploy.default.{node}/",
+            )
+            assert response.status_code == 200, response.text
+            return response.json()["version"]
+
+        await deploy(default_hard_hats)
+        assert await version_of("repairs_cube") == "v1.0"
+
+        widened = default_hard_hats.model_copy(
+            deep=True,
+            update={
+                "columns": default_hard_hats.columns
+                + [ColumnSpec(name="badge_number", type="int")],
+            },
+        )
+        await deploy(widened)
+
+        assert await version_of("hard_hats") == "v2.0"
+        # Untouched, so they keep the revisions they had.
+        assert await version_of("hard_hat") == "v1.0"
+        assert await version_of("avg_length_of_employment") == "v1.0"
+        # The cube alone follows the source, at the tier the source earned.
+        assert await version_of("repairs_cube") == "v2.0"
+
+    @pytest.mark.asyncio
     async def test_patch_and_deployment_agree_on_version(
         self,
         client,

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -2665,6 +2665,105 @@ class TestDeployments:
         ]
 
     @pytest.mark.asyncio
+    async def test_patch_and_deployment_agree_on_an_upstream_change(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        A change to a node the cube sits on must bump the cube the same on both paths.
+
+        The sibling of `test_patch_and_deployment_agree_on_version`, which only covers
+        edits to the cube itself. Here the cube's own spec is byte-identical across the
+        two deploys -- it still names the same metric and dimensions -- and only the
+        metric underneath it changes. That is the case a deploy currently cannot see:
+        an unchanged spec is skipped, so the cube keeps a revision compiled against the
+        old definition, while the PATCH path propagates into it.
+        """
+        upstreams = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+        ]
+
+        def build_metric(query: str) -> MetricSpec:
+            return default_avg_length_of_employment.model_copy(
+                deep=True,
+                update={"query": query},
+            )
+
+        original = default_avg_length_of_employment.query
+        # Same shape, different rows: the cube's elements are untouched, so nothing
+        # about the cube's own spec records that this happened.
+        edited = (
+            "SELECT avg(IF(state = 'AZ', CAST(NOW() AS DATE) - hire_date, NULL)) "
+            "FROM ${prefix}default.hard_hat"
+        )
+
+        cube = CubeSpec(
+            name="default.repairs_cube",
+            display_name="Repairs Cube",
+            description="Cube for analyzing repair orders",
+            dimensions=["${prefix}default.hard_hat.state"],
+            metrics=["${prefix}default.avg_length_of_employment"],
+            owners=["dj"],
+        )
+
+        async def deploy(namespace: str, metric_query: str) -> None:
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(
+                    namespace=namespace,
+                    nodes=(
+                        [spec.model_copy(deep=True) for spec in upstreams]
+                        + [build_metric(metric_query), cube.model_copy(deep=True)]
+                    ),
+                ),
+            )
+            assert data["status"] == "success", data
+
+        async def version_of(namespace: str, node: str) -> str:
+            response = await client.get(f"/nodes/{namespace}.default.{node}/")
+            assert response.status_code == 200, response.text
+            return response.json()["version"]
+
+        patch_ns, deploy_ns = (
+            "upstream_equivalence_patch",
+            "upstream_equivalence_deploy",
+        )
+        await deploy(patch_ns, original)
+        await deploy(deploy_ns, original)
+        assert await version_of(patch_ns, "repairs_cube") == "v1.0"
+        assert await version_of(deploy_ns, "repairs_cube") == "v1.0"
+
+        # The same upstream edit, once through PATCH and once through a deployment.
+        response = await client.patch(
+            f"/nodes/{patch_ns}.default.avg_length_of_employment",
+            json={"query": edited.replace("${prefix}", f"{patch_ns}.")},
+        )
+        assert response.status_code == 200, response.json()
+        await deploy(deploy_ns, edited)
+
+        # The metric moved on both paths -- that part already agreed.
+        assert await version_of(
+            patch_ns,
+            "avg_length_of_employment",
+        ) == await version_of(
+            deploy_ns,
+            "avg_length_of_employment",
+        )
+        # And so must the cube above it.
+        assert await version_of(patch_ns, "repairs_cube") == await version_of(
+            deploy_ns,
+            "repairs_cube",
+        )
+
+    @pytest.mark.asyncio
     async def test_patch_and_deployment_agree_on_version(
         self,
         client,

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -6418,15 +6418,15 @@ class TestValidateNodes:
                 """,
             ),
         )
-        # Also clear the order so revalidate detects a change and creates a
-        # new revision (matching the existing test_revalidate_sets_column_order
-        # trigger).
+        # Also move a stored column's type away from what the query produces, so
+        # revalidate detects a real change and forks a new revision. (A cleared
+        # column order would not: that is backfilled in place without a bump.)
         await session.execute(
             text(
                 """
                 UPDATE "column"
-                SET "order" = NULL
-                WHERE node_revision_id IN (
+                SET type = 'string'
+                WHERE name = 'dispatcher_id' AND node_revision_id IN (
                     SELECT id FROM noderevision WHERE name = 'default.test_meta_preserved'
                 )
                 """,
@@ -6548,13 +6548,14 @@ class TestValidateNodes:
         }, f"Deploy did not land descriptions: {post_deploy_descriptions}"
 
         # Force revalidate_node to detect a column change so it creates a new
-        # revision (same trigger as test_revalidate_sets_column_order_when_missing).
+        # revision. A stored type that disagrees with the query is a major change;
+        # a cleared column order is not, since that is backfilled in place.
         await session.execute(
             text(
                 """
                 UPDATE "column"
-                SET "order" = NULL
-                WHERE node_revision_id IN (
+                SET type = 'string'
+                WHERE name = 'dispatcher_id' AND node_revision_id IN (
                     SELECT id FROM noderevision WHERE name = 'meta_preserve_test.test_deploy_meta'
                 )
                 """,
@@ -6587,10 +6588,15 @@ class TestValidateNodes:
         client_with_roads: AsyncClient,
         session: AsyncSession,
     ):
-        """revalidate_node must record a history event when it creates a new
-        revision. Without it, /history?node=<name> only shows deploy-driven
-        updates and silently masks revalidate-driven version bumps (UI
-        validate, downstream propagation, manual /validate calls).
+        """revalidate_node must record a history event when it changes a node's
+        stored columns. Without it, /history?node=<name> only shows deploy-driven
+        updates and silently masks what revalidation did (UI validate, downstream
+        propagation, manual /validate calls).
+
+        The column-order backfill exercised here no longer bumps the version --
+        filling in DJ's own bookkeeping is not a change to the node -- but it does
+        still rewrite the stored row, so the audit trail must still explain it.
+        Losing the bump must not mean losing the record.
         """
         response = await client_with_roads.post(
             "/nodes/transform/",
@@ -6603,8 +6609,7 @@ class TestValidateNodes:
         )
         assert response.status_code == 201
 
-        # Force revalidate_node to create a new revision (same trigger as the
-        # column-order-cleared tests above).
+        # Clear the stored order so revalidate_node has a backfill to do.
         await session.execute(
             text(
                 """
@@ -6637,31 +6642,30 @@ class TestValidateNodes:
             )
         ).json()
 
-        # An additional history event was emitted by revalidate_node
-        # specifically (reason: revalidate) when it bumped the revision.
+        # An additional history event was emitted by revalidate_node, naming the
+        # columns whose missing order it backfilled and the version it left the
+        # node on. Without this the audit trail says nothing at all: no version
+        # changed, so nothing else records that the row was rewritten.
         revalidate_events = [
-            e
+            e["details"]
             for e in history_after
             if e.get("activity_type") == "update"
-            and (e.get("details") or {}).get("reason") == "revalidate"
+            and (e.get("details") or {}).get("reason") == "column order backfill"
         ]
-        assert len(revalidate_events) >= 1, (
-            f"Expected a revalidate-reason history event after revision bump; "
-            f"got events: {history_after}"
-        )
-        # The event details explain WHY the validator bumped the revision —
-        # in this case, by recording which columns had their missing order
-        # backfilled. Without this the audit trail says "revalidate happened"
-        # but not "this is what it changed".
-        details = revalidate_events[0]["details"]
-        assert details.get("order_fixed"), (
-            f"Expected order_fixed in revalidate event details; got {details}"
-        )
-        assert set(details["order_fixed"]) == {"repair_order_id"}, (
-            f"Expected order_fixed to list the column whose order was cleared; "
-            f"got {details}"
-        )
+        assert revalidate_events == [
+            {
+                "version": "v1.0",
+                "reason": "column order backfill",
+                "order_fixed": ["repair_order_id"],
+            },
+        ], f"Expected one backfill event; got events: {history_after}"
         assert len(history_after) > len(history_before)
+
+        # And the node itself did not turn over.
+        node_after = (
+            await client_with_roads.get("/nodes/default.test_revalidate_history")
+        ).json()
+        assert node_after["version"] == "v1.0"
 
     @pytest.mark.asyncio
     async def test_revalidate_via_propagation_writes_one_history_event(
@@ -6696,12 +6700,15 @@ class TestValidateNodes:
         )
         assert response.status_code == 201
 
-        # Force the revalidate code path to create a new revision.
+        # Force the revalidate code path to create a new revision. It has to be a
+        # real change -- a stored type the query disagrees with -- because the
+        # cheaper triggers no longer fork a revision, and a test that suppresses an
+        # event which was never going to be written proves nothing.
         await session.execute(
             text(
                 """
                 UPDATE "column"
-                SET "order" = NULL
+                SET type = 'string'
                 WHERE node_revision_id IN (
                     SELECT id FROM noderevision WHERE name = 'default.test_one_event_only'
                 )

--- a/datajunction-server/tests/internal/nodes/propagate_to_cubes_test.py
+++ b/datajunction-server/tests/internal/nodes/propagate_to_cubes_test.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import datajunction_server.internal.nodes as nodes_module
@@ -286,6 +286,53 @@ async def test_no_tier_change_leaves_cube_alone(
     )
 
     assert await _version(client, CUBE) == "v1.0"
+
+
+@pytest.mark.asyncio
+async def test_column_order_backfill_upstream_does_not_rebuild_the_cube(
+    client_with_cube_downstream: AsyncClient,
+    session: AsyncSession,
+):
+    """
+    The one upstream change that moves nothing at all.
+
+    A stored column with no `order` is DJ's own bookkeeping. Revalidating the
+    upstream fills it in against the current revision, so the upstream does not turn
+    over -- and a node that does not turn over has nothing to propagate, which is
+    what leaves the cube alone. Before the backfill was reclassified this earned the
+    upstream a major bump, and every consumer of a bump would have followed.
+
+    Pinned on the whole downstream chain rather than the cube alone, since the
+    guarantee is "no revision, so nothing moved", not something specific to cubes.
+    """
+    client = client_with_cube_downstream
+    await session.execute(
+        text(
+            """
+            UPDATE "column" SET "order" = NULL
+            WHERE node_revision_id IN (
+                SELECT id FROM noderevision WHERE name = :name
+            )
+            """,
+        ),
+        {"name": FACT},
+    )
+    await session.commit()
+    session.expire_all()
+
+    response = await client.post(f"/nodes/{FACT}/validate/")
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "valid"
+
+    assert [
+        (name, await _version(client, name))
+        for name in (FACT, "default.total_price", CUBE, UNRELATED_CUBE)
+    ] == [
+        (FACT, "v2.0"),
+        ("default.total_price", "v1.0"),
+        (CUBE, "v1.0"),
+        (UNRELATED_CUBE, "v1.0"),
+    ]
 
 
 def test_version_change_tier():

--- a/datajunction-server/tests/internal/nodes/propagate_to_cubes_test.py
+++ b/datajunction-server/tests/internal/nodes/propagate_to_cubes_test.py
@@ -64,6 +64,14 @@ async def _columns(client: AsyncClient, name: str) -> list[tuple[str, str]]:
     return [(col["name"], col["type"]) for col in response.json()["columns"]]
 
 
+async def _state(client: AsyncClient, name: str) -> tuple[str, str]:
+    """The node's version and status, which move together on a breaking change."""
+    response = await client.get(f"/nodes/{name}")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    return body["version"], body["status"]
+
+
 @pytest_asyncio.fixture
 async def client_with_cube_downstream(client_with_roads: AsyncClient) -> AsyncClient:
     """
@@ -341,3 +349,35 @@ def test_version_change_tier():
     assert version_change_tier("v1.3", "v2.0") == ChangeTier.MAJOR
     assert version_change_tier("v1.0", "v1.1") == ChangeTier.MINOR
     assert version_change_tier("v1.0", "v1.0") == ChangeTier.NONE
+
+
+@pytest.mark.asyncio
+async def test_a_removed_column_a_metric_uses_invalidates_it_and_the_cube(
+    client_with_cube_downstream: AsyncClient,
+):
+    """
+    Dropping a column the metric aggregates carries all the way to the cube.
+
+    The transform stays valid -- its own query is fine -- while the metric can no
+    longer infer a type for `sum(price)` and the cube built on that metric follows
+    it down. Each bumps, so nothing is left quietly serving a definition that no
+    longer resolves. Pinned because the failure is only visible downstream: the
+    edit that causes it looks entirely successful at the node being edited.
+    """
+    client = client_with_cube_downstream
+    response = await client.patch(
+        f"/nodes/{FACT}",
+        json={
+            "query": (
+                "SELECT repair_orders.repair_order_id, repair_orders.hard_hat_id "
+                "FROM default.repair_orders repair_orders"
+            ),
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    assert await _state(client, FACT) == ("v3.0", "valid")
+    assert await _state(client, "default.total_price") == ("v2.0", "invalid")
+    assert await _state(client, CUBE) == ("v2.0", "invalid")
+    # The cube that shares only a dimension with the edited transform is untouched.
+    assert await _state(client, UNRELATED_CUBE) == ("v1.0", "valid")

--- a/datajunction-server/tests/internal/nodes/propagate_to_cubes_test.py
+++ b/datajunction-server/tests/internal/nodes/propagate_to_cubes_test.py
@@ -1,0 +1,296 @@
+"""
+Propagation of an upstream change into downstream cubes.
+
+A cube used to be excluded from downstream propagation entirely, so an upstream
+edit left it serving a materialized table built against a definition that no
+longer existed. The only way to recompile it was a no-op edit to the cube itself.
+These tests pin that an upstream change now bumps the cube, at the upstream's own
+tier, whether or not the cube's shape moved.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import datajunction_server.internal.nodes as nodes_module
+from datajunction_server.database.node import Node
+from datajunction_server.database.user import User
+from datajunction_server.internal.nodes import _propagate_update_downstream
+from datajunction_server.models.deployment import ChangeTier, version_change_tier
+
+# The upstream transform, reduced to the three columns these tests care about so a
+# change to it is easy to read. `price` and `where` are the two things they vary:
+# `price` moves a column type the cube can see, `where` moves only which rows the
+# cube counts.
+FACT_QUERY = """SELECT
+  repair_orders.repair_order_id,
+  repair_orders.hard_hat_id,
+  {price} AS price
+FROM
+  default.repair_orders repair_orders
+JOIN
+  default.repair_order_details repair_order_details
+ON repair_orders.repair_order_id = repair_order_details.repair_order_id
+{where}"""
+
+FACT = "default.repair_orders_fact"
+CUBE = "default.repairs_by_state"
+UNRELATED_CUBE = "default.employment_by_state"
+
+
+async def _patch_fact(client: AsyncClient, price: str, where: str = "") -> str:
+    """Rewrite the upstream transform's query and return its new version."""
+    response = await client.patch(
+        f"/nodes/{FACT}",
+        json={"query": FACT_QUERY.format(price=price, where=where)},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["version"]
+
+
+async def _version(client: AsyncClient, name: str) -> str:
+    response = await client.get(f"/nodes/{name}")
+    assert response.status_code == 200, response.text
+    return response.json()["version"]
+
+
+async def _columns(client: AsyncClient, name: str) -> list[tuple[str, str]]:
+    response = await client.get(f"/nodes/{name}")
+    assert response.status_code == 200, response.text
+    return [(col["name"], col["type"]) for col in response.json()["columns"]]
+
+
+@pytest_asyncio.fixture
+async def client_with_cube_downstream(client_with_roads: AsyncClient) -> AsyncClient:
+    """
+    Roads, narrowed to a transform -> metric -> cube chain the tests can move.
+
+    A second cube sits on a metric and a dimension that are not downstream of the
+    transform at all, so "everything bumped" and "the right thing bumped" are
+    distinguishable.
+    """
+    await _patch_fact(client_with_roads, price="repair_order_details.price")
+    response = await client_with_roads.post(
+        "/nodes/metric/",
+        json={
+            "name": "default.total_price",
+            "description": "Total price",
+            "mode": "published",
+            "query": f"SELECT sum(price) FROM {FACT}",
+        },
+    )
+    assert response.status_code == 201, response.text
+    response = await client_with_roads.post(
+        "/nodes/cube/",
+        json={
+            "name": CUBE,
+            "metrics": ["default.total_price"],
+            "dimensions": ["default.hard_hat.state"],
+            "description": "Repairs by state",
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.text
+    response = await client_with_roads.post(
+        "/nodes/cube/",
+        json={
+            "name": UNRELATED_CUBE,
+            "metrics": ["default.avg_length_of_employment"],
+            "dimensions": ["default.hard_hat.state"],
+            "description": "Employment by state",
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.text
+    return client_with_roads
+
+
+@pytest.mark.asyncio
+async def test_upstream_column_change_bumps_and_recompiles_cube(
+    client_with_cube_downstream: AsyncClient,
+):
+    """
+    The reported bug: an upstream change that materially changes the cube left the
+    cube's version alone, so it kept serving a table built against the old upstream.
+    """
+    client = client_with_cube_downstream
+    assert await _version(client, CUBE) == "v1.0"
+    assert await _columns(client, CUBE) == [
+        ("default.total_price", "double"),
+        ("default.hard_hat.state", "string"),
+    ]
+
+    assert (
+        await _patch_fact(client, price="CAST(repair_order_details.price AS int)")
+        == "v3.0"
+    )
+
+    assert await _version(client, CUBE) == "v2.0"
+    # The cube's columns were re-resolved against the new upstream revision, not
+    # copied forward: sum(int) is a bigint where sum(double) was a double.
+    assert await _columns(client, CUBE) == [
+        ("default.total_price", "bigint"),
+        ("default.hard_hat.state", "string"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_upstream_filter_change_bumps_cube_with_unchanged_shape(
+    client_with_cube_downstream: AsyncClient,
+):
+    """
+    An upstream filter change moves no metric, no dimension, no column type and no
+    metric component identity -- `is_non_trivial_cube_change` returns False for it --
+    yet every row in the cube's materialized table was computed under the old
+    filter. The bump must not be gated on the cube's own shape.
+    """
+    client = client_with_cube_downstream
+    columns_before = await _columns(client, CUBE)
+
+    assert (
+        await _patch_fact(
+            client,
+            price="repair_order_details.price",
+            where="WHERE repair_order_details.discount > 0.0",
+        )
+        == "v3.0"
+    )
+
+    assert await _version(client, CUBE) == "v2.0"
+    assert await _columns(client, CUBE) == columns_before
+    assert columns_before == [
+        ("default.total_price", "double"),
+        ("default.hard_hat.state", "string"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_upstream_minor_change_bumps_cube_minor(
+    client_with_cube_downstream: AsyncClient,
+):
+    """A cube inherits the upstream's tier, so a minor upstream edit is minor here."""
+    client = client_with_cube_downstream
+
+    response = await client.patch(
+        f"/nodes/{FACT}",
+        json={"description": "Fact transform, redescribed"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["version"] == "v2.1"
+
+    assert await _version(client, CUBE) == "v1.1"
+
+
+@pytest.mark.asyncio
+async def test_cube_not_downstream_is_untouched(
+    client_with_cube_downstream: AsyncClient,
+):
+    """Propagation reaches the cubes below the changed node and no others."""
+    client = client_with_cube_downstream
+
+    await _patch_fact(client, price="CAST(repair_order_details.price AS int)")
+
+    assert await _version(client, CUBE) == "v2.0"
+    assert await _version(client, UNRELATED_CUBE) == "v1.0"
+
+
+@pytest.mark.asyncio
+async def test_cube_failure_does_not_abort_remaining_downstreams(
+    client_with_roads: AsyncClient,
+):
+    """
+    Bumping a cube can trigger a materialization rebuild, so one cube that cannot be
+    rebuilt must not cost the remaining downstreams their propagation.
+    """
+    await _patch_fact(client_with_roads, price="repair_order_details.price")
+    response = await client_with_roads.post(
+        "/nodes/metric/",
+        json={
+            "name": "default.total_price",
+            "description": "Total price",
+            "mode": "published",
+            "query": f"SELECT sum(price) FROM {FACT}",
+        },
+    )
+    assert response.status_code == 201, response.text
+    for name in ("default.cube_one", "default.cube_two"):
+        response = await client_with_roads.post(
+            "/nodes/cube/",
+            json={
+                "name": name,
+                "metrics": ["default.total_price"],
+                "dimensions": ["default.hard_hat.state"],
+                "description": "A cube",
+                "mode": "published",
+            },
+        )
+        assert response.status_code == 201, response.text
+
+    real_save = nodes_module.save_new_cube_revision
+    calls: list[str] = []
+
+    async def fail_first(session, node_revision, *args, **kwargs):
+        calls.append(node_revision.name)
+        if len(calls) == 1:
+            raise RuntimeError("cannot rebuild this cube")
+        return await real_save(session, node_revision, *args, **kwargs)
+
+    with patch.object(nodes_module, "save_new_cube_revision", fail_first):
+        await _patch_fact(
+            client_with_roads,
+            price="CAST(repair_order_details.price AS int)",
+        )
+
+    assert len(calls) == 2
+    versions = sorted(
+        [
+            await _version(client_with_roads, "default.cube_one"),
+            await _version(client_with_roads, "default.cube_two"),
+        ],
+    )
+    # The cube whose rebuild raised keeps its version; the one after it in the
+    # propagation order is still bumped.
+    assert versions == ["v1.0", "v2.0"]
+
+
+@pytest.mark.asyncio
+async def test_no_tier_change_leaves_cube_alone(
+    client_with_cube_downstream: AsyncClient,
+    session: AsyncSession,
+):
+    """
+    A propagation carrying no tier invents no cube revision. `bump_version` would
+    hand back the version the cube already has, and a second revision at the same
+    version is not a thing a cube can have.
+    """
+    client = client_with_cube_downstream
+    user = (
+        await session.execute(select(User).where(User.username == "dj"))
+    ).scalar_one()
+    fact = await Node.get_by_name(session, FACT, raise_if_not_exists=True)
+    assert fact is not None
+
+    async def discard_history(event, session):  # noqa: ARG001
+        return None
+
+    await _propagate_update_downstream(
+        session=session,
+        node=fact,
+        current_user=user,
+        save_history=discard_history,
+        change_tier=ChangeTier.NONE,
+    )
+
+    assert await _version(client, CUBE) == "v1.0"
+
+
+def test_version_change_tier():
+    """`bump_version` read backwards, including the no-change case."""
+    assert version_change_tier("v1.0", "v2.0") == ChangeTier.MAJOR
+    assert version_change_tier("v1.3", "v2.0") == ChangeTier.MAJOR
+    assert version_change_tier("v1.0", "v1.1") == ChangeTier.MINOR
+    assert version_change_tier("v1.0", "v1.0") == ChangeTier.NONE

--- a/datajunction-server/tests/internal/nodes/propagate_to_cubes_test.py
+++ b/datajunction-server/tests/internal/nodes/propagate_to_cubes_test.py
@@ -266,6 +266,69 @@ async def test_cube_failure_does_not_abort_remaining_downstreams(
 
 
 @pytest.mark.asyncio
+async def test_a_cube_failing_after_one_succeeded_keeps_the_success(
+    client_with_roads: AsyncClient,
+):
+    """
+    The rollback that recovers from a failed rebuild must not undo an earlier one.
+
+    Failing the *first* cube says nothing about this: there is no committed work for
+    the rollback to reach. `save_new_cube_revision` commits per cube, so the bump
+    before the failure is already durable -- this pins that, because the recovery
+    path rolls the session back and a single transaction spanning the walk would
+    silently lose the earlier cube's revision.
+    """
+    await _patch_fact(client_with_roads, price="repair_order_details.price")
+    response = await client_with_roads.post(
+        "/nodes/metric/",
+        json={
+            "name": "default.total_price",
+            "description": "Total price",
+            "mode": "published",
+            "query": f"SELECT sum(price) FROM {FACT}",
+        },
+    )
+    assert response.status_code == 201, response.text
+    for name in ("default.cube_one", "default.cube_two"):
+        response = await client_with_roads.post(
+            "/nodes/cube/",
+            json={
+                "name": name,
+                "metrics": ["default.total_price"],
+                "dimensions": ["default.hard_hat.state"],
+                "description": "A cube",
+                "mode": "published",
+            },
+        )
+        assert response.status_code == 201, response.text
+
+    real_save = nodes_module.save_new_cube_revision
+    calls: list[str] = []
+
+    async def fail_second(session, node_revision, *args, **kwargs):
+        calls.append(node_revision.name)
+        if len(calls) == 2:
+            raise RuntimeError("cannot rebuild this cube")
+        return await real_save(session, node_revision, *args, **kwargs)
+
+    with patch.object(nodes_module, "save_new_cube_revision", fail_second):
+        await _patch_fact(
+            client_with_roads,
+            price="CAST(repair_order_details.price AS int)",
+        )
+
+    assert len(calls) == 2
+    versions = sorted(
+        [
+            await _version(client_with_roads, "default.cube_one"),
+            await _version(client_with_roads, "default.cube_two"),
+        ],
+    )
+    # The first cube's bump survived the rollback that the second one triggered.
+    assert versions == ["v1.0", "v2.0"]
+
+
+@pytest.mark.asyncio
 async def test_no_tier_change_leaves_cube_alone(
     client_with_cube_downstream: AsyncClient,
     session: AsyncSession,

--- a/datajunction-server/tests/internal/nodes/revalidate_column_tier_test.py
+++ b/datajunction-server/tests/internal/nodes/revalidate_column_tier_test.py
@@ -8,6 +8,9 @@ major bump rebuilds a cube's materialized table. A type change stays major:
 everything reading the column is reading a different type than it was written
 against.
 
+A missing column `order` is not a change at all: it is DJ's own bookkeeping,
+backfilled in place with no new revision.
+
 The column differences are induced by editing the stored columns directly, the
 same trick the existing revalidate tests use, because they are differences
 between what is *stored* on the revision and what the validator recomputes --
@@ -53,12 +56,62 @@ async def _node(client: AsyncClient) -> tuple[str, list[tuple[str, str]]]:
     )
 
 
-async def _edit_stored_columns(session: AsyncSession, statement: str) -> None:
+async def _stored_order(session: AsyncSession) -> list[tuple[str, int | None]]:
+    """(name, order) for the current revision's stored columns, by name."""
+    session.expire_all()
+    rows = await session.execute(
+        text(
+            """
+            SELECT c.name, c."order"
+            FROM "column" c
+            JOIN noderevision nr ON nr.id = c.node_revision_id
+            JOIN node n ON n.id = nr.node_id AND n.current_version = nr.version
+            WHERE nr.name = :name
+            ORDER BY c.name
+            """,
+        ),
+        {"name": NODE},
+    )
+    return [(name, order) for name, order in rows.all()]
+
+
+async def _revalidate_events(client: AsyncClient) -> list[dict]:
+    response = await client.get(f"/history?node={NODE}")
+    assert response.status_code == 200, response.text
+    return [
+        entry["details"]
+        for entry in response.json()
+        if entry["activity_type"] == "update"
+    ]
+
+
+async def _edit_stored_columns(
+    session: AsyncSession,
+    statement: str,
+    column: str = "price",
+) -> None:
     await session.execute(
         text(
             f"""
             {statement}
-            WHERE name = 'price' AND node_revision_id IN (
+            WHERE name = :column AND node_revision_id IN (
+                SELECT id FROM noderevision WHERE name = :name
+            )
+            """,
+        ),
+        {"name": NODE, "column": column},
+    )
+    await session.commit()
+    session.expire_all()
+
+
+async def _clear_all_orders(session: AsyncSession) -> None:
+    """What a revision written before the `order` field existed looks like."""
+    await session.execute(
+        text(
+            """
+            UPDATE "column" SET "order" = NULL
+            WHERE node_revision_id IN (
                 SELECT id FROM noderevision WHERE name = :name
             )
             """,
@@ -98,17 +151,65 @@ async def test_column_type_change_is_a_major_bump(
 
 
 @pytest.mark.asyncio
-async def test_backfilled_column_order_is_a_minor_bump(
+async def test_backfilled_column_order_creates_no_revision(
     client_with_roads: AsyncClient,
     session: AsyncSession,
 ):
     """
-    A missing `order` is DJ filling in metadata it should already have stored. It
-    changes no name, no type and no value, so it sits with the additive cases.
+    A missing `order` is DJ filling in metadata it should already have stored. No
+    query changed and no name, type or value moved, so there is no new revision --
+    and so nothing downstream is rebuilt for it. The value is written to the
+    current revision in place.
     """
     await _create_node(client_with_roads)
-    await _edit_stored_columns(session, 'UPDATE "column" SET "order" = NULL')
+    await _clear_all_orders(session)
+    assert await _stored_order(session) == [("price", None), ("repair_order_id", None)]
 
     await _revalidate(client_with_roads)
 
-    assert await _node(client_with_roads) == ("v1.1", COLUMNS)
+    assert await _node(client_with_roads) == ("v1.0", COLUMNS)
+    assert await _stored_order(session) == [("price", 1), ("repair_order_id", 0)]
+
+
+@pytest.mark.asyncio
+async def test_backfilled_column_order_still_writes_a_history_event(
+    client_with_roads: AsyncClient,
+    session: AsyncSession,
+):
+    """
+    Losing the version bump must not mean losing the record that DJ touched the
+    row: a column that changes position needs an explanation somewhere.
+    """
+    await _create_node(client_with_roads)
+    await _clear_all_orders(session)
+
+    await _revalidate(client_with_roads)
+
+    assert await _revalidate_events(client_with_roads) == [
+        {
+            "version": "v1.0",
+            "reason": "column order backfill",
+            "order_fixed": ["repair_order_id", "price"],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_backfill_leaves_orders_that_are_already_set(
+    client_with_roads: AsyncClient,
+    session: AsyncSession,
+):
+    """
+    Only the missing values are filled. A partially-ordered revision is the case
+    where the backfill genuinely moves a column: `price` with no order sorts behind
+    every ordered column, and filling it in puts it back at the position the query
+    always projected it in.
+    """
+    await _create_node(client_with_roads)
+    await _edit_stored_columns(session, 'UPDATE "column" SET "order" = NULL')
+    assert await _stored_order(session) == [("price", None), ("repair_order_id", 0)]
+
+    await _revalidate(client_with_roads)
+
+    assert await _node(client_with_roads) == ("v1.0", COLUMNS)
+    assert await _stored_order(session) == [("price", 1), ("repair_order_id", 0)]

--- a/datajunction-server/tests/internal/nodes/revalidate_column_tier_test.py
+++ b/datajunction-server/tests/internal/nodes/revalidate_column_tier_test.py
@@ -6,7 +6,7 @@ cases -- nothing written before a column existed can be referencing it -- and it
 matters more now that downstream cubes inherit their upstream's tier, since a
 major bump rebuilds a cube's materialized table. A type change stays major:
 everything reading the column is reading a different type than it was written
-against.
+against, and so is a removal, which breaks anything that referenced it.
 
 A missing column `order` is not a change at all: it is DJ's own bookkeeping,
 backfilled in place with no new revision.
@@ -144,6 +144,40 @@ async def test_column_type_change_is_a_major_bump(
     """A column whose type moved breaks everything reading it, so it earns v2.0."""
     await _create_node(client_with_roads)
     await _edit_stored_columns(session, "UPDATE \"column\" SET type = 'int'")
+
+    await _revalidate(client_with_roads)
+
+    assert await _node(client_with_roads) == ("v2.0", COLUMNS)
+
+
+@pytest.mark.asyncio
+async def test_removed_column_is_a_major_bump(
+    client_with_roads: AsyncClient,
+    session: AsyncSession,
+):
+    """
+    A column the query no longer produces is breaking for anything that referenced
+    it, and must not survive onto the new revision advertising a value the node
+    cannot supply.
+    """
+    await _create_node(client_with_roads)
+    # A column stored on the revision that the query does not produce -- what a
+    # node whose query stopped selecting a field looks like from the validator's
+    # side. Cloned from an existing row so every non-null column is populated.
+    await session.execute(
+        text(
+            """
+            INSERT INTO "column" (name, type, node_revision_id, "order")
+            SELECT 'ghost', c.type, c.node_revision_id, 99
+            FROM "column" c
+            JOIN noderevision nr ON nr.id = c.node_revision_id
+            WHERE nr.name = :name AND c.name = 'price'
+            """,
+        ),
+        {"name": NODE},
+    )
+    await session.commit()
+    session.expire_all()
 
     await _revalidate(client_with_roads)
 

--- a/datajunction-server/tests/internal/nodes/revalidate_column_tier_test.py
+++ b/datajunction-server/tests/internal/nodes/revalidate_column_tier_test.py
@@ -1,0 +1,114 @@
+"""
+The version tier `revalidate_node` gives a node whose columns moved.
+
+Any column difference used to earn a major bump. That is wrong for the additive
+cases -- nothing written before a column existed can be referencing it -- and it
+matters more now that downstream cubes inherit their upstream's tier, since a
+major bump rebuilds a cube's materialized table. A type change stays major:
+everything reading the column is reading a different type than it was written
+against.
+
+The column differences are induced by editing the stored columns directly, the
+same trick the existing revalidate tests use, because they are differences
+between what is *stored* on the revision and what the validator recomputes --
+which no API payload can produce on its own.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+NODE = "default.tier_node"
+COLUMNS = [("repair_order_id", "int"), ("price", "float")]
+
+
+async def _create_node(client: AsyncClient) -> None:
+    response = await client.post(
+        "/nodes/transform/",
+        json={
+            "name": NODE,
+            "description": "A transform whose columns the tests move",
+            "mode": "published",
+            "query": "SELECT repair_order_id, price FROM default.repair_order_details",
+        },
+    )
+    assert response.status_code == 201, response.text
+    assert response.json()["version"] == "v1.0"
+    assert [(col["name"], col["type"]) for col in response.json()["columns"]] == COLUMNS
+
+
+async def _revalidate(client: AsyncClient) -> None:
+    response = await client.post(f"/nodes/{NODE}/validate/")
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "valid"
+
+
+async def _node(client: AsyncClient) -> tuple[str, list[tuple[str, str]]]:
+    response = await client.get(f"/nodes/{NODE}")
+    assert response.status_code == 200, response.text
+    return (
+        response.json()["version"],
+        [(col["name"], col["type"]) for col in response.json()["columns"]],
+    )
+
+
+async def _edit_stored_columns(session: AsyncSession, statement: str) -> None:
+    await session.execute(
+        text(
+            f"""
+            {statement}
+            WHERE name = 'price' AND node_revision_id IN (
+                SELECT id FROM noderevision WHERE name = :name
+            )
+            """,
+        ),
+        {"name": NODE},
+    )
+    await session.commit()
+    session.expire_all()
+
+
+@pytest.mark.asyncio
+async def test_added_column_is_a_minor_bump(
+    client_with_roads: AsyncClient,
+    session: AsyncSession,
+):
+    """A column the revision does not have yet is additive, so it earns v1.1."""
+    await _create_node(client_with_roads)
+    await _edit_stored_columns(session, 'DELETE FROM "column"')
+
+    await _revalidate(client_with_roads)
+
+    assert await _node(client_with_roads) == ("v1.1", COLUMNS)
+
+
+@pytest.mark.asyncio
+async def test_column_type_change_is_a_major_bump(
+    client_with_roads: AsyncClient,
+    session: AsyncSession,
+):
+    """A column whose type moved breaks everything reading it, so it earns v2.0."""
+    await _create_node(client_with_roads)
+    await _edit_stored_columns(session, "UPDATE \"column\" SET type = 'int'")
+
+    await _revalidate(client_with_roads)
+
+    assert await _node(client_with_roads) == ("v2.0", COLUMNS)
+
+
+@pytest.mark.asyncio
+async def test_backfilled_column_order_is_a_minor_bump(
+    client_with_roads: AsyncClient,
+    session: AsyncSession,
+):
+    """
+    A missing `order` is DJ filling in metadata it should already have stored. It
+    changes no name, no type and no value, so it sits with the additive cases.
+    """
+    await _create_node(client_with_roads)
+    await _edit_stored_columns(session, 'UPDATE "column" SET "order" = NULL')
+
+    await _revalidate(client_with_roads)
+
+    assert await _node(client_with_roads) == ("v1.1", COLUMNS)

--- a/datajunction-server/tests/internal/nodes/revalidate_column_tier_test.py
+++ b/datajunction-server/tests/internal/nodes/revalidate_column_tier_test.py
@@ -229,6 +229,42 @@ async def test_backfilled_column_order_still_writes_a_history_event(
 
 
 @pytest.mark.asyncio
+async def test_backfill_rides_along_on_a_revision_earned_elsewhere(
+    client_with_roads: AsyncClient,
+    session: AsyncSession,
+):
+    """
+    A legacy revision with no `order` that also earns a bump for a real reason.
+
+    The backfill no longer creates a revision of its own, but a revision created
+    for a type change deep-copies the unordered columns along with everything
+    else. Filling the index in on the way through is what keeps the new revision
+    from inheriting the gap and carrying it forward forever -- the copy is the
+    only chance to fix it, since the next revalidate will find nothing changed.
+    """
+    await _create_node(client_with_roads)
+    await _edit_stored_columns(session, "UPDATE \"column\" SET type = 'int'")
+    await _clear_all_orders(session)
+    assert await _stored_order(session) == [("price", None), ("repair_order_id", None)]
+
+    await _revalidate(client_with_roads)
+
+    # The type change earns the bump; the backfill contributes nothing to the tier.
+    assert await _node(client_with_roads) == ("v2.0", COLUMNS)
+    # The new revision's copies come out ordered, not NULL.
+    assert await _stored_order(session) == [("price", 1), ("repair_order_id", 0)]
+    # One event, explaining both what earned the bump and what rode along on it.
+    assert await _revalidate_events(client_with_roads) == [
+        {
+            "version": "v2.0",
+            "reason": "revalidate",
+            "type_changes": [{"column": "price", "from": "int", "to": "float"}],
+            "order_fixed": ["repair_order_id", "price"],
+        },
+    ]
+
+
+@pytest.mark.asyncio
 async def test_backfill_leaves_orders_that_are_already_set(
     client_with_roads: AsyncClient,
     session: AsyncSession,

--- a/datajunction-server/tests/internal/nodes/revalidate_column_tier_test.py
+++ b/datajunction-server/tests/internal/nodes/revalidate_column_tier_test.py
@@ -123,17 +123,21 @@ async def _clear_all_orders(session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
-async def test_added_column_is_a_minor_bump(
+async def test_added_column_is_a_major_bump(
     client_with_roads: AsyncClient,
     session: AsyncSession,
 ):
-    """A column the revision does not have yet is additive, so it earns v1.1."""
+    """
+    A column the revision does not have yet still came from a query the node did
+    not have before, and the cube rebuild below skips only NONE, so demoting the
+    addition would not spare any downstream work. It earns v2.0.
+    """
     await _create_node(client_with_roads)
     await _edit_stored_columns(session, 'DELETE FROM "column"')
 
     await _revalidate(client_with_roads)
 
-    assert await _node(client_with_roads) == ("v1.1", COLUMNS)
+    assert await _node(client_with_roads) == ("v2.0", COLUMNS)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

Changing a node in a material sense doesn't bump the version of the cubes downstream from it. The cube keeps serving a materialized table built against the old upstream, and the only way to fix it is pushing a no-op PR against the cube to force a recompile.

This is because `_propagate_update_downstream` calls `get_downstream_nodes(..., include_cubes=False)`, so cubes are filtered out of the downstream list before the loop runs. And even if they weren't, the loop only calls `revalidate_node`, whose cube branch sets status and returns, with no bump logic like that in `update_cube_node`.

#### Changes:

- Propagation now includes cubes, and a cube inherits the upstream's change tier (e.g., a major change upstream is a major bump on the cube)
- `update_cube_node` is extracted into `save_new_cube_revision`, so the update path and propagation build a cube revision the same way rather than drifting.

### Test Plan

- [ ] PR has an associated issue: #
- [x] make check passes
- [x] make test shows 100% unit test coverage

### Deployment Plan

An upstream edit can now trigger rematerialization of downstream cubes, which didn't happen before. Cube bumps also stop the superseded revision's workflows via the existing swap.