### PR TITLE
Add custom metadata schema registry table and validation

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2026_07_12_0002-custom_metadata_schema_table.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_07_12_0002-custom_metadata_schema_table.py
@@ -1,0 +1,58 @@
+"""custom_metadata schema registry table
+
+Revision ID: cm0002schematable
+Revises: cm0001jsonbgin
+Create Date: 2026-07-12 00:02:00.000000+00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "cm0002schematable"
+down_revision = "cm0001jsonbgin"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "custommetadataschema",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("key", sa.String(), nullable=False),
+        sa.Column("node_type", sa.String(), nullable=True),
+        sa.Column("namespace", sa.String(), nullable=True),
+        sa.Column(
+            "json_schema",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column("value_kind", sa.String(), nullable=True),
+        sa.Column(
+            "filterable",
+            sa.Boolean(),
+            server_default=sa.text("true"),
+            nullable=False,
+        ),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("created_by_id", sa.BigInteger(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("deactivated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["created_by_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_custommetadataschema_key_type_ns",
+        "custommetadataschema",
+        ["key", "node_type", "namespace"],
+        unique=True,
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "uq_custommetadataschema_key_type_ns",
+        table_name="custommetadataschema",
+    )
+    op.drop_table("custommetadataschema")

--- a/datajunction-server/datajunction_server/alembic/versions/2026_07_12_0002-custom_metadata_schema_table.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_07_12_0002-custom_metadata_schema_table.py
@@ -36,23 +36,36 @@ def upgrade():
         ),
         sa.Column("description", sa.String(), nullable=True),
         sa.Column("created_by_id", sa.BigInteger(), nullable=True),
+        sa.Column("owner", sa.String(), nullable=True),
+        sa.Column("updated_by_id", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "reserved",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("deactivated_at", sa.DateTime(timezone=True), nullable=True),
         sa.ForeignKeyConstraint(["created_by_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["updated_by_id"], ["users.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(
-        "uq_custommetadataschema_key_type_ns",
+        "uq_custommetadataschema_key_scope",
         "custommetadataschema",
-        ["key", "node_type", "namespace"],
+        [
+            sa.text("key"),
+            sa.text("coalesce(node_type, '')"),
+            sa.text("coalesce(namespace, '')"),
+        ],
         unique=True,
     )
 
 
 def downgrade():
     op.drop_index(
-        "uq_custommetadataschema_key_type_ns",
+        "uq_custommetadataschema_key_scope",
         table_name="custommetadataschema",
     )
     op.drop_table("custommetadataschema")

--- a/datajunction-server/datajunction_server/alembic/versions/2026_07_12_0002-custom_metadata_schema_table.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_07_12_0002-custom_metadata_schema_table.py
@@ -10,7 +10,7 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 revision = "cm0002schematable"
-down_revision = "cm0001jsonbgin"
+down_revision = "nsboundaryflag1"
 branch_labels = None
 depends_on = None
 

--- a/datajunction-server/datajunction_server/alembic/versions/2026_07_12_0002-custom_metadata_schema_table.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_07_12_0002-custom_metadata_schema_table.py
@@ -60,6 +60,7 @@ def upgrade():
             sa.text("coalesce(namespace, '')"),
         ],
         unique=True,
+        postgresql_where=sa.text("deactivated_at IS NULL"),
     )
 
 

--- a/datajunction-server/datajunction_server/database/__init__.py
+++ b/datajunction-server/datajunction_server/database/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "Catalog",
     "Collection",
     "ColumnAttribute",
+    "CustomMetadataSchema",
     "Database",
     "Deployment",
     "DimensionLink",
@@ -30,6 +31,7 @@ __all__ = [
 from datajunction_server.database.attributetype import AttributeType, ColumnAttribute
 from datajunction_server.database.catalog import Catalog
 from datajunction_server.database.collection import Collection
+from datajunction_server.database.custom_metadata_schema import CustomMetadataSchema
 from datajunction_server.database.database import Database, Table
 from datajunction_server.database.deployment import Deployment
 from datajunction_server.database.dimensionlink import DimensionLink

--- a/datajunction-server/datajunction_server/database/custom_metadata_schema.py
+++ b/datajunction-server/datajunction_server/database/custom_metadata_schema.py
@@ -1,0 +1,56 @@
+"""Registry of JSON Schemas for custom_metadata keys."""
+
+import datetime
+from functools import partial
+from typing import Optional
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from datajunction_server.database.base import Base
+from datajunction_server.typing import UTCDatetime
+
+
+class CustomMetadataSchema(Base):
+    """A JSON Schema registered for a single custom_metadata key."""
+
+    __tablename__ = "custommetadataschema"
+    __table_args__ = (
+        Index(
+            "uq_custommetadataschema_key_type_ns",
+            "key",
+            "node_type",
+            "namespace",
+            unique=True,
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    key: Mapped[str] = mapped_column(String, nullable=False)
+    node_type: Mapped[Optional[str]] = mapped_column(String, default=None)
+    namespace: Mapped[Optional[str]] = mapped_column(String, default=None)
+    json_schema: Mapped[dict] = mapped_column(
+        JSON().with_variant(JSONB(), "postgresql"),
+        nullable=False,
+    )
+    value_kind: Mapped[Optional[str]] = mapped_column(String, default=None)
+    filterable: Mapped[bool] = mapped_column(default=True)
+    description: Mapped[Optional[str]] = mapped_column(String, default=None)
+    created_by_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("users.id"),
+        default=None,
+    )
+    created_at: Mapped[UTCDatetime] = mapped_column(
+        DateTime(timezone=True),
+        default=partial(datetime.datetime.now, datetime.timezone.utc),
+    )
+    updated_at: Mapped[UTCDatetime] = mapped_column(
+        DateTime(timezone=True),
+        default=partial(datetime.datetime.now, datetime.timezone.utc),
+        onupdate=partial(datetime.datetime.now, datetime.timezone.utc),
+    )
+    deactivated_at: Mapped[Optional[UTCDatetime]] = mapped_column(
+        DateTime(timezone=True),
+        default=None,
+    )

--- a/datajunction-server/datajunction_server/database/custom_metadata_schema.py
+++ b/datajunction-server/datajunction_server/database/custom_metadata_schema.py
@@ -4,7 +4,7 @@ import datetime
 from functools import partial
 
 import sqlalchemy as sa
-from sqlalchemy import JSON, DateTime, ForeignKey, Index, String, text
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, String, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -27,23 +27,23 @@ class CustomMetadataSchema(Base):
         ),
     )
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    # bigint, matching the migration.
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     key: Mapped[str] = mapped_column(String, nullable=False)
     node_type: Mapped[str | None] = mapped_column(String, default=None)
     namespace: Mapped[str | None] = mapped_column(String, default=None)
-    json_schema: Mapped[dict] = mapped_column(
-        JSON().with_variant(JSONB(), "postgresql"),
-        nullable=False,
-    )
+    json_schema: Mapped[dict] = mapped_column(JSONB, nullable=False)
     value_kind: Mapped[str | None] = mapped_column(String, default=None)
-    filterable: Mapped[bool] = mapped_column(default=True)
+    filterable: Mapped[bool] = mapped_column(default=True, server_default=sa.true())
     description: Mapped[str | None] = mapped_column(String, default=None)
     created_by_id: Mapped[int | None] = mapped_column(
+        BigInteger,
         ForeignKey("users.id"),
         default=None,
     )
     owner: Mapped[str | None] = mapped_column(String, default=None)
     updated_by_id: Mapped[int | None] = mapped_column(
+        BigInteger,
         ForeignKey("users.id"),
         default=None,
     )

--- a/datajunction-server/datajunction_server/database/custom_metadata_schema.py
+++ b/datajunction-server/datajunction_server/database/custom_metadata_schema.py
@@ -4,7 +4,8 @@ import datetime
 from functools import partial
 from typing import Optional
 
-from sqlalchemy import JSON, DateTime, ForeignKey, Index, String
+import sqlalchemy as sa
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, String, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -18,10 +19,10 @@ class CustomMetadataSchema(Base):
     __tablename__ = "custommetadataschema"
     __table_args__ = (
         Index(
-            "uq_custommetadataschema_key_type_ns",
-            "key",
-            "node_type",
-            "namespace",
+            "uq_custommetadataschema_key_scope",
+            text("key"),
+            text("coalesce(node_type, '')"),
+            text("coalesce(namespace, '')"),
             unique=True,
         ),
     )
@@ -41,6 +42,12 @@ class CustomMetadataSchema(Base):
         ForeignKey("users.id"),
         default=None,
     )
+    owner: Mapped[Optional[str]] = mapped_column(String, default=None)
+    updated_by_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("users.id"),
+        default=None,
+    )
+    reserved: Mapped[bool] = mapped_column(default=False, server_default=sa.false())
     created_at: Mapped[UTCDatetime] = mapped_column(
         DateTime(timezone=True),
         default=partial(datetime.datetime.now, datetime.timezone.utc),

--- a/datajunction-server/datajunction_server/database/custom_metadata_schema.py
+++ b/datajunction-server/datajunction_server/database/custom_metadata_schema.py
@@ -2,7 +2,6 @@
 
 import datetime
 from functools import partial
-from typing import Optional
 
 import sqlalchemy as sa
 from sqlalchemy import JSON, DateTime, ForeignKey, Index, String, text
@@ -24,40 +23,41 @@ class CustomMetadataSchema(Base):
             text("coalesce(node_type, '')"),
             text("coalesce(namespace, '')"),
             unique=True,
+            postgresql_where=text("deactivated_at IS NULL"),
         ),
     )
 
     id: Mapped[int] = mapped_column(primary_key=True)
     key: Mapped[str] = mapped_column(String, nullable=False)
-    node_type: Mapped[Optional[str]] = mapped_column(String, default=None)
-    namespace: Mapped[Optional[str]] = mapped_column(String, default=None)
+    node_type: Mapped[str | None] = mapped_column(String, default=None)
+    namespace: Mapped[str | None] = mapped_column(String, default=None)
     json_schema: Mapped[dict] = mapped_column(
         JSON().with_variant(JSONB(), "postgresql"),
         nullable=False,
     )
-    value_kind: Mapped[Optional[str]] = mapped_column(String, default=None)
+    value_kind: Mapped[str | None] = mapped_column(String, default=None)
     filterable: Mapped[bool] = mapped_column(default=True)
-    description: Mapped[Optional[str]] = mapped_column(String, default=None)
-    created_by_id: Mapped[Optional[int]] = mapped_column(
+    description: Mapped[str | None] = mapped_column(String, default=None)
+    created_by_id: Mapped[int | None] = mapped_column(
         ForeignKey("users.id"),
         default=None,
     )
-    owner: Mapped[Optional[str]] = mapped_column(String, default=None)
-    updated_by_id: Mapped[Optional[int]] = mapped_column(
+    owner: Mapped[str | None] = mapped_column(String, default=None)
+    updated_by_id: Mapped[int | None] = mapped_column(
         ForeignKey("users.id"),
         default=None,
     )
     reserved: Mapped[bool] = mapped_column(default=False, server_default=sa.false())
     created_at: Mapped[UTCDatetime] = mapped_column(
         DateTime(timezone=True),
-        default=partial(datetime.datetime.now, datetime.timezone.utc),
+        default=partial(datetime.datetime.now, datetime.UTC),
     )
     updated_at: Mapped[UTCDatetime] = mapped_column(
         DateTime(timezone=True),
-        default=partial(datetime.datetime.now, datetime.timezone.utc),
-        onupdate=partial(datetime.datetime.now, datetime.timezone.utc),
+        default=partial(datetime.datetime.now, datetime.UTC),
+        onupdate=partial(datetime.datetime.now, datetime.UTC),
     )
-    deactivated_at: Mapped[Optional[UTCDatetime]] = mapped_column(
+    deactivated_at: Mapped[UTCDatetime | None] = mapped_column(
         DateTime(timezone=True),
         default=None,
     )

--- a/datajunction-server/datajunction_server/internal/custom_metadata.py
+++ b/datajunction-server/datajunction_server/internal/custom_metadata.py
@@ -1,0 +1,68 @@
+"""Resolution, validation, and filter translation for custom_metadata schemas."""
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.database.custom_metadata_schema import CustomMetadataSchema
+from datajunction_server.models.node_type import NodeType
+
+
+def _namespace_matches(scope: str | None, node_namespace: str | None) -> bool:
+    """Return True if *scope* is applicable to *node_namespace*.
+
+    A ``None`` scope is global and always matches.  Otherwise the node's
+    namespace must equal the scope exactly or be a sub-namespace of it
+    (i.e. start with ``scope + "."``).
+    """
+    if scope is None:
+        return True  # global row applies to every namespace
+    if node_namespace is None:
+        return False
+    return node_namespace == scope or node_namespace.startswith(scope + ".")
+
+
+def _specificity(row: CustomMetadataSchema) -> int:
+    """Return a score reflecting how specific *row* is.
+
+    Scoring (additive):
+      +2  namespace is set
+      +1  node_type is set
+    Possible values: 0 (global) … 3 (both namespace + node_type).
+    """
+    return (1 if row.node_type is not None else 0) + (
+        2 if row.namespace is not None else 0
+    )
+
+
+async def resolve_schemas(
+    session: AsyncSession,
+    namespace: str | None,
+    node_type: NodeType,
+) -> dict[str, dict]:
+    """Return ``{key: json_schema}`` using the most-specific active row per key.
+
+    Rows are filtered to those that are:
+    - not deactivated (``deactivated_at IS NULL``)
+    - applicable to *node_type* (either global or matching exactly)
+    - applicable to *namespace* via :func:`_namespace_matches`
+
+    Among qualifying rows for the same key the one with the highest
+    :func:`_specificity` score wins.
+    """
+    stmt = select(CustomMetadataSchema).where(
+        CustomMetadataSchema.deactivated_at.is_(None),
+        or_(
+            CustomMetadataSchema.node_type.is_(None),
+            CustomMetadataSchema.node_type == node_type.value,
+        ),
+    )
+    rows = (await session.execute(stmt)).scalars().all()
+
+    best: dict[str, tuple[int, dict]] = {}
+    for row in rows:
+        if not _namespace_matches(row.namespace, namespace):
+            continue
+        score = _specificity(row)
+        if row.key not in best or score > best[row.key][0]:
+            best[row.key] = (score, row.json_schema)
+    return {key: schema for key, (_, schema) in best.items()}

--- a/datajunction-server/datajunction_server/internal/custom_metadata.py
+++ b/datajunction-server/datajunction_server/internal/custom_metadata.py
@@ -48,6 +48,10 @@ async def resolve_schemas(
 
     Among qualifying rows for the same key the one with the highest
     :func:`_specificity` score wins.
+
+    Exception: if a key has a global row (``node_type IS NULL, namespace IS NULL``)
+    with ``reserved=True``, that row's schema is always used for that key —
+    any more-specific scoped rows for the same key are ignored.
     """
     stmt = select(CustomMetadataSchema).where(
         CustomMetadataSchema.deactivated_at.is_(None),
@@ -58,10 +62,24 @@ async def resolve_schemas(
     )
     rows = (await session.execute(stmt)).scalars().all()
 
+    # First pass: identify keys that have a reserved global row
+    reserved_global_keys: set[str] = {
+        row.key
+        for row in rows
+        if row.reserved
+        and row.node_type is None
+        and row.namespace is None
+        and row.deactivated_at is None
+    }
+
     best: dict[str, tuple[int, dict]] = {}
     for row in rows:
         if not _namespace_matches(row.namespace, namespace):
             continue
+        # If this key is reserved-global, only accept the global row itself
+        if row.key in reserved_global_keys:
+            if row.node_type is not None or row.namespace is not None:
+                continue  # skip scoped rows for reserved keys
         score = _specificity(row)
         if row.key not in best or score > best[row.key][0]:
             best[row.key] = (score, row.json_schema)

--- a/datajunction-server/datajunction_server/internal/custom_metadata.py
+++ b/datajunction-server/datajunction_server/internal/custom_metadata.py
@@ -1,9 +1,11 @@
 """Resolution, validation, and filter translation for custom_metadata schemas."""
 
+import jsonschema
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.database.custom_metadata_schema import CustomMetadataSchema
+from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.models.node_type import NodeType
 
 
@@ -84,3 +86,29 @@ async def resolve_schemas(
         if row.key not in best or score > best[row.key][0]:
             best[row.key] = (score, row.json_schema)
     return {key: schema for key, (_, schema) in best.items()}
+
+
+async def validate_custom_metadata(
+    session: AsyncSession,
+    namespace: str | None,
+    node_type: NodeType,
+    custom_metadata: dict | None,
+) -> None:
+    """Lax, write-time validation: validate only keys with a resolved schema."""
+    if not custom_metadata:
+        return
+    schemas = await resolve_schemas(session, namespace, node_type)
+    if not schemas:
+        return
+    errors: list[str] = []
+    for key, value in custom_metadata.items():
+        schema = schemas.get(key)
+        if schema is None:
+            continue  # lax: unregistered keys pass
+        validator = jsonschema.Draft202012Validator(schema)
+        for err in validator.iter_errors(value):
+            errors.append(f"custom_metadata.{key}: {err.message}")
+    if errors:
+        raise DJInvalidInputException(
+            message="custom_metadata failed schema validation:\n" + "\n".join(errors),
+        )

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -137,6 +137,7 @@ from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.ast import CompileContext
 from datajunction_server.sql.parsing.backends.antlr4 import parse, parse_rule
 from datajunction_server.typing import UTCDatetime
+from datajunction_server.internal.custom_metadata import validate_custom_metadata
 from datajunction_server.utils import (
     SEPARATOR,
     Version,
@@ -301,6 +302,13 @@ async def create_a_node(
     )
     node_revision = await create_node_revision(data, node_type, session, current_user)
 
+    await validate_custom_metadata(
+        session,
+        namespace=namespace,
+        node_type=node_type,
+        custom_metadata=data.custom_metadata,
+    )
+
     column_names = {col.name: col for col in node_revision.columns}
     if data.primary_key:
         if any(key_column not in column_names for key_column in data.primary_key):
@@ -385,6 +393,13 @@ async def create_a_cube(
         namespace=namespace,
     )
     data.namespace = namespace
+
+    await validate_custom_metadata(
+        session,
+        namespace=namespace,
+        node_type=NodeType.CUBE,
+        custom_metadata=data.custom_metadata,
+    )
 
     node = Node(
         name=data.name,
@@ -1309,6 +1324,14 @@ async def update_any_node(
     ):
         node.missing_table = data.missing_table  # type: ignore
         session.add(node)
+
+    if data.custom_metadata is not None:
+        await validate_custom_metadata(
+            session,
+            namespace=node.namespace,
+            node_type=node.type,  # type: ignore[arg-type]
+            custom_metadata=data.custom_metadata,
+        )
 
     if node.type == NodeType.CUBE:  # type: ignore
         node = cast(Node, await Node.get_cube_by_name(session, name))

--- a/datajunction-server/pyproject.toml
+++ b/datajunction-server/pyproject.toml
@@ -90,6 +90,7 @@ dependencies = [
     # Data validation
     "pydantic<2.11,>=2.0",
     "pydantic-settings>=2.10.1",
+    "jsonschema>=4.0.0",
 
     # HTTP client for GitHub API
     "httpx>=0.27.0",

--- a/datajunction-server/tests/api/test_custom_metadata_write_validation.py
+++ b/datajunction-server/tests/api/test_custom_metadata_write_validation.py
@@ -1,0 +1,141 @@
+"""
+Tests for custom_metadata validation wired into node create and update endpoints.
+
+DB seeding strategy: the ``session`` and ``client`` fixtures share the same
+AsyncSession object (``client`` calls ``get_session_override`` → ``session``).
+We insert a ``CustomMetadataSchema`` row directly through ``session`` and
+commit it so the API request (running in the same session / same DB) sees it.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.database.custom_metadata_schema import CustomMetadataSchema
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _register_schema(session: AsyncSession, key: str, json_schema: dict) -> None:
+    """Insert a CustomMetadataSchema row and flush so the client sees it."""
+    session.add(
+        CustomMetadataSchema(
+            key=key,
+            json_schema=json_schema,
+            value_kind="string",
+        ),
+    )
+    await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# create_a_node hook
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_node_rejects_bad_custom_metadata(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """
+    Creating a node with a registered key that fails the JSON Schema → 422.
+    """
+    # RED: this will pass once the hook is wired in nodes.py
+    await _register_schema(session, "grain", {"type": "string"})
+
+    resp = await client.post(
+        "/nodes/metric/",
+        json={
+            "name": "default.cm_bad_metric",
+            "description": "test metric",
+            "query": "SELECT COUNT(repair_order_id) FROM default.repair_orders",
+            "mode": "draft",
+            "custom_metadata": {"grain": 123},  # int, but schema requires string
+        },
+    )
+    assert resp.status_code == 422
+    assert "custom_metadata.grain" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_create_node_allows_unregistered_key(
+    client: AsyncClient,
+    session: AsyncSession,  # noqa: ARG001 — needed to share the same DB
+) -> None:
+    """
+    Creating a node with an unregistered custom_metadata key → success (lax validation).
+    """
+    resp = await client.post(
+        "/nodes/metric/",
+        json={
+            "name": "default.cm_ok_metric",
+            "description": "test metric",
+            "query": "SELECT COUNT(repair_order_id) FROM default.repair_orders",
+            "mode": "draft",
+            "custom_metadata": {"anything_goes": {"nested": 1}},
+        },
+    )
+    assert resp.status_code in (200, 201)
+
+
+# ---------------------------------------------------------------------------
+# update_any_node hook
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_node_rejects_bad_custom_metadata(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """
+    Patching an existing node with a registered key that fails the JSON Schema → 422.
+    """
+    await _register_schema(session, "grain", {"type": "string"})
+
+    # default.repair_orders is a source node in the template DB
+    resp = await client.patch(
+        "/nodes/default.repair_orders/",
+        json={
+            "custom_metadata": {"grain": 456},  # int, but schema requires string
+        },
+    )
+    assert resp.status_code == 422
+    assert "custom_metadata.grain" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# create_a_cube hook
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_cube_rejects_bad_custom_metadata(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """
+    Creating a cube with a registered key that fails the JSON Schema → 422.
+    Payload modeled on test_read_cube in cubes_test.py (account_revenue examples,
+    which are pre-loaded in the template DB).
+    """
+    await _register_schema(session, "owner", {"type": "string"})
+
+    resp = await client.post(
+        "/nodes/cube/",
+        json={
+            "name": "default.cm_bad_cube",
+            "description": "Cube with bad custom_metadata",
+            "metrics": ["default.number_of_account_types"],
+            "dimensions": ["default.account_type.account_type_name"],
+            "filters": [],
+            "mode": "published",
+            "custom_metadata": {"owner": 999},  # int, but schema requires string
+        },
+    )
+    assert resp.status_code == 422
+    assert "custom_metadata.owner" in resp.text

--- a/datajunction-server/tests/database/test_custom_metadata_schema_model.py
+++ b/datajunction-server/tests/database/test_custom_metadata_schema_model.py
@@ -1,0 +1,23 @@
+"""Tests for the CustomMetadataSchema ORM model and registry table."""
+
+import pytest
+from datajunction_server.database.custom_metadata_schema import CustomMetadataSchema
+
+
+@pytest.mark.asyncio
+async def test_insert_and_read_schema(session):
+    row = CustomMetadataSchema(
+        key="table_group",
+        node_type=None,
+        namespace=None,
+        json_schema={"type": "string"},
+        value_kind="string",
+        filterable=True,
+        description="arc table group",
+    )
+    session.add(row)
+    await session.commit()
+    fetched = await session.get(CustomMetadataSchema, row.id)
+    assert fetched.key == "table_group"
+    assert fetched.json_schema == {"type": "string"}
+    assert fetched.filterable is True

--- a/datajunction-server/tests/database/test_custom_metadata_schema_model.py
+++ b/datajunction-server/tests/database/test_custom_metadata_schema_model.py
@@ -1,7 +1,13 @@
 """Tests for the CustomMetadataSchema ORM model and registry table."""
 
+import datetime
+
 import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
 from datajunction_server.database.custom_metadata_schema import CustomMetadataSchema
+from datajunction_server.typing import UTCDatetime
 
 
 @pytest.mark.asyncio
@@ -56,3 +62,81 @@ async def test_reserved_defaults_to_false(session):
     await session.commit()
     fetched = await session.get(CustomMetadataSchema, row.id)
     assert fetched.reserved is False
+
+
+@pytest.mark.asyncio
+async def test_soft_deleted_row_does_not_block_reregistration(session):
+    """A soft-deleted row and a live row can coexist for the same scope.
+
+    The unique index on (key, node_type, namespace) is partial, so it only
+    constrains live rows. Otherwise a retired key could never be registered
+    again in the same scope: every read path filters ``deactivated_at IS NULL``,
+    so the writer would see no live row, INSERT, and collide with the tombstone.
+    """
+    original = CustomMetadataSchema(
+        key="retired_key",
+        node_type="metric",
+        namespace="default",
+        json_schema={"type": "string"},
+    )
+    session.add(original)
+    await session.commit()
+
+    original.deactivated_at = UTCDatetime(
+        2026,
+        7,
+        12,
+        tzinfo=datetime.UTC,
+    )
+    await session.commit()
+
+    replacement = CustomMetadataSchema(
+        key="retired_key",
+        node_type="metric",
+        namespace="default",
+        json_schema={"type": "integer"},
+    )
+    session.add(replacement)
+    await session.commit()
+
+    rows = (
+        (
+            await session.execute(
+                select(CustomMetadataSchema).where(
+                    CustomMetadataSchema.key == "retired_key",
+                ),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+    live = [row for row in rows if row.deactivated_at is None]
+    assert len(live) == 1
+    assert live[0].json_schema == {"type": "integer"}
+
+
+@pytest.mark.asyncio
+async def test_duplicate_live_scope_is_still_rejected(session):
+    """Two live rows for the same scope remain a unique violation."""
+    session.add(
+        CustomMetadataSchema(
+            key="duplicated_key",
+            node_type=None,
+            namespace=None,
+            json_schema={"type": "string"},
+        ),
+    )
+    await session.commit()
+
+    session.add(
+        CustomMetadataSchema(
+            key="duplicated_key",
+            node_type=None,
+            namespace=None,
+            json_schema={"type": "string"},
+        ),
+    )
+    with pytest.raises(IntegrityError):
+        await session.commit()
+    await session.rollback()

--- a/datajunction-server/tests/database/test_custom_metadata_schema_model.py
+++ b/datajunction-server/tests/database/test_custom_metadata_schema_model.py
@@ -21,3 +21,38 @@ async def test_insert_and_read_schema(session):
     assert fetched.key == "table_group"
     assert fetched.json_schema == {"type": "string"}
     assert fetched.filterable is True
+
+
+@pytest.mark.asyncio
+async def test_new_columns_round_trip(session):
+    """owner, updated_by_id, reserved round-trip through the ORM."""
+    row = CustomMetadataSchema(
+        key="contact",
+        node_type=None,
+        namespace=None,
+        json_schema={"type": "string"},
+        owner="team-platform",
+        updated_by_id=None,
+        reserved=True,
+    )
+    session.add(row)
+    await session.commit()
+    fetched = await session.get(CustomMetadataSchema, row.id)
+    assert fetched.owner == "team-platform"
+    assert fetched.updated_by_id is None
+    assert fetched.reserved is True
+
+
+@pytest.mark.asyncio
+async def test_reserved_defaults_to_false(session):
+    """reserved defaults to False when not supplied."""
+    row = CustomMetadataSchema(
+        key="tag",
+        node_type=None,
+        namespace=None,
+        json_schema={"type": "string"},
+    )
+    session.add(row)
+    await session.commit()
+    fetched = await session.get(CustomMetadataSchema, row.id)
+    assert fetched.reserved is False

--- a/datajunction-server/tests/internal/test_custom_metadata_resolution.py
+++ b/datajunction-server/tests/internal/test_custom_metadata_resolution.py
@@ -1,0 +1,232 @@
+"""Tests for custom_metadata schema resolution helper."""
+
+import pytest
+
+from datajunction_server.database.custom_metadata_schema import CustomMetadataSchema
+from datajunction_server.internal.custom_metadata import resolve_schemas
+from datajunction_server.models.node_type import NodeType
+
+
+@pytest.mark.asyncio
+async def test_namespace_scoped_overrides_global(session):
+    session.add_all(
+        [
+            CustomMetadataSchema(
+                key="grain",
+                node_type=None,
+                namespace=None,
+                json_schema={"type": "string"},
+                value_kind="string",
+            ),
+            CustomMetadataSchema(
+                key="grain",
+                node_type=None,
+                namespace="finance",
+                json_schema={"type": "object"},
+                value_kind="object",
+            ),
+        ],
+    )
+    await session.commit()
+
+    resolved = await resolve_schemas(
+        session,
+        namespace="finance.orders",
+        node_type=NodeType.METRIC,
+    )
+    assert resolved["grain"] == {"type": "object"}  # namespace-scoped wins
+
+    resolved_other = await resolve_schemas(
+        session,
+        namespace="growth",
+        node_type=NodeType.METRIC,
+    )
+    assert resolved_other["grain"] == {"type": "string"}  # falls back to global
+
+
+@pytest.mark.asyncio
+async def test_node_type_scoped_overrides_global(session):
+    """node_type-scoped row wins over global; non-matching node_type is excluded."""
+    session.add_all(
+        [
+            CustomMetadataSchema(
+                key="owner",
+                node_type=None,
+                namespace=None,
+                json_schema={"type": "string"},
+                value_kind="string",
+            ),
+            CustomMetadataSchema(
+                key="owner",
+                node_type=NodeType.METRIC.value,
+                namespace=None,
+                json_schema={"type": "array"},
+                value_kind="array",
+            ),
+        ],
+    )
+    await session.commit()
+
+    # node_type match wins
+    resolved_metric = await resolve_schemas(
+        session,
+        namespace=None,
+        node_type=NodeType.METRIC,
+    )
+    assert resolved_metric["owner"] == {"type": "array"}
+
+    # different node_type falls back to global
+    resolved_transform = await resolve_schemas(
+        session,
+        namespace=None,
+        node_type=NodeType.TRANSFORM,
+    )
+    assert resolved_transform["owner"] == {"type": "string"}
+
+
+@pytest.mark.asyncio
+async def test_most_specific_wins_all_four_combinations(session):
+    """Both namespace+node_type wins over all less-specific rows."""
+    session.add_all(
+        [
+            # global (score=0)
+            CustomMetadataSchema(
+                key="label",
+                node_type=None,
+                namespace=None,
+                json_schema={"type": "string"},
+                value_kind="string",
+            ),
+            # node_type only (score=1)
+            CustomMetadataSchema(
+                key="label",
+                node_type=NodeType.METRIC.value,
+                namespace=None,
+                json_schema={"type": "boolean"},
+                value_kind="boolean",
+            ),
+            # namespace only (score=2)
+            CustomMetadataSchema(
+                key="label",
+                node_type=None,
+                namespace="sales",
+                json_schema={"type": "number"},
+                value_kind="number",
+            ),
+            # both namespace + node_type (score=3)
+            CustomMetadataSchema(
+                key="label",
+                node_type=NodeType.METRIC.value,
+                namespace="sales",
+                json_schema={"type": "integer"},
+                value_kind="integer",
+            ),
+        ],
+    )
+    await session.commit()
+
+    resolved = await resolve_schemas(
+        session,
+        namespace="sales.q1",
+        node_type=NodeType.METRIC,
+    )
+    assert resolved["label"] == {"type": "integer"}  # most specific wins
+
+
+@pytest.mark.asyncio
+async def test_deactivated_rows_are_excluded(session):
+    """Rows with deactivated_at set are not returned."""
+    import datetime
+
+    session.add_all(
+        [
+            CustomMetadataSchema(
+                key="tag",
+                node_type=None,
+                namespace=None,
+                json_schema={"type": "string"},
+                value_kind="string",
+                deactivated_at=datetime.datetime(
+                    2024,
+                    1,
+                    1,
+                    tzinfo=datetime.timezone.utc,
+                ),
+            ),
+        ],
+    )
+    await session.commit()
+
+    resolved = await resolve_schemas(
+        session,
+        namespace=None,
+        node_type=NodeType.METRIC,
+    )
+    assert "tag" not in resolved
+
+
+@pytest.mark.asyncio
+async def test_empty_registry_returns_empty_dict(session):
+    """No schemas registered → empty result."""
+    resolved = await resolve_schemas(
+        session,
+        namespace="any.namespace",
+        node_type=NodeType.METRIC,
+    )
+    assert resolved == {}
+
+
+@pytest.mark.asyncio
+async def test_namespace_scoped_row_does_not_apply_to_none_namespace(session):
+    """A namespace-scoped row does not apply when the query namespace is None (line 22)."""
+    session.add(
+        CustomMetadataSchema(
+            key="k",
+            node_type=None,
+            namespace="finance",
+            json_schema={"type": "string"},
+            value_kind="string",
+        ),
+    )
+    await session.commit()
+
+    resolved = await resolve_schemas(
+        session,
+        namespace=None,
+        node_type=NodeType.METRIC,
+    )
+    assert resolved == {}
+
+
+@pytest.mark.asyncio
+async def test_equal_specificity_second_row_does_not_displace_first(session):
+    """Two global rows for the same key: the second-seen does not beat the first (branch 68->64)."""
+    schema_a = {"type": "string"}
+    schema_b = {"type": "boolean"}
+    session.add_all(
+        [
+            CustomMetadataSchema(
+                key="k",
+                node_type=None,
+                namespace=None,
+                json_schema=schema_a,
+                value_kind="string",
+            ),
+            CustomMetadataSchema(
+                key="k",
+                node_type=None,
+                namespace=None,
+                json_schema=schema_b,
+                value_kind="boolean",
+            ),
+        ],
+    )
+    await session.commit()
+
+    resolved = await resolve_schemas(
+        session,
+        namespace=None,
+        node_type=NodeType.METRIC,
+    )
+    assert len(resolved) == 1
+    assert resolved["k"] in (schema_a, schema_b)

--- a/datajunction-server/tests/internal/test_custom_metadata_resolution.py
+++ b/datajunction-server/tests/internal/test_custom_metadata_resolution.py
@@ -200,22 +200,28 @@ async def test_namespace_scoped_row_does_not_apply_to_none_namespace(session):
 
 @pytest.mark.asyncio
 async def test_equal_specificity_second_row_does_not_displace_first(session):
-    """Two namespace-scoped rows for the same key at equal specificity: first-seen is kept."""
+    """Two global rows for the same key at equal specificity: one is kept (84->76 branch)."""
     schema_a = {"type": "string"}
     schema_b = {"type": "boolean"}
+    # Use node_type-scoped rows so both match the same query; unique index only
+    # prevents duplicate (key, node_type, namespace) combos, so we use two
+    # different node_types to avoid a constraint violation.
     session.add_all(
         [
             CustomMetadataSchema(
                 key="k",
-                node_type=None,
-                namespace="alpha",
+                node_type=NodeType.METRIC.value,
+                namespace=None,
                 json_schema=schema_a,
                 value_kind="string",
             ),
+            # A global row (score=0) is added AFTER the typed row (score=1);
+            # since score=0 < score=1 the global row must NOT displace the typed
+            # row — this exercises the false branch of `score > best[row.key][0]`.
             CustomMetadataSchema(
                 key="k",
                 node_type=None,
-                namespace="beta",
+                namespace=None,
                 json_schema=schema_b,
                 value_kind="boolean",
             ),
@@ -223,12 +229,12 @@ async def test_equal_specificity_second_row_does_not_displace_first(session):
     )
     await session.commit()
 
-    # Query with a namespace that matches only "alpha" — only schema_a qualifies
     resolved = await resolve_schemas(
         session,
-        namespace="alpha.sub",
+        namespace=None,
         node_type=NodeType.METRIC,
     )
+    # The typed row (score=1) wins; global row (score=0) does not displace it
     assert resolved["k"] == schema_a
 
 

--- a/datajunction-server/tests/internal/test_custom_metadata_resolution.py
+++ b/datajunction-server/tests/internal/test_custom_metadata_resolution.py
@@ -151,7 +151,7 @@ async def test_deactivated_rows_are_excluded(session):
                     2024,
                     1,
                     1,
-                    tzinfo=datetime.timezone.utc,
+                    tzinfo=datetime.UTC,
                 ),
             ),
         ],

--- a/datajunction-server/tests/internal/test_custom_metadata_resolution.py
+++ b/datajunction-server/tests/internal/test_custom_metadata_resolution.py
@@ -1,6 +1,7 @@
 """Tests for custom_metadata schema resolution helper."""
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from datajunction_server.database.custom_metadata_schema import CustomMetadataSchema
 from datajunction_server.internal.custom_metadata import resolve_schemas
@@ -199,13 +200,16 @@ async def test_namespace_scoped_row_does_not_apply_to_none_namespace(session):
 
 
 @pytest.mark.asyncio
-async def test_equal_specificity_second_row_does_not_displace_first(session):
-    """Two global rows for the same key at equal specificity: one is kept (84->76 branch)."""
+async def test_lower_specificity_row_does_not_displace_higher(session):
+    """A lower-specificity global row does not displace a higher-specificity typed row.
+
+    Exercises the ``score > best[row.key][0]`` false branch in resolve_schemas.
+    The assertion ``resolved["k"] == schema_a`` holds regardless of DB row-return
+    order because the typed row (score=1) always beats the global row (score=0).
+    """
     schema_a = {"type": "string"}
     schema_b = {"type": "boolean"}
-    # Use node_type-scoped rows so both match the same query; unique index only
-    # prevents duplicate (key, node_type, namespace) combos, so we use two
-    # different node_types to avoid a constraint violation.
+    # node_type-scoped (score=1) and global (score=0) for the same key.
     session.add_all(
         [
             CustomMetadataSchema(
@@ -215,9 +219,6 @@ async def test_equal_specificity_second_row_does_not_displace_first(session):
                 json_schema=schema_a,
                 value_kind="string",
             ),
-            # A global row (score=0) is added AFTER the typed row (score=1);
-            # since score=0 < score=1 the global row must NOT displace the typed
-            # row — this exercises the false branch of `score > best[row.key][0]`.
             CustomMetadataSchema(
                 key="k",
                 node_type=None,
@@ -234,7 +235,7 @@ async def test_equal_specificity_second_row_does_not_displace_first(session):
         namespace=None,
         node_type=NodeType.METRIC,
     )
-    # The typed row (score=1) wins; global row (score=0) does not displace it
+    # The typed row (score=1) must win; global row (score=0) must not displace it.
     assert resolved["k"] == schema_a
 
 
@@ -307,9 +308,6 @@ async def test_non_reserved_global_loses_to_scoped(session):
 @pytest.mark.asyncio
 async def test_duplicate_global_violates_unique_index(session):
     """Inserting two global rows with the same key should raise an IntegrityError."""
-    import pytest
-    from sqlalchemy.exc import IntegrityError
-
     session.add(
         CustomMetadataSchema(
             key="dup",

--- a/datajunction-server/tests/internal/test_custom_metadata_resolution.py
+++ b/datajunction-server/tests/internal/test_custom_metadata_resolution.py
@@ -200,7 +200,7 @@ async def test_namespace_scoped_row_does_not_apply_to_none_namespace(session):
 
 @pytest.mark.asyncio
 async def test_equal_specificity_second_row_does_not_displace_first(session):
-    """Two global rows for the same key: the second-seen does not beat the first (branch 68->64)."""
+    """Two namespace-scoped rows for the same key at equal specificity: first-seen is kept."""
     schema_a = {"type": "string"}
     schema_b = {"type": "boolean"}
     session.add_all(
@@ -208,14 +208,14 @@ async def test_equal_specificity_second_row_does_not_displace_first(session):
             CustomMetadataSchema(
                 key="k",
                 node_type=None,
-                namespace=None,
+                namespace="alpha",
                 json_schema=schema_a,
                 value_kind="string",
             ),
             CustomMetadataSchema(
                 key="k",
                 node_type=None,
-                namespace=None,
+                namespace="beta",
                 json_schema=schema_b,
                 value_kind="boolean",
             ),
@@ -223,10 +223,106 @@ async def test_equal_specificity_second_row_does_not_displace_first(session):
     )
     await session.commit()
 
+    # Query with a namespace that matches only "alpha" — only schema_a qualifies
     resolved = await resolve_schemas(
         session,
-        namespace=None,
+        namespace="alpha.sub",
         node_type=NodeType.METRIC,
     )
-    assert len(resolved) == 1
-    assert resolved["k"] in (schema_a, schema_b)
+    assert resolved["k"] == schema_a
+
+
+@pytest.mark.asyncio
+async def test_reserved_global_wins_over_scoped(session):
+    """A reserved global row supersedes a more-specific namespace-scoped row for the same key."""
+    session.add_all(
+        [
+            CustomMetadataSchema(
+                key="tier",
+                node_type=None,
+                namespace=None,
+                json_schema={"type": "string", "description": "global-reserved"},
+                value_kind="string",
+                reserved=True,
+            ),
+            CustomMetadataSchema(
+                key="tier",
+                node_type=None,
+                namespace="eng",
+                json_schema={"type": "number", "description": "namespace-scoped"},
+                value_kind="number",
+            ),
+        ],
+    )
+    await session.commit()
+
+    resolved = await resolve_schemas(
+        session,
+        namespace="eng.backend",
+        node_type=NodeType.METRIC,
+    )
+    # Reserved global must win even though namespace-scoped is more specific
+    assert resolved["tier"] == {"type": "string", "description": "global-reserved"}
+
+
+@pytest.mark.asyncio
+async def test_non_reserved_global_loses_to_scoped(session):
+    """A non-reserved global row still loses to a more-specific namespace-scoped row."""
+    session.add_all(
+        [
+            CustomMetadataSchema(
+                key="tier",
+                node_type=None,
+                namespace=None,
+                json_schema={"type": "string", "description": "global-non-reserved"},
+                value_kind="string",
+                reserved=False,
+            ),
+            CustomMetadataSchema(
+                key="tier",
+                node_type=None,
+                namespace="eng",
+                json_schema={"type": "number", "description": "namespace-scoped"},
+                value_kind="number",
+            ),
+        ],
+    )
+    await session.commit()
+
+    resolved = await resolve_schemas(
+        session,
+        namespace="eng.backend",
+        node_type=NodeType.METRIC,
+    )
+    # Non-reserved global: namespace-scoped still wins
+    assert resolved["tier"] == {"type": "number", "description": "namespace-scoped"}
+
+
+@pytest.mark.asyncio
+async def test_duplicate_global_violates_unique_index(session):
+    """Inserting two global rows with the same key should raise an IntegrityError."""
+    import pytest
+    from sqlalchemy.exc import IntegrityError
+
+    session.add(
+        CustomMetadataSchema(
+            key="dup",
+            node_type=None,
+            namespace=None,
+            json_schema={"type": "string"},
+            value_kind="string",
+        ),
+    )
+    await session.commit()
+
+    session.add(
+        CustomMetadataSchema(
+            key="dup",
+            node_type=None,
+            namespace=None,
+            json_schema={"type": "number"},
+            value_kind="number",
+        ),
+    )
+    with pytest.raises(IntegrityError):
+        await session.commit()

--- a/datajunction-server/tests/internal/test_custom_metadata_validation.py
+++ b/datajunction-server/tests/internal/test_custom_metadata_validation.py
@@ -1,0 +1,80 @@
+"""Tests for custom_metadata write-time validation helper."""
+
+import pytest
+
+from datajunction_server.database.custom_metadata_schema import CustomMetadataSchema
+from datajunction_server.errors import DJInvalidInputException
+from datajunction_server.internal.custom_metadata import validate_custom_metadata
+from datajunction_server.models.node_type import NodeType
+
+
+@pytest.mark.asyncio
+async def test_registered_key_valid_passes(session):
+    session.add(
+        CustomMetadataSchema(
+            key="table_group",
+            json_schema={"type": "string"},
+            value_kind="string",
+        ),
+    )
+    await session.commit()
+    await validate_custom_metadata(
+        session,
+        None,
+        NodeType.METRIC,
+        {"table_group": "ads"},
+    )  # no raise
+
+
+@pytest.mark.asyncio
+async def test_registered_key_invalid_raises(session):
+    session.add(
+        CustomMetadataSchema(
+            key="table_group",
+            json_schema={"type": "string"},
+            value_kind="string",
+        ),
+    )
+    await session.commit()
+    with pytest.raises(DJInvalidInputException):
+        await validate_custom_metadata(
+            session,
+            None,
+            NodeType.METRIC,
+            {"table_group": 123},
+        )
+
+
+@pytest.mark.asyncio
+async def test_unregistered_key_passes(session):
+    await validate_custom_metadata(
+        session,
+        None,
+        NodeType.METRIC,
+        {"anything": {"nested": True}},
+    )  # no raise
+
+
+@pytest.mark.asyncio
+async def test_empty_and_none_pass(session):
+    await validate_custom_metadata(session, None, NodeType.METRIC, None)
+    await validate_custom_metadata(session, None, NodeType.METRIC, {})
+
+
+@pytest.mark.asyncio
+async def test_unregistered_key_skipped_while_registered_key_exists(session):
+    """Unregistered key is skipped (line 89) even when a schema exists for another key."""
+    session.add(
+        CustomMetadataSchema(
+            key="registered",
+            json_schema={"type": "string"},
+            value_kind="string",
+        ),
+    )
+    await session.commit()
+    await validate_custom_metadata(
+        session,
+        None,
+        NodeType.METRIC,
+        {"registered": "ok", "unregistered": {"anything": 1}},
+    )  # no raise: unregistered key is skipped


### PR DESCRIPTION
### Summary

`custom_metadata` is a free-form JSON bag on every node, and currently we don't check what goes into it. However, validating the schema per-key-and-namespace is useful for teams who want to register and validate schemas in custom metadata.

This PR adds a registry where a JSON Schema can be declared for a single `custom_metadata` key, and validates writes against it. A schema is registered at some scope: globally, for a namespace, for a node type, or all of the above, and the most specific applicable schema wins for a given node. A key in `custom_metadata` with no registered schema will not be validated.

Resolution picks the most specific row per key, scoring +2 for a namespace and +1 for a node type, so the resolution order would be:
- (key, node_type, namespace) beats
- (key, namespace) beats
- (key, node_type) beats
- global

Namespace matching includes sub-namespaces, so a schema on `finance` also governs `finance.reporting`. The one exception is a global row marked as reserved: it always wins and no scoped row can shadow it.

### Test Plan

- [x] PR has an associated issue: #1352
- [x] make check passes
- [x] make test shows 100% unit test coverage

### Deployment Plan

Adds one new table, but has no behavior change on its own. With an empty registry, validation is a no-op for every existing writer. The first behavioral change comes when a schema is registered, which isn't possible until the next PR.