### PR TITLE
Avoid full ORM hydration in `POST /semantic/views/list`

### DIFF
--- a/datajunction-server/datajunction_server/api/semantic_layer.py
+++ b/datajunction-server/datajunction_server/api/semantic_layer.py
@@ -306,10 +306,13 @@ async def list_views(
     full metrics/dimensions are fetched per-view via ``/views/{view}``.
     """
     try:
-        cubes = await Node.find(session, node_type=NodeType.CUBE)
+        cube_names = await Node.find_names(session, node_type=NodeType.CUBE)
     except DJException as exc:
         return _problem(exc.http_status_code or 400, exc.message)
-    return [ViewSummary(name=cube.name, uid=cube.name, features=[]) for cube in cubes]
+    return [
+        ViewSummary(name=cube_name, uid=cube_name, features=[])
+        for cube_name in cube_names
+    ]
 
 
 @router.post("/views/{view_name}", response_model=ViewDetail)

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -948,21 +948,6 @@ class Node(Base):
         return filters
 
     @classmethod
-    async def find(
-        cls,
-        session: AsyncSession,
-        prefix: str | None = None,
-        node_type: NodeType | None = None,
-        *options: ExecutableOption,
-    ) -> list[Node]:
-        """
-        Finds a list of nodes by prefix
-        """
-        statement = select(Node).where(*cls._find_filters(prefix, node_type))
-        result = await session.execute(statement.options(*options))
-        return result.unique().scalars().all()
-
-    @classmethod
     async def find_names(
         cls,
         session: AsyncSession,

--- a/datajunction-server/tests/api/semantic_layer_test.py
+++ b/datajunction-server/tests/api/semantic_layer_test.py
@@ -354,13 +354,8 @@ async def test_list_views_query_count(
     client: AsyncClient,
     capture_queries: list[str],
 ):
-    """``POST /semantic/views/list`` must stay on a small, constant number of queries.
-
-    It used to hydrate every cube as a full ORM ``Node`` object -- and
-    ``Node.created_by``/``Node.tags`` are ``lazy="selectin"`` at the mapper
-    level, so each batch of cubes triggered extra batched queries for users
-    and tags that the response never used. It now selects only the ``name``
-    column, so the query count should not grow with the number of cubes.
+    """
+    Listing views must not hydrate every cube as a full ORM ``Node``.
     """
     await _setup_cube(client)
 
@@ -374,10 +369,7 @@ async def test_list_views_query_count(
     node_queries = [query for query in capture_queries if "FROM node" in query]
     assert len(node_queries) == 1, "\n\n".join(node_queries)
 
-    # Everything else in the request is per-request auth/RBAC (user lookup,
-    # group membership, role assignments). Cap the total so that a
-    # relationship quietly becoming eager-loaded (which would fan out into
-    # extra batched selects against other tables) fails here.
+    # The remaining queries are per-request auth/RBAC.
     assert len(capture_queries) <= 4, "\n\n".join(capture_queries)
 
 

--- a/datajunction-server/tests/api/semantic_layer_test.py
+++ b/datajunction-server/tests/api/semantic_layer_test.py
@@ -349,6 +349,38 @@ async def test_semantic_endpoints_end_to_end(client: AsyncClient):
     assert resp.status_code == 404, resp.text
 
 
+@pytest.mark.asyncio
+async def test_list_views_query_count(
+    client: AsyncClient,
+    capture_queries: list[str],
+):
+    """``POST /semantic/views/list`` must stay on a small, constant number of queries.
+
+    It used to hydrate every cube as a full ORM ``Node`` object -- and
+    ``Node.created_by``/``Node.tags`` are ``lazy="selectin"`` at the mapper
+    level, so each batch of cubes triggered extra batched queries for users
+    and tags that the response never used. It now selects only the ``name``
+    column, so the query count should not grow with the number of cubes.
+    """
+    await _setup_cube(client)
+
+    capture_queries.clear()
+    resp = await _expect(
+        await client.post("/semantic/views/list", json={"runtime_configuration": {}}),
+        200,
+    )
+    assert resp.json()
+
+    node_queries = [query for query in capture_queries if "FROM node" in query]
+    assert len(node_queries) == 1, "\n\n".join(node_queries)
+
+    # Everything else in the request is per-request auth/RBAC (user lookup,
+    # group membership, role assignments). Cap the total so that a
+    # relationship quietly becoming eager-loaded (which would fan out into
+    # extra batched selects against other tables) fails here.
+    assert len(capture_queries) <= 4, "\n\n".join(capture_queries)
+
+
 # ---------------------------------------------------------------------------
 # generate_query_sql request-validation rejections
 #
@@ -418,9 +450,9 @@ async def test_list_views_djexception_returns_problem(
     client: AsyncClient,
     monkeypatch,
 ):
-    """``Node.find`` raising DJException -> problem response in list_views."""
+    """``Node.find_names`` raising DJException -> problem response in list_views."""
     monkeypatch.setattr(
-        "datajunction_server.api.semantic_layer.Node.find",
+        "datajunction_server.api.semantic_layer.Node.find_names",
         AsyncMock(
             side_effect=DJException(message="find blew up", http_status_code=418),
         ),


### PR DESCRIPTION
### Summary

`POST /semantic/views/list` hydrated a full Node ORM entity for every cube in the instance just to read the cube's name, which is expensive. Since `Node.created_by` and Node.tags are `selectin` at the mapper level, each batch of cubes fanned out into extra batched queries for users and tags that the response never used.

This PR switches it to `Node.find_names`, which selects only the name column.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
