### PR TITLE
Send owners and metadata when refreshing a materialization

### DIFF
--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -91,7 +91,10 @@ from datajunction_server.models.attribute import (
 )
 from datajunction_server.models.base import labelize
 from datajunction_server.models.cube import CubeRevisionMetadata
-from datajunction_server.models.cube_materialization import UpsertCubeMaterialization
+from datajunction_server.models.cube_materialization import (
+    UpsertCubeMaterialization,
+    principal_refs,
+)
 from datajunction_server.models.deployment import (
     ChangeTier,
     CubeSpec,
@@ -1960,9 +1963,19 @@ async def update_cube_node(
                     mat.deactivated_at = None
             await session.commit()
 
+            # ``Node.owners`` is lazy and ``get_cube_by_name`` does not eager-load
+            # it, so reading it here without an explicit refresh would emit a sync
+            # lazy-load inside the async request and surface as MissingGreenlet
+            # whenever the identity map happens not to hold it already.
+            await session.refresh(node, ["owners"])  # type: ignore
+            owners = [owner.model_dump() for owner in principal_refs(node.owners)]  # type: ignore
+
             # Serialize active materializations as complete, ready-to-use dicts
             # so dj-query can parse them directly into model inputs without merging.
             # This avoids a callback from query service back to DJ.
+            # The attribution fields (owners, custom_metadata) must match what the
+            # normal scheduling path in DruidCubeMaterializationJob.schedule sends,
+            # or the query service cannot tell who owns the refreshed workflow.
             active_mats = []
             for mat in node_revision.materializations:
                 if mat.deactivated_at:
@@ -1977,6 +1990,8 @@ async def update_cube_node(
                         "name": node_revision.name,
                         "version": node_revision.version,
                     },
+                    "owners": owners,
+                    "custom_metadata": node_revision.custom_metadata,
                 }
                 active_mats.append(mat_dict)
             query_service_client.refresh_cube_materialization(

--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -11,9 +11,9 @@ from datajunction_server.materialization.jobs.materialization_job import (
     MaterializationJob,
 )
 from datajunction_server.models.cube_materialization import (
-    PrincipalRef,
     DruidCubeConfig,
     DruidCubeMaterializationInput,
+    principal_refs,
 )
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.materialization import (
@@ -159,13 +159,7 @@ class DruidCubeMaterializationJob(DruidMaterializationJob, MaterializationJob):
                 job=materialization.job,
                 lookback_window=cube_config.lookback_window,
                 retention=cube_config.retention,
-                owners=[
-                    PrincipalRef(username=owner.username, kind=owner.kind)
-                    for owner in sorted(
-                        revision.node.owners,
-                        key=lambda owner: owner.username,
-                    )
-                ],
+                owners=principal_refs(revision.node.owners),
                 custom_metadata=revision.custom_metadata,
                 measures_materializations=cube_config.measures_materializations,
                 combiners=cube_config.combiners,

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -1,6 +1,7 @@
 """Models related to cube materialization"""
 
 import hashlib
+from collections.abc import Iterable
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, computed_field, field_validator
@@ -481,6 +482,20 @@ class PrincipalRef(BaseModel):
 
     username: str
     kind: Literal["user", "service_account", "group"] = "user"
+
+
+def principal_refs(owners: Iterable[Any]) -> list[PrincipalRef]:
+    """
+    The owners of a node, in the shape a materialization payload carries them.
+
+    Every path that hands a materialization to the query service goes through here,
+    so the attribution the query service reads is identical no matter whether the
+    materialization was scheduled fresh or refreshed in place.
+    """
+    return [
+        PrincipalRef(username=owner.username, kind=owner.kind)
+        for owner in sorted(owners, key=lambda owner: owner.username)
+    ]
 
 
 class DruidCubeMaterializationInput(BaseModel):

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -6406,6 +6406,59 @@ class TestCubeRefreshMaterialization:
         response = await client_with_repairs_cube.get(f"/nodes/{cube_name}/")
         assert response.json()["version"] == initial_version
 
+    @pytest.mark.asyncio
+    async def test_refresh_materialization_carries_attribution(
+        self,
+        client_with_repairs_cube: AsyncClient,
+        mocker,
+    ):
+        """
+        A refreshed materialization carries the same owners and custom metadata the
+        normal scheduling path sends, so the query service can work out who owns the
+        resulting workflow and which data project it belongs to.
+        """
+        cube_name = "default.test_refresh_attribution_cube"
+        mock_qs_client = mocker.MagicMock()
+        mock_qs_client.materialize.return_value = mocker.MagicMock(
+            urls=["http://workflow/setup"],
+        )
+        client_with_repairs_cube.app.dependency_overrides[get_query_service_client] = (
+            lambda: mock_qs_client
+        )
+        await make_a_test_cube(
+            client_with_repairs_cube,
+            cube_name,
+            with_materialization=True,
+        )
+
+        # Give the cube the metadata the query service routes on
+        response = await client_with_repairs_cube.patch(
+            f"/nodes/{cube_name}/",
+            json={"custom_metadata": {"project": "repairs"}},
+        )
+        assert response.status_code == 200, response.json()
+
+        mock_refresh = mocker.patch.object(
+            mock_qs_client,
+            "refresh_cube_materialization",
+            return_value=mocker.MagicMock(urls=["http://workflow/refreshed"]),
+        )
+        response = await client_with_repairs_cube.patch(
+            f"/nodes/{cube_name}/?refresh_materialization=true",
+            json={},
+        )
+        assert response.status_code == 200
+
+        materializations = mock_refresh.call_args[1]["materializations"]
+        assert [
+            (mat["owners"], mat["custom_metadata"]) for mat in materializations
+        ] == [
+            (
+                [{"username": "dj", "kind": "user"}],
+                {"project": "repairs"},
+            ),
+        ]
+
 
 class TestStopStaleCubeMaterializationWorkflows:
     """


### PR DESCRIPTION
### Summary

Refreshing a cube's materializations builds its payload by hand rather than going through `DruidCubeMaterializationJob`, and that payload doesn't include owners or custom metadata.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
