### PR TITLE
Fix namespace default branch detection

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2696,11 +2696,23 @@ class DeploymentOrchestrator:
         The span is recorded beside the cube's other backfills and never asked for
         twice, since availability does not move until the backfill lands. A branch
         deploy asks for nothing: it previews what the push would give its author,
-        and a preview does not spend hundreds of partition runs.
+        and a preview does not spend hundreds of partition runs. It says so in
+        the report, so the missing backfill reads as a choice.
         """
         coverage = block.coverage
         partition = coverage_partition(revision)
-        if not coverage or partition is None or await self._is_branch_deploy():
+        if not coverage or partition is None:
+            return
+        if await self._is_branch_deploy():
+            self.deployed_results.append(
+                DeploymentResult(
+                    name=revision.name,
+                    deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                    status=DeploymentResult.Status.SKIPPED,
+                    operation=DeploymentResult.Operation.NOOP,
+                    message="no coverage backfill on a branch deploy",
+                ),
+            )
             return
         span = coverage.span(datetime.now(UTC).date())
         if span is None:

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -286,35 +286,29 @@ def resolve_git_info_from_map(
         None,
     )
 
-    # Resolve config_ns: find the git root (has github_repo_path).
-    # If branch_ns.parent_namespace points outside the string hierarchy (a sibling),
-    # use the FK-hop parent if it was pre-loaded into ns_map.
-    # Otherwise, the git root is reachable via string ancestors.
-    config_ns: NodeNamespace | None = None
+    # Rows git config resolves from, most specific first.
+    # A pre-loaded FK parent outside the hierarchy leads.
+    candidates: list[NodeNamespace] = []
     if (
         branch_ns
         and branch_ns.parent_namespace
         and branch_ns.parent_namespace not in ancestor_names
         and branch_ns.parent_namespace in ns_map
     ):
-        fk_parent = ns_map[branch_ns.parent_namespace]
-        if fk_parent.github_repo_path:
-            config_ns = fk_parent
-    if not config_ns:
-        config_ns = next(
-            (
-                ns_map[n]
-                for n in reversed_names
-                if ns_map.get(n) and ns_map[n].github_repo_path
-            ),
-            None,
-        )
+        candidates.append(ns_map[branch_ns.parent_namespace])
+    candidates.extend(ns_map[n] for n in reversed_names if ns_map.get(n))
+
+    config_ns = next((ns for ns in candidates if ns.github_repo_path), None)
 
     if not config_ns:
         return None
 
     branch = branch_ns.git_branch if branch_ns else None
-    default_branch = config_ns.default_branch
+    # The default branch may sit on another row.
+    default_branch = next(
+        (ns.default_branch for ns in candidates if ns.default_branch),
+        None,
+    )
     # Effective git_only cascades: any ancestor (or the namespace itself)
     # with git_only=True locks all descendants. Without this the UI would
     # treat a child namespace as editable when its parent is locked,
@@ -363,6 +357,8 @@ async def get_git_info_for_namespace(
        load the git root (which carries ``github_repo_path`` / ``git_path``).
        Otherwise, look for ``github_repo_path`` among the string ancestors
        (self-contained root case).
+    3. Take ``default_branch`` from the first row that has one, in the same
+       order — branch namespaces carry the repo path but not the default branch.
     """
     ancestor_names = get_parent_namespaces(namespace) + [namespace]
     stmt = select(NodeNamespace).where(NodeNamespace.namespace.in_(ancestor_names))

--- a/datajunction-server/tests/api/namespaces_test.py
+++ b/datajunction-server/tests/api/namespaces_test.py
@@ -3691,6 +3691,54 @@ async def test_hard_delete_git_default_branch_namespace_blocked(
 
 
 @pytest.mark.asyncio
+async def test_delete_default_branch_owning_repo_blocked(
+    module__client_with_all_examples: AsyncClient,
+) -> None:
+    """
+    A branch namespace that carries its own ``github_repo_path`` -- the shape
+    branch creation writes -- still resolves its repo's default branch from the
+    git root, so both deletes are refused.
+    """
+    root = "ownrepo.root"
+    branch_ns = "ownrepo.root.main"
+
+    await module__client_with_all_examples.post(f"/namespaces/{root}/")
+    await module__client_with_all_examples.post(f"/namespaces/{branch_ns}/")
+    await module__client_with_all_examples.patch(
+        f"/namespaces/{root}/git",
+        json={"github_repo_path": "corp/ownrepo", "default_branch": "main"},
+    )
+
+    # Branch creation copies the repo path onto the branch namespace.
+    await module__client_with_all_examples.patch(
+        f"/namespaces/{branch_ns}/git",
+        json={"github_repo_path": "corp/ownrepo"},
+    )
+    await module__client_with_all_examples.patch(
+        f"/namespaces/{branch_ns}/git",
+        json={"parent_namespace": root, "git_branch": "main"},
+    )
+
+    refusal = (
+        f"Cannot delete namespace `{branch_ns}`: it is the default branch "
+        "of a git-backed namespace (corp/ownrepo). "
+        "Only non-default branch namespaces can be deleted."
+    )
+
+    response = await module__client_with_all_examples.delete(
+        f"/namespaces/{branch_ns}/",
+    )
+    assert response.status_code == 422
+    assert response.json()["message"] == refusal
+
+    response = await module__client_with_all_examples.delete(
+        f"/namespaces/{branch_ns}/hard/",
+    )
+    assert response.status_code == 422
+    assert response.json()["message"] == refusal
+
+
+@pytest.mark.asyncio
 async def test_delete_non_default_git_branch_namespace_allowed(
     module__client_with_all_examples: AsyncClient,
 ) -> None:

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -4184,7 +4184,8 @@ class TestPlanCoverageBackfill:
     ):
         """
         A branch namespace previews what the push would give its author, and a
-        preview does not spend hundreds of partition runs.
+        preview does not spend hundreds of partition runs. The report says the
+        backfill was skipped, so the author is not left guessing.
         """
         revision, materialization = await self._cube(
             session,
@@ -4203,6 +4204,15 @@ class TestPlanCoverageBackfill:
 
         assert self._queued(orchestrator) == []
         assert await self._recorded(session, materialization) == []
+        assert orchestrator.deployed_results == [
+            DeploymentResult(
+                name="default.a_cube",
+                deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                status=DeploymentResult.Status.SKIPPED,
+                operation=DeploymentResult.Operation.NOOP,
+                message="no coverage backfill on a branch deploy",
+            ),
+        ]
 
     @pytest.mark.asyncio
     async def test_an_uncountable_window_is_warned_about(

--- a/datajunction-server/tests/internal/git/test_validation.py
+++ b/datajunction-server/tests/internal/git/test_validation.py
@@ -833,35 +833,35 @@ class TestGetGitInfoForNamespace:
         """The branch namespace owns the repo path; its parent owns default_branch."""
         session.add(
             NodeNamespace(
-                namespace="demo.metrics",
-                github_repo_path="corp/dj-nodes-example",
+                namespace="shop.metrics",
+                github_repo_path="corp/examplerepo",
                 default_branch="main",
                 git_path="defs/",
             ),
         )
         session.add(
             NodeNamespace(
-                namespace="demo.metrics.main",
-                github_repo_path="corp/dj-nodes-example",
+                namespace="shop.metrics.main",
+                github_repo_path="corp/examplerepo",
                 git_branch="main",
                 git_path="defs/",
-                parent_namespace="demo.metrics",
+                parent_namespace="shop.metrics",
             ),
         )
         await session.commit()
 
-        result = await get_git_info_for_namespace(session, "demo.metrics.main")
+        result = await get_git_info_for_namespace(session, "shop.metrics.main")
 
         assert result == {
-            "repo": "corp/dj-nodes-example",
+            "repo": "corp/examplerepo",
             "branch": "main",
             "default_branch": "main",
             "path": "defs/",
             "is_default_branch": True,
-            "parent_namespace": "demo.metrics",
+            "parent_namespace": "shop.metrics",
             "git_only": False,
-            "git_root_namespace": "demo.metrics.main",
-            "branch_namespace": "demo.metrics.main",
+            "git_root_namespace": "shop.metrics.main",
+            "branch_namespace": "shop.metrics.main",
         }
 
     @pytest.mark.asyncio
@@ -869,35 +869,35 @@ class TestGetGitInfoForNamespace:
         """A feature branch owning the repo path is not the default branch."""
         session.add(
             NodeNamespace(
-                namespace="demo.metrics",
-                github_repo_path="corp/dj-nodes-example",
+                namespace="shop.metrics",
+                github_repo_path="corp/examplerepo",
                 default_branch="main",
                 git_path="defs/",
             ),
         )
         session.add(
             NodeNamespace(
-                namespace="demo.metrics.test_cube",
-                github_repo_path="corp/dj-nodes-example",
+                namespace="shop.metrics.featureone",
+                github_repo_path="corp/examplerepo",
                 git_branch="test_cube",
                 git_path="defs/",
-                parent_namespace="demo.metrics",
+                parent_namespace="shop.metrics",
             ),
         )
         await session.commit()
 
-        result = await get_git_info_for_namespace(session, "demo.metrics.test_cube")
+        result = await get_git_info_for_namespace(session, "shop.metrics.featureone")
 
         assert result == {
-            "repo": "corp/dj-nodes-example",
+            "repo": "corp/examplerepo",
             "branch": "test_cube",
             "default_branch": "main",
             "path": "defs/",
             "is_default_branch": False,
-            "parent_namespace": "demo.metrics",
+            "parent_namespace": "shop.metrics",
             "git_only": False,
-            "git_root_namespace": "demo.metrics.test_cube",
-            "branch_namespace": "demo.metrics.test_cube",
+            "git_root_namespace": "shop.metrics.featureone",
+            "branch_namespace": "shop.metrics.featureone",
         }
 
     @pytest.mark.asyncio

--- a/datajunction-server/tests/internal/git/test_validation.py
+++ b/datajunction-server/tests/internal/git/test_validation.py
@@ -828,6 +828,114 @@ class TestGetGitInfoForNamespace:
         assert result is not None
         assert result["is_default_branch"] is False
 
+    @pytest.mark.asyncio
+    async def test_default_branch_from_ancestor_row(self, session: AsyncSession):
+        """The branch namespace owns the repo path; its parent owns default_branch."""
+        session.add(
+            NodeNamespace(
+                namespace="demo.metrics",
+                github_repo_path="corp/dj-nodes-example",
+                default_branch="main",
+                git_path="defs/",
+            ),
+        )
+        session.add(
+            NodeNamespace(
+                namespace="demo.metrics.main",
+                github_repo_path="corp/dj-nodes-example",
+                git_branch="main",
+                git_path="defs/",
+                parent_namespace="demo.metrics",
+            ),
+        )
+        await session.commit()
+
+        result = await get_git_info_for_namespace(session, "demo.metrics.main")
+
+        assert result == {
+            "repo": "corp/dj-nodes-example",
+            "branch": "main",
+            "default_branch": "main",
+            "path": "defs/",
+            "is_default_branch": True,
+            "parent_namespace": "demo.metrics",
+            "git_only": False,
+            "git_root_namespace": "demo.metrics.main",
+            "branch_namespace": "demo.metrics.main",
+        }
+
+    @pytest.mark.asyncio
+    async def test_feature_branch_with_own_repo(self, session: AsyncSession):
+        """A feature branch owning the repo path is not the default branch."""
+        session.add(
+            NodeNamespace(
+                namespace="demo.metrics",
+                github_repo_path="corp/dj-nodes-example",
+                default_branch="main",
+                git_path="defs/",
+            ),
+        )
+        session.add(
+            NodeNamespace(
+                namespace="demo.metrics.test_cube",
+                github_repo_path="corp/dj-nodes-example",
+                git_branch="test_cube",
+                git_path="defs/",
+                parent_namespace="demo.metrics",
+            ),
+        )
+        await session.commit()
+
+        result = await get_git_info_for_namespace(session, "demo.metrics.test_cube")
+
+        assert result == {
+            "repo": "corp/dj-nodes-example",
+            "branch": "test_cube",
+            "default_branch": "main",
+            "path": "defs/",
+            "is_default_branch": False,
+            "parent_namespace": "demo.metrics",
+            "git_only": False,
+            "git_root_namespace": "demo.metrics.test_cube",
+            "branch_namespace": "demo.metrics.test_cube",
+        }
+
+    @pytest.mark.asyncio
+    async def test_default_branch_via_fk_parent(self, session: AsyncSession):
+        """The git root is reached by the FK hop, not by name."""
+        session.add(
+            NodeNamespace(
+                namespace="roots.repo",
+                github_repo_path="org/repo",
+                default_branch="main",
+                git_path="defs/",
+            ),
+        )
+        session.add(
+            NodeNamespace(
+                namespace="branches.main",
+                github_repo_path="org/repo",
+                git_branch="main",
+                git_path="defs/",
+                parent_namespace="roots.repo",
+            ),
+        )
+        await session.commit()
+
+        result = await get_git_info_for_namespace(session, "branches.main")
+
+        assert result == {
+            "repo": "org/repo",
+            "branch": "main",
+            "default_branch": "main",
+            "path": "defs/",
+            "is_default_branch": True,
+            "parent_namespace": "roots.repo",
+            "git_only": False,
+            "git_root_namespace": "roots.repo",
+            "branch_namespace": "branches.main",
+        }
+
     # ------------------------------------------------------------------
     # parent_namespace
     # ------------------------------------------------------------------


### PR DESCRIPTION
### Summary

Currently DJ decides whether a namespace is a git repo's default branch by comparing its `git_branch` against a `default_branch`, and it was reading both fields off the exact same namespace. However, in the data today, the branch namespace doesn't have default_branch set, leading the actual default-branch namespace to be classified as a feature branch.

With the flag wrongly false, there are several issues:
- A git-backed default-branch namespace can be hard-deleted.
- Declarative coverage backfills on main-branch deploys aren't fulfilled.
- Repointing a default-branch namespace's `git_branch` away from the default was allowed.

The change builds one ordered candidate list (FK parent first when it's outside the string hierarchy, then string ancestors most-specific-first) and resolves `github_repo_path` and `default_branch` from it independently.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
