### PR TITLE
Fix ORM over-hydration in namespace export + delete paths

### DIFF
--- a/datajunction-server/datajunction_server/api/client.py
+++ b/datajunction-server/datajunction_server/api/client.py
@@ -172,13 +172,28 @@ async def notebook_for_exporting_nodes(
         )
 
     if namespace:
-        nodes = await NodeNamespace.list_all_nodes(session, namespace)
+        # build_export_notebook only needs enough of each node to compute the
+        # notebook cell structure (parents for topological sort, dimension
+        # links, and columns/attributes) -- the heavier per-node details
+        # (materializations, availability, created_by) are re-fetched anyway
+        # by python_client_create_node for each node it renders. Use the slim
+        # export options instead of the unbounded default for the whole
+        # namespace.
+        nodes = await NodeNamespace.list_all_nodes(
+            session,
+            namespace,
+            options=Node.export_load_options(),
+        )
         introduction = (
             f"## DJ Namespace Export\n\n"
             f"Exported `{namespace}`\n\n(As of {datetime.now()})"
         )
     else:
-        nodes = await get_upstream_nodes(session, cast(str, cube))
+        nodes = await get_upstream_nodes(
+            session,
+            cast(str, cube),
+            options=Node.export_load_options(),
+        )
         cube_node = cast(
             Node,
             await Node.get_by_name(session, cast(str, cube), raise_if_not_exists=True),

--- a/datajunction-server/datajunction_server/api/namespaces.py
+++ b/datajunction-server/datajunction_server/api/namespaces.py
@@ -37,8 +37,8 @@ from datajunction_server.internal.namespaces import (
     create_or_reactivate_namespace,
     detect_parent_cycle,
     get_git_info_for_namespace,
+    get_node_names_in_namespace,
     get_node_specs_for_export,
-    get_nodes_in_namespace,
     get_nodes_in_namespace_detailed,
     get_project_config,
     get_sources_for_namespace,
@@ -333,8 +333,7 @@ async def deactivate_a_namespace(
         )
 
     # If there are no active nodes in the namespace, we can safely deactivate this namespace
-    node_list = await NodeNamespace.list_nodes(session, namespace)
-    node_names = [node.name for node in node_list]
+    node_names = await get_node_names_in_namespace(session, namespace)
     if len(node_names) == 0:
         message = f"Namespace `{namespace}` has been deactivated."
         await mark_namespace_deactivated(
@@ -419,12 +418,11 @@ async def restore_a_namespace(
             message=f"Node namespace `{namespace}` already exists and is active.",
         )
 
-    node_list = await get_nodes_in_namespace(
+    node_names = await get_node_names_in_namespace(
         session,
         namespace,
         include_deactivated=True,
     )
-    node_names = [node.name for node in node_list]
     # If cascade=true is set, we'll restore all nodes in this namespace and then
     # subsequently restore this namespace
     if cascade:

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -62,7 +62,6 @@ from datajunction_server.models.namespace import (
     NamespaceWriteResult,
     NamespaceWriteStatus,
 )
-from datajunction_server.models.node import NodeMinimumDetail
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.dag import topological_sort
@@ -76,23 +75,6 @@ logger = logging.getLogger(__name__)
 RESERVED_NAMESPACE_NAMES = [
     "user",
 ]
-
-
-async def get_nodes_in_namespace(
-    session: AsyncSession,
-    namespace: str,
-    node_type: NodeType | None = None,
-    include_deactivated: bool = False,
-) -> list[NodeMinimumDetail]:
-    """
-    Gets a list of node names in the namespace
-    """
-    return await NodeNamespace.list_nodes(
-        session,
-        namespace,
-        node_type=node_type,
-        include_deactivated=include_deactivated,
-    )
 
 
 async def get_node_names_in_namespace(

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -16,7 +16,7 @@ from ruamel.yaml import YAML
 from ruamel.yaml.comments import Comment, CommentedMap, CommentedSeq
 from sqlalchemy import bindparam, delete, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload
+from sqlalchemy.orm import joinedload
 from yamlfix import fix_code
 from yamlfix.model import YamlfixConfig, YamlNodeStyle
 
@@ -95,6 +95,28 @@ async def get_nodes_in_namespace(
     )
 
 
+async def get_node_names_in_namespace(
+    session: AsyncSession,
+    namespace: str,
+    include_deactivated: bool = False,
+) -> list[str]:
+    """
+    Gets just the names of nodes in the namespace, without hydrating any
+    ORM relationships. Callers that only need node names (e.g. to iterate
+    over for a cascade operation) should use this instead of building full
+    `NodeMinimumDetail`/`Node` objects and discarding everything but the name.
+    """
+    names_query = select(Node.name).where(
+        or_(
+            Node.namespace.like(f"{namespace}.%"),
+            Node.namespace == namespace,
+        ),
+    )
+    if include_deactivated is False:
+        names_query = names_query.where(Node.deactivated_at.is_(None))
+    return list((await session.execute(names_query)).scalars().all())
+
+
 async def get_nodes_in_namespace_detailed(
     session: AsyncSession,
     namespace: str,
@@ -118,8 +140,10 @@ async def get_nodes_in_namespace_detailed(
         )
         .options(
             joinedload(Node.current).options(
-                *NodeRevision.default_load_options(),
-                selectinload(NodeRevision.cube_elements),  # Needed for cube exports
+                # Slim load options: skips materializations, availability, and
+                # created_by, none of which get_project_config's builders read.
+                # cube_elements is already included (needed for cube exports).
+                *NodeRevision.export_load_options(),
             ),
             joinedload(Node.tags),
         )

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -335,6 +335,30 @@ async def test_list_nodes_by_namespace(
 
 
 @pytest.mark.asyncio
+async def test_list_nodes_include_deactivated(
+    client_with_namespaced_roads: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """
+    Test that ``NodeNamespace.list_nodes`` respects the ``include_deactivated``
+    flag: a deactivated node is excluded by default and only shows up when
+    ``include_deactivated=True`` is passed.
+    """
+    response = await client_with_namespaced_roads.delete("/nodes/foo.bar.dispatcher/")
+    assert response.status_code == 200
+
+    active_only = await NodeNamespace.list_nodes(session, "foo.bar")
+    assert "foo.bar.dispatcher" not in {node.name for node in active_only}
+
+    with_deactivated = await NodeNamespace.list_nodes(
+        session,
+        "foo.bar",
+        include_deactivated=True,
+    )
+    assert "foo.bar.dispatcher" in {node.name for node in with_deactivated}
+
+
+@pytest.mark.asyncio
 async def test_deactivate_namespaces(client_with_namespaced_roads: AsyncClient) -> None:
     """
     Test ``DELETE /namespaces/{namespace}``.


### PR DESCRIPTION
### Summary

This reduces ORM over-hydration in three namespace-level paths:

- `GET /namespaces/{namespace}/export/` hydrated materializations, availability, and `created_by` for every node in the namespace via `NodeRevision.default_load_options()`, but the project-config builders only read what `NodeRevision.export_load_options()` already loads (this is the same trimmed down set that `/export/spec` uses).
- `DELETE /namespaces/{namespace}/` and `POST /namespaces/{namespace}/restore/` built full `NodeMinimumDetail` / `Node` objects just to reduce them to node names, so we can switch both to just select the node name.
- `GET /datajunction-clients/python/notebook` loaded the whole namespace (or whole upstream graph for cube export) with default node-output options. We can just use `Node.export_load_options()` instead since `build_export_notebook` only needs parents (topological sort), `dimension_links`, and columns/attributes. Per-node details are re-fetched individually by `python_client_create_node` anyway.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
