### PR TITLE
Keep CTE columns that only a transitive consumer reads

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -20,6 +20,7 @@ from datajunction_server.construction.build_v3.cte import (
     _fk_key_column_names,
     collect_node_ctes,
     extract_dimension_node,
+    get_table_references_from_ast,
     inject_filter_into_select,
     references_filter_only_dimension,
     strip_role_suffix,
@@ -556,7 +557,77 @@ def collect_cte_nodes_and_needed_columns(
                         else:  # pragma: no cover
                             needed_columns_by_node[left_node_name] = left_join_cols
 
+    _add_transitive_consumer_columns(ctx, nodes_for_ctes, needed_columns_by_node)
+
     return nodes_for_ctes, needed_columns_by_node
+
+
+def _add_transitive_consumer_columns(
+    ctx: BuildContext,
+    nodes_for_ctes: list[Node],
+    needed_columns_by_node: dict[str, set[str]],
+) -> None:
+    """
+    Widen each node's needed columns to cover every CTE that reads from it.
+
+    The loops above only look at the parent node and the dimension nodes sitting
+    on a resolved join path. ``collect_node_ctes`` builds its CTE set from the
+    full transitive closure of the dependency graph, so a node can end up as a
+    CTE without ever being a resolved dimension — an intermediate transform, or a
+    dimension pulled in only as somebody else's parent. Those nodes are never
+    scanned, so the columns they read stay out of ``needed_columns_by_node`` and
+    ``filter_cte_projection`` prunes them away, leaving the consuming CTE
+    referencing a column its source no longer projects.
+
+    Walking the same closure here and unioning in what each CTE actually reads
+    keeps the two sets consistent. Only nodes already in
+    ``needed_columns_by_node`` are widened: a node with no entry is left alone so
+    it stays unpruned, which is what callers expect.
+    """
+    closure: dict[str, Node] = {}
+
+    def collect(node: Node) -> None:
+        if node.name in closure or node.type == NodeType.SOURCE:
+            return
+        closure[node.name] = node
+        if not (node.current and node.current.query):  # pragma: no cover
+            return
+        try:
+            refs = get_table_references_from_ast(ctx.get_parsed_query(node))
+        except Exception:  # pragma: no cover
+            return
+        for ref in refs:
+            if ref_node := ctx.nodes.get(ref):
+                collect(ref_node)
+
+    for node in nodes_for_ctes:
+        collect(node)
+
+    # Only nodes that are already pruned can be under-projected.
+    targets = [
+        name for name in needed_columns_by_node if name in closure or name in ctx.nodes
+    ]
+
+    for consumer in closure.values():
+        if not (consumer.current and consumer.current.query):  # pragma: no cover
+            continue
+        try:
+            consumer_ast = ctx.get_parsed_query(consumer)
+        except Exception:  # pragma: no cover
+            continue
+        for target in targets:
+            if target == consumer.name:
+                continue
+            referenced = extract_columns_referenced_from_node(consumer_ast, target)
+            if referenced - needed_columns_by_node[target]:
+                _logger.info(
+                    "filter_cte_projection: %s references cols %s from %s "
+                    "(transitive consumer)",
+                    consumer.name,
+                    sorted(referenced),
+                    target,
+                )
+            needed_columns_by_node[target].update(referenced)
 
 
 def _build_temporal_pushdown(

--- a/datajunction-server/tests/construction/build_v3/cte_transitive_consumer_test.py
+++ b/datajunction-server/tests/construction/build_v3/cte_transitive_consumer_test.py
@@ -1,0 +1,145 @@
+"""
+A CTE that enters the build only as a transitive dependency still constrains
+what its upstream CTEs may prune.
+"""
+
+import pytest
+
+
+class TestTransitiveConsumerProjection:
+    """
+    ``fact`` joins to ``item`` for one attribute, so ``item``'s CTE is pruned to
+    that attribute plus the join key. ``fact`` also reads from ``bundles``, which
+    is not a requested dimension and reaches ``item`` only through its own query
+    — the shape that used to lose a column.
+    """
+
+    async def _setup(self, client, ns: str):
+        resp = await client.post(f"/namespaces/{ns}/")
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": f"{ns}.src_item",
+                "catalog": "default",
+                "schema_": ns,
+                "table": "src_item",
+                "columns": [
+                    {"name": "item_id", "type": "int"},
+                    {"name": "kind_code", "type": "string"},
+                    {"name": "bundle_id", "type": "int"},
+                ],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": f"{ns}.src_event",
+                "catalog": "default",
+                "schema_": ns,
+                "table": "src_event",
+                "columns": [
+                    {"name": "event_id", "type": "int"},
+                    {"name": "item_id", "type": "int"},
+                    {"name": "amount", "type": "double"},
+                ],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        # Dimension: projects bundle_id alongside the requested attribute.
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": f"{ns}.item",
+                "mode": "published",
+                "primary_key": ["item_id"],
+                "query": (
+                    f"SELECT item_id, bundle_id, "
+                    f"CASE WHEN kind_code = 'AUTO' THEN 'auto' "
+                    f"ELSE 'manual' END AS channel "
+                    f"FROM {ns}.src_item"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        # Transform reading bundle_id from the dimension node. It is never a
+        # requested dimension, so nothing on a join path scans it.
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": f"{ns}.bundles",
+                "mode": "published",
+                "query": (
+                    f"SELECT i.item_id, i.bundle_id AS bundle "
+                    f"FROM {ns}.item AS i"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        # Fact joins the transform, pulling it into the CTE closure.
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": f"{ns}.fact",
+                "mode": "published",
+                "query": (
+                    f"SELECT e.event_id, e.item_id, e.amount, b.bundle "
+                    f"FROM {ns}.src_event AS e "
+                    f"LEFT JOIN {ns}.bundles AS b "
+                    f"ON e.item_id = b.item_id"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            f"/nodes/{ns}.fact/link",
+            json={
+                "dimension_node": f"{ns}.item",
+                "join_type": "left",
+                "join_on": f"{ns}.fact.item_id = {ns}.item.item_id",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": f"{ns}.total_amount",
+                "mode": "published",
+                "query": f"SELECT SUM(amount) FROM {ns}.fact",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+    @pytest.mark.asyncio
+    async def test_transitive_consumer_column_survives_pruning(
+        self,
+        client_with_service_setup,
+    ):
+        client = client_with_service_setup
+        ns = "ctetrans"
+        await self._setup(client, ns)
+
+        resp = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": [f"{ns}.total_amount"],
+                "dimensions": [f"{ns}.item.channel"],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        sql = resp.json()["grain_groups"][0]["sql"]
+
+        item_cte = sql.split(f"{ns}_bundles")[0]
+        assert "channel" in item_cte, sql
+        assert "bundle_id" in item_cte, (
+            f"{ns}.item CTE pruned bundle_id, but {ns}.bundles "
+            f"selects it from that CTE:\n\n{sql}"
+        )

--- a/datajunction-server/tests/construction/build_v3/cte_transitive_consumer_test.py
+++ b/datajunction-server/tests/construction/build_v3/cte_transitive_consumer_test.py
@@ -75,8 +75,7 @@ class TestTransitiveConsumerProjection:
                 "name": f"{ns}.bundles",
                 "mode": "published",
                 "query": (
-                    f"SELECT i.item_id, i.bundle_id AS bundle "
-                    f"FROM {ns}.item AS i"
+                    f"SELECT i.item_id, i.bundle_id AS bundle FROM {ns}.item AS i"
                 ),
             },
         )


### PR DESCRIPTION
### Summary

`/sql/measures/v3` can generate a query that references a column that its upstream CTE doesn't project, which fails with an unresolved-column error when run.

This is because of two processes that disagreed: the pruning process decided which columns each CTE should keep by looking at the requested dimensions' join paths, while the set of CTEs to emit comes from the full transitive closure of the dependency graph. Any node that lands in that closure without sitting on a join path (e.g., an intermediate transform, or a dimension pulled in only as another node's parent) was never consulted. Its own body got emitted unpruned, still referencing every column it reads, but the upstream it reads from was pruned as though the join-path nodes were its only readers.

This widens the needed-column scan to walk the same closure the CTE set is built from, so both halves agree on who the readers are. 

### Test Plan

Added a new test for the exact failing case, with a dimension pruned to one requested attribute, and a transform that reads a different column from that dimension while never being a requested dimension itself.

- [x] PR has an associated issue: #2454 
- [x] make check passes
- [x] make test shows 100% unit test coverage

Deployment Plan

None. Behaviour change is confined to SQL generation; queries that were already valid generate the same SQL, and the widened scan only ever adds columns to a projection.