### PR TITLE
Report cube materializations the query service refused

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -65,6 +65,7 @@ from datajunction_server.internal.history import EntityType
 from datajunction_server.internal.impact import propagate_impact
 from datajunction_server.internal.materializations import (
     CubeMaterializationSwap,
+    CubeMaterializationSwapOutcome,
     NodeMaterializationTeardown,
     apply_cube_materialization_swap,
     collect_materialization_teardowns,
@@ -2780,16 +2781,73 @@ class DeploymentOrchestrator:
         Hand the deployment's committed cube materialization swaps to the query
         service. Called only after the outer transaction commits, so a deploy that
         rolls back has told the query service nothing.
+
+        The push happens after the commit but before the result is handed back, so a
+        rejection is still reportable -- and has to be. Reconciliation already
+        recorded the materialization as a success on the strength of DJ's own state
+        moving; if the query service then refuses to schedule it, that success is
+        wrong in exactly the way that hid these failures until now.
         """
         request_headers = (
             dict(self.context.request.headers) if self.context.request else {}
         )
         for swap in self._cube_materialization_swaps:
-            await apply_cube_materialization_swap(
+            outcome = await apply_cube_materialization_swap(
                 self.session,
                 swap,
                 self.context.query_service_client,
                 request_headers=request_headers,
+            )
+            if not outcome.scheduled:
+                self._report_materialization_push_failure(outcome)
+
+    def _report_materialization_push_failure(
+        self,
+        outcome: CubeMaterializationSwapOutcome,
+    ) -> None:
+        """
+        Correct the deployment's report on a cube whose materialization the query
+        service refused to schedule.
+
+        FAILED, not WARNING, for the same reason a materialization the reconciler
+        could not build is failed: the author asked for this cube to be materialized
+        and it is not, `api/deployments.py` derives the aggregate status from these
+        results, and reporting `success` for it is precisely the silent gap this
+        feature exists to close.
+
+        The query service's error goes in whole. Its messages name the user, the job,
+        the data project and the table it refused, which is the only part that tells
+        the reader what to do next.
+
+        Matched against the results reconciliation already appended, by the cube's
+        name -- what every materialization result here is keyed by -- and by the
+        rebuilt materialization names, for a swap whose result was recorded under
+        one of those instead. A failure with no result to correct gets a new one
+        rather than going unmentioned.
+        """
+        message = (
+            f"Cube `{outcome.cube_name}`: the query service rejected the request to "
+            f"schedule its materialization: {outcome.error}"
+        )
+        names = {outcome.cube_name, *outcome.materialization_names}
+        matched = [
+            result
+            for result in self.deployed_results
+            if result.deploy_type == DeploymentResult.Type.MATERIALIZATION
+            and result.name in names
+        ]
+        for result in matched:
+            result.status = DeploymentResult.Status.FAILED
+            result.message = message
+        if not matched:
+            self.deployed_results.append(
+                DeploymentResult(
+                    name=outcome.cube_name,
+                    deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                    status=DeploymentResult.Status.FAILED,
+                    operation=DeploymentResult.Operation.UNKNOWN,
+                    message=message,
+                ),
             )
 
     def _stop_deleted_node_materializations(self) -> list[DeploymentResult]:

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -388,6 +388,24 @@ class CubeMaterializationSwap:
     superseded: list[Materialization]
 
 
+@dataclass
+class CubeMaterializationSwapOutcome:
+    """
+    What the query service made of a cube materialization swap.
+
+    Only the scheduling half is reported. Stopping a superseded workflow can fail
+    without the cube losing anything it was promised -- the replacement is already
+    running -- so that failure stays where `stop_cube_materialization_workflows`
+    puts it, and calling it a materialization failure here would point an operator
+    at the wrong cube.
+    """
+
+    cube_name: str
+    materialization_names: list[str]
+    scheduled: bool
+    error: str | None = None
+
+
 async def reconcile_declared_materialization(
     session: AsyncSession,
     revision: NodeRevision,
@@ -639,7 +657,7 @@ async def apply_cube_materialization_swap(
     swap: CubeMaterializationSwap,
     query_service_client: QueryServiceClient | None,
     request_headers: dict[str, str] | None = None,
-) -> None:
+) -> CubeMaterializationSwapOutcome:
     """
     Hand a committed cube materialization swap to the query service.
 
@@ -650,9 +668,19 @@ async def apply_cube_materialization_swap(
     revision cannot use.
 
     Never raises. With no query service configured there is nothing to do at all.
+    Returns what became of the scheduling instead, so a caller holding a report the
+    author will read can say the materialization did not happen: the query service
+    rejects a push for reasons DJ cannot anticipate -- ownership, data project
+    authorization, table access -- and a log line is not where the person who ran
+    the deploy is looking.
     """
+    outcome = CubeMaterializationSwapOutcome(
+        cube_name=swap.cube_name,
+        materialization_names=list(swap.rebuilt_names),
+        scheduled=True,
+    )
     if not query_service_client:
-        return
+        return outcome
     if swap.rebuilt_names:
         try:
             await schedule_materialization_jobs(
@@ -671,6 +699,11 @@ async def apply_cube_materialization_swap(
                 str(exc),
                 exc_info=True,
             )
+            outcome.scheduled = False
+            # Verbatim: the query service names the user, the job and the table it
+            # refused, and paraphrasing that would cost the reader the only part of
+            # the message that says what to do about it.
+            outcome.error = str(exc)
     stop_cube_materialization_workflows(
         query_service_client=query_service_client,
         cube_name=swap.cube_name,
@@ -678,6 +711,7 @@ async def apply_cube_materialization_swap(
         materializations=swap.superseded,
         request_headers=request_headers,
     )
+    return outcome
 
 
 def stop_cube_materialization_workflows(

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -3221,6 +3221,95 @@ class TestDeployments:
         )
 
     @pytest.mark.asyncio
+    async def test_deploy_reports_a_rejected_materialization_push(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+        mock_qs,
+    ):
+        """
+        A query service that refuses to schedule the declared materialization fails
+        the deployment, and the refusal reaches the report intact.
+
+        The push happens after the deploy has committed, so everything else about
+        the deploy still stands -- the cube is created, its DJ-side materialization
+        row exists -- and until this was reported the deployment said `success` for
+        a cube that is not materialized.
+        """
+        namespace = "cube_materialization_rejected"
+        rejection = (
+            "User `dj` is not an owner of data project `analytics`, so Jenkins job "
+            "`analytics-repairs_cube` cannot write `prodhive.analytics.repairs_cube`"
+        )
+        mock_qs.materialize_cube.side_effect = Exception(rejection)
+        cube = CubeSpec(
+            name="default.repairs_cube",
+            display_name="Repairs Cube",
+            description="""Cube for analyzing repair orders""",
+            dimensions=[
+                "${prefix}default.hard_hat.state",
+                "${prefix}default.hard_hat.birth_date",
+            ],
+            metrics=["${prefix}default.avg_length_of_employment"],
+            columns=[
+                ColumnSpec(
+                    name="${prefix}default.hard_hat.birth_date",
+                    partition=PartitionSpec(
+                        type=PartitionType.TEMPORAL,
+                        granularity=Granularity.DAY,
+                        format="yyyyMMdd",
+                    ),
+                ),
+            ],
+            materialization=MaterializationSpec(
+                schedule="0 6 * * *",
+                lookback_window="1 DAY",
+            ),
+            owners=["dj"],
+        )
+        nodes_list = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            cube,
+        ]
+        cube_name = f"{namespace}.default.repairs_cube"
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "failed"
+        assert [
+            result for result in data["results"] if result["name"] == cube_name
+        ] == [
+            {
+                "deploy_type": "node",
+                "message": "Created cube (v1.0)",
+                "name": cube_name,
+                "operation": "create",
+                "changed_fields": [],
+                "status": "success",
+            },
+            {
+                "deploy_type": "materialization",
+                "message": (
+                    f"Cube `{cube_name}`: the query service rejected the request to "
+                    f"schedule its materialization: {rejection}"
+                ),
+                "name": cube_name,
+                "operation": "create",
+                "changed_fields": [],
+                "status": "failed",
+            },
+        ]
+
+    @pytest.mark.asyncio
     async def test_deploy_cube_with_custom_metadata(
         self,
         client,

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -32,6 +32,10 @@ from datajunction_server.internal.deployment.validation import (
     CubeValidationData,
     NodeValidationResult,
 )
+from datajunction_server.internal.materializations import (
+    CubeMaterializationSwap,
+    CubeMaterializationSwapOutcome,
+)
 from datajunction_server.models.deployment import (
     ChangeTier,
     ColumnSpec,
@@ -3596,3 +3600,186 @@ class TestDeriveLegacyUnitForStorage:
             None,
         )
         assert result == MetricUnit.SECOND
+
+
+class TestApplyCubeMaterializationSwaps:
+    """
+    Reporting on the query service's answer to a cube materialization push.
+
+    The push happens after the deploy commits, and until it was reported a query
+    service that rejected it left the deployment claiming success.
+    """
+
+    @staticmethod
+    def _swap(cube_name: str, rebuilt_names: list[str]) -> CubeMaterializationSwap:
+        return CubeMaterializationSwap(
+            cube_name=cube_name,
+            previous_version="v1.0",
+            new_revision_id=7,
+            new_version="v1.1",
+            rebuilt_names=rebuilt_names,
+            superseded=[],
+        )
+
+    @staticmethod
+    def _result(name: str) -> DeploymentResult:
+        """The success reconciliation appends before the push is attempted."""
+        return DeploymentResult(
+            name=name,
+            deploy_type=DeploymentResult.Type.MATERIALIZATION,
+            status=DeploymentResult.Status.SUCCESS,
+            operation=DeploymentResult.Operation.CREATE,
+            message="cube materialization on schedule @daily",
+        )
+
+    @pytest.mark.asyncio
+    async def test_rejected_push_fails_the_reported_materialization(
+        self,
+        orchestrator,
+    ):
+        """
+        A rejection turns the cube's already-reported success into a failure that
+        repeats the query service's message word for word, while an unrelated cube
+        that pushed cleanly keeps its success.
+        """
+        orchestrator.context.request = None
+        rejection = (
+            "User `dj` does not own data project `analytics`; Jenkins job "
+            "`analytics-a_cube` cannot write `prodhive.analytics.a_cube`"
+        )
+        orchestrator._cube_materialization_swaps = [
+            self._swap("default.a_cube", ["druid_cube__full__a_cube"]),
+            self._swap("default.b_cube", ["druid_cube__full__b_cube"]),
+        ]
+        orchestrator.deployed_results = [
+            self._result("default.a_cube"),
+            self._result("default.b_cube"),
+        ]
+
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator."
+            "apply_cube_materialization_swap",
+            new=AsyncMock(
+                side_effect=[
+                    CubeMaterializationSwapOutcome(
+                        cube_name="default.a_cube",
+                        materialization_names=["druid_cube__full__a_cube"],
+                        scheduled=False,
+                        error=rejection,
+                    ),
+                    CubeMaterializationSwapOutcome(
+                        cube_name="default.b_cube",
+                        materialization_names=["druid_cube__full__b_cube"],
+                        scheduled=True,
+                    ),
+                ],
+            ),
+        ):
+            await orchestrator._apply_cube_materialization_swaps()
+
+        assert orchestrator.deployed_results == [
+            DeploymentResult(
+                name="default.a_cube",
+                deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                status=DeploymentResult.Status.FAILED,
+                operation=DeploymentResult.Operation.CREATE,
+                message=(
+                    "Cube `default.a_cube`: the query service rejected the request "
+                    f"to schedule its materialization: {rejection}"
+                ),
+            ),
+            self._result("default.b_cube"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_rejected_push_matched_by_materialization_name(
+        self,
+        orchestrator,
+    ):
+        """
+        A result recorded under the materialization's own name rather than the
+        cube's is still the result the failure belongs on.
+        """
+        orchestrator.context.request = None
+        orchestrator._cube_materialization_swaps = [
+            self._swap("default.a_cube", ["druid_cube__full__a_cube"]),
+        ]
+        orchestrator.deployed_results = [self._result("druid_cube__full__a_cube")]
+
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator."
+            "apply_cube_materialization_swap",
+            new=AsyncMock(
+                return_value=CubeMaterializationSwapOutcome(
+                    cube_name="default.a_cube",
+                    materialization_names=["druid_cube__full__a_cube"],
+                    scheduled=False,
+                    error="unreachable",
+                ),
+            ),
+        ):
+            await orchestrator._apply_cube_materialization_swaps()
+
+        assert orchestrator.deployed_results == [
+            DeploymentResult(
+                name="druid_cube__full__a_cube",
+                deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                status=DeploymentResult.Status.FAILED,
+                operation=DeploymentResult.Operation.CREATE,
+                message=(
+                    "Cube `default.a_cube`: the query service rejected the request "
+                    "to schedule its materialization: unreachable"
+                ),
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_rejected_push_with_nothing_to_correct_is_still_reported(
+        self,
+        orchestrator,
+    ):
+        """
+        A revision swap the deployment never reported a materialization for -- a
+        cube rebuilt because its definition moved, not because it declared a block
+        -- gets a result of its own rather than being dropped.
+        """
+        orchestrator.context.request = None
+        orchestrator._cube_materialization_swaps = [
+            self._swap("default.a_cube", ["druid_cube__full__a_cube"]),
+        ]
+        node_result = DeploymentResult(
+            name="default.a_cube",
+            deploy_type=DeploymentResult.Type.NODE,
+            status=DeploymentResult.Status.SUCCESS,
+            operation=DeploymentResult.Operation.UPDATE,
+            message="Updated cube (v1.1)",
+        )
+        orchestrator.deployed_results = [node_result]
+
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator."
+            "apply_cube_materialization_swap",
+            new=AsyncMock(
+                return_value=CubeMaterializationSwapOutcome(
+                    cube_name="default.a_cube",
+                    materialization_names=["druid_cube__full__a_cube"],
+                    scheduled=False,
+                    error="403 Forbidden",
+                ),
+            ),
+        ):
+            await orchestrator._apply_cube_materialization_swaps()
+
+        assert orchestrator.deployed_results == [
+            node_result,
+            DeploymentResult(
+                name="default.a_cube",
+                deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                status=DeploymentResult.Status.FAILED,
+                operation=DeploymentResult.Operation.UNKNOWN,
+                message=(
+                    "Cube `default.a_cube`: the query service rejected the request "
+                    "to schedule its materialization: 403 Forbidden"
+                ),
+            ),
+        ]

--- a/datajunction-server/tests/internal/materializations_test.py
+++ b/datajunction-server/tests/internal/materializations_test.py
@@ -4,9 +4,14 @@ Tests for node materialization helper functions.
 
 from unittest import mock
 
+import pytest
+
 from datajunction_server.database.materialization import Materialization
 from datajunction_server.internal.materializations import (
+    CubeMaterializationSwap,
+    CubeMaterializationSwapOutcome,
     NodeMaterializationTeardown,
+    apply_cube_materialization_swap,
     stop_cube_materialization_workflows,
     stop_materialization_workflows,
 )
@@ -227,3 +232,139 @@ def test_stop_materialization_workflows_reports_every_failure():
         "version v1.0, but the query service did not stop its workflow: unreachable. "
         "The workflow may still be running.",
     ]
+
+
+def _swap(rebuilt_names: list[str]) -> CubeMaterializationSwap:
+    """A swap with one superseded materialization and the given rebuilt names."""
+    return CubeMaterializationSwap(
+        cube_name="default.a_cube",
+        previous_version="v1.0",
+        new_revision_id=42,
+        new_version="v1.1",
+        rebuilt_names=rebuilt_names,
+        superseded=[
+            Materialization(
+                name="druid_cube_v3",
+                config={"workflow_names": ["cube_workflow_1"]},
+            ),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_cube_swap_reports_a_scheduled_push():
+    """
+    A push the query service accepted reports the cube scheduled, with no error to
+    carry back to the deployment.
+    """
+    query_service_client = mock.MagicMock()
+    session = mock.MagicMock()
+
+    with mock.patch(
+        "datajunction_server.internal.materializations.schedule_materialization_jobs",
+        new=mock.AsyncMock(),
+    ) as schedule:
+        outcome = await apply_cube_materialization_swap(
+            session,
+            _swap(["druid_cube_v3"]),
+            query_service_client,
+            request_headers={"cookie": "a-cookie"},
+        )
+
+    assert outcome == CubeMaterializationSwapOutcome(
+        cube_name="default.a_cube",
+        materialization_names=["druid_cube_v3"],
+        scheduled=True,
+        error=None,
+    )
+    assert schedule.call_args_list == [
+        mock.call(
+            session,
+            node_revision_id=42,
+            materialization_names=["druid_cube_v3"],
+            query_service_client=query_service_client,
+            request_headers={"cookie": "a-cookie"},
+        ),
+    ]
+    assert query_service_client.deactivate_workflows.call_args_list == [
+        mock.call(
+            workflow_names=["cube_workflow_1"],
+            request_headers={"cookie": "a-cookie"},
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_apply_cube_swap_reports_a_rejected_push():
+    """
+    A query service that refuses the push still does not raise -- the deploy has
+    committed -- but the refusal comes back verbatim, and the superseded workflow is
+    stopped regardless: DJ has already recorded it as inactive.
+    """
+    query_service_client = mock.MagicMock()
+    rejection = (
+        "User `dj` is not an owner of data project `analytics` and cannot write to "
+        "`prodhive.analytics.a_cube`"
+    )
+
+    with mock.patch(
+        "datajunction_server.internal.materializations.schedule_materialization_jobs",
+        new=mock.AsyncMock(side_effect=Exception(rejection)),
+    ):
+        outcome = await apply_cube_materialization_swap(
+            mock.MagicMock(),
+            _swap(["druid_cube_v3"]),
+            query_service_client,
+        )
+
+    assert outcome == CubeMaterializationSwapOutcome(
+        cube_name="default.a_cube",
+        materialization_names=["druid_cube_v3"],
+        scheduled=False,
+        error=rejection,
+    )
+    assert query_service_client.deactivate_workflows.call_args_list == [
+        mock.call(workflow_names=["cube_workflow_1"], request_headers=None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_apply_cube_swap_of_a_teardown_scheduled_nothing_and_failed_nothing():
+    """
+    A swap that rebuilt nothing is a teardown. There is no scheduling to fail, so it
+    reports success with no names -- a workflow the query service could not stop is
+    `stop_cube_materialization_workflows`'s to report, not a materialization failure
+    to hang on the cube.
+    """
+    query_service_client = mock.MagicMock()
+    query_service_client.deactivate_workflows.side_effect = Exception("unreachable")
+
+    outcome = await apply_cube_materialization_swap(
+        mock.MagicMock(),
+        _swap([]),
+        query_service_client,
+    )
+
+    assert outcome == CubeMaterializationSwapOutcome(
+        cube_name="default.a_cube",
+        materialization_names=[],
+        scheduled=True,
+        error=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_cube_swap_without_a_query_service():
+    """
+    With no query service configured there is nothing to push and nothing to report.
+    """
+    assert await apply_cube_materialization_swap(
+        mock.MagicMock(),
+        _swap(["druid_cube_v3"]),
+        None,
+    ) == CubeMaterializationSwapOutcome(
+        cube_name="default.a_cube",
+        materialization_names=["druid_cube_v3"],
+        scheduled=True,
+        error=None,
+    )


### PR DESCRIPTION
### Summary

Scheduling a cube's materialization happens after the deploy commits, and `apply_cube_materialization_swap` is deliberately non-raising so a slow or unhappy query service cannot block the rest of the action. This process logged the refusal but otherwise left the failures invisible.

The swap now reports whether or not scheduling was successful, and the orchestrator records the deployment result for the cube as `FAILED` if the query service didn't succeed in scheduling. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
