### PR TITLE
Record a coverage backfill after DJ launches it

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -70,10 +70,10 @@ from datajunction_server.internal.materializations import (
     apply_cube_materialization_swap,
     backfill_recorded,
     collect_materialization_teardowns,
+    coverage_backfill,
     coverage_gap,
     coverage_partition,
     reconcile_declared_materialization,
-    record_backfill,
     stop_materialization_workflows,
     swap_cube_materializations,
 )
@@ -2693,8 +2693,9 @@ class DeploymentOrchestrator:
         already has can simply hold less history than the cube now declares, and
         `coverage_gap` reads how much less off availability.
 
-        The span is recorded beside the cube's other backfills and never asked for
-        twice, since availability does not move until the backfill lands. A branch
+        A span the query service takes is recorded beside the cube's other
+        backfills and never asked for twice, since availability does not move
+        until the backfill lands. A branch
         deploy asks for nothing: it previews what the push would give its author,
         and a preview does not spend hundreds of partition runs. It says so in
         the report, so the missing backfill reads as a choice.
@@ -2738,7 +2739,6 @@ class DeploymentOrchestrator:
         await self.session.flush()
         if await backfill_recorded(self.session, materialization, span[0]):
             return
-        record_backfill(self.session, materialization, partition, span)
         self._cube_materialization_swaps.append(
             CubeMaterializationSwap(
                 cube_name=revision.name,
@@ -2747,7 +2747,7 @@ class DeploymentOrchestrator:
                 new_version=revision.version,
                 rebuilt_names=[],
                 superseded=[],
-                backfill=span,
+                backfill=coverage_backfill(materialization, partition, span),
             ),
         )
 
@@ -2933,6 +2933,9 @@ class DeploymentOrchestrator:
         bill -- so the span is reported, never capped: two years of history is a
         thing authors legitimately ask for, and a cap is something they could not
         undo from YAML.
+
+        A launch DJ could not record still ran, and warns: the next deploy sees
+        no record and asks for the same days again.
         """
         if outcome.backfill_span is None:
             self.warnings.append(
@@ -2945,6 +2948,16 @@ class DeploymentOrchestrator:
                 ),
             )
             return
+        if outcome.backfill_record_error:
+            self.warnings.append(
+                DJError(
+                    code=ErrorCode.QUERY_SERVICE_ERROR,
+                    message=(
+                        f"Cube `{outcome.cube_name}`: DJ could not record the "
+                        f"backfill it launched: {outcome.backfill_record_error}"
+                    ),
+                ),
+            )
         start, end = outcome.backfill_span
         runs = (end - start).days + 1
         self.deployed_results.append(

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -384,6 +384,18 @@ def _upsert_from_materialization(
 
 
 @dataclass
+class CoverageBackfill:
+    """
+    The days a cube's declared coverage asks for, and where DJ writes them down
+    once the query service takes the request.
+    """
+
+    span: tuple[date, date]
+    materialization_id: int
+    column_name: str
+
+
+@dataclass
 class CubeMaterializationSwap:
     """
     The query service work a cube materialization swap still owes, once DJ's own
@@ -399,7 +411,7 @@ class CubeMaterializationSwap:
 
     # The days to fill once the materialization is scheduled, resolved from the
     # cube's declared coverage against what its datasource already holds.
-    backfill: tuple[date, date] | None = None
+    backfill: CoverageBackfill | None = None
 
 
 @dataclass
@@ -422,6 +434,9 @@ class CubeMaterializationSwapOutcome:
     # The span a coverage backfill was launched over, and why it was not.
     backfill_span: tuple[date, date] | None = None
     backfill_error: str | None = None
+
+    # Why a launched backfill was not written down.
+    backfill_record_error: str | None = None
 
 
 async def reconcile_declared_materialization(
@@ -728,7 +743,8 @@ async def apply_cube_materialization_swap(
             # the message that says what to do about it.
             outcome.error = str(exc)
     if swap.backfill and outcome.scheduled:
-        _launch_backfill(
+        await _launch_backfill(
+            session,
             query_service_client,
             swap,
             swap.backfill,
@@ -745,10 +761,11 @@ async def apply_cube_materialization_swap(
     return outcome
 
 
-def _launch_backfill(
+async def _launch_backfill(
+    session: AsyncSession,
     query_service_client: QueryServiceClient,
     swap: CubeMaterializationSwap,
-    span: tuple[date, date],
+    backfill: CoverageBackfill,
     outcome: CubeMaterializationSwapOutcome,
     request_headers: dict[str, str] | None = None,
 ) -> None:
@@ -756,10 +773,13 @@ def _launch_backfill(
     Fill the days the cube declares but its Druid datasource does not hold.
 
     Launched and left: the workflow runs one job per partition, long past this
-    deploy. Never raises, and records on the outcome what the caller reports.
+    deploy. The span is written down only once the query service takes it, so a
+    refused launch is asked for again next deploy. Never raises, and records on
+    the outcome what the caller reports.
     """
+    span = backfill.span
     try:
-        query_service_client.run_cube_backfill(
+        result = query_service_client.run_cube_backfill(
             CubeBackfillInput(
                 cube_name=swap.cube_name,
                 cube_version=swap.new_version,
@@ -768,7 +788,6 @@ def _launch_backfill(
             ),
             request_headers=request_headers,
         )
-        outcome.backfill_span = span
     except Exception as exc:
         _logger.warning(
             "Failed to backfill cube=%s version=%s over %s to %s: %s (continuing)",
@@ -780,6 +799,20 @@ def _launch_backfill(
             exc_info=True,
         )
         outcome.backfill_error = str(exc)
+        return
+    outcome.backfill_span = span
+    try:
+        await record_backfill(session, backfill, result.get("job_url"))
+    except Exception as exc:
+        _logger.warning(
+            "Failed to record backfill for cube=%s over %s to %s: %s (continuing)",
+            swap.cube_name,
+            span[0],
+            span[1],
+            str(exc),
+            exc_info=True,
+        )
+        outcome.backfill_record_error = str(exc)
 
 
 def coverage_partition(revision: NodeRevision) -> Column | None:
@@ -830,11 +863,12 @@ async def backfill_recorded(
     start: date,
 ) -> bool:
     """
-    Whether DJ already asked to backfill a span reaching back to `start`.
+    Whether DJ already launched a backfill reaching back to `start`.
 
     Availability does not move until a backfill lands, so the deploy after one
-    sees the same gap and would ask for all of it again. Only DJ's own records
-    count: it writes ISO dates, while a backfill run from the API carries
+    sees the same gap and would ask for all of it again. A launch the query
+    service refused writes nothing, so the next deploy asks again. Only DJ's own
+    records count: it writes ISO dates, while a backfill run from the API carries
     partition-format values that do not mean the same thing.
 
     Read by query rather than off `materialization.backfills`, which a cube
@@ -860,26 +894,46 @@ async def backfill_recorded(
     return False
 
 
-def record_backfill(
-    session: AsyncSession,
+def coverage_backfill(
     materialization: Materialization,
     column: Column,
     span: tuple[date, date],
+) -> CoverageBackfill:
+    """
+    The record a launched coverage backfill will write.
+    """
+    return CoverageBackfill(
+        span=span,
+        materialization_id=materialization.id,
+        column_name=amenable_name(column.cube_element_name),
+    )
+
+
+async def record_backfill(
+    session: AsyncSession,
+    backfill: CoverageBackfill,
+    url: str | None = None,
 ) -> None:
     """
-    Note the span DJ asked to backfill, beside the cube's other backfills.
+    Note the span DJ launched, beside the cube's other backfills.
+
+    Written after the deploy commits, so it commits on its own. The workflow's
+    url goes with it, so a person can check what the row stands for.
     """
+    span = backfill.span
     session.add(
         Backfill(
-            materialization_id=materialization.id,
+            materialization_id=backfill.materialization_id,
             spec=[
                 PartitionBackfill(
-                    column_name=amenable_name(column.cube_element_name),
+                    column_name=backfill.column_name,
                     range=[span[0].isoformat(), span[1].isoformat()],
                 ).model_dump(),
             ],
+            urls=[url] if url else [],
         ),
     )
+    await session.commit()
 
 
 def _as_day(value: Any) -> date | None:

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1308,6 +1308,9 @@ def mock_qs(client):
     )
     query_service.materialize_cube.return_value = materialized
     query_service.materialize.return_value = materialized
+    query_service.run_cube_backfill.return_value = {
+        "job_url": "http://fake.url/backfill",
+    }
     client.app.dependency_overrides[get_query_service_client] = lambda: query_service
     yield query_service
     del client.app.dependency_overrides[get_query_service_client]
@@ -3474,7 +3477,50 @@ class TestDeployments:
         ]
 
         # The gap does not close until the backfill lands, so the next deploy sees
-        # the same one. What DJ already asked for it does not ask for again.
+        # the same one. What DJ launched it does not ask for again.
+        mock_qs.reset_mock()
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        assert mock_qs.run_cube_backfill.call_args_list == []
+
+        # A launch the query service refuses writes nothing down, so the cube is
+        # not locked out of the span: the next deploy asks for the same days.
+        mock_qs.reset_mock()
+        mock_qs.run_cube_backfill.side_effect = Exception("429 Too Many Requests")
+        cube.materialization = MaterializationSpec(
+            schedule="0 6 * * *",
+            coverage={"from": "2023-06-01"},
+        )
+        refused = CubeBackfillInput(
+            cube_name=cube_name,
+            cube_version="v1.1",
+            start_date=date(2023, 6, 1),
+            end_date=date(2025, 2, 28),
+        )
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        assert [actual.args for actual in mock_qs.run_cube_backfill.call_args_list] == [
+            (refused,),
+        ]
+
+        mock_qs.reset_mock()
+        mock_qs.run_cube_backfill.side_effect = None
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success"
+        assert [actual.args for actual in mock_qs.run_cube_backfill.call_args_list] == [
+            (refused,),
+        ]
+
+        # And once it lands, it is not asked for a third time.
         mock_qs.reset_mock()
         data = await deploy_and_wait(
             client,

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -2,7 +2,7 @@
 Unit tests for DeploymentOrchestrator
 """
 
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, date
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -37,8 +37,11 @@ from datajunction_server.internal.deployment.validation import (
     NodeValidationResult,
 )
 from datajunction_server.internal.materializations import (
+    CoverageBackfill,
     CubeMaterializationSwap,
     CubeMaterializationSwapOutcome,
+    coverage_backfill,
+    record_backfill,
 )
 from datajunction_server.models.deployment import (
     ChangeTier,
@@ -3672,7 +3675,15 @@ class TestApplyCubeMaterializationSwaps:
             new_version="v1.1",
             rebuilt_names=rebuilt_names,
             superseded=[],
-            backfill=backfill,
+            backfill=(
+                CoverageBackfill(
+                    span=backfill,
+                    materialization_id=7,
+                    column_name="date_id",
+                )
+                if backfill
+                else None
+            ),
         )
 
     @staticmethod
@@ -3919,6 +3930,55 @@ class TestApplyCubeMaterializationSwaps:
             ),
         ]
 
+    @pytest.mark.asyncio
+    async def test_an_unrecorded_backfill_is_warned_about(self, orchestrator):
+        """
+        The backfill is running, so it is reported as launched, but nothing wrote
+        it down -- and the next deploy will ask for the same days again.
+        """
+        orchestrator.context.request = None
+        orchestrator._cube_materialization_swaps = [
+            self._swap(
+                "default.a_cube",
+                [],
+                backfill=(date(2024, 1, 1), date(2024, 1, 2)),
+            ),
+        ]
+
+        with patch(
+            "datajunction_server.internal.deployment.orchestrator."
+            "apply_cube_materialization_swap",
+            new=AsyncMock(
+                return_value=CubeMaterializationSwapOutcome(
+                    cube_name="default.a_cube",
+                    materialization_names=[],
+                    scheduled=True,
+                    backfill_span=(date(2024, 1, 1), date(2024, 1, 2)),
+                    backfill_record_error="connection reset",
+                ),
+            ),
+        ):
+            await orchestrator._apply_cube_materialization_swaps()
+
+        assert orchestrator.deployed_results == [
+            DeploymentResult(
+                name="default.a_cube",
+                deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                status=DeploymentResult.Status.SUCCESS,
+                operation=DeploymentResult.Operation.CREATE,
+                message="backfilling 2024-01-01 to 2024-01-02, 2 partition runs",
+            ),
+        ]
+        assert orchestrator.warnings == [
+            DJError(
+                code=ErrorCode.QUERY_SERVICE_ERROR,
+                message=(
+                    "Cube `default.a_cube`: DJ could not record the backfill it "
+                    "launched: connection reset"
+                ),
+            ),
+        ]
+
 
 class TestPlanCoverageBackfill:
     """
@@ -4025,8 +4085,12 @@ class TestPlanCoverageBackfill:
             )
 
     @staticmethod
-    def _queued(orchestrator) -> list[tuple[date, date] | None]:
+    def _queued(orchestrator) -> list[CoverageBackfill | None]:
         return [swap.backfill for swap in orchestrator._cube_materialization_swaps]
+
+    @staticmethod
+    def _spans(orchestrator) -> list[tuple[date, date]]:
+        return [swap.backfill.span for swap in orchestrator._cube_materialization_swaps]
 
     @pytest.mark.asyncio
     async def test_gap_before_the_covered_start(
@@ -4053,16 +4117,15 @@ class TestPlanCoverageBackfill:
             {materialization.name},
         )
 
-        assert self._queued(orchestrator) == [(date(2024, 1, 1), date(2025, 2, 28))]
-        assert await self._recorded(session, materialization) == [
-            [
-                {
-                    "column_name": "date_id",
-                    "values": None,
-                    "range": ["2024-01-01", "2025-02-28"],
-                },
-            ],
+        assert self._queued(orchestrator) == [
+            CoverageBackfill(
+                span=(date(2024, 1, 1), date(2025, 2, 28)),
+                materialization_id=materialization.id,
+                column_name="date_id",
+            ),
         ]
+        # Nothing is written down until the launch lands.
+        assert await self._recorded(session, materialization) == []
 
     @pytest.mark.asyncio
     async def test_nothing_missing_before_the_start(
@@ -4114,7 +4177,7 @@ class TestPlanCoverageBackfill:
             set(),
         )
 
-        assert self._queued(orchestrator) == [(date(2024, 1, 1), date(2026, 1, 1))]
+        assert self._spans(orchestrator) == [(date(2024, 1, 1), date(2026, 1, 1))]
 
     @pytest.mark.asyncio
     async def test_a_rebuilt_cube_takes_the_whole_span(
@@ -4142,7 +4205,7 @@ class TestPlanCoverageBackfill:
             {materialization.name},
         )
 
-        assert self._queued(orchestrator) == [(date(2024, 1, 1), date(2026, 1, 1))]
+        assert self._spans(orchestrator) == [(date(2024, 1, 1), date(2026, 1, 1))]
 
     @pytest.mark.asyncio
     async def test_a_recorded_span_is_not_asked_for_twice(
@@ -4153,7 +4216,42 @@ class TestPlanCoverageBackfill:
     ):
         """
         Availability does not move until the backfill lands, so the next deploy
-        sees the same gap. What DJ already asked for it does not ask for again.
+        sees the same gap. What DJ launched it does not ask for again.
+        """
+        revision, materialization = await self._cube(
+            session,
+            current_user,
+            min_temporal_partition=["20250301"],
+        )
+        await record_backfill(
+            session,
+            coverage_backfill(
+                materialization,
+                revision.columns[0],
+                (date(2024, 1, 1), date(2025, 2, 28)),
+            ),
+        )
+
+        await self._plan(
+            orchestrator,
+            revision,
+            self._block(**{"from": date(2024, 1, 1)}),
+            materialization,
+            {materialization.name},
+        )
+
+        assert self._queued(orchestrator) == []
+
+    @pytest.mark.asyncio
+    async def test_an_unlaunched_span_is_asked_again(
+        self,
+        orchestrator,
+        session,
+        current_user,
+    ):
+        """
+        A launch the query service refused writes nothing down, so the deploy
+        after it queues the same days rather than skipping them forever.
         """
         revision, materialization = await self._cube(
             session,
@@ -4162,7 +4260,13 @@ class TestPlanCoverageBackfill:
         )
         block = self._block(**{"from": date(2024, 1, 1)})
 
-        await self._plan(orchestrator, revision, block, materialization, {"other"})
+        await self._plan(
+            orchestrator,
+            revision,
+            block,
+            materialization,
+            {materialization.name},
+        )
         await self._plan(
             orchestrator,
             revision,
@@ -4171,9 +4275,8 @@ class TestPlanCoverageBackfill:
             {materialization.name},
         )
 
-        yesterday = datetime.now(UTC).date() - timedelta(days=1)
-        assert self._queued(orchestrator) == [(date(2024, 1, 1), yesterday)]
-        assert len(await self._recorded(session, materialization)) == 1
+        span = (date(2024, 1, 1), date(2025, 2, 28))
+        assert self._spans(orchestrator) == [span, span]
 
     @pytest.mark.asyncio
     async def test_a_branch_deploy_asks_for_nothing(

--- a/datajunction-server/tests/internal/materializations_test.py
+++ b/datajunction-server/tests/internal/materializations_test.py
@@ -15,11 +15,13 @@ from datajunction_server.database.materialization import Materialization
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.partition import Partition
 from datajunction_server.internal.materializations import (
+    CoverageBackfill,
     CubeMaterializationSwap,
     CubeMaterializationSwapOutcome,
     NodeMaterializationTeardown,
     apply_cube_materialization_swap,
     backfill_recorded,
+    coverage_backfill,
     coverage_gap,
     coverage_partition,
     record_backfill,
@@ -250,7 +252,7 @@ def test_stop_materialization_workflows_reports_every_failure():
 
 def _swap(
     rebuilt_names: list[str],
-    backfill: tuple[date, date] | None = None,
+    backfill: CoverageBackfill | None = None,
 ) -> CubeMaterializationSwap:
     """A swap with one superseded materialization and the given rebuilt names."""
     return CubeMaterializationSwap(
@@ -389,8 +391,9 @@ async def test_apply_cube_swap_without_a_query_service():
 
 
 async def _apply_with_backfill(
+    session,
     query_service_client,
-    span: tuple[date, date],
+    backfill: CoverageBackfill,
     rebuilt_names: list[str] | None = None,
 ) -> CubeMaterializationSwapOutcome:
     """Apply a swap that carries a span to backfill."""
@@ -399,26 +402,34 @@ async def _apply_with_backfill(
         new=mock.AsyncMock(),
     ):
         return await apply_cube_materialization_swap(
-            mock.MagicMock(),
+            session,
             _swap(
                 rebuilt_names if rebuilt_names is not None else ["druid_cube_v3"],
-                backfill=span,
+                backfill=backfill,
             ),
             query_service_client,
         )
 
 
 @pytest.mark.asyncio
-async def test_apply_cube_swap_backfills_the_span():
+async def test_apply_cube_swap_backfills_the_span(session, current_user):
     """
     A swap carrying a span asks for exactly those days, against the new version --
-    which is what names the datasource being filled.
+    which is what names the datasource being filled -- and writes the span down
+    with the job the query service handed back.
     """
+    materialization = await _stored_materialization(session, current_user)
     query_service_client = mock.MagicMock()
+    query_service_client.run_cube_backfill.return_value = {"job_url": "http://job1"}
 
     outcome = await _apply_with_backfill(
+        session,
         query_service_client,
-        (date(2024, 1, 1), date(2024, 6, 30)),
+        coverage_backfill(
+            materialization,
+            _cube_revision().columns[0],
+            (date(2024, 1, 1), date(2024, 6, 30)),
+        ),
     )
 
     assert outcome == CubeMaterializationSwapOutcome(
@@ -428,6 +439,7 @@ async def test_apply_cube_swap_backfills_the_span():
         error=None,
         backfill_span=(date(2024, 1, 1), date(2024, 6, 30)),
         backfill_error=None,
+        backfill_record_error=None,
     )
     assert query_service_client.run_cube_backfill.call_args_list == [
         mock.call(
@@ -440,19 +452,39 @@ async def test_apply_cube_swap_backfills_the_span():
             request_headers=None,
         ),
     ]
+    assert await _recorded(session, materialization) == [
+        (
+            [
+                {
+                    "column_name": "date_0",
+                    "values": None,
+                    "range": ["2024-01-01", "2024-06-30"],
+                },
+            ],
+            ["http://job1"],
+        ),
+    ]
 
 
 @pytest.mark.asyncio
-async def test_apply_cube_swap_backfills_without_rebuilding():
+async def test_apply_cube_swap_backfills_without_rebuilding(session, current_user):
     """
     A gap fill rides on the workflow the cube already has, so its swap rebuilds
-    nothing and schedules nothing -- it only backfills.
+    nothing and schedules nothing -- it only backfills. A query service that
+    names no job still gets the span written down.
     """
+    materialization = await _stored_materialization(session, current_user)
     query_service_client = mock.MagicMock()
+    query_service_client.run_cube_backfill.return_value = {}
 
     outcome = await _apply_with_backfill(
+        session,
         query_service_client,
-        (date(2024, 1, 1), date(2024, 1, 3)),
+        coverage_backfill(
+            materialization,
+            _cube_revision().columns[0],
+            (date(2024, 1, 1), date(2024, 1, 3)),
+        ),
         rebuilt_names=[],
     )
 
@@ -463,21 +495,41 @@ async def test_apply_cube_swap_backfills_without_rebuilding():
         error=None,
         backfill_span=(date(2024, 1, 1), date(2024, 1, 3)),
         backfill_error=None,
+        backfill_record_error=None,
     )
+    assert await _recorded(session, materialization) == [
+        (
+            [
+                {
+                    "column_name": "date_0",
+                    "values": None,
+                    "range": ["2024-01-01", "2024-01-03"],
+                },
+            ],
+            [],
+        ),
+    ]
 
 
 @pytest.mark.asyncio
-async def test_apply_cube_swap_reports_a_refused_backfill():
+async def test_apply_cube_swap_reports_a_refused_backfill(session, current_user):
     """
     A backfill the query service refuses does not raise -- the materialization is
-    scheduled and the deploy has committed -- but the refusal comes back verbatim.
+    scheduled and the deploy has committed -- but the refusal comes back verbatim
+    and nothing is written down, so the next deploy asks for the same days.
     """
+    materialization = await _stored_materialization(session, current_user)
     query_service_client = mock.MagicMock()
     query_service_client.run_cube_backfill.side_effect = Exception("429 Too Many")
 
     outcome = await _apply_with_backfill(
+        session,
         query_service_client,
-        (date(2024, 1, 1), date(2024, 1, 2)),
+        coverage_backfill(
+            materialization,
+            _cube_revision().columns[0],
+            (date(2024, 1, 1), date(2024, 1, 2)),
+        ),
     )
 
     assert outcome == CubeMaterializationSwapOutcome(
@@ -487,15 +539,55 @@ async def test_apply_cube_swap_reports_a_refused_backfill():
         error=None,
         backfill_span=None,
         backfill_error="429 Too Many",
+        backfill_record_error=None,
     )
+    assert await _recorded(session, materialization) == []
+    assert await backfill_recorded(session, materialization, date(2024, 1, 1)) is False
 
 
 @pytest.mark.asyncio
-async def test_apply_cube_swap_backfills_nothing_unscheduled():
+async def test_apply_cube_swap_survives_a_record_failure(session, current_user):
+    """
+    The backfill is already running by the time DJ writes it down, so a write that
+    fails is reported rather than raised at a deploy that has committed.
+    """
+    materialization = await _stored_materialization(session, current_user)
+    query_service_client = mock.MagicMock()
+    query_service_client.run_cube_backfill.return_value = {"job_url": "http://job1"}
+
+    with mock.patch(
+        "datajunction_server.internal.materializations.record_backfill",
+        new=mock.AsyncMock(side_effect=Exception("connection reset")),
+    ):
+        outcome = await _apply_with_backfill(
+            session,
+            query_service_client,
+            coverage_backfill(
+                materialization,
+                _cube_revision().columns[0],
+                (date(2024, 1, 1), date(2024, 1, 2)),
+            ),
+        )
+
+    assert outcome == CubeMaterializationSwapOutcome(
+        cube_name="default.a_cube",
+        materialization_names=["druid_cube_v3"],
+        scheduled=True,
+        error=None,
+        backfill_span=(date(2024, 1, 1), date(2024, 1, 2)),
+        backfill_error=None,
+        backfill_record_error="connection reset",
+    )
+    assert await _recorded(session, materialization) == []
+
+
+@pytest.mark.asyncio
+async def test_apply_cube_swap_backfills_nothing_unscheduled(session, current_user):
     """
     A backfill needs the workflow the scheduling would have created, so a rejected
     push takes the backfill with it.
     """
+    materialization = await _stored_materialization(session, current_user)
     query_service_client = mock.MagicMock()
 
     with mock.patch(
@@ -503,8 +595,15 @@ async def test_apply_cube_swap_backfills_nothing_unscheduled():
         new=mock.AsyncMock(side_effect=Exception("403 Forbidden")),
     ):
         outcome = await apply_cube_materialization_swap(
-            mock.MagicMock(),
-            _swap(["druid_cube_v3"], backfill=(date(2024, 1, 1), date(2024, 1, 2))),
+            session,
+            _swap(
+                ["druid_cube_v3"],
+                backfill=coverage_backfill(
+                    materialization,
+                    _cube_revision().columns[0],
+                    (date(2024, 1, 1), date(2024, 1, 2)),
+                ),
+            ),
             query_service_client,
         )
 
@@ -515,8 +614,10 @@ async def test_apply_cube_swap_backfills_nothing_unscheduled():
         error="403 Forbidden",
         backfill_span=None,
         backfill_error=None,
+        backfill_record_error=None,
     )
     assert query_service_client.run_cube_backfill.call_args_list == []
+    assert await _recorded(session, materialization) == []
 
 
 def _cube_revision(
@@ -634,19 +735,18 @@ async def _stored_materialization(session, current_user) -> Materialization:
     return materialization
 
 
-async def _recorded(session, materialization: Materialization) -> list[list]:
-    """The backfill specs stored against a materialization."""
-    return list(
-        (
+async def _recorded(session, materialization: Materialization) -> list[tuple]:
+    """The backfill specs and urls stored against a materialization."""
+    return [
+        tuple(row)
+        for row in (
             await session.execute(
-                select(Backfill.spec).where(
+                select(Backfill.spec, Backfill.urls).where(
                     Backfill.materialization_id == materialization.id,
                 ),
             )
-        )
-        .scalars()
-        .all(),
-    )
+        ).all()
+    ]
 
 
 @pytest.mark.asyncio
@@ -657,21 +757,26 @@ async def test_record_backfill_is_read_back(session, current_user):
     """
     materialization = await _stored_materialization(session, current_user)
 
-    record_backfill(
+    await record_backfill(
         session,
-        materialization,
-        _cube_revision().columns[0],
-        (date(2024, 1, 1), date(2024, 6, 30)),
+        coverage_backfill(
+            materialization,
+            _cube_revision().columns[0],
+            (date(2024, 1, 1), date(2024, 6, 30)),
+        ),
     )
 
     assert await _recorded(session, materialization) == [
-        [
-            {
-                "column_name": "date_0",
-                "values": None,
-                "range": ["2024-01-01", "2024-06-30"],
-            },
-        ],
+        (
+            [
+                {
+                    "column_name": "date_0",
+                    "values": None,
+                    "range": ["2024-01-01", "2024-06-30"],
+                },
+            ],
+            [],
+        ),
     ]
     assert await backfill_recorded(session, materialization, date(2024, 1, 1)) is True
     assert await backfill_recorded(session, materialization, date(2024, 6, 1)) is True


### PR DESCRIPTION
### Summary

We should only record a backfill if it was successfully launched via the query service. If it wasn't, then DJ will never try to reconcile a failed backfill.

With this PR, we only record the backfill in the database after `run_cube_backfill` returns.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
