### PR TITLE
Fix ORM over-hydration in measures, dimensions, git_sync APIs

### DIFF
--- a/datajunction-server/datajunction_server/api/dimensions.py
+++ b/datajunction-server/datajunction_server/api/dimensions.py
@@ -7,10 +7,11 @@ from typing import cast
 
 from fastapi import Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import load_only
 
-from datajunction_server.api.helpers import get_node_by_name
 from datajunction_server.api.nodes import list_nodes
 from datajunction_server.database.node import Node
+from datajunction_server.errors import DJNodeNotFound
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.access.authorization import (
     AccessChecker,
@@ -79,7 +80,12 @@ async def find_nodes_with_dimension(
     """
     dimension_node = cast(
         Node,
-        await Node.get_by_name(session, name, raise_if_not_exists=True),
+        await Node.get_by_name(
+            session,
+            name,
+            options=[load_only(Node.id, Node.name)],
+            raise_if_not_exists=True,
+        ),
     )
     access_checker.add_node(dimension_node, access.ResourceAction.READ)
 
@@ -104,9 +110,21 @@ async def find_nodes_with_common_dimensions(
     """
     Find all nodes that have the list of common dimensions
     """
+    dimension_nodes = await Node.get_by_names(
+        session,
+        dimension,
+        options=[load_only(Node.id, Node.name)],
+    )
+    found_names = {node.name for node in dimension_nodes}
+    missing = [dim for dim in dimension if dim not in found_names]
+    if missing:
+        raise DJNodeNotFound(
+            message=f"A node with name `{missing[0]}` does not exist.",
+            http_status_code=404,
+        )
     nodes = await get_nodes_with_common_dimensions(
         session,
-        [await get_node_by_name(session, dim) for dim in dimension],  # type: ignore
+        dimension_nodes,
         node_type,
     )
     access_checker.add_nodes(nodes, access.ResourceAction.READ)

--- a/datajunction-server/datajunction_server/api/git_sync.py
+++ b/datajunction-server/datajunction_server/api/git_sync.py
@@ -306,7 +306,11 @@ async def sync_node_to_git(
     attributed via Co-authored-by trailer.
     """
     # Get the node
-    node = await Node.get_by_name(session, node_name, options=Node.cube_load_options())
+    node = await Node.get_by_name(
+        session,
+        node_name,
+        options=Node.export_load_options(),
+    )
     if not node:
         raise DJDoesNotExistException(
             message=f"Node '{node_name}' does not exist.",

--- a/datajunction-server/datajunction_server/api/measures.py
+++ b/datajunction-server/datajunction_server/api/measures.py
@@ -7,7 +7,7 @@ import logging
 from fastapi import Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, selectinload
 
 from datajunction_server.database import Node, NodeRevision
 from datajunction_server.database.column import Column
@@ -41,8 +41,8 @@ async def get_measure_by_name(
                 .where(Measure.name == measure_name)
                 .options(
                     joinedload(Measure.columns).options(
-                        joinedload(Column.node_revision).options(
-                            *NodeRevision.default_load_options(),
+                        joinedload(Column.node_revision).load_only(
+                            NodeRevision.name,
                         ),
                     ),
                 ),
@@ -66,22 +66,30 @@ async def get_node_columns(
     """
     Finds all the specified node columns or raises if they don't exist
     """
+    node_names = [node_column.node for node_column in node_columns]
+    nodes = await Node.get_by_names(
+        session,
+        node_names,
+        options=[
+            joinedload(Node.current).options(
+                selectinload(NodeRevision.columns),
+            ),
+        ],
+    )
+    nodes_by_name = {node.name: node for node in nodes}
+
     measure_columns = []
     for node_column in node_columns:
-        node = await Node.get_by_name(
-            session,
-            node_column.node,
-            options=[
-                joinedload(Node.current).options(*NodeRevision.default_load_options()),
-            ],
+        node = nodes_by_name.get(node_column.node)
+        available = (
+            [
+                col
+                for col in node.current.columns  # type: ignore
+                if col.name == node_column.column
+            ]
+            if node
+            else []
         )
-        available = [
-            col
-            for col in node.current.columns  # type: ignore
-            if col.name == node_column.column
-        ]
-        for col in available:
-            await session.refresh(col, ["node_revision"])
         if len(available) == 0:
             raise DJDoesNotExistException(
                 message=f"Column `{node_column.column}` does not exist on "

--- a/datajunction-server/datajunction_server/api/measures.py
+++ b/datajunction-server/datajunction_server/api/measures.py
@@ -72,7 +72,11 @@ async def get_node_columns(
         node_names,
         options=[
             joinedload(Node.current).options(
-                selectinload(NodeRevision.columns),
+                selectinload(NodeRevision.columns).options(
+                    joinedload(Column.node_revision).load_only(
+                        NodeRevision.name,
+                    ),
+                ),
             ),
         ],
     )

--- a/datajunction-server/tests/api/dimensions_test.py
+++ b/datajunction-server/tests/api/dimensions_test.py
@@ -314,3 +314,13 @@ async def test_list_nodes_with_common_dimension(
         "default.avg_repair_order_discounts",
         "default.avg_time_to_dispatch",
     }
+
+    response = await module__client_with_roads_and_acc_revenue.get(
+        "/dimensions/common/?dimension=default.hard_hat&dimension=does.not.exist",
+    )
+    assert response.status_code == 404
+    assert response.json() == {
+        "message": "A node with name `does.not.exist` does not exist.",
+        "errors": [],
+        "warnings": [],
+    }


### PR DESCRIPTION
### Summary

- `get_node_columns`: replace per-column `Node.get_by_name` (full default load graph + per-column session.refresh) with a single batched `Node.get_by_names` call, matching columns in Python
- `get_measure_by_name`: drop the full `NodeRevision.default_load_options()` chain on `Column.node_revision` and use `load_only(NodeRevision.name)` since that's all `ColumnOutput` reads
- `find_nodes_with_dimension`: load only `Node.id`/`Node.name` instead of the full default load graph, since only those are used downstream
- `find_nodes_with_common_dimensions`: batch the per-dimension `get_node_by_name` calls into one `Node.get_by_names` call with just `load_only(Node.id, Node.name)`
- `sync_node_to_git`: switch from `Node.cube_load_options()` to the slimmer `Node.export_load_options()`, which already covers `cube_elements` and everything `to_spec` touches

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
