### PR TITLE
Rewire depth param through `GET /nodes/{name}/dimensions`

### DIFF
--- a/datajunction-server/datajunction_server/api/nodes.py
+++ b/datajunction-server/datajunction_server/api/nodes.py
@@ -1403,7 +1403,7 @@ async def list_all_dimension_attributes(
     access_checker.add_request_by_node_name(name, ResourceAction.READ)
     await access_checker.check(on_denied=AccessDenialMode.RAISE)
 
-    dimensions = await get_dimension_attributes(session, name)
+    dimensions = await get_dimension_attributes(session, name, depth=depth)
     filter_only_dimensions = await get_filter_only_dimensions(session, name)
     return dimensions + filter_only_dimensions
 

--- a/datajunction-server/datajunction_server/sql/dag.py
+++ b/datajunction-server/datajunction_server/sql/dag.py
@@ -10,7 +10,7 @@ from collections import namedtuple
 from dataclasses import dataclass, field
 from typing import cast
 
-from sqlalchemy import and_, bindparam, func, join, or_, select, text
+from sqlalchemy import and_, bindparam, func, join, literal, or_, select, text
 from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, joinedload, load_only, noload, selectinload
@@ -345,9 +345,11 @@ async def get_dimension_attributes(
     session: AsyncSession,
     node_name: str,
     include_deactivated: bool = True,
+    depth: int = 30,
 ):
     """
-    Get all dimension attributes for a given node.
+    Get all dimension attributes for a given node. `depth` bounds how many
+    dimension link hops are traversed from the node.
     """
     node = cast(
         Node,
@@ -387,7 +389,12 @@ async def get_dimension_attributes(
             # Derived metric - use get_dimensions which handles intersection
             dimensions = cast(
                 list[DimensionAttributeOutput],
-                await get_dimensions(session, node, with_attributes=True),
+                await get_dimensions(
+                    session,
+                    node,
+                    with_attributes=True,
+                    depth=depth,
+                ),
             )
             # Prepend the metric's name to each dimension's path
             for dim in dimensions:
@@ -411,6 +418,7 @@ async def get_dimension_attributes(
         session,
         node,
         include_deactivated,
+        depth,
     )
     dimensions_map = {dim.id: dim for dim, _, _ in dimension_nodes_and_paths}
 
@@ -504,10 +512,12 @@ async def get_dimension_nodes(
     session: AsyncSession,
     node: Node,
     include_deactivated: bool = True,
+    depth: int = 30,
 ) -> list[tuple[Node, list[str], list[str] | None]]:
     """
     Discovers all dimension nodes in the given node's dimensions graph using a recursive
-    CTE query to build out the dimension links.
+    CTE query to build out the dimension links. The traversal stops once `join_path`
+    reaches `depth` hops from the starting node.
     """
     dag = (
         (
@@ -517,6 +527,7 @@ async def get_dimension_nodes(
                 NodeRevision.node_id,
                 array([NodeRevision.node_id]).label("join_path"),  # start path
                 array([DimensionLink.role]).label("role"),
+                literal(1).label("level"),
             )
             .where(DimensionLink.node_revision_id == node.current.id)
             .join(Node, DimensionLink.dimension_id == Node.id)
@@ -541,6 +552,7 @@ async def get_dimension_nodes(
                 "join_path",
             ),
             func.array_cat(dag.c.role, array([DimensionLink.role])).label("role"),
+            (dag.c.level + 1).label("level"),
         )
         .join(DimensionLink, dag.c.id == DimensionLink.node_revision_id)
         .join(Node, DimensionLink.dimension_id == Node.id)
@@ -548,7 +560,8 @@ async def get_dimension_nodes(
             NodeRevision,
             (Node.id == NodeRevision.node_id)
             & (Node.current_version == NodeRevision.version),
-        ),
+        )
+        .where(dag.c.level < depth),
     )
 
     node_selector = select(Node, paths.c.join_path, paths.c.role)

--- a/datajunction-server/tests/api/nodes_test.py
+++ b/datajunction-server/tests/api/nodes_test.py
@@ -8642,6 +8642,81 @@ async def test_get_dimension_dag_diamond_inbound(
 
 
 @pytest.mark.asyncio
+async def test_list_dimension_attributes_depth_limit(
+    client_with_roads: AsyncClient,
+) -> None:
+    """
+    ``GET /nodes/{name}/dimensions/?depth=`` should bound how many dimension-link
+    hops are traversed. Build a 3-level chain of dimension nodes
+    (source -> dim_1 -> dim_2 -> dim_3) and confirm a small ``depth`` excludes the
+    attributes of the deeper dimension nodes while a larger ``depth`` includes them.
+    """
+    for name in ("dim_1", "dim_2", "dim_3"):
+        response = await client_with_roads.post(
+            "/nodes/dimension/",
+            json={
+                "name": f"default.depth_limit_{name}",
+                "query": "SELECT hard_hat_id FROM default.hard_hats",
+                "primary_key": ["hard_hat_id"],
+                "mode": "published",
+            },
+        )
+        assert response.status_code == 201
+
+    response = await client_with_roads.post(
+        "/nodes/transform/",
+        json={
+            "name": "default.depth_limit_source",
+            "query": "SELECT hard_hat_id FROM default.hard_hats",
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201
+
+    links = [
+        ("default.depth_limit_source", "default.depth_limit_dim_1"),
+        ("default.depth_limit_dim_1", "default.depth_limit_dim_2"),
+        ("default.depth_limit_dim_2", "default.depth_limit_dim_3"),
+    ]
+    for from_node, to_node in links:
+        response = await client_with_roads.post(
+            f"/nodes/{from_node}/link",
+            json={
+                "dimension_node": to_node,
+                "join_on": f"{from_node}.hard_hat_id = {to_node}.hard_hat_id",
+            },
+        )
+        assert response.status_code in (200, 201)
+
+    response = await client_with_roads.get(
+        "/nodes/default.depth_limit_source/dimensions/?depth=1",
+    )
+    assert response.status_code == 200
+    depth_1_node_names = {d["node_name"] for d in response.json()}
+    assert "default.depth_limit_dim_1" in depth_1_node_names
+    assert "default.depth_limit_dim_2" not in depth_1_node_names
+    assert "default.depth_limit_dim_3" not in depth_1_node_names
+
+    response = await client_with_roads.get(
+        "/nodes/default.depth_limit_source/dimensions/?depth=2",
+    )
+    assert response.status_code == 200
+    depth_2_node_names = {d["node_name"] for d in response.json()}
+    assert "default.depth_limit_dim_1" in depth_2_node_names
+    assert "default.depth_limit_dim_2" in depth_2_node_names
+    assert "default.depth_limit_dim_3" not in depth_2_node_names
+
+    response = await client_with_roads.get(
+        "/nodes/default.depth_limit_source/dimensions/?depth=30",
+    )
+    assert response.status_code == 200
+    depth_full_node_names = {d["node_name"] for d in response.json()}
+    assert "default.depth_limit_dim_1" in depth_full_node_names
+    assert "default.depth_limit_dim_2" in depth_full_node_names
+    assert "default.depth_limit_dim_3" in depth_full_node_names
+
+
+@pytest.mark.asyncio
 async def test_get_dimension_dag_duplicate_role_links(
     client_with_roads: AsyncClient,
 ) -> None:

--- a/datajunction-server/tests/sql/dag_test.py
+++ b/datajunction-server/tests/sql/dag_test.py
@@ -231,6 +231,167 @@ async def test_get_dimension_attributes_metric_on_dimension_node(
 
 
 @pytest.mark.asyncio
+async def test_get_dimension_attributes_depth_bound(
+    session: AsyncSession,
+    current_user: User,
+) -> None:
+    """
+    ``get_dimension_attributes`` (and the ``get_dimension_nodes`` recursive CTE it
+    relies on) should stop traversing the dimension link graph once ``depth`` hops
+    have been followed. Build a source node linked to a 3-level-deep chain of
+    dimension nodes (fact -> dim_1 -> dim_2 -> dim_3) and confirm that a small
+    ``depth`` excludes the deeper dimensions while a large ``depth`` includes them.
+    """
+    dim_3_ref = Node(
+        name="default.depth_dim_3",
+        type=NodeType.DIMENSION,
+        current_version="1",
+        created_by_id=current_user.id,
+    )
+    dim_3 = NodeRevision(
+        node=dim_3_ref,
+        name=dim_3_ref.name,
+        type=dim_3_ref.type,
+        display_name="Depth Dim 3",
+        version="1",
+        columns=[
+            Column(name="id", type=IntegerType(), order=0),
+            Column(name="attr_3", type=StringType(), order=1),
+        ],
+        created_by_id=current_user.id,
+    )
+    dim_3_ref.current = dim_3
+
+    dim_2_ref = Node(
+        name="default.depth_dim_2",
+        type=NodeType.DIMENSION,
+        current_version="1",
+        created_by_id=current_user.id,
+    )
+    dim_2 = NodeRevision(
+        node=dim_2_ref,
+        name=dim_2_ref.name,
+        type=dim_2_ref.type,
+        display_name="Depth Dim 2",
+        version="1",
+        columns=[
+            Column(name="id", type=IntegerType(), order=0),
+            Column(name="attr_2", type=StringType(), order=1),
+        ],
+        created_by_id=current_user.id,
+    )
+    dim_2_ref.current = dim_2
+
+    dim_1_ref = Node(
+        name="default.depth_dim_1",
+        type=NodeType.DIMENSION,
+        current_version="1",
+        created_by_id=current_user.id,
+    )
+    dim_1 = NodeRevision(
+        node=dim_1_ref,
+        name=dim_1_ref.name,
+        type=dim_1_ref.type,
+        display_name="Depth Dim 1",
+        version="1",
+        columns=[
+            Column(name="id", type=IntegerType(), order=0),
+            Column(name="attr_1", type=StringType(), order=1),
+        ],
+        created_by_id=current_user.id,
+    )
+    dim_1_ref.current = dim_1
+
+    session.add_all(
+        [dim_1, dim_1_ref, dim_2, dim_2_ref, dim_3, dim_3_ref],
+    )
+    await session.flush()
+
+    fact_ref = Node(
+        name="default.depth_fact",
+        type=NodeType.SOURCE,
+        current_version="1",
+        created_by_id=current_user.id,
+    )
+    fact = NodeRevision(
+        node=fact_ref,
+        name=fact_ref.name,
+        type=fact_ref.type,
+        display_name="Depth Fact",
+        version="1",
+        columns=[Column(name="id", type=IntegerType(), order=0)],
+        created_by_id=current_user.id,
+    )
+    fact_ref.current = fact
+    session.add_all([fact, fact_ref])
+    await session.flush()
+
+    session.add_all(
+        [
+            DimensionLink(
+                dimension_id=dim_1_ref.id,
+                node_revision_id=fact.id,
+                join_sql="default.depth_fact.id = default.depth_dim_1.id",
+            ),
+            DimensionLink(
+                dimension_id=dim_2_ref.id,
+                node_revision_id=dim_1.id,
+                join_sql="default.depth_dim_1.id = default.depth_dim_2.id",
+            ),
+            DimensionLink(
+                dimension_id=dim_3_ref.id,
+                node_revision_id=dim_2.id,
+                join_sql="default.depth_dim_2.id = default.depth_dim_3.id",
+            ),
+        ],
+    )
+    await session.commit()
+
+    depth_1_attrs = await get_dimension_attributes(
+        session,
+        "default.depth_fact",
+        depth=1,
+    )
+    depth_2_attrs = await get_dimension_attributes(
+        session,
+        "default.depth_fact",
+        depth=2,
+    )
+    depth_full_attrs = await get_dimension_attributes(
+        session,
+        "default.depth_fact",
+        depth=30,
+    )
+
+    depth_1_names = {d.name for d in depth_1_attrs}
+    depth_2_names = {d.name for d in depth_2_attrs}
+    depth_full_names = {d.name for d in depth_full_attrs}
+
+    # depth=1 only reaches depth_dim_1.
+    assert depth_1_names == {
+        "default.depth_dim_1.id",
+        "default.depth_dim_1.attr_1",
+    }
+    # depth=2 additionally reaches depth_dim_2, but not depth_dim_3.
+    assert depth_2_names == {
+        "default.depth_dim_1.id",
+        "default.depth_dim_1.attr_1",
+        "default.depth_dim_2.id",
+        "default.depth_dim_2.attr_2",
+    }
+    # A depth large enough to cover the whole chain reaches depth_dim_3 too.
+    assert depth_full_names == {
+        "default.depth_dim_1.id",
+        "default.depth_dim_1.attr_1",
+        "default.depth_dim_2.id",
+        "default.depth_dim_2.attr_2",
+        "default.depth_dim_3.id",
+        "default.depth_dim_3.attr_3",
+    }
+    assert len(depth_1_attrs) < len(depth_2_attrs) < len(depth_full_attrs)
+
+
+@pytest.mark.asyncio
 async def test_topological_sort(session: AsyncSession) -> None:
     """
     Test ``topological_sort``.


### PR DESCRIPTION
### Summary

We had a `depth` parameter exposed on the dimensions graph endpoint, but it wasn't wired through to `get_dimension_nodes`' recursive CTE. This changes it so that it stops expanding once level reaches depth, and makes `get_dimension_attributes` / `get_dimensions_dag` callers thread the endpoint's depth query param through.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
