### PR TITLE
Stop over-hydrating Node ORM entities in collections endpoints

### DIFF
--- a/datajunction-server/datajunction_server/api/collection.py
+++ b/datajunction-server/datajunction_server/api/collection.py
@@ -6,12 +6,12 @@ import logging
 from http import HTTPStatus
 
 from fastapi import Depends, HTTPException, Response
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import load_only, noload, selectinload
 from sqlalchemy.sql.operators import is_
 
-from datajunction_server.database.collection import Collection
+from datajunction_server.database.collection import Collection, CollectionNodes
 from datajunction_server.database.node import Node
 from datajunction_server.database.user import User
 from datajunction_server.errors import DJException
@@ -169,19 +169,18 @@ async def delete_nodes_from_collection(
     """
     Delete one or more nodes from a collection
     """
-    collection = await Collection.get_by_name(session, name)
-    nodes = await Node.get_by_names(
-        session=session,
-        names=data,
-        options=[
-            load_only(Node.id, Node.name),
-            noload(Node.created_by),
-            noload(Node.tags),
-        ],
+    collection = await Collection.get_by_name(session, name, raise_if_not_exists=True)
+    # Delete the join rows directly. Going through `collection.nodes` would load
+    # every node in the collection to remove a few, and the read-modify-write it
+    # implies races with a concurrent edit. Names that match nothing delete nothing,
+    # which is the same outcome the membership check gave.
+    await session.execute(
+        delete(CollectionNodes).where(
+            CollectionNodes.collection_id == collection.id,  # type: ignore
+            CollectionNodes.node_id.in_(
+                select(Node.id).where(Node.name.in_(data)),
+            ),
+        ),
     )
-    for node in nodes:
-        if node in collection.nodes:  # type: ignore
-            collection.nodes.remove(node)  # type: ignore
     await session.commit()
-    await session.refresh(collection)
     return Response(status_code=HTTPStatus.NO_CONTENT)

--- a/datajunction-server/datajunction_server/api/collection.py
+++ b/datajunction-server/datajunction_server/api/collection.py
@@ -8,6 +8,7 @@ from http import HTTPStatus
 from fastapi import Depends, HTTPException, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import load_only, noload, selectinload
 from sqlalchemy.sql.operators import is_
 
 from datajunction_server.database.collection import Collection
@@ -87,7 +88,9 @@ async def list_collections(
     List all collections
     """
     collections = await session.execute(
-        select(Collection).where(is_(Collection.deactivated_at, None)),
+        select(Collection)
+        .where(is_(Collection.deactivated_at, None))
+        .options(noload(Collection.nodes)),
     )
     return collections.scalars().all()
 
@@ -105,6 +108,13 @@ async def get_collection(
         session,
         name=name,
         raise_if_not_exists=True,
+        options=[
+            selectinload(Collection.nodes).options(
+                load_only(Node.name),
+                noload(Node.created_by),
+                noload(Node.tags),
+            ),
+        ],
     )
     return collection  # type: ignore
 
@@ -124,7 +134,15 @@ async def add_nodes_to_collection(
     Add one or more nodes to a collection
     """
     collection = await Collection.get_by_name(session, name, raise_if_not_exists=True)
-    nodes = await Node.get_by_names(session=session, names=data)
+    nodes = await Node.get_by_names(
+        session=session,
+        names=data,
+        options=[
+            load_only(Node.id, Node.name),
+            noload(Node.created_by),
+            noload(Node.tags),
+        ],
+    )
     if not nodes:
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND,
@@ -152,7 +170,15 @@ async def delete_nodes_from_collection(
     Delete one or more nodes from a collection
     """
     collection = await Collection.get_by_name(session, name)
-    nodes = await Node.get_by_names(session=session, names=data)
+    nodes = await Node.get_by_names(
+        session=session,
+        names=data,
+        options=[
+            load_only(Node.id, Node.name),
+            noload(Node.created_by),
+            noload(Node.tags),
+        ],
+    )
     for node in nodes:
         if node in collection.nodes:  # type: ignore
             collection.nodes.remove(node)  # type: ignore

--- a/datajunction-server/datajunction_server/database/collection.py
+++ b/datajunction-server/datajunction_server/database/collection.py
@@ -8,6 +8,7 @@ from functools import partial
 from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql.base import ExecutableOption
 
 from datajunction_server.database.base import Base
 from datajunction_server.database.node import Node
@@ -58,11 +59,14 @@ class Collection(Base):
         session: AsyncSession,
         name: str,
         raise_if_not_exists: bool = False,
+        options: list[ExecutableOption] | None = None,
     ) -> Collection | None:
         """
         Get a collection by name
         """
         statement = select(Collection).where(Collection.name == name)
+        if options:
+            statement = statement.options(*options)
         collection = (await session.execute(statement)).scalar()
         if not collection and raise_if_not_exists:
             raise DJDoesNotExistException(

--- a/datajunction-server/tests/api/collections_test.py
+++ b/datajunction-server/tests/api/collections_test.py
@@ -173,6 +173,23 @@ class TestCollections:
         assert response.status_code == 204
 
     @pytest.mark.asyncio
+    async def test_collections_removing_from_a_missing_collection(
+        self,
+        module__client_with_account_revenue: AsyncClient,
+    ) -> None:
+        """
+        Test removing nodes from a collection that does not exist
+        """
+        response = await module__client_with_account_revenue.post(
+            "/collections/no%20such%20collection/remove/",
+            json=["default.payment_type"],
+        )
+        assert response.status_code == 404
+        assert response.json()["message"] == (
+            "Collection with name `no such collection` does not exist."
+        )
+
+    @pytest.mark.asyncio
     async def test_collections_deleting(
         self,
         module__client_with_account_revenue: AsyncClient,


### PR DESCRIPTION
### Summary

- `GET /collections/` keeps hydrating `Collection.nodes` even though `CollectionInfo` never returns nodes, so we can remove the `selectin` load of every node (and each node's `created_by`/`tags`) per collection.
- `GET /collections/{name}` now loads only `Node.name` since that is all that's needed for the output.
- `POST /collections/{name}/nodes/` and `/remove/` fetch only the node name and id, since this info is all that's needed to mutate the join table.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
