### PR TITLE
perf: resolve dimension indegrees + node names with direct query

### DIFF
--- a/datajunction-server/datajunction_server/api/dimensions.py
+++ b/datajunction-server/datajunction_server/api/dimensions.py
@@ -36,12 +36,17 @@ router = SecureAPIRouter(tags=["dimensions"])
 @router.get("/dimensions/", response_model=list[NodeIndegreeOutput])
 async def list_dimensions(
     prefix: str | None = None,
+    limit: int | None = None,
     *,
     session: AsyncSession = Depends(get_session),
     access_checker: AccessChecker = Depends(get_access_checker),
 ) -> list[NodeIndegreeOutput]:
     """
-    List all available dimensions.
+    List available dimensions, most useful first.
+
+    Dimensions on a repo's default branch come before those on feature branches,
+    and within each group the most linked-to dimensions come first. `limit` caps
+    how many are returned; omit it for the full list.
     """
     node_names = await list_nodes(
         node_type=NodeType.DIMENSION,
@@ -50,13 +55,15 @@ async def list_dimensions(
         access_checker=access_checker,
     )
     node_indegrees = await get_dimension_dag_indegree(session, node_names)
-    return sorted(
+    main_branch = await Node.main_branch_names(session, node_names)
+    ranked = sorted(
         [
             NodeIndegreeOutput(name=node, indegree=node_indegrees[node])
             for node in node_names
         ],
-        key=lambda n: -n.indegree,
+        key=lambda n: (n.name not in main_branch, -n.indegree),
     )
+    return ranked[:limit] if limit is not None else ranked
 
 
 @router.get("/dimensions/{name}/nodes/", response_model=list[NodeNameOutput])

--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -283,8 +283,10 @@ async def list_nodes(
     """
     List the available nodes.
     """
-    nodes = await Node.find(session, prefix, node_type)  # type: ignore
-    access_checker.add_nodes(nodes, access.ResourceAction.READ)
+    # Only the names are needed, here and for the access check.
+    node_names = await Node.find_names(session, prefix, node_type)
+    for node_name in node_names:
+        access_checker.add_request_by_node_name(node_name, access.ResourceAction.READ)
     return await access_checker.approved_resource_names()
 
 

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -151,6 +151,19 @@ def _normalize_for_search(text_col):
     )
 
 
+def _on_main_branch(ns_alias, parent_ns_alias):
+    """
+    SQL expression that is true when a node's namespace tracks its repo's
+    default branch, or is not repo-backed at all.
+    """
+    return case(
+        (parent_ns_alias.namespace.is_(None), True),
+        (parent_ns_alias.default_branch.is_(None), True),
+        (ns_alias.git_branch == parent_ns_alias.default_branch, True),
+        else_=False,
+    )
+
+
 def _build_search_score(
     nr_alias,
     ns_alias,
@@ -190,12 +203,7 @@ def _build_search_score(
             * _SEARCH_WEIGHT_DISPLAY_NAME,
         )
     branch_boost = case(
-        (parent_ns_alias.namespace.is_(None), _SEARCH_BOOST_MAIN),
-        (parent_ns_alias.default_branch.is_(None), _SEARCH_BOOST_MAIN),
-        (
-            ns_alias.git_branch == parent_ns_alias.default_branch,
-            _SEARCH_BOOST_MAIN,
-        ),
+        (_on_main_branch(ns_alias, parent_ns_alias), _SEARCH_BOOST_MAIN),
         else_=_SEARCH_BOOST_BRANCH,
     )
     popularity = 1.0 + _SEARCH_POPULARITY_WEIGHT * func.ln(
@@ -970,6 +978,39 @@ class Node(Base):
         statement = select(Node.name).where(*cls._find_filters(prefix, node_type))
         result = await session.execute(statement)
         return list(result.scalars().all())
+
+    @classmethod
+    async def main_branch_names(
+        cls,
+        session: AsyncSession,
+        names: list[str],
+    ) -> set[str]:
+        """
+        Of the given node names, returns those whose namespace tracks its repo's
+        default branch (or is not repo-backed).
+        """
+        if not names:
+            return set()
+
+        from datajunction_server.database.namespace import NodeNamespace
+
+        ns_alias = aliased(NodeNamespace)
+        parent_ns_alias = aliased(NodeNamespace)
+        statement = (
+            select(Node.name)
+            .select_from(Node)
+            .outerjoin(ns_alias, Node.namespace == ns_alias.namespace)
+            .outerjoin(
+                parent_ns_alias,
+                ns_alias.parent_namespace == parent_ns_alias.namespace,
+            )
+            .where(
+                Node.name.in_(names),
+                _on_main_branch(ns_alias, parent_ns_alias),
+            )
+        )
+        result = await session.execute(statement)
+        return set(result.scalars().all())
 
     @classmethod
     async def _build_filtered_node_statement(

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -923,6 +923,23 @@ class Node(Base):
         return node
 
     @classmethod
+    def _find_filters(
+        cls,
+        prefix: str | None = None,
+        node_type: NodeType | None = None,
+    ) -> list:
+        """
+        Filters shared by ``find`` and ``find_names``: active nodes, optionally
+        narrowed to a name prefix and a node type.
+        """
+        filters = [is_(Node.deactivated_at, None)]
+        if prefix:
+            filters.append(Node.name.like(f"{prefix}%"))  # type: ignore
+        if node_type:
+            filters.append(Node.type == node_type)
+        return filters
+
+    @classmethod
     async def find(
         cls,
         session: AsyncSession,
@@ -933,15 +950,26 @@ class Node(Base):
         """
         Finds a list of nodes by prefix
         """
-        statement = select(Node).where(is_(Node.deactivated_at, None))
-        if prefix:
-            statement = statement.where(
-                Node.name.like(f"{prefix}%"),  # type: ignore
-            )
-        if node_type:
-            statement = statement.where(Node.type == node_type)
+        statement = select(Node).where(*cls._find_filters(prefix, node_type))
         result = await session.execute(statement.options(*options))
         return result.unique().scalars().all()
+
+    @classmethod
+    async def find_names(
+        cls,
+        session: AsyncSession,
+        prefix: str | None = None,
+        node_type: NodeType | None = None,
+    ) -> list[str]:
+        """
+        Finds node names by prefix and type.
+
+        Selects the name column directly, so no ORM entities are built and the
+        session's identity map is left untouched.
+        """
+        statement = select(Node.name).where(*cls._find_filters(prefix, node_type))
+        result = await session.execute(statement)
+        return list(result.scalars().all())
 
     @classmethod
     async def _build_filtered_node_statement(

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -13,7 +13,7 @@ from typing import cast
 from sqlalchemy import and_, bindparam, func, join, or_, select, text
 from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload
+from sqlalchemy.orm import aliased, joinedload, selectinload
 from sqlalchemy.sql.base import ExecutableOption
 from sqlalchemy.sql.operators import is_
 
@@ -1561,28 +1561,37 @@ async def get_dimension_dag_indegree(session, node_names: list[str]) -> dict[str
     of dimension links that reference this node. Non-dimension nodes will always have an
     indegree of 0.
     """
-    nodes = await Node.get_by_names(session, node_names)
-    dimension_ids = [node.id for node in nodes]
+    if not node_names:
+        return {}
+
+    # Aggregate directly rather than hydrating ORM nodes and their eager loads.
+    linking_revision = aliased(NodeRevision)
+    linking_node = aliased(Node)
     statement = (
-        select(
-            DimensionLink.dimension_id,
-            func.count(DimensionLink.id),
+        select(Node.name, func.count(linking_node.id))
+        .select_from(Node)
+        .outerjoin(DimensionLink, DimensionLink.dimension_id == Node.id)
+        .outerjoin(
+            linking_revision,
+            DimensionLink.node_revision_id == linking_revision.id,
         )
-        .where(DimensionLink.dimension_id.in_(dimension_ids))
-        .join(NodeRevision, DimensionLink.node_revision_id == NodeRevision.id)
-        .join(
-            Node,
+        # Only a node's current revision contributes to indegree; a failed join
+        # leaves a NULL that count() skips.
+        .outerjoin(
+            linking_node,
             and_(
-                Node.id == NodeRevision.node_id,
-                Node.current_version == NodeRevision.version,
+                linking_node.id == linking_revision.node_id,
+                linking_node.current_version == linking_revision.version,
             ),
         )
-        .group_by(DimensionLink.dimension_id)
+        .where(
+            Node.name.in_(node_names),
+            is_(Node.deactivated_at, None),
+        )
+        .group_by(Node.name)
     )
     result = await session.execute(statement)
-    link_counts = {link[0]: link[1] for link in result.unique().all()}
-    dimension_dag_indegree = {node.name: link_counts.get(node.id, 0) for node in nodes}
-    return dimension_dag_indegree
+    return {name: indegree for name, indegree in result.all()}
 
 
 async def get_cubes_using_dimensions(

--- a/datajunction-server/tests/api/dimensions_test.py
+++ b/datajunction-server/tests/api/dimensions_test.py
@@ -44,6 +44,14 @@ async def test_list_dimension(
 
 
 @pytest.mark.asyncio
+async def test_main_branch_names_with_no_names(session: AsyncSession) -> None:
+    """
+    An empty name list resolves to an empty set without issuing a query.
+    """
+    assert await Node.main_branch_names(session, []) == set()
+
+
+@pytest.mark.asyncio
 async def test_list_dimension_limit(client_with_roads: AsyncClient) -> None:
     """
     ``limit`` caps the response to the highest-ranked dimensions, and omitting it

--- a/datajunction-server/tests/api/dimensions_test.py
+++ b/datajunction-server/tests/api/dimensions_test.py
@@ -37,6 +37,38 @@ async def test_list_dimension(
 
 
 @pytest.mark.asyncio
+async def test_list_dimension_query_count(
+    client_with_roads: AsyncClient,
+    capture_queries: list[str],
+) -> None:
+    """
+    ``GET /dimensions/`` must stay on a small, constant number of queries.
+
+    The dimension picker in the UI loads this list in full on every mount, so
+    the cost here is paid interactively. It used to hydrate every dimension node
+    as a full ORM object -- pulling in columns, parents, dimension links and
+    those links' target dimensions -- which ran into the hundreds of queries and
+    tens of seconds on a large instance.
+    """
+    response = await client_with_roads.get("/dimensions/")
+    assert response.status_code == 200
+
+    # The endpoint's own work is two queries: list the dimension nodes, then
+    # aggregate their indegrees.
+    node_queries = [
+        query
+        for query in capture_queries
+        if "FROM node" in query or "FROM dimensionlink" in query
+    ]
+    assert len(node_queries) == 2, "\n\n".join(node_queries)
+
+    # Everything else in the request is per-request auth/RBAC. Cap the total so
+    # that a relationship quietly becoming eager-loaded (which would fan out
+    # into extra batched selects against other tables) fails here.
+    assert len(capture_queries) <= 8, "\n\n".join(capture_queries)
+
+
+@pytest.mark.asyncio
 async def test_list_nodes_with_dimension(
     module__client_with_roads_and_acc_revenue: AsyncClient,
 ) -> None:

--- a/datajunction-server/tests/api/dimensions_test.py
+++ b/datajunction-server/tests/api/dimensions_test.py
@@ -4,6 +4,13 @@ Tests for the dimensions API.
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.database.dimensionlink import DimensionLink
+from datajunction_server.database.namespace import NodeNamespace
+from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.user import User
+from datajunction_server.models.node_type import NodeType
 
 
 @pytest.mark.asyncio
@@ -37,6 +44,93 @@ async def test_list_dimension(
 
 
 @pytest.mark.asyncio
+async def test_list_dimension_limit(client_with_roads: AsyncClient) -> None:
+    """
+    ``limit`` caps the response to the highest-ranked dimensions, and omitting it
+    still returns the full list.
+    """
+    full = await client_with_roads.get("/dimensions/")
+    assert full.status_code == 200
+    all_dims = full.json()
+    assert len(all_dims) > 3
+
+    limited = await client_with_roads.get("/dimensions/?limit=3")
+    assert limited.status_code == 200
+    assert limited.json() == all_dims[:3]
+
+
+@pytest.mark.asyncio
+async def test_list_dimension_ranks_main_branch_first(
+    client_with_roads: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """
+    A dimension on a feature branch sorts below main-branch dimensions even when
+    it is linked to more often, so a branch's copies cannot crowd out the
+    authoritative ones.
+    """
+    current_user = (await User.get_by_username(session, "dj")) or (
+        await session.get(User, 1)
+    )
+    session.add_all(
+        [
+            NodeNamespace(namespace="proj", default_branch="main"),
+            NodeNamespace(
+                namespace="proj.feature_x",
+                parent_namespace="proj",
+                git_branch="feature_x",
+            ),
+        ],
+    )
+    await session.commit()
+
+    branch_dim = Node(
+        name="proj.feature_x.busy_dim",
+        type=NodeType.DIMENSION,
+        namespace="proj.feature_x",
+        created_by_id=current_user.id,
+    )
+    branch_dim_rev = NodeRevision(
+        node=branch_dim,
+        name=branch_dim.name,
+        type=branch_dim.type,
+        version="v1.0",
+        created_by_id=current_user.id,
+    )
+    session.add_all([branch_dim, branch_dim_rev])
+    await session.flush()
+    branch_dim.current_version = "v1.0"
+
+    # Link every roads fact revision at it so its indegree beats every main dim.
+    roads_revisions = (
+        await session.execute(
+            NodeRevision.__table__.select().limit(20),  # type: ignore[attr-defined]
+        )
+    ).fetchall()
+    for revision in roads_revisions:
+        session.add(
+            DimensionLink(
+                dimension_id=branch_dim.id,
+                node_revision_id=revision.id,
+                join_sql=f"x.id = {branch_dim.name}.id",
+            ),
+        )
+    await session.commit()
+
+    response = await client_with_roads.get("/dimensions/")
+    assert response.status_code == 200
+    names = [dim["name"] for dim in response.json()]
+    assert branch_dim.name in names, "branch dimension should still be listed"
+
+    by_name = {dim["name"]: dim for dim in response.json()}
+    branch_indegree = by_name[branch_dim.name]["indegree"]
+    main_names = [name for name in names if not name.startswith("proj.feature_x.")]
+    assert branch_indegree > 0, "fixture should give the branch dim a real indegree"
+    # Every main-branch dimension outranks it, including ones linked to less often.
+    assert names.index(branch_dim.name) == len(main_names)
+
+
+@pytest.mark.asyncio
 async def test_list_dimension_query_count(
     client_with_roads: AsyncClient,
     capture_queries: list[str],
@@ -53,19 +147,19 @@ async def test_list_dimension_query_count(
     response = await client_with_roads.get("/dimensions/")
     assert response.status_code == 200
 
-    # The endpoint's own work is two queries: list the dimension nodes, then
-    # aggregate their indegrees.
+    # The endpoint's own work is three queries: list the dimension nodes,
+    # aggregate their indegrees, and classify which sit on a default branch.
     node_queries = [
         query
         for query in capture_queries
         if "FROM node" in query or "FROM dimensionlink" in query
     ]
-    assert len(node_queries) == 2, "\n\n".join(node_queries)
+    assert len(node_queries) == 3, "\n\n".join(node_queries)
 
     # Everything else in the request is per-request auth/RBAC. Cap the total so
     # that a relationship quietly becoming eager-loaded (which would fan out
     # into extra batched selects against other tables) fails here.
-    assert len(capture_queries) <= 8, "\n\n".join(capture_queries)
+    assert len(capture_queries) <= 9, "\n\n".join(capture_queries)
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/api/graphql/common_dimensions_test.py
+++ b/datajunction-server/tests/api/graphql/common_dimensions_test.py
@@ -5,40 +5,9 @@ Tests for the common dimensions query.
 from collections.abc import AsyncGenerator
 
 import pytest
-import pytest_asyncio
 from httpx import AsyncClient
-from sqlalchemy import event
-from sqlalchemy.ext.asyncio import AsyncSession
 
-
-@pytest_asyncio.fixture
-async def capture_queries(
-    session: AsyncSession,
-) -> AsyncGenerator[list[str], None]:
-    """
-    Returns a list of strings, where each string represents a SQL statement
-    captured during the test.
-    """
-    queries = []
-    sync_engine = session.bind.sync_engine
-
-    def before_cursor_execute(
-        _conn,
-        _cursor,
-        statement,
-        _parameters,
-        _context,
-        _executemany,
-    ):
-        queries.append(statement)
-
-    # Attach event listener to capture queries
-    event.listen(sync_engine, "before_cursor_execute", before_cursor_execute)
-
-    yield queries
-
-    # Detach event listener after the test
-    event.remove(sync_engine, "before_cursor_execute", before_cursor_execute)
+# ``capture_queries`` is a shared fixture defined in tests/conftest.py
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -39,7 +39,7 @@ from fastapi_cache.backends.inmemory import InMemoryBackend
 from httpx import AsyncClient
 from psycopg import connect
 from pytest_mock import MockerFixture
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
@@ -2507,3 +2507,33 @@ async def clean_current_user(clean_session: AsyncSession) -> User:
     await clean_session.commit()
     await clean_session.refresh(new_user)
     return new_user
+
+
+@pytest_asyncio.fixture
+async def capture_queries(
+    session: AsyncSession,
+) -> AsyncGenerator[list[str], None]:
+    """
+    Returns a list of strings, where each string represents a SQL statement
+    captured during the test.
+    """
+    queries = []
+    sync_engine = session.bind.sync_engine
+
+    def before_cursor_execute(
+        _conn,
+        _cursor,
+        statement,
+        _parameters,
+        _context,
+        _executemany,
+    ):
+        queries.append(statement)
+
+    # Attach event listener to capture queries
+    event.listen(sync_engine, "before_cursor_execute", before_cursor_execute)
+
+    yield queries
+
+    # Detach event listener after the test
+    event.remove(sync_engine, "before_cursor_execute", before_cursor_execute)

--- a/datajunction-server/tests/sql/dag_test.py
+++ b/datajunction-server/tests/sql/dag_test.py
@@ -443,6 +443,8 @@ class TestGetDimensionDagIndegree:
             (["default.fact1"], {"default.fact1": 0}),
             # Nonexistent node: should skip
             (["nonexistent.dim"], {}),
+            # No names requested: short-circuits without querying
+            ([], {}),
             # Deactivated dimension should not be included
             (
                 ["default.dim1", "default.fact1", "default.deactivated_dim"],

--- a/datajunction-server/tests/sql/dag_test.py
+++ b/datajunction-server/tests/sql/dag_test.py
@@ -466,6 +466,36 @@ class TestGetDimensionDagIndegree:
         assert result == expected
 
     @pytest.mark.asyncio
+    async def test_get_dimension_dag_indegree_issues_one_query(
+        self,
+        session: AsyncSession,
+        dimension_test_graph,
+        capture_queries: list[str],
+    ):
+        """
+        Indegrees must be resolved with a single aggregate query.
+
+        This previously hydrated full ORM ``Node`` objects just to map names to
+        ids, which dragged in each node's columns, parents, dimension links and
+        those links' dimensions. On a large instance ``GET /dimensions/`` spent
+        tens of seconds issuing hundreds of eager-load queries because of it.
+        """
+        node_names = [
+            "default.dim1",
+            "default.dim2",
+            "default.dim3",
+            "default.fact1",
+        ]
+        result = await get_dimension_dag_indegree(session, node_names)
+        assert result == {
+            "default.dim1": 1,
+            "default.dim2": 2,
+            "default.dim3": 0,
+            "default.fact1": 0,
+        }
+        assert len(capture_queries) == 1
+
+    @pytest.mark.asyncio
     async def test_node_downstreams_with_fanout(
         self,
         module__session: AsyncSession,


### PR DESCRIPTION
### Summary

`GET /dimensions/` can be very slow for large numbers of nodes.

This is because `get_dimension_dag_indegree` hydrated a full ORM Node for every dimension node purely to map names to ids. The default load options then eagerly pulled each node's columns, parents, materializations, availability and dimension links -- plus the target dimension (and its current revision) behind every link. With `Node.tags` and `Node.created_by` eagerly loaded at the mapper level, each of those nodes fanned out further still.

This change replaces the two-step lookup with one aggregate query that goes from names straight to counts. The endpoint now does two queries against the node tables instead of hundreds.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
