### PR TITLE
Add materialization coverage in YAML

### DIFF
--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -743,6 +743,10 @@ class Node(Base):
             # Configs persisted before `retention` existed will be built with the
             # default on their next run, so that is what the export should show.
             retention=config.get("retention", DEFAULT_CUBE_RETENTION),
+            # Coverage has no default: unlike `retention`, an absent value means the
+            # author declared no span rather than that they accepted DJ's. Stored as
+            # the aliased `from`/`to`/`window` keys, so it validates straight back.
+            coverage=config.get("coverage"),
         )
 
     @classmethod

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -743,9 +743,7 @@ class Node(Base):
             # Configs persisted before `retention` existed will be built with the
             # default on their next run, so that is what the export should show.
             retention=config.get("retention", DEFAULT_CUBE_RETENTION),
-            # Coverage has no default: unlike `retention`, an absent value means the
-            # author declared no span rather than that they accepted DJ's. Stored as
-            # the aliased `from`/`to`/`window` keys, so it validates straight back.
+            # No default: absent means the author declared none.
             coverage=config.get("coverage"),
         )
 

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -743,7 +743,6 @@ class Node(Base):
             # Configs persisted before `retention` existed will be built with the
             # default on their next run, so that is what the export should show.
             retention=config.get("retention", DEFAULT_CUBE_RETENTION),
-            # No default: absent means the author declared none.
             coverage=config.get("coverage"),
         )
 

--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -525,5 +525,8 @@ async def build_cube_materialization(
         combiners=combiners,
         lookback_window=upsert_input.lookback_window if incremental else None,
         retention=upsert_input.retention,
+        # Unconditional, unlike `lookback_window`: coverage is the span the cube
+        # should serve, which a full rebuild has just as much of an answer for.
+        coverage=upsert_input.coverage,
     )
     return config

--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -525,8 +525,7 @@ async def build_cube_materialization(
         combiners=combiners,
         lookback_window=upsert_input.lookback_window if incremental else None,
         retention=upsert_input.retention,
-        # Unconditional, unlike `lookback_window`: coverage is the span the cube
-        # should serve, which a full rebuild has just as much of an answer for.
+        # Unconditional: a full rebuild serves a span too.
         coverage=upsert_input.coverage,
     )
     return config

--- a/datajunction-server/datajunction_server/internal/cube_materializations.py
+++ b/datajunction-server/datajunction_server/internal/cube_materializations.py
@@ -525,7 +525,6 @@ async def build_cube_materialization(
         combiners=combiners,
         lookback_window=upsert_input.lookback_window if incremental else None,
         retention=upsert_input.retention,
-        # Unconditional: a full rebuild serves a span too.
         coverage=upsert_input.coverage,
     )
     return config

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -4,7 +4,7 @@ import time
 from collections import Counter
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from datetime import UTC
+from datetime import UTC, datetime
 from typing import cast
 
 from sqlalchemy import func, or_, select, text
@@ -68,8 +68,12 @@ from datajunction_server.internal.materializations import (
     CubeMaterializationSwapOutcome,
     NodeMaterializationTeardown,
     apply_cube_materialization_swap,
+    backfill_recorded,
     collect_materialization_teardowns,
+    coverage_gap,
+    coverage_partition,
     reconcile_declared_materialization,
+    record_backfill,
     stop_materialization_workflows,
     swap_cube_materializations,
 )
@@ -361,6 +365,9 @@ class DeploymentOrchestrator:
         self._timer = DeploymentTimer()
         self._cube_materialization_swaps: list[CubeMaterializationSwap] = []
         self._materialization_teardowns: list[NodeMaterializationTeardown] = []
+        # Cubes rebuilt onto a new, empty datasource.
+        self._rebuilt_cubes: set[str] = set()
+        self._branch_deploy: bool | None = None
 
     @property
     def _history_user(self) -> str:
@@ -2344,9 +2351,8 @@ class DeploymentOrchestrator:
                 declared=declared,
             )
             if swap:
-                if swap.rebuilt_names and declared:
-                    # A new version means an empty datasource.
-                    swap.backfill = declared.coverage
+                if swap.rebuilt_names:
+                    self._rebuilt_cubes.add(new_revision.name)
                 self._cube_materialization_swaps.append(swap)
 
     def _declared_materializations(self) -> dict[str, MaterializationSpec]:
@@ -2544,11 +2550,9 @@ class DeploymentOrchestrator:
         schedule anything -- an unchanged re-declare, or a block a revision swap has
         already built from, costs no remote call at all.
 
-        `active_names` is what the cube had materialized before reconciling. A block
-        that builds a name absent from it writes a datasource with nothing in it, so
-        a declared `coverage` is handed on as the span to backfill. Everything else
-        the reconciler changes -- the schedule, the lookback window, the coverage
-        itself -- keeps the datasource the cube already has.
+        `active_names` is what the cube had materialized before reconciling, which
+        says whether the block wrote a datasource the cube did not have. It is
+        `_plan_coverage_backfill` that reads it, once the row is in hand.
         """
         operation = (
             DeploymentResult.Operation.CREATE
@@ -2655,13 +2659,14 @@ class DeploymentOrchestrator:
                         new_version=revision.version,
                         rebuilt_names=[materialization.name],
                         superseded=[],
-                        backfill=(
-                            block.coverage
-                            if materialization.name not in active_names
-                            else None
-                        ),
                     ),
                 )
+            await self._plan_coverage_backfill(
+                revision,
+                block,
+                materialization,
+                active_names,
+            )
         self.deployed_results.append(
             DeploymentResult(
                 name=revision.name,
@@ -2669,6 +2674,68 @@ class DeploymentOrchestrator:
                 status=DeploymentResult.Status.SUCCESS,
                 operation=operation,
                 message=f"cube materialization on schedule {block.schedule}",
+            ),
+        )
+
+    async def _plan_coverage_backfill(
+        self,
+        revision: NodeRevision,
+        block: MaterializationSpec,
+        materialization: Materialization,
+        active_names: set[str],
+    ) -> None:
+        """
+        Queue the backfill a cube's declared coverage asks for.
+
+        Two things leave a cube short of the span it declares. A datasource this
+        deploy minted -- a rebuilt version, or a materialization the cube did not
+        have -- is empty, so the whole span is missing. A datasource the cube
+        already has can simply hold less history than the cube now declares, and
+        `coverage_gap` reads how much less off availability.
+
+        The span is recorded beside the cube's other backfills and never asked for
+        twice, since availability does not move until the backfill lands. A branch
+        deploy asks for nothing: it previews what the push would give its author,
+        and a preview does not spend hundreds of partition runs.
+        """
+        coverage = block.coverage
+        partition = coverage_partition(revision)
+        if not coverage or partition is None or await self._is_branch_deploy():
+            return
+        span = coverage.span(datetime.now(UTC).date())
+        if span is None:
+            self.warnings.append(
+                DJError(
+                    code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
+                    message=(
+                        f"Cube `{revision.name}`: DJ counts a coverage window in "
+                        "days or weeks only."
+                    ),
+                ),
+            )
+            return
+        fresh = (
+            revision.name in self._rebuilt_cubes
+            or materialization.name not in active_names
+        )
+        if not fresh:
+            span = coverage_gap(span, revision)
+        if span is None:
+            return
+        # A backfill needs the materialization's id.
+        await self.session.flush()
+        if await backfill_recorded(self.session, materialization, span[0]):
+            return
+        record_backfill(self.session, materialization, partition, span)
+        self._cube_materialization_swaps.append(
+            CubeMaterializationSwap(
+                cube_name=revision.name,
+                previous_version=revision.version,
+                new_revision_id=revision.id,
+                new_version=revision.version,
+                rebuilt_names=[],
+                superseded=[],
+                backfill=span,
             ),
         )
 
@@ -2806,16 +2873,12 @@ class DeploymentOrchestrator:
         moving; if the query service then refuses to schedule it, that success is
         wrong in exactly the way that hid these failures until now.
 
-        A coverage backfill rides along with the scheduling, on every deploy but a
-        branch one. A branch namespace exists so its author can see what the push
-        would give them, and hundreds of partition runs is not part of the preview.
+        A swap carrying a coverage backfill is queued after the one that schedules
+        the materialization, so the workflow the backfill runs on exists by then.
         """
         request_headers = (
             dict(self.context.request.headers) if self.context.request else {}
         )
-        if await self._is_branch_deploy():
-            for swap in self._cube_materialization_swaps:
-                swap.backfill = None
         for swap in self._cube_materialization_swaps:
             outcome = await apply_cube_materialization_swap(
                 self.session,
@@ -2834,49 +2897,44 @@ class DeploymentOrchestrator:
 
         A branch is a namespace of its own, linked to a git branch, so the target
         namespace is what says which. A namespace with no git root behind it -- a
-        plain `dj deploy` -- is not a branch.
+        plain `dj deploy` -- is not a branch. Asked once per deploy.
         """
-        git_info = await get_git_info_for_namespace(
-            self.session,
-            self.deployment_spec.namespace,
-        )
-        return git_info is not None and not git_info["is_default_branch"]
+        if self._branch_deploy is None:
+            git_info = await get_git_info_for_namespace(
+                self.session,
+                self.deployment_spec.namespace,
+            )
+            self._branch_deploy = (
+                git_info is not None and not git_info["is_default_branch"]
+            )
+        return self._branch_deploy
 
     def _report_backfill(
         self,
         outcome: CubeMaterializationSwapOutcome,
     ) -> None:
         """
-        Say what the cube's new datasource is being filled with.
+        Say what days the cube is being filled with, and what they cost.
 
-        The run count is the point of the warning. A backfill runs one job per day
-        of the declared span, and a mistyped `from` is worth seeing at deploy time
-        rather than on a bill -- so the span is reported as launched, never capped:
-        two years of history is a thing authors legitimately ask for, and a cap is
-        something they could not undo from YAML.
+        The run count is the point. A backfill runs one job per day of the span,
+        and a mistyped `from` is worth seeing at deploy time rather than on a
+        bill -- so the span is reported, never capped: two years of history is a
+        thing authors legitimately ask for, and a cap is something they could not
+        undo from YAML.
         """
         if outcome.backfill_span is None:
             self.warnings.append(
                 DJError(
-                    code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
+                    code=ErrorCode.QUERY_SERVICE_ERROR,
                     message=(
-                        f"Cube `{outcome.cube_name}`: no backfill ran. "
-                        f"{outcome.backfill_error}"
+                        f"Cube `{outcome.cube_name}`: the query service refused "
+                        f"the backfill: {outcome.backfill_error}"
                     ),
                 ),
             )
             return
         start, end = outcome.backfill_span
         runs = (end - start).days + 1
-        self.warnings.append(
-            DJError(
-                code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
-                message=(
-                    f"Cube `{outcome.cube_name}`: backfilling {start} to {end} "
-                    f"costs {runs} partition runs."
-                ),
-            ),
-        )
         self.deployed_results.append(
             DeploymentResult(
                 name=outcome.cube_name,

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -73,6 +73,7 @@ from datajunction_server.internal.materializations import (
     stop_materialization_workflows,
     swap_cube_materializations,
 )
+from datajunction_server.internal.namespaces import get_git_info_for_namespace
 from datajunction_server.internal.nodes import (
     derive_frozen_measures_bulk,
     is_non_trivial_cube_change,
@@ -2328,6 +2329,7 @@ class DeploymentOrchestrator:
         )
         declared_specs = self._declared_materializations()
         for old_revision, new_revision in swappable:
+            declared = declared_specs.get(new_revision.name)
             swap = await swap_cube_materializations(
                 self.session,
                 old_revision,
@@ -2339,9 +2341,12 @@ class DeploymentOrchestrator:
                     old_revision,
                     new_revision,
                 ),
-                declared=declared_specs.get(new_revision.name),
+                declared=declared,
             )
             if swap:
+                if swap.rebuilt_names and declared:
+                    # A new version means an empty datasource.
+                    swap.backfill = declared.coverage
                 self._cube_materialization_swaps.append(swap)
 
     def _declared_materializations(self) -> dict[str, MaterializationSpec]:
@@ -2458,6 +2463,7 @@ class DeploymentOrchestrator:
                         declared[name],
                         persisted.get(name),
                         access_checker,
+                        {mat.name for mat in active.get(name, [])},
                     )
             elif name in removing:
                 self._remove_cube_materialization(
@@ -2526,6 +2532,7 @@ class DeploymentOrchestrator:
         block: MaterializationSpec,
         persisted: MaterializationSpec | MaterializationAction | None,
         access_checker: AccessChecker | None,
+        active_names: set[str],
     ) -> None:
         """
         Configure one cube's materialization from its declared block.
@@ -2536,6 +2543,12 @@ class DeploymentOrchestrator:
         any DJ-side state actually moved, and only then is the query service asked to
         schedule anything -- an unchanged re-declare, or a block a revision swap has
         already built from, costs no remote call at all.
+
+        `active_names` is what the cube had materialized before reconciling. A block
+        that builds a name absent from it writes a datasource with nothing in it, so
+        a declared `coverage` is handed on as the span to backfill. Everything else
+        the reconciler changes -- the schedule, the lookback window, the coverage
+        itself -- keeps the datasource the cube already has.
         """
         operation = (
             DeploymentResult.Operation.CREATE
@@ -2642,6 +2655,11 @@ class DeploymentOrchestrator:
                         new_version=revision.version,
                         rebuilt_names=[materialization.name],
                         superseded=[],
+                        backfill=(
+                            block.coverage
+                            if materialization.name not in active_names
+                            else None
+                        ),
                     ),
                 )
         self.deployed_results.append(
@@ -2787,10 +2805,17 @@ class DeploymentOrchestrator:
         recorded the materialization as a success on the strength of DJ's own state
         moving; if the query service then refuses to schedule it, that success is
         wrong in exactly the way that hid these failures until now.
+
+        A coverage backfill rides along with the scheduling, on every deploy but a
+        branch one. A branch namespace exists so its author can see what the push
+        would give them, and hundreds of partition runs is not part of the preview.
         """
         request_headers = (
             dict(self.context.request.headers) if self.context.request else {}
         )
+        if await self._is_branch_deploy():
+            for swap in self._cube_materialization_swaps:
+                swap.backfill = None
         for swap in self._cube_materialization_swaps:
             outcome = await apply_cube_materialization_swap(
                 self.session,
@@ -2800,6 +2825,67 @@ class DeploymentOrchestrator:
             )
             if not outcome.scheduled:
                 self._report_materialization_push_failure(outcome)
+            elif swap.backfill:
+                self._report_backfill(outcome)
+
+    async def _is_branch_deploy(self) -> bool:
+        """
+        Whether this deploy targets a feature branch rather than the default one.
+
+        A branch is a namespace of its own, linked to a git branch, so the target
+        namespace is what says which. A namespace with no git root behind it -- a
+        plain `dj deploy` -- is not a branch.
+        """
+        git_info = await get_git_info_for_namespace(
+            self.session,
+            self.deployment_spec.namespace,
+        )
+        return git_info is not None and not git_info["is_default_branch"]
+
+    def _report_backfill(
+        self,
+        outcome: CubeMaterializationSwapOutcome,
+    ) -> None:
+        """
+        Say what the cube's new datasource is being filled with.
+
+        The run count is the point of the warning. A backfill runs one job per day
+        of the declared span, and a mistyped `from` is worth seeing at deploy time
+        rather than on a bill -- so the span is reported as launched, never capped:
+        two years of history is a thing authors legitimately ask for, and a cap is
+        something they could not undo from YAML.
+        """
+        if outcome.backfill_span is None:
+            self.warnings.append(
+                DJError(
+                    code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
+                    message=(
+                        f"Cube `{outcome.cube_name}`: no backfill ran. "
+                        f"{outcome.backfill_error}"
+                    ),
+                ),
+            )
+            return
+        start, end = outcome.backfill_span
+        runs = (end - start).days + 1
+        self.warnings.append(
+            DJError(
+                code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
+                message=(
+                    f"Cube `{outcome.cube_name}`: backfilling {start} to {end} "
+                    f"costs {runs} partition runs."
+                ),
+            ),
+        )
+        self.deployed_results.append(
+            DeploymentResult(
+                name=outcome.cube_name,
+                deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                status=DeploymentResult.Status.SUCCESS,
+                operation=DeploymentResult.Operation.CREATE,
+                message=f"backfilling {start} to {end}, {runs} partition runs",
+            ),
+        )
 
     def _report_materialization_push_failure(
         self,

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -361,7 +361,6 @@ def _upsert_from_materialization(
             strategy=materialization.strategy,
             schedule=materialization.schedule,
             lookback_window=lookback_window,
-            # Kept when an unrelated cube edit rebuilds.
             coverage=config.get("coverage"),
         )
     return UpsertMaterialization(

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -348,9 +348,9 @@ def _upsert_from_materialization(
     """
     Recover the user's materialization intent from a persisted materialization.
 
-    Only the intent -- job type, strategy, schedule and lookback window -- is
-    carried over; everything else in a stored config is generated content derived
-    from the revision it was built against.
+    Only the intent -- job type, strategy, schedule, lookback window and declared
+    coverage -- is carried over; everything else in a stored config is generated
+    content derived from the revision it was built against.
     """
     config = materialization.config if isinstance(materialization.config, dict) else {}
     lookback_window = config.get("lookback_window")
@@ -361,6 +361,10 @@ def _upsert_from_materialization(
             strategy=materialization.strategy,
             schedule=materialization.schedule,
             lookback_window=lookback_window,
+            # Recovered so a rebuild triggered by an unrelated cube edit does not
+            # quietly drop the coverage the author declared. A cube materialized
+            # outside YAML has none, and reads back as None.
+            coverage=config.get("coverage"),
         )
     return UpsertMaterialization(
         job=job_type.value.name,  # type: ignore
@@ -456,6 +460,7 @@ async def reconcile_declared_materialization(
             strategy=declared.strategy,
             schedule=declared.schedule,
             lookback_window=declared.lookback_window,
+            coverage=declared.coverage,
         ),
         access_checker,
         current_user=current_user,
@@ -582,6 +587,7 @@ async def swap_cube_materializations(
                         "schedule": declared.schedule,
                         "strategy": declared.strategy,
                         "lookback_window": declared.lookback_window,
+                        "coverage": declared.coverage,
                     },
                 )
             new_materialization = await create_new_materialization(

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -3,7 +3,7 @@
 import logging
 import zlib
 from dataclasses import dataclass
-from datetime import UTC
+from datetime import UTC, date
 
 from pydantic import ValidationError
 from sqlalchemy import select
@@ -34,6 +34,7 @@ from datajunction_server.models.column import SemanticType
 from datajunction_server.models.cube_materialization import UpsertCubeMaterialization
 from datajunction_server.models.deployment import MaterializationSpec
 from datajunction_server.models.materialization import (
+    CoverageSpec,
     DruidCubeConfigInput,
     DruidMeasuresCubeConfig,
     DruidMetricsCubeConfig,
@@ -46,6 +47,7 @@ from datajunction_server.models.materialization import (
 )
 from datajunction_server.models.metric import TranslatedSQL
 from datajunction_server.models.node_type import NodeType
+from datajunction_server.models.preaggregation import CubeBackfillInput
 from datajunction_server.models.query import ColumnMetadata
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.parsing import ast
@@ -388,6 +390,10 @@ class CubeMaterializationSwap:
     rebuilt_names: list[str]
     superseded: list[Materialization]
 
+    # The span to backfill once the replacement is scheduled. Set only when the
+    # swap mints an empty Druid datasource and the cube declares `coverage`.
+    backfill: CoverageSpec | None = None
+
 
 @dataclass
 class CubeMaterializationSwapOutcome:
@@ -405,6 +411,10 @@ class CubeMaterializationSwapOutcome:
     materialization_names: list[str]
     scheduled: bool
     error: str | None = None
+
+    # The span a coverage backfill was launched over, and why it was not.
+    backfill_span: tuple[date, date] | None = None
+    backfill_error: str | None = None
 
 
 async def reconcile_declared_materialization(
@@ -670,6 +680,9 @@ async def apply_cube_materialization_swap(
     their workflow running would keep posting availability for a table the current
     revision cannot use.
 
+    A swap carrying a `backfill` span then fills the datasource it just minted,
+    which is empty until something does.
+
     Never raises. With no query service configured there is nothing to do at all.
     Returns what became of the scheduling instead, so a caller holding a report the
     author will read can say the materialization did not happen: the query service
@@ -707,6 +720,8 @@ async def apply_cube_materialization_swap(
             # refused, and paraphrasing that would cost the reader the only part of
             # the message that says what to do about it.
             outcome.error = str(exc)
+        if swap.backfill and outcome.scheduled:
+            _launch_backfill(query_service_client, swap, outcome, request_headers)
     stop_cube_materialization_workflows(
         query_service_client=query_service_client,
         cube_name=swap.cube_name,
@@ -715,6 +730,49 @@ async def apply_cube_materialization_swap(
         request_headers=request_headers,
     )
     return outcome
+
+
+def _launch_backfill(
+    query_service_client: QueryServiceClient,
+    swap: CubeMaterializationSwap,
+    outcome: CubeMaterializationSwapOutcome,
+    request_headers: dict[str, str] | None = None,
+) -> None:
+    """
+    Fill the swap's new, empty Druid datasource over the cube's declared span.
+
+    A new datasource is named for the cube version and the spec hash, so it starts
+    with nothing in it and the declared span is exactly what it is missing. Launched
+    and left: the workflow runs one job per partition, long past this deploy.
+
+    Never raises, and records on the outcome what the caller has to report.
+    """
+    span = swap.backfill.span(date.today()) if swap.backfill else None
+    if span is None:
+        outcome.backfill_error = "DJ cannot count this coverage window in days."
+        return
+    try:
+        query_service_client.run_cube_backfill(
+            CubeBackfillInput(
+                cube_name=swap.cube_name,
+                cube_version=swap.new_version,
+                start_date=span[0],
+                end_date=span[1],
+            ),
+            request_headers=request_headers,
+        )
+        outcome.backfill_span = span
+    except Exception as exc:
+        _logger.warning(
+            "Failed to backfill cube=%s version=%s over %s to %s: %s (continuing)",
+            swap.cube_name,
+            swap.new_version,
+            span[0],
+            span[1],
+            str(exc),
+            exc_info=True,
+        )
+        outcome.backfill_error = str(exc)
 
 
 def stop_cube_materialization_workflows(

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -3,7 +3,8 @@
 import logging
 import zlib
 from dataclasses import dataclass
-from datetime import UTC, date
+from datetime import UTC, date, timedelta
+from typing import Any
 
 from pydantic import ValidationError
 from sqlalchemy import select
@@ -12,6 +13,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.construction.build import get_default_criteria
 from datajunction_server.construction.build_v2 import QueryBuilder
+from datajunction_server.database.backfill import Backfill
+from datajunction_server.database.column import Column
 from datajunction_server.database.history import (
     ActivityType,
     EntityType,
@@ -34,7 +37,6 @@ from datajunction_server.models.column import SemanticType
 from datajunction_server.models.cube_materialization import UpsertCubeMaterialization
 from datajunction_server.models.deployment import MaterializationSpec
 from datajunction_server.models.materialization import (
-    CoverageSpec,
     DruidCubeConfigInput,
     DruidMeasuresCubeConfig,
     DruidMetricsCubeConfig,
@@ -47,8 +49,13 @@ from datajunction_server.models.materialization import (
 )
 from datajunction_server.models.metric import TranslatedSQL
 from datajunction_server.models.node_type import NodeType
+from datajunction_server.models.partition import (
+    PartitionBackfill,
+    parse_partition_value,
+)
 from datajunction_server.models.preaggregation import CubeBackfillInput
 from datajunction_server.models.query import ColumnMetadata
+from datajunction_server.naming import amenable_name
 from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.ast import CompileContext
@@ -390,9 +397,9 @@ class CubeMaterializationSwap:
     rebuilt_names: list[str]
     superseded: list[Materialization]
 
-    # The span to backfill once the replacement is scheduled. Set only when the
-    # swap mints an empty Druid datasource and the cube declares `coverage`.
-    backfill: CoverageSpec | None = None
+    # The days to fill once the materialization is scheduled, resolved from the
+    # cube's declared coverage against what its datasource already holds.
+    backfill: tuple[date, date] | None = None
 
 
 @dataclass
@@ -680,8 +687,8 @@ async def apply_cube_materialization_swap(
     their workflow running would keep posting availability for a table the current
     revision cannot use.
 
-    A swap carrying a `backfill` span then fills the datasource it just minted,
-    which is empty until something does.
+    A swap carrying a `backfill` span then fills the days the cube's datasource
+    is missing, whether the swap just minted it or it was already there.
 
     Never raises. With no query service configured there is nothing to do at all.
     Returns what became of the scheduling instead, so a caller holding a report the
@@ -720,8 +727,14 @@ async def apply_cube_materialization_swap(
             # refused, and paraphrasing that would cost the reader the only part of
             # the message that says what to do about it.
             outcome.error = str(exc)
-        if swap.backfill and outcome.scheduled:
-            _launch_backfill(query_service_client, swap, outcome, request_headers)
+    if swap.backfill and outcome.scheduled:
+        _launch_backfill(
+            query_service_client,
+            swap,
+            swap.backfill,
+            outcome,
+            request_headers,
+        )
     stop_cube_materialization_workflows(
         query_service_client=query_service_client,
         cube_name=swap.cube_name,
@@ -735,22 +748,16 @@ async def apply_cube_materialization_swap(
 def _launch_backfill(
     query_service_client: QueryServiceClient,
     swap: CubeMaterializationSwap,
+    span: tuple[date, date],
     outcome: CubeMaterializationSwapOutcome,
     request_headers: dict[str, str] | None = None,
 ) -> None:
     """
-    Fill the swap's new, empty Druid datasource over the cube's declared span.
+    Fill the days the cube declares but its Druid datasource does not hold.
 
-    A new datasource is named for the cube version and the spec hash, so it starts
-    with nothing in it and the declared span is exactly what it is missing. Launched
-    and left: the workflow runs one job per partition, long past this deploy.
-
-    Never raises, and records on the outcome what the caller has to report.
+    Launched and left: the workflow runs one job per partition, long past this
+    deploy. Never raises, and records on the outcome what the caller reports.
     """
-    span = swap.backfill.span(date.today()) if swap.backfill else None
-    if span is None:
-        outcome.backfill_error = "DJ cannot count this coverage window in days."
-        return
     try:
         query_service_client.run_cube_backfill(
             CubeBackfillInput(
@@ -773,6 +780,114 @@ def _launch_backfill(
             exc_info=True,
         )
         outcome.backfill_error = str(exc)
+
+
+def coverage_partition(revision: NodeRevision) -> Column | None:
+    """
+    The one temporal partition a coverage backfill runs over.
+
+    Coverage is a span of days on a single axis. A cube partitioned on more than
+    one temporal column, or on none, has no such axis, so nothing here can say
+    which days it holds or which column a backfill would name.
+    """
+    partitions = revision.temporal_partition_columns()
+    return partitions[0] if len(partitions) == 1 else None
+
+
+def coverage_gap(
+    span: tuple[date, date],
+    revision: NodeRevision,
+) -> tuple[date, date] | None:
+    """
+    The leading days of `span` a cube's datasource does not hold yet.
+
+    Availability is a bounding box -- min of mins, max of maxes -- so the only
+    knowably missing days are the ones before its earliest. A hole inside the
+    span cannot be seen from here, and the trailing edge is the schedule's job.
+
+    A cube with no availability holds nothing, so the whole span is missing.
+    `None` when the cube already reaches back far enough, or when its
+    availability cannot be read against the partition format.
+    """
+    start, end = span
+    availability = revision.availability
+    if availability is None:
+        return span
+    partition = coverage_partition(revision)
+    values = availability.min_temporal_partition or []
+    if partition is None or len(values) != 1:
+        return None
+    # Availability may hold a number.
+    covered = parse_partition_value(str(values[0]), partition.partition.format)
+    if covered is None or covered <= start:
+        return None
+    return start, min(covered - timedelta(days=1), end)
+
+
+async def backfill_recorded(
+    session: AsyncSession,
+    materialization: Materialization,
+    start: date,
+) -> bool:
+    """
+    Whether DJ already asked to backfill a span reaching back to `start`.
+
+    Availability does not move until a backfill lands, so the deploy after one
+    sees the same gap and would ask for all of it again. Only DJ's own records
+    count: it writes ISO dates, while a backfill run from the API carries
+    partition-format values that do not mean the same thing.
+
+    Read by query rather than off `materialization.backfills`, which a cube
+    materialized for the first time has not loaded.
+    """
+    specs = (
+        (
+            await session.execute(
+                select(Backfill.spec).where(
+                    Backfill.materialization_id == materialization.id,
+                ),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for spec in specs:
+        for entry in spec or []:
+            span = entry.get("range") if isinstance(entry, dict) else None
+            recorded = _as_day(span[0]) if span else None
+            if recorded and recorded <= start:
+                return True
+    return False
+
+
+def record_backfill(
+    session: AsyncSession,
+    materialization: Materialization,
+    column: Column,
+    span: tuple[date, date],
+) -> None:
+    """
+    Note the span DJ asked to backfill, beside the cube's other backfills.
+    """
+    session.add(
+        Backfill(
+            materialization_id=materialization.id,
+            spec=[
+                PartitionBackfill(
+                    column_name=amenable_name(column.cube_element_name),
+                    range=[span[0].isoformat(), span[1].isoformat()],
+                ).model_dump(),
+            ],
+        ),
+    )
+
+
+def _as_day(value: Any) -> date | None:
+    """A recorded range bound, if DJ wrote it."""
+    try:
+        return date.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def stop_cube_materialization_workflows(

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -361,9 +361,7 @@ def _upsert_from_materialization(
             strategy=materialization.strategy,
             schedule=materialization.schedule,
             lookback_window=lookback_window,
-            # Recovered so a rebuild triggered by an unrelated cube edit does not
-            # quietly drop the coverage the author declared. A cube materialized
-            # outside YAML has none, and reads back as None.
+            # Kept when an unrelated cube edit rebuilds.
             coverage=config.get("coverage"),
         )
     return UpsertMaterialization(

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -279,9 +279,7 @@ class UpsertCubeMaterialization(BaseModel):
     # How long the Druid datasource keeps ingested data. Applies under both strategies.
     retention: str | None = DEFAULT_CUBE_RETENTION
 
-    # The span of partitions the cube should serve, as declared in YAML. Carried so it
-    # reaches the stored config and comes back out through `to_spec`; nothing schedules
-    # or backfills against it yet.
+    # Declared span. Nothing backfills against it yet.
     coverage: CoverageSpec | None = None
 
     @field_validator("job")
@@ -479,9 +477,7 @@ class DruidCubeConfig(BaseModel):
     # Configs persisted before this field existed pick up the default on their next build.
     retention: str | None = DEFAULT_CUBE_RETENTION
 
-    # The declared span of partitions the cube should serve. This is where a declared
-    # `coverage:` block comes to rest, and what `Node.to_spec` reads it back out of.
-    # Configs persisted before this field existed read back as no declared coverage.
+    # Where a declared span comes to rest.
     coverage: CoverageSpec | None = None
 
 

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -279,7 +279,6 @@ class UpsertCubeMaterialization(BaseModel):
     # How long the Druid datasource keeps ingested data. Applies under both strategies.
     retention: str | None = DEFAULT_CUBE_RETENTION
 
-    # Declared span. Nothing backfills against it yet.
     coverage: CoverageSpec | None = None
 
     @field_validator("job")
@@ -477,7 +476,6 @@ class DruidCubeConfig(BaseModel):
     # Configs persisted before this field existed pick up the default on their next build.
     retention: str | None = DEFAULT_CUBE_RETENTION
 
-    # Where a declared span comes to rest.
     coverage: CoverageSpec | None = None
 
 

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -16,6 +16,7 @@ from datajunction_server.models.decompose import (
 from datajunction_server.models.materialization import (
     DEFAULT_CUBE_RETENTION,
     DRUID_AGG_MAPPING,
+    CoverageSpec,
     MaterializationJobTypeEnum,
     MaterializationStrategy,
 )
@@ -278,6 +279,11 @@ class UpsertCubeMaterialization(BaseModel):
     # How long the Druid datasource keeps ingested data. Applies under both strategies.
     retention: str | None = DEFAULT_CUBE_RETENTION
 
+    # The span of partitions the cube should serve, as declared in YAML. Carried so it
+    # reaches the stored config and comes back out through `to_spec`; nothing schedules
+    # or backfills against it yet.
+    coverage: CoverageSpec | None = None
+
     @field_validator("job")
     def validate_job(
         cls,
@@ -472,6 +478,11 @@ class DruidCubeConfig(BaseModel):
     # How long the Druid datasource keeps ingested data. Applies under both strategies.
     # Configs persisted before this field existed pick up the default on their next build.
     retention: str | None = DEFAULT_CUBE_RETENTION
+
+    # The declared span of partitions the cube should serve. This is where a declared
+    # `coverage:` block comes to rest, and what `Node.to_spec` reads it back out of.
+    # Configs persisted before this field existed read back as no declared coverage.
+    coverage: CoverageSpec | None = None
 
 
 class PrincipalRef(BaseModel):

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -28,6 +28,7 @@ from datajunction_server.models.dimensionlink import (
 from datajunction_server.models.impact import DownstreamImpact
 from datajunction_server.models.materialization import (
     DEFAULT_CUBE_RETENTION,
+    CoverageSpec,
     MaterializationStrategy,
 )
 from datajunction_server.models.node import (
@@ -327,10 +328,10 @@ class MaterializationSpec(BaseModel):
     Declarative materialization config for a cube.
 
     Deliberately carries only what the author decides: when to build, how, how
-    far back to look, and how long the result is kept. The backend that runs it
-    (and everything it derives -- the measures queries, combiner SQL, Druid spec,
-    output tables) is DJ's choice, so no `job` field is exposed here and the
-    block stays portable if that choice changes.
+    far back to look, how much of history to serve, and how long the result is
+    kept. The backend that runs it (and everything it derives -- the measures
+    queries, combiner SQL, Druid spec, output tables) is DJ's choice, so no `job`
+    field is exposed here and the block stays portable if that choice changes.
     """
 
     schedule: str
@@ -340,6 +341,27 @@ class MaterializationSpec(BaseModel):
     # Unlike `lookback_window`, this is meaningful under both strategies: a full
     # rebuild is exactly the case that loads the widest span of history.
     retention: str | None = DEFAULT_CUBE_RETENTION
+
+    # The span of partitions the cube should serve. Absent means the author has
+    # declared none. Stored and echoed back only for now -- reconciling toward it
+    # by backfilling the gaps is separate work.
+    coverage: CoverageSpec | None = None
+
+    @model_validator(mode="after")
+    def clear_empty_coverage(self) -> "MaterializationSpec":
+        """
+        A `coverage:` block that declares neither form declares nothing, so normalize
+        it away to absent.
+
+        Same reasoning as `clear_lookback_for_full`: "no coverage block" and "an
+        empty coverage block" mean the same thing, and letting them compare unequal
+        would churn a live workflow on deploy. It also keeps the round trip honest --
+        a config stored before coverage existed reads back as no declared coverage
+        rather than as an empty block.
+        """
+        if self.coverage == CoverageSpec():
+            self.coverage = None
+        return self
 
     @model_validator(mode="after")
     def clear_lookback_for_full(self) -> "MaterializationSpec":

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -342,23 +342,12 @@ class MaterializationSpec(BaseModel):
     # rebuild is exactly the case that loads the widest span of history.
     retention: str | None = DEFAULT_CUBE_RETENTION
 
-    # The span of partitions the cube should serve. Absent means the author has
-    # declared none. Stored and echoed back only for now -- reconciling toward it
-    # by backfilling the gaps is separate work.
+    # The span the cube should serve.
     coverage: CoverageSpec | None = None
 
     @model_validator(mode="after")
     def clear_empty_coverage(self) -> "MaterializationSpec":
-        """
-        A `coverage:` block that declares neither form declares nothing, so normalize
-        it away to absent.
-
-        Same reasoning as `clear_lookback_for_full`: "no coverage block" and "an
-        empty coverage block" mean the same thing, and letting them compare unequal
-        would churn a live workflow on deploy. It also keeps the round trip honest --
-        a config stored before coverage existed reads back as no declared coverage
-        rather than as an empty block.
-        """
+        """Treat an empty coverage block as absent."""
         if self.coverage == CoverageSpec():
             self.coverage = None
         return self

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -342,7 +342,6 @@ class MaterializationSpec(BaseModel):
     # rebuild is exactly the case that loads the widest span of history.
     retention: str | None = DEFAULT_CUBE_RETENTION
 
-    # The span the cube should serve.
     coverage: CoverageSpec | None = None
 
     @model_validator(mode="after")

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -1,7 +1,9 @@
 """Models for materialization"""
 
 import enum
-from typing import TYPE_CHECKING, Literal
+from collections.abc import Callable
+from datetime import date
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import (
     BaseModel,
@@ -9,6 +11,8 @@ from pydantic import (
     Field,
     RootModel,
     field_validator,
+    model_serializer,
+    model_validator,
 )
 
 from datajunction_server.enum import StrEnum
@@ -57,6 +61,101 @@ DRUID_SKETCH_TYPES = {"HLLSketchMerge"}
 # ingest reaching further back fails at load time with a retention rule violation.
 # 400 days covers a full year of history plus room for late-arriving restatements.
 DEFAULT_CUBE_RETENTION = "400 DAYS"
+
+
+class CoverageSpec(BaseModel):
+    """
+    The span of partitions a cube's materialization should serve.
+
+    Distinct from `lookback_window`, which says how far back a single scheduled run
+    reaches. Coverage is the *maintained* span: the range the cube is expected to
+    hold at rest, which later work reconciles toward by backfilling whatever of it
+    is missing. Nothing acts on it yet -- it is parsed, validated, stored and read
+    back out, and that is all.
+
+    Two mutually exclusive forms:
+
+      coverage: {from: 2024-01-01, to: 2024-06-30}   # a fixed span
+      coverage: {window: 800 DAYS}                   # a rolling trailing span
+
+    `to` is optional under the first form; omitting it means the span is ongoing.
+    """
+
+    # `from` and `to` are INCLUSIVE dates, matching the FROM_PARTITION/TO_PARTITION
+    # convention the backfill workflow already speaks: it computes a
+    # TO_PARTITION_PLUS_1 precisely because its own range helper excludes the end.
+    # Do not "fix" these to exclusive -- doing so silently drops the last partition
+    # of every declared span, and quietly disagrees with the workflow that has to
+    # fill it.
+    #
+    # `from` is a Python keyword, so the field is named `from_` and aliased, in the
+    # same way `SourceSpec.schema_` handles `schema`.
+    from_: date | None = Field(default=None, alias="from")
+    to: date | None = None
+
+    # A duration string in the same style as `lookback_window` (e.g. "800 DAYS").
+    # Left as a free-form string deliberately: `lookback_window` has no parsing or
+    # validation of its own anywhere in the server -- it is interpolated straight
+    # into `INTERVAL {lookback_window}` -- so validating shape here would accept a
+    # narrower set of durations than the field it is modelled on.
+    window: str | None = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @model_validator(mode="after")
+    def validate_form(self) -> "CoverageSpec":
+        """
+        Enforce the two forms and normalize the window, so that two specs meaning
+        the same span compare equal.
+
+        Equality is load-bearing: `reconcile_declared_materialization` compares the
+        declared block against what is already stored to decide whether to touch the
+        query service at all, so a purely cosmetic difference would churn a live
+        workflow on every deploy.
+        """
+        if self.window is not None:
+            self.window = " ".join(self.window.split())
+        if self.window and (self.from_ or self.to):
+            raise DJInvalidInputException(
+                message=(
+                    "A materialization `coverage` block declares either a fixed span "
+                    "(`from`, with an optional `to`) or a rolling `window`, not both."
+                ),
+            )
+        if self.to and not self.from_:
+            raise DJInvalidInputException(
+                message=(
+                    "A materialization `coverage` block with a `to` needs a `from`: "
+                    "an end date on its own does not say where the span starts."
+                ),
+            )
+        if self.from_ and self.to and self.to < self.from_:
+            raise DJInvalidInputException(
+                message=(
+                    f"A materialization `coverage` block ends before it starts: "
+                    f"`to` ({self.to.isoformat()}) precedes `from` "
+                    f"({self.from_.isoformat()})."
+                ),
+            )
+        return self
+
+    @model_serializer(mode="wrap")
+    def serialize(self, handler: Callable[["CoverageSpec"], dict[str, Any]]) -> dict:
+        """
+        Emit the authored key `from` rather than the field name `from_`, and dates as
+        ISO strings under every dump mode.
+
+        Both matter for the round trip. The stored materialization config is built
+        with a plain `model_dump()` into a JSON column, which cannot hold a `date`;
+        and the YAML `dj pull` writes is dumped without `by_alias`, so a `from_:` key
+        would come back out of DJ spelled differently from the way it went in.
+        """
+        return {
+            ("from" if key == "from_" else key): (
+                value.isoformat() if isinstance(value, date) else value
+            )
+            for key, value in handler(self).items()
+        }
 
 
 class MaterializationStrategy(StrEnum):

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -65,91 +65,55 @@ DEFAULT_CUBE_RETENTION = "400 DAYS"
 
 class CoverageSpec(BaseModel):
     """
-    The span of partitions a cube's materialization should serve.
+    The span a cube's materialization should serve.
 
-    Distinct from `lookback_window`, which says how far back a single scheduled run
-    reaches. Coverage is the *maintained* span: the range the cube is expected to
-    hold at rest, which later work reconciles toward by backfilling whatever of it
-    is missing. Nothing acts on it yet -- it is parsed, validated, stored and read
-    back out, and that is all.
+    Either a fixed span or a rolling one, never both:
 
-    Two mutually exclusive forms:
+      coverage: {from: 2024-01-01, to: 2024-06-30}
+      coverage: {window: 800 DAYS}
 
-      coverage: {from: 2024-01-01, to: 2024-06-30}   # a fixed span
-      coverage: {window: 800 DAYS}                   # a rolling trailing span
-
-    `to` is optional under the first form; omitting it means the span is ongoing.
+    Omitting `to` leaves the span ongoing.
     """
 
-    # `from` and `to` are INCLUSIVE dates, matching the FROM_PARTITION/TO_PARTITION
-    # convention the backfill workflow already speaks: it computes a
-    # TO_PARTITION_PLUS_1 precisely because its own range helper excludes the end.
-    # Do not "fix" these to exclusive -- doing so silently drops the last partition
-    # of every declared span, and quietly disagrees with the workflow that has to
-    # fill it.
-    #
-    # `from` is a Python keyword, so the field is named `from_` and aliased, in the
-    # same way `SourceSpec.schema_` handles `schema`.
+    # Inclusive, matching FROM_PARTITION and TO_PARTITION.
+    # `from` is a keyword, so alias it.
     from_: date | None = Field(default=None, alias="from")
     to: date | None = None
 
-    # A duration string in the same style as `lookback_window` (e.g. "800 DAYS").
-    # Left as a free-form string deliberately: `lookback_window` has no parsing or
-    # validation of its own anywhere in the server -- it is interpolated straight
-    # into `INTERVAL {lookback_window}` -- so validating shape here would accept a
-    # narrower set of durations than the field it is modelled on.
+    # Free-form, like `lookback_window`, which parses nothing.
     window: str | None = None
 
     model_config = ConfigDict(populate_by_name=True)
 
     @model_validator(mode="after")
-    def validate_form(self) -> "CoverageSpec":
+    def check_form(self) -> "CoverageSpec":
         """
-        Enforce the two forms and normalize the window, so that two specs meaning
-        the same span compare equal.
-
-        Equality is load-bearing: `reconcile_declared_materialization` compares the
-        declared block against what is already stored to decide whether to touch the
-        query service at all, so a purely cosmetic difference would churn a live
-        workflow on every deploy.
+        Enforce that either a fixed span is declared or a rolling window is
+        declared, but not both.
         """
+        # Collapse whitespace so equal spans compare equal.
         if self.window is not None:
             self.window = " ".join(self.window.split())
         if self.window and (self.from_ or self.to):
             raise DJInvalidInputException(
-                message=(
-                    "A materialization `coverage` block declares either a fixed span "
-                    "(`from`, with an optional `to`) or a rolling `window`, not both."
-                ),
+                message="Declare a fixed span or a window, not both.",
             )
         if self.to and not self.from_:
             raise DJInvalidInputException(
-                message=(
-                    "A materialization `coverage` block with a `to` needs a `from`: "
-                    "an end date on its own does not say where the span starts."
-                ),
+                message="Coverage needs a `from` to go with `to`.",
             )
         if self.from_ and self.to and self.to < self.from_:
             raise DJInvalidInputException(
                 message=(
-                    f"A materialization `coverage` block ends before it starts: "
-                    f"`to` ({self.to.isoformat()}) precedes `from` "
-                    f"({self.from_.isoformat()})."
+                    f"Coverage ends before it starts: {self.to.isoformat()} "
+                    f"precedes {self.from_.isoformat()}."
                 ),
             )
         return self
 
     @model_serializer(mode="wrap")
     def serialize(self, handler: Callable[["CoverageSpec"], dict[str, Any]]) -> dict:
-        """
-        Emit the authored key `from` rather than the field name `from_`, and dates as
-        ISO strings under every dump mode.
-
-        Both matter for the round trip. The stored materialization config is built
-        with a plain `model_dump()` into a JSON column, which cannot hold a `date`;
-        and the YAML `dj pull` writes is dumped without `by_alias`, so a `from_:` key
-        would come back out of DJ spelled differently from the way it went in.
-        """
+        """Emit `from`, and dates as strings, for JSON and YAML."""
         return {
             ("from" if key == "from_" else key): (
                 value.isoformat() if isinstance(value, date) else value

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -1,8 +1,9 @@
 """Models for materialization"""
 
 import enum
+import re
 from collections.abc import Callable
-from datetime import date
+from datetime import date, timedelta
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import (
@@ -62,6 +63,9 @@ DRUID_SKETCH_TYPES = {"HLLSketchMerge"}
 # 400 days covers a full year of history plus room for late-arriving restatements.
 DEFAULT_CUBE_RETENTION = "400 DAYS"
 
+# Rolling window units DJ can count in days.
+WINDOW_UNIT_DAYS = {"DAY": 1, "WEEK": 7}
+
 
 class CoverageSpec(BaseModel):
     """
@@ -80,7 +84,7 @@ class CoverageSpec(BaseModel):
     from_: date | None = Field(default=None, alias="from")
     to: date | None = None
 
-    # Free-form, like `lookback_window`, which parses nothing.
+    # Free-form, like `lookback_window`. `span` reads days and weeks.
     window: str | None = None
 
     model_config = ConfigDict(populate_by_name=True)
@@ -110,6 +114,24 @@ class CoverageSpec(BaseModel):
                 ),
             )
         return self
+
+    def span(self, today: date) -> tuple[date, date] | None:
+        """
+        The first and last date this coverage asks a backfill to run.
+
+        An ongoing fixed span ends yesterday, the last full day. `None` when a
+        rolling window names a unit `WINDOW_UNIT_DAYS` cannot count.
+        """
+        end = self.to or today - timedelta(days=1)
+        if self.from_:
+            return self.from_, end
+        match = re.fullmatch(r"(\d+)\s+([A-Za-z]+)", self.window or "")
+        if not match:
+            return None
+        unit = WINDOW_UNIT_DAYS.get(match.group(2).upper().rstrip("S"))
+        if not unit:
+            return None
+        return end - timedelta(days=int(match.group(1)) * unit - 1), end
 
     @model_serializer(mode="wrap")
     def serialize(self, handler: Callable[["CoverageSpec"], dict[str, Any]]) -> dict:

--- a/datajunction-server/datajunction_server/models/partition.py
+++ b/datajunction-server/datajunction_server/models/partition.py
@@ -1,7 +1,7 @@
 """Partition-related models."""
 
 import re
-from datetime import datetime
+from datetime import date, datetime
 
 from pydantic import ConfigDict
 from pydantic.main import BaseModel
@@ -141,3 +141,23 @@ def render_partition_value(moment: datetime, format_: str | None) -> int | None:
             _TOKEN_PATTERN.sub(lambda m: PARTITION_FORMAT_TOKENS[m.group()], format_),
         ),
     )
+
+
+def parse_partition_value(value: str, format_: str | None) -> date | None:
+    """
+    Read a partition value back as the day it names.
+
+    The reverse of ``render_partition_value``, and unlike it happy with
+    separators: ``yyyy-MM-dd`` renders no integer but still names a day. None
+    when there is no format, or the value does not match it.
+    """
+    if not format_:
+        return None
+    pattern = _TOKEN_PATTERN.sub(
+        lambda m: PARTITION_FORMAT_TOKENS[m.group()],
+        format_,
+    )
+    try:
+        return datetime.strptime(value, pattern).date()
+    except (TypeError, ValueError):
+        return None

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -3221,6 +3221,147 @@ class TestDeployments:
         )
 
     @pytest.mark.asyncio
+    async def test_deploy_cube_with_declared_coverage(
+        self,
+        session,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+        mock_qs,
+    ):
+        """
+        A declared `coverage:` block survives the whole trip -- into the stored
+        materialization config and back out through `to_spec` as the same YAML the
+        author wrote -- under both of its forms.
+
+        Nothing acts on it yet: the value reaches Druid through no part of the
+        materialization the query service is handed.
+        """
+        namespace = "cube_coverage"
+        cube = CubeSpec(
+            name="default.repairs_cube",
+            display_name="Repairs Cube",
+            description="""Cube for analyzing repair orders""",
+            dimensions=[
+                "${prefix}default.hard_hat.state",
+                "${prefix}default.hard_hat.birth_date",
+            ],
+            metrics=["${prefix}default.avg_length_of_employment"],
+            columns=[
+                ColumnSpec(
+                    name="${prefix}default.hard_hat.birth_date",
+                    partition=PartitionSpec(
+                        type=PartitionType.TEMPORAL,
+                        granularity=Granularity.DAY,
+                        format="yyyyMMdd",
+                    ),
+                ),
+            ],
+            materialization=MaterializationSpec(
+                schedule="0 6 * * *",
+                coverage={"from": "2024-01-01", "to": "2024-06-30"},
+            ),
+            owners=["dj"],
+        )
+        nodes_list = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            cube,
+        ]
+        cube_name = f"{namespace}.default.repairs_cube"
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+
+        session.expire_all()
+        deployed = await Node.get_by_name(
+            session,
+            cube_name,
+            options=Node.cube_load_options(),
+        )
+        # Stored as the authored keys, and JSON-safe -- the config column cannot
+        # hold a `date`.
+        assert [
+            materialization.config["coverage"]
+            for materialization in deployed.current.materializations
+        ] == [{"from": "2024-01-01", "to": "2024-06-30", "window": None}]
+        exported = await deployed.to_spec(session)
+        assert exported.materialization == MaterializationSpec(
+            schedule="0 6 * * *",
+            strategy=MaterializationStrategy.INCREMENTAL_TIME,
+            lookback_window="1 DAY",
+            coverage={"from": "2024-01-01", "to": "2024-06-30"},
+        )
+        # What `dj pull` writes back out is the block the author wrote.
+        assert exported.model_dump(mode="json", exclude_none=True)[
+            "materialization"
+        ] == {
+            "schedule": "0 6 * * *",
+            "strategy": "incremental_time",
+            "lookback_window": "1 DAY",
+            "retention": "400 DAYS",
+            "coverage": {"from": "2024-01-01", "to": "2024-06-30"},
+        }
+        scheduled = mock_qs.materialize_cube.call_args.kwargs["materialization_input"]
+        assert not hasattr(scheduled, "coverage")
+
+        # The rolling form replaces the fixed one rather than accumulating alongside it.
+        cube.materialization = MaterializationSpec(
+            schedule="0 6 * * *",
+            coverage={"window": "800 DAYS"},
+        )
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+
+        session.expire_all()
+        deployed = await Node.get_by_name(
+            session,
+            cube_name,
+            options=Node.cube_load_options(),
+        )
+        assert [
+            materialization.config["coverage"]
+            for materialization in deployed.current.materializations
+        ] == [{"from": None, "to": None, "window": "800 DAYS"}]
+        exported = await deployed.to_spec(session)
+        assert exported.materialization == MaterializationSpec(
+            schedule="0 6 * * *",
+            strategy=MaterializationStrategy.INCREMENTAL_TIME,
+            lookback_window="1 DAY",
+            coverage={"window": "800 DAYS"},
+        )
+        assert exported.model_dump(mode="json", exclude_none=True)[
+            "materialization"
+        ] == {
+            "schedule": "0 6 * * *",
+            "strategy": "incremental_time",
+            "lookback_window": "1 DAY",
+            "retention": "400 DAYS",
+            "coverage": {"window": "800 DAYS"},
+        }
+
+        # Re-declaring the same coverage changes nothing, so the reconciler leaves
+        # the live workflow alone.
+        mock_qs.reset_mock()
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        assert mock_qs.materialize_cube.call_count == 0
+
+    @pytest.mark.asyncio
     async def test_deploy_reports_a_rejected_materialization_push(
         self,
         client,

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import uuid
 from contextlib import asynccontextmanager
+from datetime import date, timedelta
 from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -55,6 +56,7 @@ from datajunction_server.models.node import (
 )
 from datajunction_server.database.user import PrincipalKind
 from datajunction_server.models.cube_materialization import PrincipalRef
+from datajunction_server.models.preaggregation import CubeBackfillInput
 from datajunction_server.utils import get_query_service_client
 from tests.authz import VALIDATOR_AUTH_SERVICE, deny
 from tests.construction.build_v3 import assert_sql_equal
@@ -3219,6 +3221,9 @@ class TestDeployments:
             "v1.0",
             "0 3 * * *",
         )
+        # A block that declares no coverage says nothing about how much history the
+        # cube should hold, so there is no span to backfill.
+        assert mock_qs.run_cube_backfill.call_args_list == []
 
     @pytest.mark.asyncio
     async def test_deploy_cube_with_declared_coverage(
@@ -3237,8 +3242,8 @@ class TestDeployments:
         materialization config and back out through `to_spec` as the same YAML the
         author wrote -- under both of its forms.
 
-        Nothing acts on it yet: the value reaches Druid through no part of the
-        materialization the query service is handed.
+        The value reaches Druid through no part of the materialization the query
+        service is handed. It drives a backfill instead, which is a call of its own.
         """
         namespace = "cube_coverage"
         cube = CubeSpec(
@@ -3313,7 +3318,41 @@ class TestDeployments:
         scheduled = mock_qs.materialize_cube.call_args.kwargs["materialization_input"]
         assert not hasattr(scheduled, "coverage")
 
+        # The cube's first datasource is empty, so the declared span is backfilled
+        # into it, and the deployment says what that costs.
+        assert mock_qs.run_cube_backfill.call_args.args == (
+            CubeBackfillInput(
+                cube_name=cube_name,
+                cube_version="v1.0",
+                start_date=date(2024, 1, 1),
+                end_date=date(2024, 6, 30),
+            ),
+        )
+        assert [
+            result
+            for result in data["results"]
+            if result["deploy_type"] == "materialization"
+        ] == [
+            {
+                "name": cube_name,
+                "deploy_type": "materialization",
+                "status": "success",
+                "operation": "create",
+                "message": "cube materialization on schedule 0 6 * * *",
+                "changed_fields": [],
+            },
+            {
+                "name": cube_name,
+                "deploy_type": "materialization",
+                "status": "success",
+                "operation": "create",
+                "message": "backfilling 2024-01-01 to 2024-06-30, 182 partition runs",
+                "changed_fields": [],
+            },
+        ]
+
         # The rolling form replaces the fixed one rather than accumulating alongside it.
+        mock_qs.reset_mock()
         cube.materialization = MaterializationSpec(
             schedule="0 6 * * *",
             coverage={"window": "800 DAYS"},
@@ -3350,6 +3389,9 @@ class TestDeployments:
             "retention": "400 DAYS",
             "coverage": {"window": "800 DAYS"},
         }
+        # Editing the coverage of a cube that already has its datasource does not
+        # refill it: the span moved, the datasource it is served from did not.
+        assert mock_qs.run_cube_backfill.call_args_list == []
 
         # Re-declaring the same coverage changes nothing, so the reconciler leaves
         # the live workflow alone.
@@ -3360,6 +3402,26 @@ class TestDeployments:
         )
         assert data["status"] == "success"
         assert mock_qs.materialize_cube.call_count == 0
+        assert mock_qs.run_cube_backfill.call_args_list == []
+
+        # A new cube version means a datasource nothing has written to yet, so the
+        # rolling window is counted back from yesterday and filled in.
+        mock_qs.reset_mock()
+        cube.description = "Cube for analyzing repair orders, revised"
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        yesterday = date.today() - timedelta(days=1)
+        assert mock_qs.run_cube_backfill.call_args.args == (
+            CubeBackfillInput(
+                cube_name=cube_name,
+                cube_version="v1.1",
+                start_date=yesterday - timedelta(days=799),
+                end_date=yesterday,
+            ),
+        )
 
     @pytest.mark.asyncio
     async def test_deploy_reports_a_rejected_materialization_push(

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import uuid
 from contextlib import asynccontextmanager
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -16,6 +16,7 @@ from datajunction_server.api.deployments import (
     InProcessExecutor,
     _normalize_repo_path,
 )
+from datajunction_server.database.availabilitystate import AvailabilityState
 from datajunction_server.database.materialization import Materialization
 from datajunction_server.database.node import Node, NodeRelationship
 from datajunction_server.database.tag import Tag
@@ -3413,7 +3414,7 @@ class TestDeployments:
             DeploymentSpec(namespace=namespace, nodes=nodes_list),
         )
         assert data["status"] == "success"
-        yesterday = date.today() - timedelta(days=1)
+        yesterday = datetime.now(UTC).date() - timedelta(days=1)
         assert mock_qs.run_cube_backfill.call_args.args == (
             CubeBackfillInput(
                 cube_name=cube_name,
@@ -3422,6 +3423,65 @@ class TestDeployments:
                 end_date=yesterday,
             ),
         )
+
+        # Once the cube reports what it holds, a span declared before that is the
+        # gap, and only the days ahead of the earliest one it reports are filled.
+        mock_qs.reset_mock()
+        session.expire_all()
+        deployed = await Node.get_by_name(
+            session,
+            cube_name,
+            options=Node.cube_load_options(),
+        )
+        deployed.current.availability = AvailabilityState(
+            catalog="default",
+            table="a_cube",
+            valid_through_ts=0,
+            min_temporal_partition=["20250301"],
+        )
+        session.add(deployed.current)
+        await session.commit()
+        cube.materialization = MaterializationSpec(
+            schedule="0 6 * * *",
+            coverage={"from": "2024-01-01"},
+        )
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        assert mock_qs.run_cube_backfill.call_args.args == (
+            CubeBackfillInput(
+                cube_name=cube_name,
+                cube_version="v1.1",
+                start_date=date(2024, 1, 1),
+                end_date=date(2025, 2, 28),
+            ),
+        )
+        assert [
+            result
+            for result in data["results"]
+            if result["message"].startswith("backfilling")
+        ] == [
+            {
+                "name": cube_name,
+                "deploy_type": "materialization",
+                "status": "success",
+                "operation": "create",
+                "message": "backfilling 2024-01-01 to 2025-02-28, 425 partition runs",
+                "changed_fields": [],
+            },
+        ]
+
+        # The gap does not close until the backfill lands, so the next deploy sees
+        # the same one. What DJ already asked for it does not ask for again.
+        mock_qs.reset_mock()
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        assert mock_qs.run_cube_backfill.call_args_list == []
 
     @pytest.mark.asyncio
     async def test_deploy_reports_a_rejected_materialization_push(

--- a/datajunction-server/tests/construction/build_v3/preagg_freshness_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_freshness_test.py
@@ -1,6 +1,6 @@
 """Tests for preagg_freshness.py - freshness gating for pre-aggregations."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import pytest
 
@@ -15,7 +15,10 @@ from datajunction_server.construction.build_v3.preagg_freshness import (
     preagg_is_fresh,
     temporal_grain_axis,
 )
-from datajunction_server.models.partition import render_partition_value
+from datajunction_server.models.partition import (
+    parse_partition_value,
+    render_partition_value,
+)
 from datajunction_server.construction.build_v3.types import BuildContext
 from datajunction_server.database.availabilitystate import AvailabilityState
 from datajunction_server.database.column import Column
@@ -175,6 +178,27 @@ class TestRenderPartitionValue:
     def test_render(self, format_, expected):
         moment = datetime(2026, 7, 31, 14, 5, 9, tzinfo=timezone.utc)
         assert render_partition_value(moment, format_) == expected
+
+
+class TestParsePartitionValue:
+    """Reading a partition value back as the day it names."""
+
+    @pytest.mark.parametrize(
+        "value, format_, expected",
+        [
+            ("20260731", "yyyyMMdd", date(2026, 7, 31)),
+            # Separators name a day even though they render no integer.
+            ("2026-07-31", "yyyy-MM-dd", date(2026, 7, 31)),
+            # An hourly value names the day it falls in.
+            ("2026073114", "yyyyMMddHH", date(2026, 7, 31)),
+            # The value does not match the format.
+            ("2026-07-31", "yyyyMMdd", None),
+            # No format to read it against.
+            ("20260731", None, None),
+        ],
+    )
+    def test_parse(self, value, format_, expected):
+        assert parse_partition_value(value, format_) == expected
 
 
 class TestUpperBounds:

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -2,21 +2,25 @@
 Unit tests for DeploymentOrchestrator
 """
 
-from datetime import UTC, date
+from datetime import UTC, date, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from sqlalchemy import select
 
+from datajunction_server.database.availabilitystate import AvailabilityState
+from datajunction_server.database.backfill import Backfill
 from datajunction_server.database.catalog import Catalog
 from datajunction_server.database.column import Column
 from datajunction_server.database.dimensionlink import (
     JoinCardinality,
     JoinType,
 )
+from datajunction_server.database.materialization import Materialization
 from datajunction_server.database.namespace import NodeNamespace
 from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.partition import Partition
 from datajunction_server.database.tag import Tag
 from datajunction_server.database.user import OAuthProvider, User
 from datajunction_server.errors import DJError, DJInvalidDeploymentConfig, ErrorCode
@@ -46,6 +50,7 @@ from datajunction_server.models.deployment import (
     DimensionReferenceLinkSpec,
     HierarchyLevelSpec,
     HierarchySpec,
+    MaterializationSpec,
     MetricSpec,
     PartitionSpec,
     PartitionType,
@@ -55,10 +60,10 @@ from datajunction_server.models.deployment import (
 )
 from datajunction_server.models.dimensionlink import JoinLinkInput
 from datajunction_server.models.history import ActivityType
-from datajunction_server.models.materialization import CoverageSpec
 from datajunction_server.models.node import MetricUnit, NodeStatus
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.partition import Granularity
+from datajunction_server.sql.parsing.types import StringType
 
 
 @pytest.fixture
@@ -3615,7 +3620,7 @@ class TestApplyCubeMaterializationSwaps:
     def _swap(
         cube_name: str,
         rebuilt_names: list[str],
-        backfill: CoverageSpec | None = None,
+        backfill: tuple[date, date] | None = None,
     ) -> CubeMaterializationSwap:
         return CubeMaterializationSwap(
             cube_name=cube_name,
@@ -3793,19 +3798,18 @@ class TestApplyCubeMaterializationSwaps:
     @pytest.mark.asyncio
     async def test_backfill_is_reported_with_its_run_count(self, orchestrator):
         """
-        A launched backfill is reported alongside the materialization, and the runs
-        it costs are warned about -- never capped, so a wide span still runs and a
-        mistyped `from` is visible at deploy time rather than at billing time.
+        A launched backfill is reported with the runs it costs -- never capped, so
+        a wide span still runs and a mistyped `from` is visible at deploy time
+        rather than at billing time.
         """
         orchestrator.context.request = None
         orchestrator._cube_materialization_swaps = [
             self._swap(
                 "default.a_cube",
-                ["druid_cube__full__a_cube"],
-                backfill=CoverageSpec(from_=date(2024, 1, 1), to=date(2024, 6, 30)),
+                [],
+                backfill=(date(2024, 1, 1), date(2024, 6, 30)),
             ),
         ]
-        orchestrator.deployed_results = [self._result("default.a_cube")]
 
         with patch(
             "datajunction_server.internal.deployment.orchestrator."
@@ -3813,7 +3817,7 @@ class TestApplyCubeMaterializationSwaps:
             new=AsyncMock(
                 return_value=CubeMaterializationSwapOutcome(
                     cube_name="default.a_cube",
-                    materialization_names=["druid_cube__full__a_cube"],
+                    materialization_names=[],
                     scheduled=True,
                     backfill_span=(date(2024, 1, 1), date(2024, 6, 30)),
                 ),
@@ -3822,7 +3826,6 @@ class TestApplyCubeMaterializationSwaps:
             await orchestrator._apply_cube_materialization_swaps()
 
         assert orchestrator.deployed_results == [
-            self._result("default.a_cube"),
             DeploymentResult(
                 name="default.a_cube",
                 deploy_type=DeploymentResult.Type.MATERIALIZATION,
@@ -3831,28 +3834,20 @@ class TestApplyCubeMaterializationSwaps:
                 message="backfilling 2024-01-01 to 2024-06-30, 182 partition runs",
             ),
         ]
-        assert orchestrator.warnings == [
-            DJError(
-                code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
-                message=(
-                    "Cube `default.a_cube`: backfilling 2024-01-01 to 2024-06-30 "
-                    "costs 182 partition runs."
-                ),
-            ),
-        ]
+        assert orchestrator.warnings == []
 
     @pytest.mark.asyncio
-    async def test_backfill_that_never_ran_is_warned_about(self, orchestrator):
+    async def test_a_refused_backfill_is_warned_about(self, orchestrator):
         """
-        A cube whose datasource is new and empty and whose backfill did not launch
-        is the one case worth a warning of its own: nothing else will fill it.
+        A cube left with days it declares and does not hold is worth a warning of
+        its own: the materialization is running, so nothing else says so.
         """
         orchestrator.context.request = None
         orchestrator._cube_materialization_swaps = [
             self._swap(
                 "default.a_cube",
-                ["druid_cube__full__a_cube"],
-                backfill=CoverageSpec(window="6 MONTHS"),
+                [],
+                backfill=(date(2024, 1, 1), date(2024, 6, 30)),
             ),
         ]
 
@@ -3862,9 +3857,9 @@ class TestApplyCubeMaterializationSwaps:
             new=AsyncMock(
                 return_value=CubeMaterializationSwapOutcome(
                     cube_name="default.a_cube",
-                    materialization_names=["druid_cube__full__a_cube"],
+                    materialization_names=[],
                     scheduled=True,
-                    backfill_error="DJ cannot count this coverage window in days.",
+                    backfill_error="429 Too Many Requests",
                 ),
             ),
         ):
@@ -3873,97 +3868,361 @@ class TestApplyCubeMaterializationSwaps:
         assert orchestrator.deployed_results == []
         assert orchestrator.warnings == [
             DJError(
+                code=ErrorCode.QUERY_SERVICE_ERROR,
+                message=(
+                    "Cube `default.a_cube`: the query service refused the "
+                    "backfill: 429 Too Many Requests"
+                ),
+            ),
+        ]
+
+
+class TestPlanCoverageBackfill:
+    """
+    Deciding what a cube's declared `coverage:` still owes it.
+
+    A datasource this deploy minted is empty and needs the whole span; one the
+    cube already has needs only the days before what availability reports.
+    """
+
+    @staticmethod
+    async def _cube(
+        session,
+        current_user,
+        min_temporal_partition: list[str] | None = None,
+        partitioned: bool = True,
+        name: str = "default.a_cube",
+    ) -> tuple[NodeRevision, Materialization]:
+        """A stored cube revision and the materialization it is served by."""
+        columns = [
+            Column(
+                name="date_id",
+                display_name="date_id",
+                type=StringType(),
+                partition=Partition(
+                    type_=PartitionType.TEMPORAL,
+                    granularity=Granularity.DAY,
+                    format="yyyyMMdd",
+                ),
+                order=0,
+            ),
+        ]
+        node = Node(
+            name=name,
+            type=NodeType.CUBE,
+            current_version="v1.0",
+            created_by_id=current_user.id,
+        )
+        revision = NodeRevision(
+            name=name,
+            node=node,
+            version="v1.0",
+            type=NodeType.CUBE,
+            created_by_id=current_user.id,
+            columns=columns if partitioned else [],
+            availability=(
+                AvailabilityState(
+                    catalog="default",
+                    table="a_cube",
+                    valid_through_ts=0,
+                    min_temporal_partition=min_temporal_partition,
+                )
+                if min_temporal_partition is not None
+                else None
+            ),
+        )
+        materialization = Materialization(
+            node_revision=revision,
+            name="druid_cube__full__date_id",
+            schedule="@daily",
+            config={},
+        )
+        session.add(materialization)
+        await session.commit()
+        return revision, materialization
+
+    @staticmethod
+    async def _recorded(session, materialization: Materialization) -> list[list]:
+        """The backfill specs stored against a materialization."""
+        return list(
+            (
+                await session.execute(
+                    select(Backfill.spec).where(
+                        Backfill.materialization_id == materialization.id,
+                    ),
+                )
+            )
+            .scalars()
+            .all(),
+        )
+
+    @staticmethod
+    def _block(**coverage) -> MaterializationSpec:
+        return MaterializationSpec(schedule="@daily", coverage=coverage)
+
+    @staticmethod
+    async def _plan(
+        orchestrator,
+        revision: NodeRevision,
+        block: MaterializationSpec,
+        materialization: Materialization,
+        active_names: set[str],
+        branch: bool = False,
+    ) -> None:
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator."
+            "get_git_info_for_namespace",
+            new=AsyncMock(return_value={"is_default_branch": not branch}),
+        ):
+            await orchestrator._plan_coverage_backfill(
+                revision,
+                block,
+                materialization,
+                active_names,
+            )
+
+    @staticmethod
+    def _queued(orchestrator) -> list[tuple[date, date] | None]:
+        return [swap.backfill for swap in orchestrator._cube_materialization_swaps]
+
+    @pytest.mark.asyncio
+    async def test_gap_before_the_covered_start(
+        self,
+        orchestrator,
+        session,
+        current_user,
+    ):
+        """
+        A cube that already holds data back to March is short everything the
+        declared span asks for before it, and that is what gets queued.
+        """
+        revision, materialization = await self._cube(
+            session,
+            current_user,
+            min_temporal_partition=["20250301"],
+        )
+
+        await self._plan(
+            orchestrator,
+            revision,
+            self._block(**{"from": date(2024, 1, 1)}),
+            materialization,
+            {materialization.name},
+        )
+
+        assert self._queued(orchestrator) == [(date(2024, 1, 1), date(2025, 2, 28))]
+        assert await self._recorded(session, materialization) == [
+            [
+                {
+                    "column_name": "date_id",
+                    "values": None,
+                    "range": ["2024-01-01", "2025-02-28"],
+                },
+            ],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_nothing_missing_before_the_start(
+        self,
+        orchestrator,
+        session,
+        current_user,
+    ):
+        """A cube already reaching back past what it declares owes nothing."""
+        revision, materialization = await self._cube(
+            session,
+            current_user,
+            min_temporal_partition=["20230101"],
+        )
+
+        await self._plan(
+            orchestrator,
+            revision,
+            self._block(**{"from": date(2024, 1, 1)}),
+            materialization,
+            {materialization.name},
+        )
+
+        assert self._queued(orchestrator) == []
+        assert await self._recorded(session, materialization) == []
+
+    @pytest.mark.asyncio
+    async def test_a_new_datasource_takes_the_whole_span(
+        self,
+        orchestrator,
+        session,
+        current_user,
+    ):
+        """
+        A materialization the cube did not have writes an empty datasource, so
+        availability says nothing about it and the whole span is missing.
+        """
+        revision, materialization = await self._cube(
+            session,
+            current_user,
+            min_temporal_partition=["20250301"],
+        )
+
+        await self._plan(
+            orchestrator,
+            revision,
+            self._block(**{"from": date(2024, 1, 1), "to": date(2026, 1, 1)}),
+            materialization,
+            set(),
+        )
+
+        assert self._queued(orchestrator) == [(date(2024, 1, 1), date(2026, 1, 1))]
+
+    @pytest.mark.asyncio
+    async def test_a_rebuilt_cube_takes_the_whole_span(
+        self,
+        orchestrator,
+        session,
+        current_user,
+    ):
+        """
+        A cube rebuilt onto a new version writes a datasource named for it, so the
+        availability its previous version posted describes a different table.
+        """
+        revision, materialization = await self._cube(
+            session,
+            current_user,
+            min_temporal_partition=["20250301"],
+        )
+        orchestrator._rebuilt_cubes = {revision.name}
+
+        await self._plan(
+            orchestrator,
+            revision,
+            self._block(**{"from": date(2024, 1, 1), "to": date(2026, 1, 1)}),
+            materialization,
+            {materialization.name},
+        )
+
+        assert self._queued(orchestrator) == [(date(2024, 1, 1), date(2026, 1, 1))]
+
+    @pytest.mark.asyncio
+    async def test_a_recorded_span_is_not_asked_for_twice(
+        self,
+        orchestrator,
+        session,
+        current_user,
+    ):
+        """
+        Availability does not move until the backfill lands, so the next deploy
+        sees the same gap. What DJ already asked for it does not ask for again.
+        """
+        revision, materialization = await self._cube(
+            session,
+            current_user,
+            min_temporal_partition=["20250301"],
+        )
+        block = self._block(**{"from": date(2024, 1, 1)})
+
+        await self._plan(orchestrator, revision, block, materialization, {"other"})
+        await self._plan(
+            orchestrator,
+            revision,
+            block,
+            materialization,
+            {materialization.name},
+        )
+
+        yesterday = datetime.now(UTC).date() - timedelta(days=1)
+        assert self._queued(orchestrator) == [(date(2024, 1, 1), yesterday)]
+        assert len(await self._recorded(session, materialization)) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_branch_deploy_asks_for_nothing(
+        self,
+        orchestrator,
+        session,
+        current_user,
+    ):
+        """
+        A branch namespace previews what the push would give its author, and a
+        preview does not spend hundreds of partition runs.
+        """
+        revision, materialization = await self._cube(
+            session,
+            current_user,
+            min_temporal_partition=["20250301"],
+        )
+
+        await self._plan(
+            orchestrator,
+            revision,
+            self._block(**{"from": date(2024, 1, 1)}),
+            materialization,
+            {materialization.name},
+            branch=True,
+        )
+
+        assert self._queued(orchestrator) == []
+        assert await self._recorded(session, materialization) == []
+
+    @pytest.mark.asyncio
+    async def test_an_uncountable_window_is_warned_about(
+        self,
+        orchestrator,
+        session,
+        current_user,
+    ):
+        """A window DJ cannot turn into days fills nothing, and says so."""
+        revision, materialization = await self._cube(session, current_user)
+
+        await self._plan(
+            orchestrator,
+            revision,
+            self._block(window="6 MONTHS"),
+            materialization,
+            {materialization.name},
+        )
+
+        assert self._queued(orchestrator) == []
+        assert orchestrator.warnings == [
+            DJError(
                 code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
                 message=(
-                    "Cube `default.a_cube`: no backfill ran. DJ cannot count this "
-                    "coverage window in days."
+                    "Cube `default.a_cube`: DJ counts a coverage window in days "
+                    "or weeks only."
                 ),
             ),
         ]
 
     @pytest.mark.asyncio
-    async def test_a_branch_deploy_backfills_nothing(self, orchestrator):
+    async def test_no_coverage_and_no_axis_ask_for_nothing(
+        self,
+        orchestrator,
+        session,
+        current_user,
+    ):
         """
-        A branch namespace is a preview of what the push would give its author, and
-        hundreds of partition runs are not part of a preview.
+        A block that declares no span asks for nothing, and neither does a cube
+        with no single temporal partition to run a span over.
         """
-        orchestrator.context.request = None
-        swap = self._swap(
-            "default.a_cube",
-            ["druid_cube__full__a_cube"],
-            backfill=CoverageSpec(from_=date(2024, 1, 1)),
+        revision, materialization = await self._cube(session, current_user)
+
+        await self._plan(
+            orchestrator,
+            revision,
+            MaterializationSpec(schedule="@daily"),
+            materialization,
+            {materialization.name},
         )
-        orchestrator._cube_materialization_swaps = [swap]
+        unpartitioned, _ = await self._cube(
+            session,
+            current_user,
+            partitioned=False,
+            name="default.no_axis_cube",
+        )
+        await self._plan(
+            orchestrator,
+            unpartitioned,
+            self._block(**{"from": date(2024, 1, 1)}),
+            materialization,
+            {materialization.name},
+        )
 
-        with (
-            patch(
-                "datajunction_server.internal.deployment.orchestrator."
-                "get_git_info_for_namespace",
-                new=AsyncMock(return_value={"is_default_branch": False}),
-            ),
-            patch(
-                "datajunction_server.internal.deployment.orchestrator."
-                "apply_cube_materialization_swap",
-                new=AsyncMock(
-                    return_value=CubeMaterializationSwapOutcome(
-                        cube_name="default.a_cube",
-                        materialization_names=["druid_cube__full__a_cube"],
-                        scheduled=True,
-                    ),
-                ),
-            ),
-        ):
-            await orchestrator._apply_cube_materialization_swaps()
-
-        assert swap.backfill is None
-        assert orchestrator.deployed_results == []
+        assert self._queued(orchestrator) == []
         assert orchestrator.warnings == []
-
-    @pytest.mark.asyncio
-    async def test_the_default_branch_still_backfills(self, orchestrator):
-        """
-        The branch guard is about feature branches. A namespace tracking the repo's
-        default branch is where the cube people query lives.
-        """
-        orchestrator.context.request = None
-        swap = self._swap(
-            "default.a_cube",
-            ["druid_cube__full__a_cube"],
-            backfill=CoverageSpec(from_=date(2024, 1, 1), to=date(2024, 1, 3)),
-        )
-        orchestrator._cube_materialization_swaps = [swap]
-
-        with (
-            patch(
-                "datajunction_server.internal.deployment.orchestrator."
-                "get_git_info_for_namespace",
-                new=AsyncMock(return_value={"is_default_branch": True}),
-            ),
-            patch(
-                "datajunction_server.internal.deployment.orchestrator."
-                "apply_cube_materialization_swap",
-                new=AsyncMock(
-                    return_value=CubeMaterializationSwapOutcome(
-                        cube_name="default.a_cube",
-                        materialization_names=["druid_cube__full__a_cube"],
-                        scheduled=True,
-                        backfill_span=(date(2024, 1, 1), date(2024, 1, 3)),
-                    ),
-                ),
-            ),
-        ):
-            await orchestrator._apply_cube_materialization_swaps()
-
-        assert swap.backfill == CoverageSpec(
-            from_=date(2024, 1, 1),
-            to=date(2024, 1, 3),
-        )
-        assert orchestrator.deployed_results == [
-            DeploymentResult(
-                name="default.a_cube",
-                deploy_type=DeploymentResult.Type.MATERIALIZATION,
-                status=DeploymentResult.Status.SUCCESS,
-                operation=DeploymentResult.Operation.CREATE,
-                message="backfilling 2024-01-01 to 2024-01-03, 3 partition runs",
-            ),
-        ]

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -2,7 +2,7 @@
 Unit tests for DeploymentOrchestrator
 """
 
-from datetime import UTC
+from datetime import UTC, date
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -55,6 +55,7 @@ from datajunction_server.models.deployment import (
 )
 from datajunction_server.models.dimensionlink import JoinLinkInput
 from datajunction_server.models.history import ActivityType
+from datajunction_server.models.materialization import CoverageSpec
 from datajunction_server.models.node import MetricUnit, NodeStatus
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.partition import Granularity
@@ -3611,7 +3612,11 @@ class TestApplyCubeMaterializationSwaps:
     """
 
     @staticmethod
-    def _swap(cube_name: str, rebuilt_names: list[str]) -> CubeMaterializationSwap:
+    def _swap(
+        cube_name: str,
+        rebuilt_names: list[str],
+        backfill: CoverageSpec | None = None,
+    ) -> CubeMaterializationSwap:
         return CubeMaterializationSwap(
             cube_name=cube_name,
             previous_version="v1.0",
@@ -3619,6 +3624,7 @@ class TestApplyCubeMaterializationSwaps:
             new_version="v1.1",
             rebuilt_names=rebuilt_names,
             superseded=[],
+            backfill=backfill,
         )
 
     @staticmethod
@@ -3781,5 +3787,183 @@ class TestApplyCubeMaterializationSwaps:
                     "Cube `default.a_cube`: the query service rejected the request "
                     "to schedule its materialization: 403 Forbidden"
                 ),
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_backfill_is_reported_with_its_run_count(self, orchestrator):
+        """
+        A launched backfill is reported alongside the materialization, and the runs
+        it costs are warned about -- never capped, so a wide span still runs and a
+        mistyped `from` is visible at deploy time rather than at billing time.
+        """
+        orchestrator.context.request = None
+        orchestrator._cube_materialization_swaps = [
+            self._swap(
+                "default.a_cube",
+                ["druid_cube__full__a_cube"],
+                backfill=CoverageSpec(from_=date(2024, 1, 1), to=date(2024, 6, 30)),
+            ),
+        ]
+        orchestrator.deployed_results = [self._result("default.a_cube")]
+
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator."
+            "apply_cube_materialization_swap",
+            new=AsyncMock(
+                return_value=CubeMaterializationSwapOutcome(
+                    cube_name="default.a_cube",
+                    materialization_names=["druid_cube__full__a_cube"],
+                    scheduled=True,
+                    backfill_span=(date(2024, 1, 1), date(2024, 6, 30)),
+                ),
+            ),
+        ):
+            await orchestrator._apply_cube_materialization_swaps()
+
+        assert orchestrator.deployed_results == [
+            self._result("default.a_cube"),
+            DeploymentResult(
+                name="default.a_cube",
+                deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                status=DeploymentResult.Status.SUCCESS,
+                operation=DeploymentResult.Operation.CREATE,
+                message="backfilling 2024-01-01 to 2024-06-30, 182 partition runs",
+            ),
+        ]
+        assert orchestrator.warnings == [
+            DJError(
+                code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
+                message=(
+                    "Cube `default.a_cube`: backfilling 2024-01-01 to 2024-06-30 "
+                    "costs 182 partition runs."
+                ),
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_backfill_that_never_ran_is_warned_about(self, orchestrator):
+        """
+        A cube whose datasource is new and empty and whose backfill did not launch
+        is the one case worth a warning of its own: nothing else will fill it.
+        """
+        orchestrator.context.request = None
+        orchestrator._cube_materialization_swaps = [
+            self._swap(
+                "default.a_cube",
+                ["druid_cube__full__a_cube"],
+                backfill=CoverageSpec(window="6 MONTHS"),
+            ),
+        ]
+
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator."
+            "apply_cube_materialization_swap",
+            new=AsyncMock(
+                return_value=CubeMaterializationSwapOutcome(
+                    cube_name="default.a_cube",
+                    materialization_names=["druid_cube__full__a_cube"],
+                    scheduled=True,
+                    backfill_error="DJ cannot count this coverage window in days.",
+                ),
+            ),
+        ):
+            await orchestrator._apply_cube_materialization_swaps()
+
+        assert orchestrator.deployed_results == []
+        assert orchestrator.warnings == [
+            DJError(
+                code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
+                message=(
+                    "Cube `default.a_cube`: no backfill ran. DJ cannot count this "
+                    "coverage window in days."
+                ),
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_branch_deploy_backfills_nothing(self, orchestrator):
+        """
+        A branch namespace is a preview of what the push would give its author, and
+        hundreds of partition runs are not part of a preview.
+        """
+        orchestrator.context.request = None
+        swap = self._swap(
+            "default.a_cube",
+            ["druid_cube__full__a_cube"],
+            backfill=CoverageSpec(from_=date(2024, 1, 1)),
+        )
+        orchestrator._cube_materialization_swaps = [swap]
+
+        with (
+            patch(
+                "datajunction_server.internal.deployment.orchestrator."
+                "get_git_info_for_namespace",
+                new=AsyncMock(return_value={"is_default_branch": False}),
+            ),
+            patch(
+                "datajunction_server.internal.deployment.orchestrator."
+                "apply_cube_materialization_swap",
+                new=AsyncMock(
+                    return_value=CubeMaterializationSwapOutcome(
+                        cube_name="default.a_cube",
+                        materialization_names=["druid_cube__full__a_cube"],
+                        scheduled=True,
+                    ),
+                ),
+            ),
+        ):
+            await orchestrator._apply_cube_materialization_swaps()
+
+        assert swap.backfill is None
+        assert orchestrator.deployed_results == []
+        assert orchestrator.warnings == []
+
+    @pytest.mark.asyncio
+    async def test_the_default_branch_still_backfills(self, orchestrator):
+        """
+        The branch guard is about feature branches. A namespace tracking the repo's
+        default branch is where the cube people query lives.
+        """
+        orchestrator.context.request = None
+        swap = self._swap(
+            "default.a_cube",
+            ["druid_cube__full__a_cube"],
+            backfill=CoverageSpec(from_=date(2024, 1, 1), to=date(2024, 1, 3)),
+        )
+        orchestrator._cube_materialization_swaps = [swap]
+
+        with (
+            patch(
+                "datajunction_server.internal.deployment.orchestrator."
+                "get_git_info_for_namespace",
+                new=AsyncMock(return_value={"is_default_branch": True}),
+            ),
+            patch(
+                "datajunction_server.internal.deployment.orchestrator."
+                "apply_cube_materialization_swap",
+                new=AsyncMock(
+                    return_value=CubeMaterializationSwapOutcome(
+                        cube_name="default.a_cube",
+                        materialization_names=["druid_cube__full__a_cube"],
+                        scheduled=True,
+                        backfill_span=(date(2024, 1, 1), date(2024, 1, 3)),
+                    ),
+                ),
+            ),
+        ):
+            await orchestrator._apply_cube_materialization_swaps()
+
+        assert swap.backfill == CoverageSpec(
+            from_=date(2024, 1, 1),
+            to=date(2024, 1, 3),
+        )
+        assert orchestrator.deployed_results == [
+            DeploymentResult(
+                name="default.a_cube",
+                deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                status=DeploymentResult.Status.SUCCESS,
+                operation=DeploymentResult.Operation.CREATE,
+                message="backfilling 2024-01-01 to 2024-01-03, 3 partition runs",
             ),
         ]

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -3608,6 +3608,49 @@ class TestDeriveLegacyUnitForStorage:
         assert result == MetricUnit.SECOND
 
 
+class TestSwapCubeMaterializations:
+    """
+    Which cubes a version swap rebuilt, and so which start on an empty datasource.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_swap_that_rebuilt_nothing(self, orchestrator):
+        """
+        A swap that supersedes without rebuilding keeps the datasource the cube
+        already has, so the cube is not one a coverage backfill has to fill.
+        """
+        old_revision = MagicMock(name="old")
+        new_revision = MagicMock()
+        new_revision.name = "default.a_cube"
+        swap = CubeMaterializationSwap(
+            cube_name="default.a_cube",
+            previous_version="v1.0",
+            new_revision_id=7,
+            new_version="v1.1",
+            rebuilt_names=[],
+            superseded=[],
+        )
+        with (
+            patch(
+                "datajunction_server.internal.deployment.orchestrator."
+                "swap_cube_materializations",
+                AsyncMock(return_value=swap),
+            ),
+            patch(
+                "datajunction_server.internal.deployment.orchestrator."
+                "is_non_trivial_cube_change",
+                AsyncMock(return_value=False),
+            ),
+        ):
+            await orchestrator._swap_cube_materializations(
+                {"default.a_cube": old_revision},
+                [new_revision],
+            )
+
+        assert orchestrator._rebuilt_cubes == set()
+        assert orchestrator._cube_materialization_swaps == [swap]
+
+
 class TestApplyCubeMaterializationSwaps:
     """
     Reporting on the query service's answer to a cube materialization push.

--- a/datajunction-server/tests/internal/materializations_test.py
+++ b/datajunction-server/tests/internal/materializations_test.py
@@ -2,6 +2,7 @@
 Tests for node materialization helper functions.
 """
 
+from datetime import date, timedelta
 from unittest import mock
 
 import pytest
@@ -15,7 +16,9 @@ from datajunction_server.internal.materializations import (
     stop_cube_materialization_workflows,
     stop_materialization_workflows,
 )
+from datajunction_server.models.materialization import CoverageSpec
 from datajunction_server.models.node_type import NodeType
+from datajunction_server.models.preaggregation import CubeBackfillInput
 
 
 def test_stop_cube_workflows_prefers_stored_workflow_names():
@@ -234,7 +237,10 @@ def test_stop_materialization_workflows_reports_every_failure():
     ]
 
 
-def _swap(rebuilt_names: list[str]) -> CubeMaterializationSwap:
+def _swap(
+    rebuilt_names: list[str],
+    backfill: CoverageSpec | None = None,
+) -> CubeMaterializationSwap:
     """A swap with one superseded materialization and the given rebuilt names."""
     return CubeMaterializationSwap(
         cube_name="default.a_cube",
@@ -248,6 +254,7 @@ def _swap(rebuilt_names: list[str]) -> CubeMaterializationSwap:
                 config={"workflow_names": ["cube_workflow_1"]},
             ),
         ],
+        backfill=backfill,
     )
 
 
@@ -368,3 +375,161 @@ async def test_apply_cube_swap_without_a_query_service():
         scheduled=True,
         error=None,
     )
+
+
+async def _apply_with_backfill(
+    query_service_client,
+    coverage: CoverageSpec,
+) -> CubeMaterializationSwapOutcome:
+    """Apply a swap that mints a new datasource over the given coverage."""
+    with mock.patch(
+        "datajunction_server.internal.materializations.schedule_materialization_jobs",
+        new=mock.AsyncMock(),
+    ):
+        return await apply_cube_materialization_swap(
+            mock.MagicMock(),
+            _swap(["druid_cube_v3"], backfill=coverage),
+            query_service_client,
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_cube_swap_backfills_a_fixed_span():
+    """
+    A declared span with both ends is backfilled exactly as written, against the
+    new version -- which is what names the empty datasource.
+    """
+    query_service_client = mock.MagicMock()
+
+    outcome = await _apply_with_backfill(
+        query_service_client,
+        CoverageSpec(from_=date(2024, 1, 1), to=date(2024, 6, 30)),
+    )
+
+    assert outcome == CubeMaterializationSwapOutcome(
+        cube_name="default.a_cube",
+        materialization_names=["druid_cube_v3"],
+        scheduled=True,
+        error=None,
+        backfill_span=(date(2024, 1, 1), date(2024, 6, 30)),
+        backfill_error=None,
+    )
+    assert query_service_client.run_cube_backfill.call_args_list == [
+        mock.call(
+            CubeBackfillInput(
+                cube_name="default.a_cube",
+                cube_version="v1.1",
+                start_date=date(2024, 1, 1),
+                end_date=date(2024, 6, 30),
+            ),
+            request_headers=None,
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_apply_cube_swap_backfills_an_ongoing_span():
+    """A span with no `to` runs up to yesterday, the last full day."""
+    yesterday = date.today() - timedelta(days=1)
+
+    outcome = await _apply_with_backfill(
+        mock.MagicMock(),
+        CoverageSpec(from_=date(2024, 1, 1)),
+    )
+
+    assert outcome.backfill_span == (date(2024, 1, 1), yesterday)
+
+
+@pytest.mark.asyncio
+async def test_apply_cube_swap_backfills_a_rolling_window():
+    """A rolling window is counted back from yesterday, inclusive of both ends."""
+    yesterday = date.today() - timedelta(days=1)
+
+    outcome = await _apply_with_backfill(
+        mock.MagicMock(),
+        CoverageSpec(window="800 DAYS"),
+    )
+
+    assert outcome.backfill_span == (yesterday - timedelta(days=799), yesterday)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("window", ["6 MONTHS", "a while"])
+async def test_apply_cube_swap_cannot_count_the_window(window):
+    """
+    A window DJ cannot turn into days -- an unknown unit, or a duration that reads
+    as nothing at all -- launches nothing, and says so rather than leaving the
+    datasource quietly empty.
+    """
+    query_service_client = mock.MagicMock()
+
+    outcome = await _apply_with_backfill(
+        query_service_client,
+        CoverageSpec(window=window),
+    )
+
+    assert outcome == CubeMaterializationSwapOutcome(
+        cube_name="default.a_cube",
+        materialization_names=["druid_cube_v3"],
+        scheduled=True,
+        error=None,
+        backfill_span=None,
+        backfill_error="DJ cannot count this coverage window in days.",
+    )
+    assert query_service_client.run_cube_backfill.call_args_list == []
+
+
+@pytest.mark.asyncio
+async def test_apply_cube_swap_reports_a_refused_backfill():
+    """
+    A backfill the query service refuses does not raise -- the materialization is
+    scheduled and the deploy has committed -- but the refusal comes back verbatim.
+    """
+    query_service_client = mock.MagicMock()
+    query_service_client.run_cube_backfill.side_effect = Exception("429 Too Many")
+
+    outcome = await _apply_with_backfill(
+        query_service_client,
+        CoverageSpec(from_=date(2024, 1, 1), to=date(2024, 1, 2)),
+    )
+
+    assert outcome == CubeMaterializationSwapOutcome(
+        cube_name="default.a_cube",
+        materialization_names=["druid_cube_v3"],
+        scheduled=True,
+        error=None,
+        backfill_span=None,
+        backfill_error="429 Too Many",
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_cube_swap_backfills_nothing_unscheduled():
+    """
+    A backfill needs the workflow the scheduling would have created, so a rejected
+    push takes the backfill with it.
+    """
+    query_service_client = mock.MagicMock()
+
+    with mock.patch(
+        "datajunction_server.internal.materializations.schedule_materialization_jobs",
+        new=mock.AsyncMock(side_effect=Exception("403 Forbidden")),
+    ):
+        outcome = await apply_cube_materialization_swap(
+            mock.MagicMock(),
+            _swap(
+                ["druid_cube_v3"],
+                backfill=CoverageSpec(from_=date(2024, 1, 1)),
+            ),
+            query_service_client,
+        )
+
+    assert outcome == CubeMaterializationSwapOutcome(
+        cube_name="default.a_cube",
+        materialization_names=["druid_cube_v3"],
+        scheduled=False,
+        error="403 Forbidden",
+        backfill_span=None,
+        backfill_error=None,
+    )
+    assert query_service_client.run_cube_backfill.call_args_list == []

--- a/datajunction-server/tests/internal/materializations_test.py
+++ b/datajunction-server/tests/internal/materializations_test.py
@@ -2,23 +2,34 @@
 Tests for node materialization helper functions.
 """
 
-from datetime import date, timedelta
+from datetime import date
 from unittest import mock
 
 import pytest
+from sqlalchemy import select
 
+from datajunction_server.database.availabilitystate import AvailabilityState
+from datajunction_server.database.backfill import Backfill
+from datajunction_server.database.column import Column
 from datajunction_server.database.materialization import Materialization
+from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.partition import Partition
 from datajunction_server.internal.materializations import (
     CubeMaterializationSwap,
     CubeMaterializationSwapOutcome,
     NodeMaterializationTeardown,
     apply_cube_materialization_swap,
+    backfill_recorded,
+    coverage_gap,
+    coverage_partition,
+    record_backfill,
     stop_cube_materialization_workflows,
     stop_materialization_workflows,
 )
-from datajunction_server.models.materialization import CoverageSpec
 from datajunction_server.models.node_type import NodeType
+from datajunction_server.models.partition import Granularity, PartitionType
 from datajunction_server.models.preaggregation import CubeBackfillInput
+from datajunction_server.sql.parsing.types import StringType
 
 
 def test_stop_cube_workflows_prefers_stored_workflow_names():
@@ -239,7 +250,7 @@ def test_stop_materialization_workflows_reports_every_failure():
 
 def _swap(
     rebuilt_names: list[str],
-    backfill: CoverageSpec | None = None,
+    backfill: tuple[date, date] | None = None,
 ) -> CubeMaterializationSwap:
     """A swap with one superseded materialization and the given rebuilt names."""
     return CubeMaterializationSwap(
@@ -379,31 +390,35 @@ async def test_apply_cube_swap_without_a_query_service():
 
 async def _apply_with_backfill(
     query_service_client,
-    coverage: CoverageSpec,
+    span: tuple[date, date],
+    rebuilt_names: list[str] | None = None,
 ) -> CubeMaterializationSwapOutcome:
-    """Apply a swap that mints a new datasource over the given coverage."""
+    """Apply a swap that carries a span to backfill."""
     with mock.patch(
         "datajunction_server.internal.materializations.schedule_materialization_jobs",
         new=mock.AsyncMock(),
     ):
         return await apply_cube_materialization_swap(
             mock.MagicMock(),
-            _swap(["druid_cube_v3"], backfill=coverage),
+            _swap(
+                rebuilt_names if rebuilt_names is not None else ["druid_cube_v3"],
+                backfill=span,
+            ),
             query_service_client,
         )
 
 
 @pytest.mark.asyncio
-async def test_apply_cube_swap_backfills_a_fixed_span():
+async def test_apply_cube_swap_backfills_the_span():
     """
-    A declared span with both ends is backfilled exactly as written, against the
-    new version -- which is what names the empty datasource.
+    A swap carrying a span asks for exactly those days, against the new version --
+    which is what names the datasource being filled.
     """
     query_service_client = mock.MagicMock()
 
     outcome = await _apply_with_backfill(
         query_service_client,
-        CoverageSpec(from_=date(2024, 1, 1), to=date(2024, 6, 30)),
+        (date(2024, 1, 1), date(2024, 6, 30)),
     )
 
     assert outcome == CubeMaterializationSwapOutcome(
@@ -428,55 +443,27 @@ async def test_apply_cube_swap_backfills_a_fixed_span():
 
 
 @pytest.mark.asyncio
-async def test_apply_cube_swap_backfills_an_ongoing_span():
-    """A span with no `to` runs up to yesterday, the last full day."""
-    yesterday = date.today() - timedelta(days=1)
-
-    outcome = await _apply_with_backfill(
-        mock.MagicMock(),
-        CoverageSpec(from_=date(2024, 1, 1)),
-    )
-
-    assert outcome.backfill_span == (date(2024, 1, 1), yesterday)
-
-
-@pytest.mark.asyncio
-async def test_apply_cube_swap_backfills_a_rolling_window():
-    """A rolling window is counted back from yesterday, inclusive of both ends."""
-    yesterday = date.today() - timedelta(days=1)
-
-    outcome = await _apply_with_backfill(
-        mock.MagicMock(),
-        CoverageSpec(window="800 DAYS"),
-    )
-
-    assert outcome.backfill_span == (yesterday - timedelta(days=799), yesterday)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("window", ["6 MONTHS", "a while"])
-async def test_apply_cube_swap_cannot_count_the_window(window):
+async def test_apply_cube_swap_backfills_without_rebuilding():
     """
-    A window DJ cannot turn into days -- an unknown unit, or a duration that reads
-    as nothing at all -- launches nothing, and says so rather than leaving the
-    datasource quietly empty.
+    A gap fill rides on the workflow the cube already has, so its swap rebuilds
+    nothing and schedules nothing -- it only backfills.
     """
     query_service_client = mock.MagicMock()
 
     outcome = await _apply_with_backfill(
         query_service_client,
-        CoverageSpec(window=window),
+        (date(2024, 1, 1), date(2024, 1, 3)),
+        rebuilt_names=[],
     )
 
     assert outcome == CubeMaterializationSwapOutcome(
         cube_name="default.a_cube",
-        materialization_names=["druid_cube_v3"],
+        materialization_names=[],
         scheduled=True,
         error=None,
-        backfill_span=None,
-        backfill_error="DJ cannot count this coverage window in days.",
+        backfill_span=(date(2024, 1, 1), date(2024, 1, 3)),
+        backfill_error=None,
     )
-    assert query_service_client.run_cube_backfill.call_args_list == []
 
 
 @pytest.mark.asyncio
@@ -490,7 +477,7 @@ async def test_apply_cube_swap_reports_a_refused_backfill():
 
     outcome = await _apply_with_backfill(
         query_service_client,
-        CoverageSpec(from_=date(2024, 1, 1), to=date(2024, 1, 2)),
+        (date(2024, 1, 1), date(2024, 1, 2)),
     )
 
     assert outcome == CubeMaterializationSwapOutcome(
@@ -517,10 +504,7 @@ async def test_apply_cube_swap_backfills_nothing_unscheduled():
     ):
         outcome = await apply_cube_materialization_swap(
             mock.MagicMock(),
-            _swap(
-                ["druid_cube_v3"],
-                backfill=CoverageSpec(from_=date(2024, 1, 1)),
-            ),
+            _swap(["druid_cube_v3"], backfill=(date(2024, 1, 1), date(2024, 1, 2))),
             query_service_client,
         )
 
@@ -533,3 +517,187 @@ async def test_apply_cube_swap_backfills_nothing_unscheduled():
         backfill_error=None,
     )
     assert query_service_client.run_cube_backfill.call_args_list == []
+
+
+def _cube_revision(
+    min_temporal_partition: list[str] | None = None,
+    partitions: int = 1,
+) -> NodeRevision:
+    """A day-partitioned cube revision, optionally with availability."""
+    columns = [
+        Column(
+            name=f"date_{index}",
+            display_name=f"date_{index}",
+            type=StringType(),
+            partition=Partition(
+                type_=PartitionType.TEMPORAL,
+                granularity=Granularity.DAY,
+                format="yyyyMMdd",
+            ),
+        )
+        for index in range(partitions)
+    ]
+    return NodeRevision(
+        name="default.a_cube",
+        type=NodeType.CUBE,
+        columns=columns,
+        availability=(
+            AvailabilityState(
+                catalog="default",
+                table="a_cube",
+                valid_through_ts=0,
+                min_temporal_partition=min_temporal_partition,
+            )
+            if min_temporal_partition is not None
+            else None
+        ),
+    )
+
+
+def test_coverage_partition_needs_one_axis():
+    """
+    Coverage is a span of days on a single axis, so a cube partitioned on two
+    temporal columns, or none, has no axis to run one over.
+    """
+    assert coverage_partition(_cube_revision(partitions=0)) is None
+    assert coverage_partition(_cube_revision(partitions=2)) is None
+    assert coverage_partition(_cube_revision()).name == "date_0"
+
+
+def test_coverage_gap_without_availability():
+    """A cube that has posted no availability holds nothing at all."""
+    span = (date(2024, 1, 1), date(2024, 6, 30))
+
+    assert coverage_gap(span, _cube_revision()) == span
+
+
+@pytest.mark.parametrize("covered", ["20250301", 20250301])
+def test_coverage_gap_before_the_covered_start(covered):
+    """
+    The gap runs from the declared start to the day before the cube's earliest,
+    read out of availability in the partition's own format, written either way.
+    """
+    assert coverage_gap(
+        (date(2024, 1, 1), date(2026, 8, 1)),
+        _cube_revision(min_temporal_partition=[covered]),
+    ) == (date(2024, 1, 1), date(2025, 2, 28))
+
+
+def test_coverage_gap_stops_at_the_declared_end():
+    """
+    A span that ends before the cube's earliest day is missing in full, rather
+    than reported as reaching up to a day the cube never declared.
+    """
+    assert coverage_gap(
+        (date(2024, 1, 1), date(2024, 6, 30)),
+        _cube_revision(min_temporal_partition=["20250301"]),
+    ) == (date(2024, 1, 1), date(2024, 6, 30))
+
+
+@pytest.mark.parametrize(
+    "revision",
+    [
+        # The cube already reaches back further than it declares.
+        _cube_revision(min_temporal_partition=["20230101"]),
+        # It reaches back to exactly the declared start.
+        _cube_revision(min_temporal_partition=["20240101"]),
+        # Its availability does not read against the partition format.
+        _cube_revision(min_temporal_partition=["2024-01-01"]),
+        # It reports a bound per axis, and there is more than one axis.
+        _cube_revision(min_temporal_partition=["20240101", "01"], partitions=2),
+    ],
+)
+def test_coverage_gap_leaves_nothing_to_fill(revision):
+    """Nothing knowably missing, and nothing guessed at."""
+    assert coverage_gap((date(2024, 1, 1), date(2026, 8, 1)), revision) is None
+
+
+async def _stored_materialization(session, current_user) -> Materialization:
+    """A stored cube materialization to hang backfill records on."""
+    revision = _cube_revision()
+    revision.version = "v1.0"
+    revision.created_by_id = current_user.id
+    revision.node = Node(
+        name=revision.name,
+        type=NodeType.CUBE,
+        current_version="v1.0",
+        created_by_id=current_user.id,
+    )
+    materialization = Materialization(
+        node_revision=revision,
+        name="druid_cube_v3",
+        schedule="@daily",
+        config={},
+    )
+    session.add(materialization)
+    await session.commit()
+    return materialization
+
+
+async def _recorded(session, materialization: Materialization) -> list[list]:
+    """The backfill specs stored against a materialization."""
+    return list(
+        (
+            await session.execute(
+                select(Backfill.spec).where(
+                    Backfill.materialization_id == materialization.id,
+                ),
+            )
+        )
+        .scalars()
+        .all(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_backfill_is_read_back(session, current_user):
+    """
+    A recorded span stops the next deploy asking for the same days again, and any
+    span it already reaches back over.
+    """
+    materialization = await _stored_materialization(session, current_user)
+
+    record_backfill(
+        session,
+        materialization,
+        _cube_revision().columns[0],
+        (date(2024, 1, 1), date(2024, 6, 30)),
+    )
+
+    assert await _recorded(session, materialization) == [
+        [
+            {
+                "column_name": "date_0",
+                "values": None,
+                "range": ["2024-01-01", "2024-06-30"],
+            },
+        ],
+    ]
+    assert await backfill_recorded(session, materialization, date(2024, 1, 1)) is True
+    assert await backfill_recorded(session, materialization, date(2024, 6, 1)) is True
+    assert (
+        await backfill_recorded(session, materialization, date(2023, 12, 31)) is False
+    )
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        # A backfill run from the API, in partition format rather than ISO.
+        [{"column_name": "date_0", "range": [20240101, 20240630]}],
+        # One naming values rather than a range.
+        [{"column_name": "date_0", "values": [20240101], "range": None}],
+        # Nothing at all.
+        [],
+    ],
+)
+@pytest.mark.asyncio
+async def test_backfill_recorded_reads_djs_own(session, current_user, spec):
+    """
+    Only DJ's own records count. A backfill posted through the API says nothing
+    about the span a cube declares.
+    """
+    materialization = await _stored_materialization(session, current_user)
+    session.add(Backfill(materialization_id=materialization.id, spec=spec))
+
+    assert await backfill_recorded(session, materialization, date(2024, 1, 1)) is False

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -1,7 +1,13 @@
+import json
+from datetime import date
+
 import pytest
 from pydantic import ValidationError
 
-from datajunction_server.errors import DJInvalidDeploymentConfig
+from datajunction_server.errors import (
+    DJInvalidDeploymentConfig,
+    DJInvalidInputException,
+)
 from datajunction_server.models.deployment import (
     ChangeTier,
     ColumnSpec,
@@ -27,7 +33,10 @@ from datajunction_server.models.deployment import (
     eq_or_fallback,
     fold_change_tiers,
 )
-from datajunction_server.models.materialization import MaterializationStrategy
+from datajunction_server.models.materialization import (
+    CoverageSpec,
+    MaterializationStrategy,
+)
 from datajunction_server.models.node import MetricUnit, NodeMode, NodeType
 
 
@@ -1033,6 +1042,7 @@ def test_materialization_spec_defaults():
         "strategy": MaterializationStrategy.INCREMENTAL_TIME,
         "lookback_window": "1 DAY",
         "retention": "400 DAYS",
+        "coverage": None,
     }
 
 
@@ -1044,6 +1054,7 @@ def test_materialization_spec_retention_override():
         "strategy": MaterializationStrategy.INCREMENTAL_TIME,
         "lookback_window": "1 DAY",
         "retention": "30 DAYS",
+        "coverage": None,
     }
 
 
@@ -1063,11 +1074,146 @@ def test_materialization_spec_full_strategy_drops_lookback():
         "strategy": MaterializationStrategy.FULL,
         "lookback_window": None,
         "retention": "400 DAYS",
+        "coverage": None,
     }
     assert declared == MaterializationSpec(
         schedule="0 6 * * *",
         strategy=MaterializationStrategy.FULL,
     )
+
+
+def test_materialization_spec_coverage_fixed_span():
+    """
+    A fixed span is declared as an inclusive ``from``/``to`` pair, and dumps back out
+    under the authored ``from`` key rather than the ``from_`` field name.
+    """
+    spec = MaterializationSpec(
+        schedule="0 6 * * *",
+        coverage={"from": "2024-01-01", "to": "2024-06-30"},
+    )
+    assert spec.coverage == CoverageSpec(from_=date(2024, 1, 1), to=date(2024, 6, 30))
+    assert spec.model_dump() == {
+        "schedule": "0 6 * * *",
+        "strategy": MaterializationStrategy.INCREMENTAL_TIME,
+        "lookback_window": "1 DAY",
+        "retention": "400 DAYS",
+        "coverage": {"from": "2024-01-01", "to": "2024-06-30", "window": None},
+    }
+
+
+def test_materialization_spec_coverage_open_ended_span():
+    """``to`` is optional: a span with only a ``from`` is ongoing."""
+    spec = MaterializationSpec(
+        schedule="0 6 * * *",
+        coverage={"from": "2024-01-01"},
+    )
+    assert spec.model_dump(mode="json", exclude_none=True) == {
+        "schedule": "0 6 * * *",
+        "strategy": "incremental_time",
+        "lookback_window": "1 DAY",
+        "retention": "400 DAYS",
+        "coverage": {"from": "2024-01-01"},
+    }
+
+
+def test_materialization_spec_coverage_rolling_window():
+    """The other form is a trailing duration, in the style of ``lookback_window``."""
+    spec = MaterializationSpec(
+        schedule="0 6 * * *",
+        coverage={"window": "800 DAYS"},
+    )
+    assert spec.coverage == CoverageSpec(window="800 DAYS")
+    assert spec.model_dump(mode="json", exclude_none=True) == {
+        "schedule": "0 6 * * *",
+        "strategy": "incremental_time",
+        "lookback_window": "1 DAY",
+        "retention": "400 DAYS",
+        "coverage": {"window": "800 DAYS"},
+    }
+
+
+def test_materialization_spec_without_coverage():
+    """Coverage is optional, and absent means the author has declared no span."""
+    assert MaterializationSpec(schedule="0 6 * * *").coverage is None
+
+
+def test_materialization_spec_empty_coverage_is_absent():
+    """
+    A ``coverage:`` block declaring neither form declares nothing, so it normalizes to
+    absent -- otherwise it would compare unequal to the same spec without the block and
+    churn a live workflow on every deploy.
+    """
+    spec = MaterializationSpec(schedule="0 6 * * *", coverage={})
+    assert spec.coverage is None
+    assert spec == MaterializationSpec(schedule="0 6 * * *")
+
+
+def test_materialization_spec_coverage_equality_ignores_spelling():
+    """
+    Two specs meaning the same span compare equal however they were spelled: dates are
+    parsed rather than kept as text, and the window's whitespace is collapsed.
+    """
+    assert MaterializationSpec(
+        schedule="0 6 * * *",
+        coverage={"from": "2024-01-01"},
+    ) == MaterializationSpec(
+        schedule="0 6 * * *",
+        coverage=CoverageSpec(from_=date(2024, 1, 1)),
+    )
+    assert MaterializationSpec(
+        schedule="0 6 * * *",
+        coverage={"window": "  800   DAYS "},
+    ) == MaterializationSpec(schedule="0 6 * * *", coverage={"window": "800 DAYS"})
+
+
+def test_materialization_spec_coverage_rejects_both_forms():
+    """A fixed span and a rolling window say different things about the same cube."""
+    with pytest.raises(DJInvalidInputException) as exc_info:
+        MaterializationSpec(
+            schedule="0 6 * * *",
+            coverage={"from": "2024-01-01", "window": "800 DAYS"},
+        )
+    assert exc_info.value.message == (
+        "A materialization `coverage` block declares either a fixed span "
+        "(`from`, with an optional `to`) or a rolling `window`, not both."
+    )
+
+
+def test_materialization_spec_coverage_rejects_to_without_from():
+    """An end date on its own does not describe a span."""
+    with pytest.raises(DJInvalidInputException) as exc_info:
+        MaterializationSpec(schedule="0 6 * * *", coverage={"to": "2024-06-30"})
+    assert exc_info.value.message == (
+        "A materialization `coverage` block with a `to` needs a `from`: "
+        "an end date on its own does not say where the span starts."
+    )
+
+
+def test_materialization_spec_coverage_rejects_backwards_span():
+    """A span that ends before it starts covers nothing."""
+    with pytest.raises(DJInvalidInputException) as exc_info:
+        MaterializationSpec(
+            schedule="0 6 * * *",
+            coverage={"from": "2024-06-30", "to": "2024-01-01"},
+        )
+    assert exc_info.value.message == (
+        "A materialization `coverage` block ends before it starts: "
+        "`to` (2024-01-01) precedes `from` (2024-06-30)."
+    )
+
+
+def test_coverage_spec_survives_a_json_round_trip():
+    """
+    What ``model_dump`` produces is exactly what validates back, which is what lets a
+    declared span pass through the JSON materialization config unchanged.
+    """
+    for coverage in (
+        CoverageSpec(from_=date(2024, 1, 1), to=date(2024, 6, 30)),
+        CoverageSpec(from_=date(2024, 1, 1)),
+        CoverageSpec(window="800 DAYS"),
+    ):
+        stored = json.loads(json.dumps(coverage.model_dump()))
+        assert CoverageSpec.model_validate(stored) == coverage
 
 
 def test_cube_spec_incremental_requires_temporal_partition():

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -1209,6 +1209,39 @@ def test_coverage_spec_survives_a_json_round_trip():
         assert CoverageSpec.model_validate(stored) == coverage
 
 
+@pytest.mark.parametrize(
+    ("coverage", "span"),
+    [
+        # A fixed span with both ends is already the answer.
+        (
+            CoverageSpec(from_=date(2024, 1, 1), to=date(2024, 6, 30)),
+            (date(2024, 1, 1), date(2024, 6, 30)),
+        ),
+        # An ongoing span runs to yesterday, the last full day.
+        (
+            CoverageSpec(from_=date(2024, 1, 1)),
+            (date(2024, 1, 1), date(2026, 8, 22)),
+        ),
+        # A rolling window counts back from yesterday, both ends included.
+        (
+            CoverageSpec(window="800 DAYS"),
+            (date(2024, 6, 14), date(2026, 8, 22)),
+        ),
+        (
+            CoverageSpec(window="2 weeks"),
+            (date(2026, 8, 9), date(2026, 8, 22)),
+        ),
+        # A window in a unit DJ cannot count in days.
+        (CoverageSpec(window="6 MONTHS"), None),
+        # A window that reads as no duration at all.
+        (CoverageSpec(window="a while"), None),
+    ],
+)
+def test_coverage_spec_span(coverage, span):
+    """The days a declared span asks a backfill to run, as of a given day."""
+    assert coverage.span(date(2026, 8, 23)) == span
+
+
 def test_cube_spec_incremental_requires_temporal_partition():
     """An incremental cube with no temporal partition has nothing to increment over."""
     with pytest.raises(DJInvalidDeploymentConfig) as exc_info:

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -1173,20 +1173,14 @@ def test_materialization_spec_coverage_rejects_both_forms():
             schedule="0 6 * * *",
             coverage={"from": "2024-01-01", "window": "800 DAYS"},
         )
-    assert exc_info.value.message == (
-        "A materialization `coverage` block declares either a fixed span "
-        "(`from`, with an optional `to`) or a rolling `window`, not both."
-    )
+    assert exc_info.value.message == ("Declare a fixed span or a window, not both.")
 
 
 def test_materialization_spec_coverage_rejects_to_without_from():
     """An end date on its own does not describe a span."""
     with pytest.raises(DJInvalidInputException) as exc_info:
         MaterializationSpec(schedule="0 6 * * *", coverage={"to": "2024-06-30"})
-    assert exc_info.value.message == (
-        "A materialization `coverage` block with a `to` needs a `from`: "
-        "an end date on its own does not say where the span starts."
-    )
+    assert exc_info.value.message == ("Coverage needs a `from` to go with `to`.")
 
 
 def test_materialization_spec_coverage_rejects_backwards_span():
@@ -1197,8 +1191,7 @@ def test_materialization_spec_coverage_rejects_backwards_span():
             coverage={"from": "2024-06-30", "to": "2024-01-01"},
         )
     assert exc_info.value.message == (
-        "A materialization `coverage` block ends before it starts: "
-        "`to` (2024-01-01) precedes `from` (2024-06-30)."
+        "Coverage ends before it starts: 2024-01-01 precedes 2024-06-30."
     )
 
 


### PR DESCRIPTION
### Summary

A cube author can already declare when to materialize and how far back each run rewrites via YAML, but they can't declare the backfill `coverage` via YAML. 

The author should be able to state the expected end state and have DJ manage the backfills needed:
```yaml
materialization:
  schedule: 0 9 * * *
  strategy: incremental_time
  lookback_window: 3 DAYS
  coverage:
    from: 2024-01-01
```

Supported coverage options include:
```yaml
# Ongoing from a specific date
coverage:
  from: 2024-01-01

# Fixed span
coverage:
  from: 2024-01-01
  to: 2024-06-30

# Rolling span -- partitions can age out of the target
coverage:
  window: 800 DAYS
```

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
