### PR TITLE
Dimension Picker Typeahead

### DIFF
--- a/datajunction-ui/src/app/pages/AddEditNodePage/FormikSelect.jsx
+++ b/datajunction-ui/src/app/pages/AddEditNodePage/FormikSelect.jsx
@@ -3,6 +3,7 @@
  */
 import { useField } from 'formik';
 import Select from 'react-select';
+import AsyncSelect from 'react-select/async';
 
 export const FormikSelect = ({
   selectOptions,
@@ -17,6 +18,9 @@ export const FormikSelect = ({
   onChange: customOnChange,
   menuPortalTarget,
   styles,
+  // When provided, options are fetched from the server as the user types and
+  // `selectOptions` is only the initial list shown before anything is typed.
+  loadOptions = null,
   ...rest
 }) => {
   // eslint-disable-next-line no-unused-vars
@@ -57,16 +61,26 @@ export const FormikSelect = ({
           )
         : [];
     } else {
-      // For single-select, find the matching option
-      return selectOptions.find(opt => opt.value === field.value) || null;
+      // For single-select, find the matching option. When options are loaded
+      // asynchronously the current value often isn't among them, so fall back
+      // to the raw value rather than rendering an empty control.
+      return (
+        selectOptions.find(opt => opt.value === field.value) ||
+        (loadOptions ? { value: field.value, label: field.value } : null)
+      );
     }
   };
 
+  const SelectComponent = loadOptions ? AsyncSelect : Select;
+
   return (
-    <Select
+    <SelectComponent
       className={className}
       value={getSelectValue()}
       options={selectOptions}
+      {...(loadOptions
+        ? { loadOptions, defaultOptions: selectOptions, cacheOptions: true }
+        : {})}
       name={field.name}
       placeholder={placeholder}
       onBlur={field.onBlur}

--- a/datajunction-ui/src/app/pages/NodePage/AddComplexDimensionLinkPopover.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/AddComplexDimensionLinkPopover.jsx
@@ -12,6 +12,7 @@ import { langs } from '@uiw/codemirror-extensions-langs';
 export default function AddComplexDimensionLinkPopover({
   node,
   dimensions,
+  loadDimensionOptions = null,
   existingLink = null,
   isEditMode = false,
   onSubmit,
@@ -236,6 +237,7 @@ export default function AddComplexDimensionLinkPopover({
                           ) : (
                             <FormikSelect
                               selectOptions={dimensions}
+                              loadOptions={loadDimensionOptions}
                               formikFieldName="dimensionNode"
                               placeholder="Select dimension"
                             />

--- a/datajunction-ui/src/app/pages/NodePage/ManageDimensionLinksDialog.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/ManageDimensionLinksDialog.jsx
@@ -11,6 +11,7 @@ export default function ManageDimensionLinksDialog({
   column,
   node,
   dimensions,
+  loadDimensionOptions = null,
   fkLinks,
   referenceLink,
   onSubmit,
@@ -328,6 +329,7 @@ export default function ManageDimensionLinksDialog({
                               </label>
                               <FormikSelect
                                 selectOptions={dimensions}
+                                loadOptions={loadDimensionOptions}
                                 formikFieldName="fkDimensions"
                                 placeholder="Select dimensions"
                                 isMulti={true}
@@ -403,6 +405,7 @@ export default function ManageDimensionLinksDialog({
                               </label>
                               <FormikSelect
                                 selectOptions={dimensions}
+                                loadOptions={loadDimensionOptions}
                                 formikFieldName="dimensionNode"
                                 placeholder="Select dimension"
                                 defaultValue={

--- a/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeColumnTab.jsx
@@ -10,11 +10,16 @@ import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import foundation from 'react-syntax-highlighter/dist/esm/styles/hljs/foundation';
 import { getColumnIdentifier } from '../../utils/column';
 
+// How many dimensions to show before the user narrows the list by typing.
+const DIMENSION_OPTIONS_LIMIT = 100;
+
 export default function NodeColumnTab({ node, djClient, readOnly = false }) {
   const [attributes, setAttributes] = useState([]);
   const [dimensions, setDimensions] = useState([]);
+  const [dimensionsError, setDimensionsError] = useState(null);
   const [columns, setColumns] = useState([]);
   const [links, setLinks] = useState([]);
+  const dimensionSearchAbort = React.useRef(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -36,9 +41,12 @@ export default function NodeColumnTab({ node, djClient, readOnly = false }) {
     fetchData().catch(console.error);
   }, [djClient]);
 
+  // Only the most-linked dimensions are loaded up front; the rest are reachable
+  // by typing, which searches server-side.
   useEffect(() => {
     const fetchData = async () => {
-      const dimensions = await djClient.dimensions();
+      setDimensionsError(null);
+      const dimensions = await djClient.dimensions(DIMENSION_OPTIONS_LIMIT);
       const options = dimensions.map(dim => {
         return {
           value: dim.name,
@@ -47,8 +55,41 @@ export default function NodeColumnTab({ node, djClient, readOnly = false }) {
       });
       setDimensions(options);
     };
-    fetchData().catch(console.error);
+    fetchData().catch(error => {
+      console.error(error);
+      setDimensionsError('Could not load dimensions. Try reloading the page.');
+    });
   }, [djClient]);
+
+  // react-select calls this on every keystroke; the previous request is
+  // abandoned so out-of-order responses can't overwrite newer ones.
+  const loadDimensionOptions = React.useCallback(
+    async inputValue => {
+      const query = (inputValue || '').trim();
+      if (!query) {
+        return dimensions;
+      }
+      if (dimensionSearchAbort.current) {
+        dimensionSearchAbort.current.abort();
+      }
+      const controller = new AbortController();
+      dimensionSearchAbort.current = controller;
+      try {
+        const matches = await djClient.searchDimensions(query, {
+          signal: controller.signal,
+          limit: DIMENSION_OPTIONS_LIMIT,
+        });
+        return matches.map(dim => ({ value: dim.name, label: dim.name }));
+      } catch (error) {
+        if (error.name === 'AbortError') {
+          return [];
+        }
+        console.error(error);
+        return [];
+      }
+    },
+    [djClient, dimensions],
+  );
 
   const showColumnAttributes = col => {
     const columnIdentifier = getColumnIdentifier(node, col);
@@ -256,6 +297,7 @@ export default function NodeColumnTab({ node, djClient, readOnly = false }) {
                     column={col}
                     node={node}
                     dimensions={dimensions}
+                    loadDimensionOptions={loadDimensionOptions}
                     fkLinks={fkLinksForColumn}
                     referenceLink={referenceLink}
                     onSubmit={async () => {
@@ -359,10 +401,16 @@ export default function NodeColumnTab({ node, djClient, readOnly = false }) {
         >
           <h3 style={{ margin: 0 }}>
             Complex Dimension Links (Custom Join SQL)
+            {dimensionsError ? (
+              <span role="alert" className="alert alert-danger">
+                {dimensionsError}
+              </span>
+            ) : null}
           </h3>
           <AddComplexDimensionLinkPopover
             node={node}
             dimensions={dimensions}
+            loadDimensionOptions={loadDimensionOptions}
             onSubmit={async () => {
               const res = await djClient.node(node.name);
               setLinks(res.dimension_links);
@@ -411,6 +459,7 @@ export default function NodeColumnTab({ node, djClient, readOnly = false }) {
                         <AddComplexDimensionLinkPopover
                           node={node}
                           dimensions={dimensions}
+                          loadDimensionOptions={loadDimensionOptions}
                           existingLink={link}
                           isEditMode={true}
                           onSubmit={async () => {

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -1774,12 +1774,41 @@ export const DataJunctionAPI = {
     );
     return { status: response.status, json: await response.json() };
   },
-  dimensions: async function () {
+  // The full list runs to tens of thousands of entries on a large instance, so
+  // callers that render it should ask for a limit and use `searchDimensions`
+  // for anything past the cut-off.
+  dimensions: async function (limit = null) {
+    const query = limit ? `?limit=${limit}` : '';
     return await (
-      await fetch(`${DJ_URL}/dimensions`, {
+      await fetch(`${DJ_URL}/dimensions/${query}`, {
         credentials: 'include',
       })
     ).json();
+  },
+
+  searchDimensions: async function (query, { signal, limit = 100 } = {}) {
+    const gqlQuery = `
+      query SearchDimensions($q: String!, $limit: Int!) {
+        findNodes(search: $q, nodeTypes: [DIMENSION], limit: $limit) {
+          name
+          current {
+            displayName
+          }
+        }
+      }
+    `;
+    const response = await fetch(DJ_GQL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      signal,
+      body: JSON.stringify({ query: gqlQuery, variables: { q: query, limit } }),
+    });
+    const result = await response.json();
+    return (result?.data?.findNodes || []).map(node => ({
+      name: node.name,
+      displayName: node.current?.displayName || node.name,
+    }));
   },
   nodeDimensions: async function (nodeName) {
     return await (

--- a/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
+++ b/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
@@ -908,9 +908,37 @@ describe('DataJunctionAPI', () => {
   it('calls dimensions correctly', async () => {
     fetch.mockResponseOnce(JSON.stringify(mocks.dimensions));
     await DataJunctionAPI.dimensions();
-    expect(fetch).toHaveBeenCalledWith(`${DJ_URL}/dimensions`, {
+    expect(fetch).toHaveBeenCalledWith(`${DJ_URL}/dimensions/`, {
       credentials: 'include',
     });
+  });
+
+  it('calls dimensions with a limit', async () => {
+    fetch.mockResponseOnce(JSON.stringify(mocks.dimensions));
+    await DataJunctionAPI.dimensions(100);
+    expect(fetch).toHaveBeenCalledWith(`${DJ_URL}/dimensions/?limit=100`, {
+      credentials: 'include',
+    });
+  });
+
+  it('calls searchDimensions correctly', async () => {
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        data: {
+          findNodes: [
+            { name: 'default.hard_hat', current: { displayName: 'Hard Hat' } },
+            { name: 'default.us_state', current: null },
+          ],
+        },
+      }),
+    );
+    const results = await DataJunctionAPI.searchDimensions('hard', {
+      limit: 10,
+    });
+    expect(results).toEqual([
+      { name: 'default.hard_hat', displayName: 'Hard Hat' },
+      { name: 'default.us_state', displayName: 'default.us_state' },
+    ]);
   });
 
   it('calls setAttributes correctly', async () => {


### PR DESCRIPTION
### Summary

The dimension picker on a node's Columns tab loaded every dimension node on mount and filtered them in the browser. On a large instance that's tens of thousands of options in a synchronous select, so the dropdown takes many seconds to become usable and looks broken while it waits.

We now load only the top 100 dimensions up front and search the rest server-side as the user types, reusing the ranking node search already applies. Each keystroke supersedes the last request, so a slow response can't overwrite a newer one.

Additionally:
- `FormikSelect` falls back to the raw field value when the selected option isn't among the loaded ones. Without this, an existing dimension link would render as an empty control once options load lazily.
- A failed load now informs the user in the UI.

This uses the limit parameter added to `GET /dimensions/` in #2430.

### Test Plan

- [ ] PR has an associated issue: #
- [x] make check passes
- [x] make test shows 100% unit test coverage

### Deployment Plan

Depends on #2430