### PR TITLE
Avoid Postgres bind-parameter limit in name-based lookups

### DIFF
--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -30,7 +30,7 @@ from sqlalchemy import (
     select,
 )
 from sqlalchemy import Column as SqlalchemyColumn
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import (
@@ -136,6 +136,17 @@ _SEARCH_MIN_FUZZY_LENGTH = 2
 # field if it's a (normalized) substring OR its word-similarity clears this bar,
 # giving typo/partial tolerance without flooding results with junk.
 _SEARCH_WORD_SIMILARITY_THRESHOLD = 0.6
+
+
+def _name_in(names: list[str]) -> sa.ColumnElement:
+    """
+    Build a ``Node.name = ANY(:names)`` predicate from a caller-supplied list of
+    names, passed as a single array bind parameter rather than expanding into
+    one bind parameter per name via ``IN (...)``. Postgres/psycopg cap a
+    statement at 65,535 bind parameters, which a plain ``Node.name.in_(names)``
+    can exceed once ``names`` gets large (e.g. all of a user's created nodes).
+    """
+    return Node.name == sa.any_(sa.literal(names, type_=ARRAY(String)))
 
 
 def _normalize_for_search(text_col):
@@ -812,7 +823,7 @@ class Node(Base):
         if not names:
             return []
 
-        statement = select(Node).where(Node.name.in_(names))
+        statement = select(Node).where(_name_in(names))
 
         options = options or [
             joinedload(Node.current).options(
@@ -1005,7 +1016,7 @@ class Node(Base):
                 ns_alias.parent_namespace == parent_ns_alias.namespace,
             )
             .where(
-                Node.name.in_(names),
+                _name_in(names),
                 _on_main_branch(ns_alias, parent_ns_alias),
             )
         )
@@ -1091,9 +1102,7 @@ class Node(Base):
                 Node.name.in_(nodes_with_dimensions),
             )
         if names:
-            statement = statement.where(
-                Node.name.in_(names),  # type: ignore
-            )
+            statement = statement.where(_name_in(names))
         if fragment:
             statement = statement.where(
                 or_(

--- a/datajunction-server/tests/database/node_test.py
+++ b/datajunction-server/tests/database/node_test.py
@@ -1,0 +1,94 @@
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.database.node import Node, NodeType
+from datajunction_server.database.user import OAuthProvider, User
+
+# Postgres/psycopg cap a statement at 65,535 bind parameters. A naive
+# `Node.name.in_(names)` expands to one bind parameter per name, so this needs
+# to comfortably clear that limit to prove the fix.
+_OVER_PARAM_LIMIT = 70_000
+
+
+@pytest_asyncio.fixture
+async def a_user(session: AsyncSession) -> User:
+    """
+    A user to satisfy Node.created_by_id.
+    """
+    user = User(username="node_test_user", oauth_provider=OAuthProvider.BASIC)
+    session.add(user)
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def a_node(session: AsyncSession, a_user: User) -> Node:
+    """
+    A single persisted node to look up amid a huge list of names.
+    """
+    node = Node(
+        name="basic.source.node_test_target",
+        type=NodeType.SOURCE,
+        created_by_id=a_user.id,
+    )
+    session.add(node)
+    await session.commit()
+    return node
+
+
+@pytest.mark.asyncio
+class TestGetByNames:
+    """
+    Tests for ``Node.get_by_names``, in particular that it does not build a SQL
+    statement with one bind parameter per requested name (which blows past
+    Postgres/psycopg's 65,535 bind parameter cap for large inputs).
+    """
+
+    async def test_empty_list_returns_empty(self, session: AsyncSession):
+        """
+        Empty input short-circuits to an empty result without querying.
+        """
+        assert await Node.get_by_names(session, []) == []
+
+    async def test_large_name_list_does_not_exceed_bind_parameter_limit(
+        self,
+        session: AsyncSession,
+        a_node: Node,
+    ):
+        """
+        A names list larger than Postgres's 65,535 bind parameter cap must not
+        raise, and must still find the one real match. Mostly-nonexistent
+        names are fine: the point is the parameter count, not the hit rate.
+        """
+        names = [f"missing.node.{i}" for i in range(_OVER_PARAM_LIMIT)]
+        # Insert the real name in the middle so ordering is also exercised.
+        insert_at = _OVER_PARAM_LIMIT // 2
+        names.insert(insert_at, a_node.name)
+
+        results = await Node.get_by_names(session, names, options=[])
+
+        assert len(results) == 1
+        assert results[0].name == a_node.name
+
+    async def test_ordering_matches_input_order(
+        self,
+        session: AsyncSession,
+        a_node: Node,
+    ):
+        """
+        Results come back ordered to match the input names list, not database
+        order, and names with no match are simply skipped.
+        """
+        other = Node(
+            name="basic.source.node_test_other",
+            type=NodeType.SOURCE,
+            created_by_id=a_node.created_by_id,
+        )
+        session.add(other)
+        await session.commit()
+
+        names = [other.name, "does.not.exist", a_node.name]
+        results = await Node.get_by_names(session, names, options=[])
+
+        assert [node.name for node in results] == [other.name, a_node.name]


### PR DESCRIPTION
### Summary

In `Node.get_by_names` and its siblings, it used this pattern to filter down to a list of nodes with the specified names: `Node.name.in_(names)`. However, SQLAlchemy expands that into one bind parameter per name. Since Postgres caps a statement at 65535 bind parameters, endpoints like `GET /users/{username}` for a user with tens of thousands of created nodes returns `OperationalError: number of parameters must be between 0 and 65535`.

This PR replaces it with a single Postgres array bind parameter via `Node.name == sa.any_(sa.literal(names, type_=ARRAY(String)))`, which compiles to exactly one bind parameter regardless of list size and produces identical query plans to the `IN(...)` form (verified via `EXPLAIN` on both a small and a large name list).

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
