### PR TITLE
Avoid ORM over-hydration in `GET /users/{username}`

### DIFF
--- a/datajunction-server/datajunction_server/api/users.py
+++ b/datajunction-server/datajunction_server/api/users.py
@@ -2,18 +2,20 @@
 User related APIs.
 """
 
+from collections import defaultdict
+
 from fastapi import Depends, Query
 from sqlalchemy import distinct, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload
 
-from datajunction_server.database.column import Column
 from datajunction_server.database.history import History
 from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.tag import Tag, TagNodeRelationship
 from datajunction_server.database.user import User
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.models.node import NodeMinimumDetail
+from datajunction_server.models.tag import TagMinimum
 from datajunction_server.models.user import UserActivity
 from datajunction_server.utils import get_session, get_settings
 
@@ -37,20 +39,73 @@ async def list_nodes_by_username(
         & (History.activity_type.in_(activity_types)),
     )
     result = await session.execute(statement)
-    nodes = await Node.get_by_names(
-        session=session,
-        names=list(set(result.scalars().all())),
-        options=[
-            joinedload(Node.current).options(
-                selectinload(NodeRevision.cube_elements)
-                .selectinload(Column.node_revision)
-                .options(
-                    selectinload(NodeRevision.node),
-                ),
-            ),
-        ],
+    names = list(set(result.scalars().all()))
+    if not names:
+        return []
+
+    # Column-only select of exactly the fields `NodeMinimumDetail` needs, joined
+    # to the node's current revision. This avoids hydrating `Node`/`NodeRevision`
+    # ORM entities altogether, which would otherwise fan out into the mapper's
+    # eager-loaded relationships (`created_by`, `node`, `catalog`, etc.) for
+    # every node the user has ever touched.
+    nodes_statement = (
+        select(
+            Node.name,
+            Node.type,
+            Node.current_version,
+            NodeRevision.display_name,
+            NodeRevision.description,
+            NodeRevision.status,
+            NodeRevision.mode,
+            NodeRevision.updated_at,
+        )
+        .join(
+            NodeRevision,
+            (NodeRevision.node_id == Node.id)
+            & (NodeRevision.version == Node.current_version),
+        )
+        .where(Node.name.in_(names))
     )
-    return [node.current for node in nodes]
+    rows = (await session.execute(nodes_statement)).all()
+
+    tags_statement = (
+        select(Node.name, Tag.name)
+        .select_from(Node)
+        .join(TagNodeRelationship, TagNodeRelationship.node_id == Node.id)
+        .join(Tag, Tag.id == TagNodeRelationship.tag_id)
+        .where(Node.name.in_(names))
+    )
+    tags_by_node: dict[str, list[TagMinimum]] = defaultdict(list)
+    for node_name, tag_name in (await session.execute(tags_statement)).all():
+        tags_by_node[node_name].append(TagMinimum(name=tag_name))
+
+    history_statement = select(
+        distinct(History.entity_name),
+        History.user,
+    ).where(
+        History.entity_name.in_(names)
+        & (History.entity_type == EntityType.NODE)
+        & (History.user.is_not(None)),
+    )
+    editors_by_node: dict[str, set[str]] = defaultdict(set)
+    for node_name, editor in (await session.execute(history_statement)).all():
+        editors_by_node[node_name].add(editor)
+
+    return [
+        NodeMinimumDetail(
+            name=row.name,
+            display_name=row.display_name,
+            description=row.description,
+            version=row.current_version,
+            type=row.type,
+            status=row.status,
+            mode=row.mode,
+            updated_at=row.updated_at,
+            tags=tags_by_node.get(row.name, []),
+            edited_by=list(editors_by_node.get(row.name, set())),
+        )
+        for row in rows
+    ]
 
 
 @router.get("/users", response_model=list[str | UserActivity])

--- a/datajunction-server/datajunction_server/api/users.py
+++ b/datajunction-server/datajunction_server/api/users.py
@@ -64,7 +64,7 @@ async def list_nodes_by_username(
             (NodeRevision.node_id == Node.id)
             & (NodeRevision.version == Node.current_version),
         )
-        .where(Node.name.in_(names))
+        .where(Node.name.in_(names) & Node.deactivated_at.is_(None))
     )
     rows = (await session.execute(nodes_statement)).all()
 

--- a/datajunction-server/tests/api/users_test.py
+++ b/datajunction-server/tests/api/users_test.py
@@ -129,3 +129,24 @@ class TestUsers:
         hard_hat_node = nodes_by_name["default.hard_hat"]
         assert hard_hat_node["tags"] == [{"name": "user_activity_tag"}]
         assert hard_hat_node["edited_by"] == ["dj"]
+
+    @pytest.mark.asyncio
+    async def test_list_nodes_by_user_excludes_deactivated(
+        self,
+        client_with_roads: AsyncClient,
+    ) -> None:
+        """
+        Test that ``GET /users/{username}`` omits nodes the user touched that
+        have since been deactivated.
+        """
+
+        response = await client_with_roads.get("/users/dj")
+        assert response.status_code == 200
+        assert "default.hard_hat" in {node["name"] for node in response.json()}
+
+        delete_response = await client_with_roads.delete("/nodes/default.hard_hat")
+        assert delete_response.status_code == 200
+
+        response = await client_with_roads.get("/users/dj")
+        assert response.status_code == 200
+        assert "default.hard_hat" not in {node["name"] for node in response.json()}

--- a/datajunction-server/tests/api/users_test.py
+++ b/datajunction-server/tests/api/users_test.py
@@ -79,3 +79,53 @@ class TestUsers:
             ("default.avg_time_to_dispatch", "metric"),
         }
         assert expected_roads_nodes.issubset(actual_nodes)
+
+    @pytest.mark.asyncio
+    async def test_list_nodes_by_user_no_history(
+        self,
+        module__client_with_roads: AsyncClient,
+    ) -> None:
+        """
+        Test ``GET /users/{username}`` for a user with no matching history
+        returns an empty list without querying nodes/tags/history further.
+        """
+
+        response = await module__client_with_roads.get(
+            "/users/a-user-with-no-history-whatsoever",
+        )
+        assert response.status_code == 200
+        assert response.json() == []
+
+    @pytest.mark.asyncio
+    async def test_list_nodes_by_user_tags_and_edited_by(
+        self,
+        client_with_roads: AsyncClient,
+    ) -> None:
+        """
+        Test that ``GET /users/{username}`` includes tags on nodes the user
+        has touched, and correctly populates `edited_by` from history (rather
+        than always returning it empty).
+        """
+
+        # Create a tag and attach it to a node created by the `dj` user
+        tag_response = await client_with_roads.post(
+            "/tags/",
+            json={
+                "name": "user_activity_tag",
+                "description": "A tag for testing user activity",
+                "tag_type": "test",
+            },
+        )
+        assert tag_response.status_code == 201
+
+        tag_node_response = await client_with_roads.post(
+            "/nodes/default.hard_hat/tags/?tag_names=user_activity_tag",
+        )
+        assert tag_node_response.status_code == 200
+
+        response = await client_with_roads.get("/users/dj")
+        assert response.status_code == 200
+        nodes_by_name = {node["name"]: node for node in response.json()}
+        hard_hat_node = nodes_by_name["default.hard_hat"]
+        assert hard_hat_node["tags"] == [{"name": "user_activity_tag"}]
+        assert hard_hat_node["edited_by"] == ["dj"]


### PR DESCRIPTION
### Summary

Replace ORM Node/NodeRevision fetch (this has an unused `cube_elements` eager-load chain plus mapper-level `selectin`/`joined` loads on `created_by`, `node`, and `catalog`) with a column-only select scoped to exactly the fields the output model `NodeMinimumDetail` needs. Tags and `edited_by` are populated via targeted queries instead of relationship hydration.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
