### PR TITLE
Keep YAML dates as strings for the deploy request

### DIFF
--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -5,6 +5,7 @@ import socket
 import subprocess
 import urllib.parse
 import urllib.request
+from datetime import date
 from enum import Enum
 from pathlib import Path
 import time
@@ -25,6 +26,19 @@ from datajunction.rendering import print_deployment_header, print_results
 
 # TODO: replace with generated models from OpenAPI spec once client codegen is set up.
 # Canonical definitions live in datajunction_server/models/deployment.py.
+
+
+def _stringify_dates(value: Any) -> Any:
+    """
+    Replace dates and datetimes with ISO 8601 strings, recursively.
+    """
+    if isinstance(value, date):  # datetime subclasses date
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {key: _stringify_dates(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_stringify_dates(item) for item in value]
+    return value
 
 
 class DeploymentStatus(str, Enum):
@@ -290,7 +304,7 @@ class DeploymentService:
     @staticmethod
     def read_yaml_file(path: str | Path) -> dict[str, Any]:
         with open(path) as f:
-            return yaml.safe_load(f)
+            return _stringify_dates(yaml.safe_load(f))
 
     @staticmethod
     def _resolve_email_to_github_username(

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -1682,3 +1682,91 @@ def test_collect_nodes_skips_vendored_dirs_and_list_yamls(tmp_path):
 
     node_names = [n.get("name") for n in spec["nodes"]]
     assert node_names == ["foo.bar"]  # only the legitimate node survived
+
+
+def test_read_yaml_file_top_level_date(tmp_path):
+    """An unquoted top-level date becomes an ISO string."""
+    path = tmp_path / "node.yaml"
+    path.write_text("name: ns.thing\nvalid_from: 2026-08-17\n")
+
+    assert DeploymentService.read_yaml_file(path) == {
+        "name": "ns.thing",
+        "valid_from": "2026-08-17",
+    }
+
+
+def test_read_yaml_file_nested_date(tmp_path):
+    """A date nested in a dict becomes an ISO string."""
+    path = tmp_path / "cube.yaml"
+    path.write_text(
+        "name: ns.cube\n"
+        "materialization:\n"
+        "  strategy: incremental_time\n"
+        "  coverage:\n"
+        "    from: 2026-08-17\n",
+    )
+
+    assert DeploymentService.read_yaml_file(path) == {
+        "name": "ns.cube",
+        "materialization": {
+            "strategy": "incremental_time",
+            "coverage": {"from": "2026-08-17"},
+        },
+    }
+
+
+def test_read_yaml_file_date_in_list(tmp_path):
+    """Dates inside lists become ISO strings."""
+    path = tmp_path / "node.yaml"
+    path.write_text(
+        "name: ns.thing\nbackfills:\n  - 2026-08-17\n  - start: 2026-01-01\n",
+    )
+
+    assert DeploymentService.read_yaml_file(path) == {
+        "name": "ns.thing",
+        "backfills": ["2026-08-17", {"start": "2026-01-01"}],
+    }
+
+
+def test_read_yaml_file_datetime_keeps_time(tmp_path):
+    """A datetime keeps its time, not just the date."""
+    path = tmp_path / "node.yaml"
+    path.write_text("name: ns.thing\nstarted_at: 2026-08-17 09:30:15\n")
+
+    assert DeploymentService.read_yaml_file(path) == {
+        "name": "ns.thing",
+        "started_at": "2026-08-17T09:30:15",
+    }
+
+
+def test_read_yaml_file_quoted_date_unchanged(tmp_path):
+    """A quoted date passes through unchanged."""
+    path = tmp_path / "node.yaml"
+    path.write_text('name: ns.thing\nvalid_from: "2026-08-17"\n')
+
+    assert DeploymentService.read_yaml_file(path) == {
+        "name": "ns.thing",
+        "valid_from": "2026-08-17",
+    }
+
+
+def test_read_yaml_file_without_dates(tmp_path):
+    """A file with no dates comes back unchanged."""
+    path = tmp_path / "node.yaml"
+    path.write_text(
+        "name: ns.thing\n"
+        "query: SELECT 1\n"
+        "columns:\n"
+        "  - name: one\n"
+        "    type: int\n"
+        "enabled: true\n"
+        "count: 3\n",
+    )
+
+    assert DeploymentService.read_yaml_file(path) == {
+        "name": "ns.thing",
+        "query": "SELECT 1",
+        "columns": [{"name": "one", "type": "int"}],
+        "enabled": True,
+        "count": 3,
+    }


### PR DESCRIPTION
### Summary

A user writing a date in YAML will get this error message:
```
ERROR: Object of type date is not JSON serializable
```

This is because YAML's implicit typing resolves an unquoted `2026-08-17` into a `datetime.date` rather than a string. The client's `read_yaml_file` hands the raw dict as json to the request, which then leads to this JSON serialization error.

The fix converts dates and datetimes to ISO strings recursively at `read_yaml_file`, so everything downstream just sees a string.


### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
