### PR TITLE
[RBAC PR 4 follow-up] Add scoped restrictive enforcement

### DIFF
--- a/datajunction-server/datajunction_server/config.py
+++ b/datajunction-server/datajunction_server/config.py
@@ -12,8 +12,13 @@ from cachelib.base import BaseCache
 from cachelib.file import FileSystemCache
 from cachelib.redis import RedisCache
 from celery import Celery
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings
+
+from datajunction_server.naming import parse_scope_pattern
+
+RESTRICTIVE_SCOPE_ACTIONS = {"read", "write", "execute", "delete", "manage"}
+RESTRICTIVE_SCOPE_TYPES = {"node", "namespace"}
 
 
 class DatabaseConfig(BaseModel):
@@ -216,11 +221,45 @@ class Settings(BaseSettings):  # pragma: no cover
     # permissive. Applied before the default_access_policy fallback.
     default_access_role: str | None = None
 
+    # Rules that require an explicit principal, group, or service-account grant.
+    # Entries use "action:scope_type:scope_value", for example
+    # "write:node:finance.*". Actions are exact, so configure each governed
+    # mutating action and every resource shape separately.
+    restrictive_scopes: list[str] = Field(default_factory=list)
+
     # Require configured break-glass admins before serving requests.
     # Restrictive default access also enables this check automatically.
     # RBAC_ADMIN_USERS uses JSON list syntax, for example ["admin-user"].
     rbac_require_admin: bool = False
     rbac_admin_users: list[str] = Field(default_factory=list)
+
+    @field_validator("restrictive_scopes")
+    @classmethod
+    def validate_restrictive_scopes(cls, values: list[str]) -> list[str]:
+        """Reject malformed policy rules while loading settings."""
+        for value in values:
+            parts = value.split(":")
+            if len(parts) != 3:
+                raise ValueError(
+                    "restrictive scope must be 'action:scope_type:scope_value'",
+                )
+            action, scope_type, scope_value = parts
+            if (
+                action not in RESTRICTIVE_SCOPE_ACTIONS
+                or scope_type not in RESTRICTIVE_SCOPE_TYPES
+            ):
+                raise ValueError(
+                    "restrictive scope action and scope type must be supported values",
+                )
+            if (
+                scope_value != scope_value.strip()
+                or parse_scope_pattern(scope_value) is None
+            ):
+                raise ValueError(
+                    "restrictive scope value must be '*', an exact scope, "
+                    "or a subtree ending in '.*'",
+                )
+        return values
 
     # Interval in seconds with which to expire caching of any indexes
     index_cache_expire: int = 60

--- a/datajunction-server/datajunction_server/internal/access/authorization/service.py
+++ b/datajunction-server/datajunction_server/internal/access/authorization/service.py
@@ -6,7 +6,7 @@ import logging
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
 from functools import cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     from datajunction_server.database.rbac import RoleScope
@@ -20,6 +20,8 @@ from datajunction_server.models.access import (
     ResourceAction,
     ResourceRequest,
     ResourceType,
+    RestrictiveScopeRule,
+    parse_restrictive_scope_rule,
     parse_scope_pattern,
 )
 from datajunction_server.utils import (
@@ -103,7 +105,7 @@ class RBACAuthorizationService(AuthorizationService):
 
     name = "rbac"
 
-    PERMISSION_HIERARCHY = {
+    PERMISSION_HIERARCHY: ClassVar[dict[ResourceAction, set[ResourceAction]]] = {
         ResourceAction.MANAGE: {
             ResourceAction.MANAGE,
             ResourceAction.DELETE,
@@ -163,28 +165,33 @@ class RBACAuthorizationService(AuthorizationService):
                 )
                 for request in requests
             ]
-        candidate_scopes = self.candidate_scopes(auth_context)
-        return [self._make_decision(request, candidate_scopes) for request in requests]
+        explicit_scopes = self.explicit_scopes(auth_context)
+        restrictive_rules = self.restrictive_rules()
+        return [
+            self._make_decision(
+                request,
+                explicit_scopes,
+                auth_context.default_scopes,
+                restrictive_rules,
+            )
+            for request in requests
+        ]
 
     @classmethod
-    def candidate_scopes(cls, auth_context: AuthContext) -> list["RoleScope"]:
-        """
-        Collect every scope that could grant a request for this context.
-
-        This is the union of the principal's own (non-expired) role scopes and
-        the configured default-access role's scopes. Collecting all candidates
-        up front (rather than short-circuiting source by source) keeps the
-        decision a single resolve step, leaving room for future deny/precedence
-        rules without restructuring.
-        """
+    def explicit_scopes(cls, auth_context: AuthContext) -> list["RoleScope"]:
+        """Collect non-expired principal and group scopes."""
         scopes: list[RoleScope] = []
         now = datetime.now(UTC)
         for assignment in auth_context.role_assignments:
             if assignment.expires_at and assignment.expires_at < now:
                 continue
             scopes.extend(assignment.role.scopes)
-        scopes.extend(auth_context.default_scopes)
         return scopes
+
+    @classmethod
+    def candidate_scopes(cls, auth_context: AuthContext) -> list["RoleScope"]:
+        """Collect explicit and default-role scopes."""
+        return [*cls.explicit_scopes(auth_context), *auth_context.default_scopes]
 
     def authorize_explicit_grants(
         self,
@@ -202,29 +209,64 @@ class RBACAuthorizationService(AuthorizationService):
     def _make_decision(
         self,
         request: ResourceRequest,
-        candidate_scopes: list["RoleScope"],
+        explicit_scopes: list["RoleScope"],
+        default_scopes: list["RoleScope"],
+        restrictive_rules: list[RestrictiveScopeRule],
     ) -> AccessDecision:
         """
         Convert ResourceRequest to AccessDecision.
 
-        Evaluates the candidate scopes (explicit grants + default-access role)
-        collected once per authorize() call and approves if any grants the
-        request. Otherwise falls back to the configured default_access_policy.
+        Explicit grants are considered first. Restrictive policy then blocks
+        fallback access before the default-access role and default policy.
         """
-        granted = any(
-            self._scope_grants_permission(
-                scope,
-                request.verb,
-                request.access_object.resource_type,
-                request.access_object.name,
+        if self._matching_scope(explicit_scopes, request):
+            return AccessDecision(
+                request=request,
+                approved=True,
+                reason="explicit_grant",
             )
-            for scope in candidate_scopes
+        restrictive_rule = self._matching_restrictive_rule(
+            request,
+            restrictive_rules,
         )
-        if granted:
-            return AccessDecision(request=request, approved=True)
+        if restrictive_rule:
+            return AccessDecision(
+                request=request,
+                approved=False,
+                reason=f"restrictive_scope:{restrictive_rule}",
+            )
+        if self._matching_scope(default_scopes, request):
+            return AccessDecision(
+                request=request,
+                approved=True,
+                reason="default_access_role",
+            )
+        approved = settings.default_access_policy == "permissive"
         return AccessDecision(
             request=request,
-            approved=(settings.default_access_policy == "permissive"),
+            approved=approved,
+            reason=f"default_access_policy_{settings.default_access_policy}",
+        )
+
+    @classmethod
+    def _matching_scope(
+        cls,
+        scopes: list["RoleScope"],
+        request: ResourceRequest,
+    ) -> "RoleScope | None":
+        """Return the first role scope that grants a request."""
+        return next(
+            (
+                scope
+                for scope in scopes
+                if cls._scope_grants_permission(
+                    scope,
+                    request.verb,
+                    request.access_object.resource_type,
+                    request.access_object.name,
+                )
+            ),
+            None,
         )
 
     def _make_explicit_grant_decision(
@@ -417,26 +459,59 @@ class RBACAuthorizationService(AuthorizationService):
         if action not in granted_actions:
             return False
 
-        # Handle global access. Blank is not global -- it is outside the grammar,
-        # so it falls through to the matcher below and grants nothing.
-        if scope.scope_value == "*":
-            # Global scope matches any resource of the same type
-            return scope.scope_type == resource_type
+        return cls._resource_in_scope(
+            scope.scope_type,
+            scope.scope_value,
+            resource_type,
+            resource_name,
+        )
 
-        # Same resource type - use pattern matching
-        if scope.scope_type == resource_type:
-            return cls.resource_matches_pattern(resource_name, scope.scope_value)
-
-        # Cross-resource-type: namespace scope can cover nodes
-        if (
-            scope.scope_type == ResourceType.NAMESPACE
-            and resource_type == ResourceType.NODE
-        ):
-            # Check if node name matches the namespace pattern
-            return cls.resource_matches_pattern(resource_name, scope.scope_value)
-
-        # No match
+    @classmethod
+    def _resource_in_scope(
+        cls,
+        scope_type: ResourceType,
+        scope_value: str,
+        resource_type: ResourceType,
+        resource_name: str,
+    ) -> bool:
+        """Return whether a resource falls under a supported scope pattern."""
+        if scope_value == "*":
+            return scope_type == resource_type
+        if scope_type == resource_type:
+            return cls.resource_matches_pattern(resource_name, scope_value)
+        if scope_type == ResourceType.NAMESPACE and resource_type == ResourceType.NODE:
+            return cls.resource_matches_pattern(resource_name, scope_value)
         return False
+
+    @classmethod
+    def restrictive_rules(cls) -> list[RestrictiveScopeRule]:
+        """Parse configured restrictive policy rules."""
+        return [
+            parse_restrictive_scope_rule(value)
+            for value in getattr(settings, "restrictive_scopes", []) or []
+        ]
+
+    @classmethod
+    def _matching_restrictive_rule(
+        cls,
+        request: ResourceRequest,
+        rules: list[RestrictiveScopeRule],
+    ) -> RestrictiveScopeRule | None:
+        """Return the first exact-action restrictive rule covering a request."""
+        return next(
+            (
+                rule
+                for rule in rules
+                if rule.action == request.verb
+                and cls._resource_in_scope(
+                    rule.scope_type,
+                    rule.scope_value,
+                    request.access_object.resource_type,
+                    request.access_object.name,
+                )
+            ),
+            None,
+        )
 
 
 class PassthroughAuthorizationService(AuthorizationService):

--- a/datajunction-server/datajunction_server/models/access.py
+++ b/datajunction-server/datajunction_server/models/access.py
@@ -5,7 +5,7 @@ Models for authorization
 from dataclasses import dataclass
 
 from datajunction_server.database.node import Node, NodeRevision
-from datajunction_server.naming import SEPARATOR
+from datajunction_server.naming import parse_scope_pattern
 from datajunction_server.typing import StrEnum
 
 
@@ -30,31 +30,43 @@ class ResourceAction(StrEnum):
     MANAGE = "manage"  # Grant/revoke permissions (RBAC-specific)
 
 
-def parse_scope_pattern(value: str) -> tuple[str, str] | None:
-    """
-    Parse exact, trailing-wildcard, and global scope patterns.
+@dataclass(frozen=True)
+class RestrictiveScopeRule:
+    """A configured action and resource scope that requires an explicit grant."""
 
-    A blank value is outside the grammar rather than a global scope: the global
-    scope is spelled ``*``, which is what scope input has required since #2339.
-    Reading blanks as global would let a legacy or out-of-band row grant every
-    resource of its type.
-    """
-    if not value:
-        return None
-    if value == "*":
-        return ("global", "")
-    if (
-        value.startswith(SEPARATOR)
-        or value.endswith(SEPARATOR)
-        or SEPARATOR * 2 in value
-    ):
-        return None
-    if "*" not in value:
-        return ("exact", value)
-    if value.count("*") != 1 or not value.endswith(f"{SEPARATOR}*"):
-        return None
-    prefix = value[: -len(f"{SEPARATOR}*")]
-    return ("subtree", prefix) if prefix else None
+    action: ResourceAction
+    scope_type: ResourceType
+    scope_value: str
+
+    def __str__(self) -> str:
+        return f"{self.action.value}:{self.scope_type.value}:{self.scope_value}"
+
+
+def parse_restrictive_scope_rule(value: str) -> RestrictiveScopeRule:
+    """Parse ``action:scope_type:scope_value`` using the RBAC scope grammar."""
+    parts = value.split(":")
+    if len(parts) != 3:
+        raise ValueError(
+            "restrictive scope must be 'action:scope_type:scope_value'",
+        )
+    action_value, scope_type_value, scope_value = parts
+    try:
+        action = ResourceAction(action_value)
+        scope_type = ResourceType(scope_type_value)
+    except ValueError as exc:
+        raise ValueError(
+            "restrictive scope action and scope type must be supported values",
+        ) from exc
+    if scope_value != scope_value.strip() or parse_scope_pattern(scope_value) is None:
+        raise ValueError(
+            "restrictive scope value must be '*', an exact scope, "
+            "or a subtree ending in '.*'",
+        )
+    return RestrictiveScopeRule(
+        action=action,
+        scope_type=scope_type,
+        scope_value=scope_value,
+    )
 
 
 @dataclass(frozen=True)

--- a/datajunction-server/datajunction_server/naming.py
+++ b/datajunction-server/datajunction_server/naming.py
@@ -36,6 +36,26 @@ LOOKUP_CHARS = {
 }
 
 
+def parse_scope_pattern(value: str) -> tuple[str, str] | None:
+    """Parse exact, trailing-wildcard, and global scope patterns."""
+    if not value:
+        return None
+    if value == "*":
+        return ("global", "")
+    if (
+        value.startswith(SEPARATOR)
+        or value.endswith(SEPARATOR)
+        or SEPARATOR * 2 in value
+    ):
+        return None
+    if "*" not in value:
+        return ("exact", value)
+    if value.count("*") != 1 or not value.endswith(f"{SEPARATOR}*"):
+        return None
+    prefix = value[: -len(f"{SEPARATOR}*")]
+    return ("subtree", prefix) if prefix else None
+
+
 def amenable_name(name: str) -> str:
     """Takes a string and makes it have only alphanumerics"""
     ret: list[str] = []

--- a/datajunction-server/tests/internal/authorization_test.py
+++ b/datajunction-server/tests/internal/authorization_test.py
@@ -3,11 +3,13 @@
 import logging
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from typing import cast
+from typing import ClassVar, cast
 
 import pytest
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from datajunction_server.config import Settings
 from datajunction_server.database.group_member import GroupMember
 from datajunction_server.database.rbac import Role, RoleAssignment, RoleScope
 from datajunction_server.database.user import PrincipalKind, User
@@ -31,6 +33,7 @@ from datajunction_server.models.access import (
     ResourceAction,
     ResourceRequest,
     ResourceType,
+    parse_restrictive_scope_rule,
 )
 
 
@@ -1140,6 +1143,249 @@ class TestDefaultAccessRole:
         )
         results = await access_checker.check(on_denied=AccessDenialMode.RETURN)
         assert results[0].approved is False
+
+
+class TestRestrictiveScopes:
+    """Tests for per-action restrictive policy within namespace boundaries."""
+
+    SERVICE_SETTINGS = (
+        "datajunction_server.internal.access.authorization.service.settings"
+    )
+    BOUNDARY_RULES: ClassVar[tuple[str, ...]] = (
+        "write:namespace:shared.main",
+        "write:namespace:shared.main.*",
+        "write:node:shared.main.*",
+        "delete:namespace:shared.main",
+        "delete:namespace:shared.main.*",
+        "delete:node:shared.main.*",
+        "manage:namespace:shared.main",
+        "manage:namespace:shared.main.*",
+        "manage:node:shared.main.*",
+    )
+
+    @staticmethod
+    def request(
+        action: ResourceAction,
+        resource_type: ResourceType,
+        name: str,
+    ) -> ResourceRequest:
+        return ResourceRequest(
+            verb=action,
+            access_object=Resource(name=name, resource_type=resource_type),
+        )
+
+    @staticmethod
+    def context(
+        explicit_scopes=None,
+        default_scopes=None,
+        is_admin: bool = False,
+    ) -> AuthContext:
+        assignments = (
+            [
+                SimpleNamespace(
+                    expires_at=None,
+                    role=SimpleNamespace(scopes=explicit_scopes),
+                ),
+            ]
+            if explicit_scopes
+            else []
+        )
+        return AuthContext(
+            user_id=1,
+            username="test-user",
+            oauth_provider="basic",
+            role_assignments=assignments,
+            is_admin=is_admin,
+            default_scopes=default_scopes or [],
+        )
+
+    def configure(self, mocker, rules=None, default_policy="permissive"):
+        service_settings = mocker.patch(self.SERVICE_SETTINGS)
+        service_settings.restrictive_scopes = (
+            self.BOUNDARY_RULES if rules is None else rules
+        )
+        service_settings.default_access_policy = default_policy
+
+    @pytest.mark.parametrize(
+        "action",
+        [ResourceAction.WRITE, ResourceAction.DELETE, ResourceAction.MANAGE],
+    )
+    @pytest.mark.parametrize(
+        "resource_type,name",
+        [
+            (ResourceType.NAMESPACE, "shared.main"),
+            (ResourceType.NAMESPACE, "shared.main.finance"),
+            (ResourceType.NODE, "shared.main.revenue"),
+        ],
+    )
+    def test_boundary_rules_cover_every_mutating_resource_shape(
+        self,
+        mocker,
+        action,
+        resource_type,
+        name,
+    ):
+        self.configure(mocker)
+        request = self.request(action, resource_type, name)
+
+        decision = RBACAuthorizationService().authorize(
+            self.context(),
+            [request],
+        )[0]
+
+        assert decision.approved is False
+        assert decision.reason and decision.reason.startswith("restrictive_scope:")
+
+    def test_only_configured_actions_and_boundary_are_restricted(self, mocker):
+        self.configure(mocker, rules=["write:node:shared.main.*"])
+        requests = [
+            self.request(
+                ResourceAction.WRITE,
+                ResourceType.NODE,
+                "shared.main.revenue",
+            ),
+            self.request(
+                ResourceAction.READ,
+                ResourceType.NODE,
+                "shared.main.revenue",
+            ),
+            self.request(
+                ResourceAction.EXECUTE,
+                ResourceType.NODE,
+                "shared.main.revenue",
+            ),
+            self.request(
+                ResourceAction.WRITE,
+                ResourceType.NODE,
+                "shared.other.revenue",
+            ),
+        ]
+
+        decisions = RBACAuthorizationService().authorize(self.context(), requests)
+
+        assert [decision.approved for decision in decisions] == [
+            False,
+            True,
+            True,
+            True,
+        ]
+
+    def test_explicit_grant_allows_restricted_request(self, mocker):
+        self.configure(mocker, rules=["write:node:shared.main.*"])
+        explicit_scope = SimpleNamespace(
+            action=ResourceAction.WRITE,
+            scope_type=ResourceType.NODE,
+            scope_value="shared.main.*",
+        )
+        request = self.request(
+            ResourceAction.WRITE,
+            ResourceType.NODE,
+            "shared.main.revenue",
+        )
+
+        decision = RBACAuthorizationService().authorize(
+            self.context(explicit_scopes=[explicit_scope]),
+            [request],
+        )[0]
+
+        assert decision.approved is True
+        assert decision.reason == "explicit_grant"
+
+    def test_default_role_cannot_bypass_restrictive_rule(self, mocker):
+        self.configure(mocker, rules=["write:node:shared.main.*"])
+        default_scope = SimpleNamespace(
+            action=ResourceAction.WRITE,
+            scope_type=ResourceType.NODE,
+            scope_value="*",
+        )
+        request = self.request(
+            ResourceAction.WRITE,
+            ResourceType.NODE,
+            "shared.main.revenue",
+        )
+
+        decision = RBACAuthorizationService().authorize(
+            self.context(default_scopes=[default_scope]),
+            [request],
+        )[0]
+
+        assert decision.approved is False
+        assert decision.reason == "restrictive_scope:write:node:shared.main.*"
+
+    def test_empty_configuration_preserves_permissive_fallback(self, mocker):
+        self.configure(mocker, rules=[])
+        request = self.request(
+            ResourceAction.WRITE,
+            ResourceType.NODE,
+            "shared.main.revenue",
+        )
+
+        decision = RBACAuthorizationService().authorize(
+            self.context(),
+            [request],
+        )[0]
+
+        assert decision.approved is True
+        assert decision.reason == "default_access_policy_permissive"
+
+    def test_global_namespace_rule_does_not_restrict_nodes(self, mocker):
+        self.configure(mocker, rules=["write:namespace:*"])
+        requests = [
+            self.request(ResourceAction.WRITE, ResourceType.NAMESPACE, "shared.main"),
+            self.request(
+                ResourceAction.WRITE,
+                ResourceType.NODE,
+                "shared.main.revenue",
+            ),
+        ]
+
+        decisions = RBACAuthorizationService().authorize(self.context(), requests)
+
+        assert [decision.approved for decision in decisions] == [False, True]
+
+    @pytest.mark.parametrize(
+        "rule",
+        [
+            "writes:node:shared.main.*",
+            "write:nodes:shared.main.*",
+            "write:node:shared*",
+            "write:node:.*",
+            "write:node:**",
+            "write:node:",
+            "write:node",
+            " write:node:shared.main.*",
+        ],
+    )
+    def test_settings_reject_malformed_rules(self, rule):
+        with pytest.raises(ValidationError, match="restrictive scope"):
+            Settings(restrictive_scopes=[rule])
+
+    @pytest.mark.parametrize(
+        "rule",
+        [
+            "write:node",
+            "writes:node:shared.main.*",
+            "write:nodes:shared.main.*",
+            "write:node:shared*",
+            "write:node: shared.main.*",
+        ],
+    )
+    def test_runtime_parser_rejects_malformed_rules(self, rule):
+        with pytest.raises(ValueError, match="restrictive scope"):
+            parse_restrictive_scope_rule(rule)
+
+    def test_settings_parse_json_list_from_environment(self, monkeypatch):
+        monkeypatch.setenv(
+            "RESTRICTIVE_SCOPES",
+            '["write:node:shared.main.*","delete:node:shared.main.*"]',
+        )
+
+        settings = Settings()
+
+        assert settings.restrictive_scopes == [
+            "write:node:shared.main.*",
+            "delete:node:shared.main.*",
+        ]
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/internal/authorization_test.py
+++ b/datajunction-server/tests/internal/authorization_test.py
@@ -1255,6 +1255,16 @@ class TestRestrictiveScopes:
                 "shared.main.revenue",
             ),
             self.request(
+                ResourceAction.DELETE,
+                ResourceType.NODE,
+                "shared.main.revenue",
+            ),
+            self.request(
+                ResourceAction.MANAGE,
+                ResourceType.NODE,
+                "shared.main.revenue",
+            ),
+            self.request(
                 ResourceAction.WRITE,
                 ResourceType.NODE,
                 "shared.other.revenue",
@@ -1268,7 +1278,68 @@ class TestRestrictiveScopes:
             True,
             True,
             True,
+            True,
+            True,
         ]
+
+    @pytest.mark.parametrize(
+        "rule,resource_type,name,approved",
+        [
+            (
+                "write:namespace:shared.main",
+                ResourceType.NAMESPACE,
+                "shared.main",
+                False,
+            ),
+            (
+                "write:namespace:shared.main",
+                ResourceType.NAMESPACE,
+                "shared.main.finance",
+                True,
+            ),
+            (
+                "write:namespace:shared.main",
+                ResourceType.NODE,
+                "shared.main.revenue",
+                True,
+            ),
+            (
+                "write:namespace:shared.main.*",
+                ResourceType.NAMESPACE,
+                "shared.main",
+                True,
+            ),
+            (
+                "write:namespace:shared.main.*",
+                ResourceType.NAMESPACE,
+                "shared.main.finance",
+                False,
+            ),
+            (
+                "write:namespace:shared.main.*",
+                ResourceType.NODE,
+                "shared.main.revenue",
+                False,
+            ),
+        ],
+    )
+    def test_exact_and_subtree_rules_keep_existing_scope_meanings(
+        self,
+        mocker,
+        rule,
+        resource_type,
+        name,
+        approved,
+    ):
+        self.configure(mocker, rules=[rule])
+        request = self.request(ResourceAction.WRITE, resource_type, name)
+
+        decision = RBACAuthorizationService().authorize(
+            self.context(),
+            [request],
+        )[0]
+
+        assert decision.approved is approved
 
     def test_explicit_grant_allows_restricted_request(self, mocker):
         self.configure(mocker, rules=["write:node:shared.main.*"])
@@ -1311,6 +1382,31 @@ class TestRestrictiveScopes:
 
         assert decision.approved is False
         assert decision.reason == "restrictive_scope:write:node:shared.main.*"
+
+    def test_default_read_role_applies_when_only_write_is_restricted(self, mocker):
+        self.configure(
+            mocker,
+            rules=["write:node:shared.main.*"],
+            default_policy="restrictive",
+        )
+        default_scope = SimpleNamespace(
+            action=ResourceAction.READ,
+            scope_type=ResourceType.NODE,
+            scope_value="*",
+        )
+        request = self.request(
+            ResourceAction.READ,
+            ResourceType.NODE,
+            "shared.main.revenue",
+        )
+
+        decision = RBACAuthorizationService().authorize(
+            self.context(default_scopes=[default_scope]),
+            [request],
+        )[0]
+
+        assert decision.approved is True
+        assert decision.reason == "default_access_role"
 
     def test_empty_configuration_preserves_permissive_fallback(self, mocker):
         self.configure(mocker, rules=[])

--- a/datajunction-server/tests/internal/authorization_test.py
+++ b/datajunction-server/tests/internal/authorization_test.py
@@ -1180,16 +1180,7 @@ class TestRestrictiveScopes:
         default_scopes=None,
         is_admin: bool = False,
     ) -> AuthContext:
-        assignments = (
-            [
-                SimpleNamespace(
-                    expires_at=None,
-                    role=SimpleNamespace(scopes=explicit_scopes),
-                ),
-            ]
-            if explicit_scopes
-            else []
-        )
+        assignments = [_assignment(explicit_scopes)] if explicit_scopes else []
         return AuthContext(
             user_id=1,
             username="test-user",
@@ -1236,51 +1227,33 @@ class TestRestrictiveScopes:
         assert decision.approved is False
         assert decision.reason and decision.reason.startswith("restrictive_scope:")
 
-    def test_only_configured_actions_and_boundary_are_restricted(self, mocker):
+    @pytest.mark.parametrize(
+        "action,name,approved",
+        [
+            (ResourceAction.WRITE, "shared.main.revenue", False),
+            (ResourceAction.READ, "shared.main.revenue", True),
+            (ResourceAction.EXECUTE, "shared.main.revenue", True),
+            (ResourceAction.DELETE, "shared.main.revenue", True),
+            (ResourceAction.MANAGE, "shared.main.revenue", True),
+            (ResourceAction.WRITE, "shared.other.revenue", True),
+        ],
+    )
+    def test_only_configured_actions_and_boundary_are_restricted(
+        self,
+        mocker,
+        action,
+        name,
+        approved,
+    ):
         self.configure(mocker, rules=["write:node:shared.main.*"])
-        requests = [
-            self.request(
-                ResourceAction.WRITE,
-                ResourceType.NODE,
-                "shared.main.revenue",
-            ),
-            self.request(
-                ResourceAction.READ,
-                ResourceType.NODE,
-                "shared.main.revenue",
-            ),
-            self.request(
-                ResourceAction.EXECUTE,
-                ResourceType.NODE,
-                "shared.main.revenue",
-            ),
-            self.request(
-                ResourceAction.DELETE,
-                ResourceType.NODE,
-                "shared.main.revenue",
-            ),
-            self.request(
-                ResourceAction.MANAGE,
-                ResourceType.NODE,
-                "shared.main.revenue",
-            ),
-            self.request(
-                ResourceAction.WRITE,
-                ResourceType.NODE,
-                "shared.other.revenue",
-            ),
-        ]
+        request = self.request(action, ResourceType.NODE, name)
 
-        decisions = RBACAuthorizationService().authorize(self.context(), requests)
+        decision = RBACAuthorizationService().authorize(
+            self.context(),
+            [request],
+        )[0]
 
-        assert [decision.approved for decision in decisions] == [
-            False,
-            True,
-            True,
-            True,
-            True,
-            True,
-        ]
+        assert decision.approved is approved
 
     @pytest.mark.parametrize(
         "rule,resource_type,name,approved",


### PR DESCRIPTION
Tracking: #2234 (step 4).

With a permissive default, a missing grant allows every ordinary metadata mutation. Operators need a way to require explicit grants for `shared.main` writes while unrelated namespaces keep their current behavior.

This draft adds a `RESTRICTIVE_SCOPES` setting:
- Entries use `action:scope_type:scope_value`, such as `write:node:shared.main.*`.
- An admin bypass or explicit principal, group, or service-account grant can approve a matching request.
- A matching rule denies before the default-access role and permissive fallback are considered.
- Actions match exactly, so `WRITE`, `DELETE`, and `MANAGE` are configured separately while `READ` and `EXECUTE` remain open.
- Settings validation rejects unknown actions, resource types, and patterns outside the shared scope grammar during startup.
- Decisions identify the matched restrictive rule or fallback source in their reason.

This draft uses an explicit scope set for namespace boundaries and preserves existing scope meanings. Protecting `shared.main` for one action requires the namespace root, namespace subtree, and node subtree:

```text
write:namespace:shared.main
write:namespace:shared.main.*
write:node:shared.main.*
```

The empty default leaves existing deployments unchanged. Rollout begins only when an operator supplies rules and provisions the matching grants.

---
Verification:

Started a local FastAPI harness on `:18084` that routed HTTP requests through `RBACAuthorizationService` with `DEFAULT_ACCESS_POLICY=permissive` and this write boundary:

```text
RESTRICTIVE_SCOPES=[
  "write:namespace:shared.main",
  "write:namespace:shared.main.*",
  "write:node:shared.main.*"
]
```

1. An ungranted write inside the boundary was denied.

```bash
curl http://127.0.0.1:18084/check/write/node/shared.main.revenue
# {"approved":false,"reason":"restrictive_scope:write:namespace:shared.main.*"}
```

2. An explicit grant approved the same request. A default-role grant remained denied.

```bash
curl -H 'x-grant: explicit' http://127.0.0.1:18084/check/write/node/shared.main.revenue
# {"approved":true,"reason":"explicit_grant"}

curl -H 'x-grant: default' http://127.0.0.1:18084/check/write/node/shared.main.revenue
# {"approved":false,"reason":"restrictive_scope:write:namespace:shared.main.*"}
```

3. Read access inside the boundary and writes outside it followed the permissive baseline.

```bash
curl http://127.0.0.1:18084/check/read/node/shared.main.revenue
# {"approved":true,"reason":"default_access_policy_permissive"}

curl http://127.0.0.1:18084/check/write/node/shared.other.revenue
# {"approved":true,"reason":"default_access_policy_permissive"}
```