### PR TITLE
Accept multiple materialization configs on a cube

### DIFF
--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -707,9 +707,16 @@ class Node(Base):
     async def _materialization_spec(
         self,
         session: AsyncSession,
-    ) -> MaterializationSpec | None:
+    ) -> MaterializationSpec | list[MaterializationSpec] | None:
         """
         Project this cube's persisted materialization back into the declarative form.
+
+        A cube carrying more than one -- an incremental build for freshness beside a
+        periodic full rebuild -- projects as a list, so the export names all of them
+        and a push of what was pulled leaves the cube as it found it. One
+        materialization still projects as a scalar, which is the shape the vast
+        majority of manifests are written in and the shape a round trip should
+        preserve.
 
         Only the authored fields round-trip. Everything else on the stored
         config -- measures queries, combiner SQL, the Druid spec, output tables --
@@ -743,19 +750,34 @@ class Node(Base):
         if not cube_materializations:
             return None
 
-        materialization = cube_materializations[0]
-        config = (
-            materialization.config if isinstance(materialization.config, dict) else {}
-        )
-        return MaterializationSpec(
-            schedule=materialization.schedule,
-            strategy=materialization.strategy,
-            lookback_window=config.get("lookback_window"),
-            # Configs persisted before `retention` existed will be built with the
-            # default on their next run, so that is what the export should show.
-            retention=config.get("retention", DEFAULT_CUBE_RETENTION),
-            coverage=config.get("coverage"),
-        )
+        # One entry per strategy. Strategy is what tells declared entries apart, so a
+        # cube that somehow carries two rows of the same one -- they differ only by
+        # partition suffix -- cannot be described by a block naming both, and
+        # exporting one would produce YAML that fails to parse.
+        specs = []
+        seen_strategies = set()
+        for materialization in cube_materializations:
+            if materialization.strategy in seen_strategies:
+                continue
+            seen_strategies.add(materialization.strategy)
+            config = (
+                materialization.config
+                if isinstance(materialization.config, dict)
+                else {}
+            )
+            specs.append(
+                MaterializationSpec(
+                    schedule=materialization.schedule,
+                    strategy=materialization.strategy,
+                    lookback_window=config.get("lookback_window"),
+                    # Configs persisted before `retention` existed will be built with
+                    # the default on their next run, so that is what the export
+                    # should show.
+                    retention=config.get("retention", DEFAULT_CUBE_RETENTION),
+                    coverage=config.get("coverage"),
+                ),
+            )
+        return specs[0] if len(specs) == 1 else specs
 
     @classmethod
     def cube_load_options(cls) -> list[ExecutableOption]:

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -73,7 +73,7 @@ from datajunction_server.internal.materializations import (
     coverage_backfill,
     coverage_gap,
     coverage_partition,
-    reconcile_declared_materialization,
+    reconcile_declared_materializations,
     stop_materialization_workflows,
     swap_cube_materializations,
 )
@@ -101,6 +101,7 @@ from datajunction_server.models.deployment import (
     SourceSpec,
     TagSpec,
     bump_version,
+    declared_materialization_blocks,
     eq_or_fallback,
     render_prefixes,
 )
@@ -110,6 +111,7 @@ from datajunction_server.models.dimensionlink import (
 )
 from datajunction_server.models.hierarchy import HierarchyLevelInput
 from datajunction_server.models.history import ActivityType
+from datajunction_server.models.materialization import MaterializationStrategy
 from datajunction_server.models.node import (
     DEFAULT_DRAFT_VERSION,
     DEFAULT_PUBLISHED_VERSION,
@@ -218,6 +220,20 @@ def _diff_column_metadata(
             notes.append(f"Column '{col_name}': {'; '.join(col_notes)}")
 
     return notes
+
+
+def _blocks_by_strategy(
+    blocks: list[MaterializationSpec],
+) -> dict[MaterializationStrategy, MaterializationSpec]:
+    """
+    Declared blocks keyed by the strategy that identifies them.
+
+    Comparing two declarations this way ignores the order they were written in,
+    which carries no meaning: what a cube pulled from the server lists in name
+    order, an author is free to write the other way round, and reading that as a
+    change would report an update on every deploy of an untouched cube.
+    """
+    return {block.strategy: block for block in blocks}
 
 
 class _DryRunRollback(Exception):
@@ -2336,7 +2352,7 @@ class DeploymentOrchestrator:
         )
         declared_specs = self._declared_materializations()
         for old_revision, new_revision in swappable:
-            declared = declared_specs.get(new_revision.name)
+            declared = declared_specs.get(new_revision.name, [])
             swap = await swap_cube_materializations(
                 self.session,
                 old_revision,
@@ -2355,9 +2371,13 @@ class DeploymentOrchestrator:
                     self._rebuilt_cubes.add(new_revision.name)
                 self._cube_materialization_swaps.append(swap)
 
-    def _declared_materializations(self) -> dict[str, MaterializationSpec]:
+    def _declared_materializations(self) -> dict[str, list[MaterializationSpec]]:
         """
-        The materialization block each declared cube carries, keyed by rendered name.
+        The materialization blocks each declared cube carries, keyed by rendered name.
+
+        A cube may declare one block or several -- see `CubeSpec.materialization` --
+        and both arrive here as a list, so nothing downstream has to care which shape
+        the manifest was written in.
 
         A cube that declares no block is absent from the mapping, which is distinct
         from one that declares `materialization: none` -- see
@@ -2366,10 +2386,9 @@ class DeploymentOrchestrator:
         materialized".
         """
         return {
-            spec.rendered_name: spec.materialization
+            spec.rendered_name: spec.declared_materializations
             for spec in self.deployment_spec.nodes
-            if isinstance(spec, CubeSpec)
-            and isinstance(spec.materialization, MaterializationSpec)
+            if isinstance(spec, CubeSpec) and spec.declared_materializations
         }
 
     def _cubes_declaring_no_materialization(self) -> set[str]:
@@ -2433,7 +2452,13 @@ class DeploymentOrchestrator:
         # has already had its materialization rebuilt onto it by
         # `_swap_cube_materializations`, and a dry run skips that rebuild entirely --
         # reading the revision would make the two disagree.
-        persisted: dict[str, MaterializationSpec | MaterializationAction | None] = {
+        persisted: dict[
+            str,
+            MaterializationSpec
+            | list[MaterializationSpec]
+            | MaterializationAction
+            | None,
+        ] = {
             name: existing.materialization
             for name in cube_names
             if isinstance(existing := plan.existing_specs.get(name), CubeSpec)
@@ -2535,30 +2560,40 @@ class DeploymentOrchestrator:
     async def _declare_cube_materialization(
         self,
         revision: NodeRevision,
-        block: MaterializationSpec,
-        persisted: MaterializationSpec | MaterializationAction | None,
+        blocks: list[MaterializationSpec],
+        persisted: MaterializationSpec
+        | list[MaterializationSpec]
+        | MaterializationAction
+        | None,
         access_checker: AccessChecker | None,
         active_names: set[str],
     ) -> None:
         """
-        Configure one cube's materialization from its declared block.
+        Configure one cube's materializations from its declared blocks.
 
-        The reported operation compares the block against what the cube declared
+        A cube declares one block or several, and they are reconciled together: what
+        the blocks name is what the cube ends up materialized by, and the operation
+        is reported for the cube as a whole rather than per block, so that a cube
+        that swapped one strategy for another reads as an update rather than as a
+        creation beside an unmentioned removal.
+
+        The reported operation compares the blocks against what the cube declared
         before this deploy, so it says the same thing on a dry run as on the wet run
-        that follows. `reconcile_declared_materialization` decides separately whether
+        that follows. `reconcile_declared_materializations` decides separately whether
         any DJ-side state actually moved, and only then is the query service asked to
         schedule anything -- an unchanged re-declare, or a block a revision swap has
         already built from, costs no remote call at all.
 
         `active_names` is what the cube had materialized before reconciling, which
-        says whether the block wrote a datasource the cube did not have. It is
+        says whether a block wrote a datasource the cube did not have. It is
         `_plan_coverage_backfill` that reads it, once the row is in hand.
         """
         operation = (
             DeploymentResult.Operation.CREATE
             if persisted is None
             else DeploymentResult.Operation.UPDATE
-            if persisted != block
+            if _blocks_by_strategy(declared_materialization_blocks(persisted))
+            != _blocks_by_strategy(blocks)
             else DeploymentResult.Operation.NOOP
         )
         if not self.dry_run:
@@ -2566,14 +2601,10 @@ class DeploymentOrchestrator:
             # assert narrows the Optional for mypy.
             assert access_checker is not None
             try:
-                (
-                    materialization,
-                    changed,
-                    superseded,
-                ) = await reconcile_declared_materialization(
+                reconciled, superseded = await reconcile_declared_materializations(
                     self.session,
                     revision,
-                    block,
+                    blocks,
                     access_checker=access_checker,
                     current_user=self.context.current_user,
                 )
@@ -2605,40 +2636,43 @@ class DeploymentOrchestrator:
                 )
                 return
 
+            changed = [entry for entry in reconciled if entry.changed]
             if changed:
-                # The block can be unchanged while the built config is not -- a cube
+                # A block can be unchanged while the built config is not -- a cube
                 # materialized outside YAML, or one whose definition moved underneath
                 # an untouched schedule.
                 if operation == DeploymentResult.Operation.NOOP:
                     operation = DeploymentResult.Operation.UPDATE
-                self.session.add(
-                    History(
-                        entity_type=EntityType.MATERIALIZATION,
-                        entity_name=materialization.name,
-                        node=revision.name,
-                        activity_type=(
-                            ActivityType.CREATE
-                            if operation == DeploymentResult.Operation.CREATE
-                            else ActivityType.UPDATE
+                for entry in changed:
+                    self.session.add(
+                        History(
+                            entity_type=EntityType.MATERIALIZATION,
+                            entity_name=entry.materialization.name,
+                            node=revision.name,
+                            activity_type=(
+                                ActivityType.CREATE
+                                if operation == DeploymentResult.Operation.CREATE
+                                else ActivityType.UPDATE
+                            ),
+                            details={
+                                "materialization": entry.materialization.name,
+                                "schedule": entry.block.schedule,
+                                "strategy": entry.block.strategy.value,
+                                "lookback_window": entry.block.lookback_window,
+                                "superseded_materializations": [
+                                    mat.name for mat in superseded
+                                ],
+                            },
+                            user=self._history_user,
                         ),
-                        details={
-                            "materialization": materialization.name,
-                            "schedule": block.schedule,
-                            "strategy": block.strategy.value,
-                            "lookback_window": block.lookback_window,
-                            "superseded_materializations": [
-                                mat.name for mat in superseded
-                            ],
-                        },
-                        user=self._history_user,
-                    ),
-                )
+                    )
                 if superseded:
-                    # Stopped before the declared materialization is scheduled, and as
-                    # its own unit of work, because both sit on the same cube version:
-                    # a superseded row with no workflow names of its own falls back to
-                    # the stop-by-cube-and-version endpoint, which would take the
-                    # replacement down with it if that had already been scheduled.
+                    # Stopped before the declared materializations are scheduled, and
+                    # as its own unit of work, because both sit on the same cube
+                    # version: a superseded row with no workflow names of its own
+                    # falls back to the stop-by-cube-and-version endpoint, which would
+                    # take the replacements down with it if those had already been
+                    # scheduled.
                     self._cube_materialization_swaps.append(
                         CubeMaterializationSwap(
                             cube_name=revision.name,
@@ -2649,33 +2683,35 @@ class DeploymentOrchestrator:
                             superseded=superseded,
                         ),
                     )
-                # The row itself was updated in place, so the workflow it names is
-                # replaced by scheduling it again rather than stopped.
+                # The rows themselves were updated in place, so the workflows they
+                # name are replaced by scheduling them again rather than stopped.
                 self._cube_materialization_swaps.append(
                     CubeMaterializationSwap(
                         cube_name=revision.name,
                         previous_version=revision.version,
                         new_revision_id=revision.id,
                         new_version=revision.version,
-                        rebuilt_names=[materialization.name],
+                        rebuilt_names=[entry.materialization.name for entry in changed],
                         superseded=[],
                     ),
                 )
-            await self._plan_coverage_backfill(
-                revision,
-                block,
-                materialization,
-                active_names,
+            for entry in reconciled:
+                await self._plan_coverage_backfill(
+                    revision,
+                    entry.block,
+                    entry.materialization,
+                    active_names,
+                )
+        for block in blocks:
+            self.deployed_results.append(
+                DeploymentResult(
+                    name=revision.name,
+                    deploy_type=DeploymentResult.Type.MATERIALIZATION,
+                    status=DeploymentResult.Status.SUCCESS,
+                    operation=operation,
+                    message=f"cube materialization on schedule {block.schedule}",
+                ),
             )
-        self.deployed_results.append(
-            DeploymentResult(
-                name=revision.name,
-                deploy_type=DeploymentResult.Type.MATERIALIZATION,
-                status=DeploymentResult.Status.SUCCESS,
-                operation=operation,
-                message=f"cube materialization on schedule {block.schedule}",
-            ),
-        )
 
     async def _plan_coverage_backfill(
         self,

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -2,6 +2,7 @@
 
 import logging
 import zlib
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, timedelta
 from typing import Any
@@ -439,20 +440,40 @@ class CubeMaterializationSwapOutcome:
     backfill_record_error: str | None = None
 
 
-async def reconcile_declared_materialization(
+@dataclass
+class ReconciledMaterialization:
+    """
+    One declared block and the materialization row it now owns.
+
+    `changed` says whether DJ-side state actually moved for this row, so a deploy
+    that re-declares what is already configured can skip the query service entirely.
+    """
+
+    block: MaterializationSpec
+    materialization: Materialization
+    changed: bool
+
+
+async def reconcile_declared_materializations(
     session: AsyncSession,
     revision: NodeRevision,
-    declared: MaterializationSpec,
+    declared: Sequence[MaterializationSpec],
     *,
     access_checker: AccessChecker,
     current_user: User,
-) -> tuple[Materialization, bool, list[Materialization]]:
+) -> tuple[list[ReconciledMaterialization], list[Materialization]]:
     """
-    Bring a cube revision's materialization in line with its declared block.
+    Bring a cube revision's materializations in line with its declared blocks.
 
-    Returns the materialization, whether anything actually changed -- so a deploy
-    that re-declares what is already configured can skip the query service entirely
-    -- and the materializations the block superseded.
+    Returns what each declared block resolved to, and the materializations the
+    blocks together superseded.
+
+    A cube may declare more than one block -- typically an `incremental_time` build
+    for freshness beside a periodic `full` rebuild that corrects late-arriving data
+    -- and each is reconciled the same way. They cannot collide: the row name is
+    derived from job, strategy and partition, the job is fixed for a cube and the
+    strategies are unique by validation, so every declared block owns a row of its
+    own.
 
     Mirrors what `POST /nodes/{name}/materialization/` does -- build the config, then
     update the row of the same name in place rather than inserting a second one,
@@ -462,9 +483,9 @@ async def reconcile_declared_materialization(
     equal and is silently dropped. Rescheduling is the whole point of a declared
     block, so all three are compared here.
 
-    A declared block describes *the* materialization for its cube, so every other
-    active row on the revision is deactivated. The rule is "any active row whose name
-    the block did not build" rather than "any row of the same job type", because a
+    The declared blocks describe *the* materializations for their cube, so every
+    other active row on the revision is deactivated. The rule is "any active row
+    whose name no block built" rather than "any row of the same job type", because a
     cube's materializations are all writing one Druid datasource and a full rebuild
     replaces that datasource wholesale -- so a legacy `druid_measures_cube` row is
     just as much a competing writer as a second `druid_cube` row, and matching on job
@@ -477,55 +498,67 @@ async def reconcile_declared_materialization(
     and DJ cannot rebuild it from a declared block, so superseding it would stop a
     workflow nothing here can replace.
     """
-    # Snapshotted before the build, which sets the new materialization's backref and
-    # so appends it to this very collection -- searching afterwards would find the
-    # build itself, call it unchanged, and then detach it.
+    # Snapshotted before the builds, each of which sets the new materialization's
+    # backref and so appends it to this very collection -- searching afterwards would
+    # find the build itself, call it unchanged, and then detach it.
     before = list(revision.materializations)
-    built = await create_new_materialization(
-        session,
-        revision,
-        UpsertCubeMaterialization(
-            job=MaterializationJobTypeEnum.DRUID_CUBE.value.name,  # type: ignore
-            strategy=declared.strategy,
-            schedule=declared.schedule,
-            lookback_window=declared.lookback_window,
-            coverage=declared.coverage,
-        ),
-        access_checker,
-        current_user=current_user,
-    )
-    existing = next(
-        (mat for mat in before if mat.name == built.name),
-        None,
-    )
+    builds = [
+        (
+            block,
+            await create_new_materialization(
+                session,
+                revision,
+                UpsertCubeMaterialization(
+                    job=MaterializationJobTypeEnum.DRUID_CUBE.value.name,  # type: ignore
+                    strategy=block.strategy,
+                    schedule=block.schedule,
+                    lookback_window=block.lookback_window,
+                    coverage=block.coverage,
+                ),
+                access_checker,
+                current_user=current_user,
+            ),
+        )
+        for block in declared
+    ]
+    built_names = {built.name for _, built in builds}
     superseded = [
         mat
         for mat in before
-        if mat.name != built.name and not mat.deactivated_at and not mat.is_cube_planner
+        if mat.name not in built_names
+        and not mat.deactivated_at
+        and not mat.is_cube_planner
     ]
     for materialization in superseded:
         materialization.deactivated_at = UTCDatetime.now(UTC)  # type: ignore
-    if existing is None:
-        session.add(built)
-        return built, True, superseded
 
-    # `create_new_materialization` sets the backref, which would insert a duplicate
-    # row alongside the one being updated.
-    built.node_revision = None  # type: ignore
-    unchanged = (
-        existing.config == built.config
-        and existing.schedule == built.schedule
-        and existing.strategy == built.strategy
-        and existing.deactivated_at is None
-        and not superseded
-    )
-    if unchanged:
-        return existing, False, superseded
-    existing.config = built.config
-    existing.schedule = built.schedule
-    existing.strategy = built.strategy
-    existing.deactivated_at = None
-    return existing, True, superseded
+    reconciled = []
+    for block, built in builds:
+        existing = next((mat for mat in before if mat.name == built.name), None)
+        if existing is None:
+            session.add(built)
+            reconciled.append(ReconciledMaterialization(block, built, True))
+            continue
+
+        # `create_new_materialization` sets the backref, which would insert a
+        # duplicate row alongside the one being updated.
+        built.node_revision = None  # type: ignore
+        unchanged = (
+            existing.config == built.config
+            and existing.schedule == built.schedule
+            and existing.strategy == built.strategy
+            and existing.deactivated_at is None
+            and not superseded
+        )
+        if unchanged:
+            reconciled.append(ReconciledMaterialization(block, existing, False))
+            continue
+        existing.config = built.config
+        existing.schedule = built.schedule
+        existing.strategy = built.strategy
+        existing.deactivated_at = None
+        reconciled.append(ReconciledMaterialization(block, existing, True))
+    return reconciled, superseded
 
 
 async def swap_cube_materializations(
@@ -536,7 +569,7 @@ async def swap_cube_materializations(
     access_checker: AccessChecker,
     current_user: User,
     previous_table_usable: bool,
-    declared: MaterializationSpec | None = None,
+    declared: Sequence[MaterializationSpec] = (),
 ) -> CubeMaterializationSwap | None:
     """
     Rebuild a cube's materializations against a new revision and retire the old ones.
@@ -611,12 +644,27 @@ async def swap_cube_materializations(
                 # rebuild triggered by the same deploy must build what the YAML now
                 # says. Only cube materializations can be declared; anything else
                 # keeps what was recovered.
+                #
+                # Which block, when the cube declares several: the one naming the
+                # strategy this row was built with, since that is what identifies a
+                # declared entry. A row whose strategy nothing declares falls to the
+                # first block, which is what a cube declaring exactly one has always
+                # done -- and is the only sensible answer, since a rebuild has to
+                # produce something for a row that is being retired either way.
+                block = next(
+                    (
+                        candidate
+                        for candidate in declared
+                        if candidate.strategy == upsert.strategy
+                    ),
+                    declared[0],
+                )
                 upsert = upsert.model_copy(
                     update={
-                        "schedule": declared.schedule,
-                        "strategy": declared.strategy,
-                        "lookback_window": declared.lookback_window,
-                        "coverage": declared.coverage,
+                        "schedule": block.schedule,
+                        "strategy": block.strategy,
+                        "lookback_window": block.lookback_window,
+                        "coverage": block.coverage,
                     },
                 )
             new_materialization = await create_new_materialization(

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Iterable
 from enum import Enum, IntEnum
 from typing import Annotated, Any, ClassVar, Literal
@@ -377,6 +378,28 @@ class MaterializationAction(str, Enum):
     NONE = "none"
 
 
+def declared_materialization_blocks(
+    materialization: MaterializationSpec
+    | list[MaterializationSpec]
+    | MaterializationAction
+    | None,
+) -> list[MaterializationSpec]:
+    """
+    A cube's `materialization:` value as the list of blocks it declares.
+
+    The scalar and the list form mean the same thing to everything past parsing, and
+    neither an absent block nor the teardown sentinel declares anything to build, so
+    reducing all four shapes to a list is what keeps the rest of the deployment path
+    from caring which one the manifest was written in. Which of the two empty cases
+    is which is read off `materialization` directly.
+    """
+    if isinstance(materialization, MaterializationSpec):
+        return [materialization]
+    if isinstance(materialization, list):
+        return list(materialization)
+    return []
+
+
 class ColumnSpec(BaseModel):
     """
     Represents a column.
@@ -660,8 +683,6 @@ class NodeSpec(NamespacedSpec):
         Return a copy of this spec with all ${prefix} placeholders resolved.
         Needed for accurate diffs against existing specs that store fully-qualified names.
         """
-        import json
-
         raw = self.model_dump(mode="json")
         prefix = f"{self.namespace}{SEPARATOR}" if self.namespace else ""
         rendered_json = json.dumps(raw).replace("${prefix}", prefix)
@@ -1078,7 +1099,18 @@ class CubeSpec(NodeSpec):
     # materialization is not managed here and whatever exists is left alone. Only a
     # value can carry intent through serialization, so removal is spelled
     # `materialization: none` rather than inferred from a key being present.
-    materialization: MaterializationSpec | MaterializationAction | None = None
+    #
+    # A list declares more than one, which a cube legitimately needs: an
+    # `incremental_time` build for freshness alongside a periodic `full` rebuild
+    # that corrects late-arriving data, out-of-order events and dimension
+    # backfills. `strategy` is what tells two entries apart -- `job` is not
+    # authorable (see `MaterializationSpec`) and everything else is a knob rather
+    # than an identity -- so two entries sharing one are rejected below. The scalar
+    # form stays valid and means exactly what it always did; nothing has to be
+    # rewritten as a one-element list.
+    materialization: (
+        MaterializationSpec | list[MaterializationSpec] | MaterializationAction | None
+    ) = None
 
     FIELD_CHANGE_TIERS: ClassVar[dict[str, ChangeTier]] = {
         # Adding or removing a metric or a dimension changes the cube's columns.
@@ -1136,15 +1168,40 @@ class CubeSpec(NodeSpec):
         build. The partition is read from the cube's own columns (see ColumnSpec.
         partition) -- it is not restated on the materialization block, so that a cube
         carrying the same dimension in two roles can say which role partitions it.
+
+        A list is checked entry by entry, and additionally for the two shapes that
+        have no meaning: an empty one, which cannot be told from the teardown
+        sentinel, and repeated strategies, which leave no way to say which declared
+        entry a given materialization answers to.
         """
-        if (
-            isinstance(self.materialization, MaterializationSpec)
-            and self.materialization.strategy
-            == MaterializationStrategy.INCREMENTAL_TIME
-            and not any(
-                col.partition and col.partition.type == PartitionType.TEMPORAL
-                for col in self.columns or []
-            )
+        if isinstance(self.materialization, list):
+            if not self.materialization:
+                raise DJInvalidDeploymentConfig(
+                    message=(
+                        f"Cube `{self.name}` declares an empty `materialization:` "
+                        "list. Use `materialization: none` to remove the cube's "
+                        "materialization, or omit the key to leave it alone."
+                    ),
+                )
+            seen: set[MaterializationStrategy] = set()
+            for block in self.materialization:
+                if block.strategy in seen:
+                    raise DJInvalidDeploymentConfig(
+                        message=(
+                            f"Cube `{self.name}` declares more than one "
+                            f"`{block.strategy.value}` materialization. Strategies "
+                            "identify a cube's materializations, so each one may "
+                            "appear at most once."
+                        ),
+                    )
+                seen.add(block.strategy)
+
+        if any(
+            block.strategy == MaterializationStrategy.INCREMENTAL_TIME
+            for block in self.declared_materializations
+        ) and not any(
+            col.partition and col.partition.type == PartitionType.TEMPORAL
+            for col in self.columns or []
         ):
             raise DJInvalidDeploymentConfig(
                 message=(
@@ -1155,6 +1212,11 @@ class CubeSpec(NodeSpec):
                 ),
             )
         return self
+
+    @property
+    def declared_materializations(self) -> list[MaterializationSpec]:
+        """The materialization blocks this cube declares, scalar and list alike."""
+        return declared_materialization_blocks(self.materialization)
 
     @property
     def rendered_metrics(self) -> list[str]:
@@ -1233,9 +1295,16 @@ def _norm(v: Any) -> Any:
 
 
 def _as_comparable_set(value: Any) -> set:
-    """Reduce a list field to a set of hashable, comparable items."""
+    """
+    Reduce a list field to a set of hashable, comparable items.
+
+    A model is reduced to its canonical JSON rather than to a tuple of its fields,
+    because a field of its own can hold a nested model or a dict -- a
+    materialization's `coverage`, a column's `partition` -- and a tuple carrying one
+    of those cannot go into a set at all.
+    """
     return {
-        tuple(sorted(item.model_dump().items()))
+        json.dumps(item.model_dump(mode="json"), sort_keys=True)
         if isinstance(item, BaseModel)
         else item
         for item in value or []

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -6934,6 +6934,300 @@ class TestDeclaredCubeMaterializations:
             (full_name, "0 6 * * *", "full", False),
         ]
 
+    @pytest.mark.asyncio
+    async def test_dropping_a_block_stops_it(
+        self,
+        client,
+        upstreams,
+        mock_qs,
+    ):
+        """
+        Shrinking a declared pair back to one takes the dropped materialization down.
+
+        The blocks are the whole list, so deleting the full rebuild from YAML has to
+        stop it -- left running it keeps rewriting the datasource the incremental
+        build loads, and nothing in the repo records that it exists.
+
+        The stop is what makes the survivor churn. DJ has no workflow name for a
+        materialization it built here, so it falls back to the cube-and-version
+        endpoint, which stops every workflow on the revision including the one still
+        declared. The reconciler answers that by treating an otherwise unchanged
+        block as changed whenever anything was superseded, so the incremental build
+        is scheduled again rather than silently left stopped.
+        """
+        namespace = "cube_mat_shrunk"
+        cube_name = f"{namespace}.default.repairs_cube"
+        full_name = f"druid_cube__full__{namespace}.default.hard_hat.hire_date"
+        incremental = MaterializationSpec(
+            schedule="59 23 * * *",
+            lookback_window="1 DAY",
+        )
+        nodes = [
+            *upstreams,
+            self._cube(
+                materialization=[
+                    incremental,
+                    MaterializationSpec(
+                        schedule="0 6 * * *",
+                        strategy=MaterializationStrategy.FULL,
+                    ),
+                ],
+            ),
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert await self._persisted_materializations(client, cube_name) == [
+            (
+                self._materialization_name(namespace),
+                "59 23 * * *",
+                "incremental_time",
+                True,
+            ),
+            (full_name, "0 6 * * *", "full", True),
+        ]
+
+        mock_qs.reset_mock()
+        nodes[-1] = self._cube(materialization=incremental)
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "update",
+                "success",
+                "cube materialization on schedule 59 23 * * *",
+            ),
+        ]
+        assert [call[0] for call in mock_qs.method_calls] == [
+            "deactivate_cube_workflow",
+            "materialize_cube",
+        ]
+        assert mock_qs.deactivate_cube_workflow.call_args_list == [
+            mock.call(cube_name, version="v1.0", request_headers=mock.ANY),
+        ]
+        rescheduled = mock_qs.materialize_cube.call_args.kwargs["materialization_input"]
+        assert rescheduled.strategy == MaterializationStrategy.INCREMENTAL_TIME
+        assert await self._persisted_materializations(client, cube_name) == [
+            (
+                self._materialization_name(namespace),
+                "59 23 * * *",
+                "incremental_time",
+                True,
+            ),
+            (full_name, "0 6 * * *", "full", False),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_declared_block_supersedes_a_legacy_row(
+        self,
+        client,
+        upstreams,
+        mock_qs,
+    ):
+        """
+        A materialization made outside the deploy is taken down by a deploy that
+        declares a block, even when no block could have built it.
+
+        This is the two-writers case: someone materialized the cube through the API
+        or the UI, and a later push of YAML that declares its own block removes what
+        they set up. The older `druid_measures_cube` job cannot be declared at all,
+        so no block ever builds its name -- and it is superseded anyway, because
+        every materialization on a cube writes the one Druid datasource and matching
+        on job type would leave this one running.
+        """
+        namespace = "cube_mat_legacy_supersede"
+        cube_name = f"{namespace}.default.repairs_cube"
+        legacy_name = (
+            f"druid_measures_cube__incremental_time__"
+            f"{namespace}.default.hard_hat.hire_date"
+        )
+        nodes = [
+            *upstreams,
+            self._cube(),
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+
+        response = await client.post(
+            f"/nodes/{cube_name}/materialization/",
+            json={
+                "job": "druid_measures_cube",
+                "strategy": "incremental_time",
+                "schedule": "@daily",
+                "config": {"spark": {}, "lookback_window": "1 DAY"},
+            },
+        )
+        assert response.status_code == 200, response.json()
+
+        mock_qs.reset_mock()
+        nodes[-1] = self._cube(
+            materialization=MaterializationSpec(
+                schedule="0 6 * * *",
+                lookback_window="1 DAY",
+            ),
+        )
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "create",
+                "success",
+                "cube materialization on schedule 0 6 * * *",
+            ),
+        ]
+        assert [call[0] for call in mock_qs.method_calls] == [
+            "deactivate_cube_workflow",
+            "materialize_cube",
+        ]
+        assert mock_qs.deactivate_cube_workflow.call_args_list == [
+            mock.call(cube_name, version="v1.0", request_headers=mock.ANY),
+        ]
+        assert await self._persisted_materializations(client, cube_name) == [
+            (legacy_name, "@daily", "incremental_time", False),
+            (
+                self._materialization_name(namespace),
+                "0 6 * * *",
+                "incremental_time",
+                True,
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_absent_key_leaves_a_pair_alone(
+        self,
+        client,
+        upstreams,
+        mock_qs,
+    ):
+        """
+        Omitting the key still means "not managed here" for a cube with more than one
+        materialization, so both keep running and the deploy warns once.
+
+        Worth pinning beside the pair the sentinel tears down: the two spellings are
+        the only thing between adopting a cube into YAML and stopping every workflow
+        it has.
+        """
+        namespace = "cube_mat_pair_undeclared"
+        cube_name = f"{namespace}.default.repairs_cube"
+        full_name = f"druid_cube__full__{namespace}.default.hard_hat.hire_date"
+        nodes = [
+            *upstreams,
+            self._cube(
+                materialization=[
+                    MaterializationSpec(
+                        schedule="59 23 * * *",
+                        lookback_window="1 DAY",
+                    ),
+                    MaterializationSpec(
+                        schedule="0 6 * * *",
+                        strategy=MaterializationStrategy.FULL,
+                    ),
+                ],
+            ),
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+
+        mock_qs.reset_mock()
+        nodes[-1] = self._cube()
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        warning = self._undeclared_warning(cube_name)
+        assert self._materialization_results(data) == [
+            (cube_name, "noop", "warning", warning),
+        ]
+        assert [item["message"] for item in data["warnings"]] == [warning]
+        assert mock_qs.method_calls == []
+        assert await self._persisted_materializations(client, cube_name) == [
+            (
+                self._materialization_name(namespace),
+                "59 23 * * *",
+                "incremental_time",
+                True,
+            ),
+            (full_name, "0 6 * * *", "full", True),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_one_strategy_exports_once(
+        self,
+        session,
+        client,
+        upstreams,
+        mock_qs,
+    ):
+        """
+        A cube carrying two rows of one strategy exports a block naming it once.
+
+        Two rows of a strategy differ only by their partition suffix, so a block
+        cannot describe both -- and strategy is what tells declared blocks apart, so
+        naming it twice is YAML the parser rejects. Only the first by name is
+        exported, which keeps `dj pull` on such a cube writing a file that pushes.
+        """
+        namespace = "cube_mat_dup_strategy"
+        cube_name = f"{namespace}.default.repairs_cube"
+        nodes = [
+            *upstreams,
+            self._cube(
+                materialization=MaterializationSpec(
+                    schedule="0 6 * * *",
+                    lookback_window="1 DAY",
+                ),
+            ),
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+
+        # A second row of the same strategy, on another partition.
+        cube = await Node.get_by_name(session, cube_name)
+        session.add(
+            Materialization(
+                node_revision_id=cube.current.id,
+                name="druid_cube__incremental_time__zzz.other_partition",
+                strategy=MaterializationStrategy.INCREMENTAL_TIME,
+                schedule="@daily",
+                config={"lookback_window": "3 DAY"},
+                job="DruidCubeMaterializationJob",
+            ),
+        )
+        await session.commit()
+
+        session.expire_all()
+        deployed = await Node.get_by_name(
+            session,
+            cube_name,
+            options=Node.cube_load_options(),
+        )
+        assert (await deployed.to_spec(session)).materialization == (
+            MaterializationSpec(
+                schedule="0 6 * * *",
+                strategy=MaterializationStrategy.INCREMENTAL_TIME,
+                lookback_window="1 DAY",
+            )
+        )
+
 
 @pytest.mark.xdist_group(name="deployments")
 class TestDeploymentHistoryTracking:

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -6632,6 +6632,308 @@ class TestDeclaredCubeMaterializations:
         assert scheduled.cube.name == working_name
         assert await self._persisted_materializations(client, broken_name) == []
 
+    @pytest.mark.asyncio
+    async def test_two_declared_materializations_are_both_deployed(
+        self,
+        client,
+        session,
+        upstreams,
+        mock_qs,
+    ):
+        """
+        A cube declaring an incremental build beside a periodic full rebuild gets
+        both, and neither supersedes the other.
+
+        This is what production already runs on cubes materialized outside YAML: the
+        incremental one keeps the datasource fresh, and the full one periodically
+        rewrites it to pick up late-arriving data, out-of-order events and dimension
+        backfills.
+        """
+        namespace = "cube_mat_two_declared"
+        cube_name = f"{namespace}.default.repairs_cube"
+        full_name = f"druid_cube__full__{namespace}.default.hard_hat.hire_date"
+        nodes = [
+            *upstreams,
+            self._cube(
+                materialization=[
+                    MaterializationSpec(
+                        schedule="59 23 * * *",
+                        lookback_window="1 DAY",
+                    ),
+                    MaterializationSpec(
+                        schedule="0 6 * * *",
+                        strategy=MaterializationStrategy.FULL,
+                    ),
+                ],
+            ),
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "create",
+                "success",
+                "cube materialization on schedule 59 23 * * *",
+            ),
+            (
+                cube_name,
+                "create",
+                "success",
+                "cube materialization on schedule 0 6 * * *",
+            ),
+        ]
+        assert mock_qs.materialize_cube.call_count == 2
+        assert mock_qs.deactivate_cube_workflow.call_args_list == []
+        assert await self._persisted_materializations(client, cube_name) == [
+            (
+                self._materialization_name(namespace),
+                "59 23 * * *",
+                "incremental_time",
+                True,
+            ),
+            (full_name, "0 6 * * *", "full", True),
+        ]
+
+        # Both round-trip back out, so a cube pulled and pushed keeps both.
+        session.expire_all()
+        deployed = await Node.get_by_name(
+            session,
+            cube_name,
+            options=Node.cube_load_options(),
+        )
+        assert (await deployed.to_spec(session)).materialization == [
+            MaterializationSpec(
+                schedule="0 6 * * *",
+                strategy=MaterializationStrategy.FULL,
+                lookback_window=None,
+            ),
+            MaterializationSpec(
+                schedule="59 23 * * *",
+                strategy=MaterializationStrategy.INCREMENTAL_TIME,
+                lookback_window="1 DAY",
+            ),
+        ]
+
+        # And re-pushing the pair unchanged churns neither live workflow.
+        mock_qs.reset_mock()
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "noop",
+                "success",
+                "cube materialization on schedule 59 23 * * *",
+            ),
+            (
+                cube_name,
+                "noop",
+                "success",
+                "cube materialization on schedule 0 6 * * *",
+            ),
+        ]
+        assert mock_qs.method_calls == []
+
+    @pytest.mark.asyncio
+    async def test_adding_a_full_rebuild_leaves_the_incremental_alone(
+        self,
+        client,
+        upstreams,
+        mock_qs,
+    ):
+        """
+        Growing a scalar declaration into a pair adds the second materialization
+        without touching the first: the incremental build is unchanged, so its
+        workflow is neither stopped nor rescheduled.
+        """
+        namespace = "cube_mat_grown"
+        cube_name = f"{namespace}.default.repairs_cube"
+        full_name = f"druid_cube__full__{namespace}.default.hard_hat.hire_date"
+        incremental = MaterializationSpec(
+            schedule="59 23 * * *",
+            lookback_window="1 DAY",
+        )
+        nodes = [*upstreams, self._cube(materialization=incremental)]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert mock_qs.materialize_cube.call_count == 1
+
+        mock_qs.reset_mock()
+        nodes[-1] = self._cube(
+            materialization=[
+                incremental,
+                MaterializationSpec(
+                    schedule="0 6 * * *",
+                    strategy=MaterializationStrategy.FULL,
+                ),
+            ],
+        )
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "update",
+                "success",
+                "cube materialization on schedule 59 23 * * *",
+            ),
+            (
+                cube_name,
+                "update",
+                "success",
+                "cube materialization on schedule 0 6 * * *",
+            ),
+        ]
+        # Only the new one is scheduled, and nothing is stopped.
+        assert [call[0] for call in mock_qs.method_calls] == ["materialize_cube"]
+        scheduled = mock_qs.materialize_cube.call_args.kwargs["materialization_input"]
+        assert scheduled.strategy == MaterializationStrategy.FULL
+        assert await self._persisted_materializations(client, cube_name) == [
+            (
+                self._materialization_name(namespace),
+                "59 23 * * *",
+                "incremental_time",
+                True,
+            ),
+            (full_name, "0 6 * * *", "full", True),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_definition_edit_rebuilds_every_declared_materialization(
+        self,
+        client,
+        upstreams,
+        default_num_repair_orders,
+        mock_qs,
+    ):
+        """
+        A cube edit swaps its materializations onto the new revision, and a cube that
+        declares two must come out of that with two -- rebuilt under the strategy
+        each was declared with rather than collapsed onto whichever block came first.
+        """
+        namespace = "cube_mat_two_rebuilt"
+        cube_name = f"{namespace}.default.repairs_cube"
+        full_name = f"druid_cube__full__{namespace}.default.hard_hat.hire_date"
+        blocks = [
+            MaterializationSpec(schedule="59 23 * * *", lookback_window="1 DAY"),
+            MaterializationSpec(
+                schedule="0 6 * * *",
+                strategy=MaterializationStrategy.FULL,
+            ),
+        ]
+        nodes = [
+            *upstreams,
+            default_num_repair_orders,
+            self._cube(materialization=blocks),
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+
+        mock_qs.reset_mock()
+        nodes[-1] = self._cube(
+            metrics=[
+                "${prefix}default.avg_length_of_employment",
+                "${prefix}default.num_repair_orders",
+            ],
+            materialization=blocks,
+        )
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert mock_qs.deactivate_cube_workflow.call_args_list == [
+            mock.call(cube_name, version="v1.0", request_headers=mock.ANY),
+        ]
+        assert await self._persisted_materializations(client, cube_name) == [
+            (
+                self._materialization_name(namespace),
+                "59 23 * * *",
+                "incremental_time",
+                True,
+            ),
+            (full_name, "0 6 * * *", "full", True),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_explicit_none_removes_every_declared_materialization(
+        self,
+        client,
+        upstreams,
+        mock_qs,
+    ):
+        """
+        The teardown sentinel still means the whole cube, not one of its
+        materializations: a cube that declared two comes down entirely.
+        """
+        namespace = "cube_mat_two_removed"
+        cube_name = f"{namespace}.default.repairs_cube"
+        full_name = f"druid_cube__full__{namespace}.default.hard_hat.hire_date"
+        nodes = [
+            *upstreams,
+            self._cube(
+                materialization=[
+                    MaterializationSpec(
+                        schedule="59 23 * * *",
+                        lookback_window="1 DAY",
+                    ),
+                    MaterializationSpec(
+                        schedule="0 6 * * *",
+                        strategy=MaterializationStrategy.FULL,
+                    ),
+                ],
+            ),
+        ]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+
+        mock_qs.reset_mock()
+        nodes[-1] = self._cube(materialization=MaterializationAction.NONE)
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert self._materialization_results(data) == [
+            (
+                cube_name,
+                "delete",
+                "success",
+                "cube materialization removed by `materialization: none`",
+            ),
+        ]
+        assert mock_qs.deactivate_cube_workflow.call_args_list == [
+            mock.call(cube_name, version="v1.0", request_headers=mock.ANY),
+        ]
+        assert await self._persisted_materializations(client, cube_name) == [
+            (
+                self._materialization_name(namespace),
+                "59 23 * * *",
+                "incremental_time",
+                False,
+            ),
+            (full_name, "0 6 * * *", "full", False),
+        ]
+
 
 @pytest.mark.xdist_group(name="deployments")
 class TestDeploymentHistoryTracking:

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -1379,3 +1379,186 @@ def test_cube_spec_teardown_needs_no_temporal_partition():
         materialization=MaterializationAction.NONE,
     )
     assert spec.materialization == MaterializationAction.NONE
+
+
+def _cube_declaring(materialization) -> CubeSpec:
+    """The same partitioned cube, declaring whatever is handed to it."""
+    return CubeSpec(
+        namespace="test",
+        name="my_cube",
+        metrics=["${prefix}num_orders"],
+        dimensions=["${prefix}date_dim.dateint"],
+        columns=[
+            ColumnSpec(
+                name="${prefix}date_dim.dateint",
+                partition=PartitionSpec(
+                    type=PartitionType.TEMPORAL,
+                    granularity=Granularity.DAY,
+                    format="yyyyMMdd",
+                ),
+            ),
+        ],
+        materialization=materialization,
+    )
+
+
+def test_cube_spec_accepts_several_materializations():
+    """
+    A cube legitimately needs two: an incremental build for freshness and a periodic
+    full rebuild that corrects late-arriving data and dimension backfills.
+    """
+    spec = _cube_declaring(
+        [
+            MaterializationSpec(schedule="59 23 * * *", lookback_window="1 DAY"),
+            MaterializationSpec(
+                schedule="0 6 * * *",
+                strategy=MaterializationStrategy.FULL,
+            ),
+        ],
+    )
+    assert spec.declared_materializations == [
+        MaterializationSpec(schedule="59 23 * * *", lookback_window="1 DAY"),
+        MaterializationSpec(
+            schedule="0 6 * * *",
+            strategy=MaterializationStrategy.FULL,
+            lookback_window=None,
+        ),
+    ]
+
+
+def test_cube_spec_scalar_materialization_reads_as_one_block():
+    """
+    The scalar form is not a legacy shape to be migrated: it stays exactly what it
+    was, and only the reading of it is common with the list form.
+    """
+    spec = _partitioned_cube(schedule="0 6 * * *")
+    assert spec.materialization == MaterializationSpec(schedule="0 6 * * *")
+    assert spec.declared_materializations == [
+        MaterializationSpec(schedule="0 6 * * *"),
+    ]
+
+
+def test_cube_spec_declares_nothing_without_a_block():
+    """Neither an absent block nor the teardown sentinel declares anything to build."""
+    assert _partitioned_cube().declared_materializations == []
+    assert _cube_declaring(MaterializationAction.NONE).declared_materializations == []
+
+
+def test_cube_spec_rejects_repeated_materialization_strategy():
+    """
+    Strategy is what matches a declared entry to the materialization it owns, so two
+    entries sharing one leave no way to say which is which.
+    """
+    with pytest.raises(DJInvalidDeploymentConfig) as exc_info:
+        _cube_declaring(
+            [
+                MaterializationSpec(schedule="59 23 * * *"),
+                MaterializationSpec(schedule="0 6 * * *"),
+            ],
+        )
+    assert exc_info.value.message == (
+        "Cube `my_cube` declares more than one `incremental_time` materialization. "
+        "Strategies identify a cube's materializations, so each one may appear at "
+        "most once."
+    )
+
+
+def test_cube_spec_rejects_empty_materialization_list():
+    """An empty list cannot be told from the teardown sentinel, so it is refused."""
+    with pytest.raises(DJInvalidDeploymentConfig) as exc_info:
+        _cube_declaring([])
+    assert exc_info.value.message == (
+        "Cube `my_cube` declares an empty `materialization:` list. Use "
+        "`materialization: none` to remove the cube's materialization, or omit the "
+        "key to leave it alone."
+    )
+
+
+def test_cube_spec_incremental_entry_in_a_list_still_needs_a_partition():
+    """The partition requirement is per entry, not per cube."""
+    with pytest.raises(DJInvalidDeploymentConfig) as exc_info:
+        CubeSpec(
+            namespace="test",
+            name="my_cube",
+            metrics=["${prefix}num_orders"],
+            dimensions=["${prefix}date_dim.dateint"],
+            materialization=[
+                MaterializationSpec(
+                    schedule="0 6 * * *",
+                    strategy=MaterializationStrategy.FULL,
+                ),
+                MaterializationSpec(schedule="59 23 * * *"),
+            ],
+        )
+    assert exc_info.value.message == (
+        "Cube `my_cube` declares an `incremental_time` materialization but no "
+        "temporal partition. Add `partition: {type: temporal, ...}` to the cube "
+        "column that partitions it, or use `strategy: full`."
+    )
+
+
+def test_cube_spec_materialization_shapes_survive_serialization():
+    """
+    Every shape a cube can declare has to mean the same thing after a round trip, or
+    a spec pulled from the server and pushed back would change what the cube does.
+    """
+    blocks = [
+        MaterializationSpec(schedule="59 23 * * *", lookback_window="1 DAY"),
+        MaterializationSpec(
+            schedule="0 6 * * *",
+            strategy=MaterializationStrategy.FULL,
+            lookback_window=None,
+        ),
+    ]
+    for declared in (
+        blocks,
+        blocks[0],
+        MaterializationAction.NONE,
+        None,
+    ):
+        spec = _cube_declaring(declared)
+        assert CubeSpec.model_validate(spec.model_dump()).materialization == declared
+        assert spec.rendered_spec().materialization == declared
+
+
+def test_cube_spec_eq_ignores_a_list_of_materializations():
+    """
+    Whichever shape the block is written in, it is not part of the cube's definition
+    and must not mint a revision. The diff still names it, at tier NONE.
+    """
+    one = _cube_declaring(
+        [
+            MaterializationSpec(schedule="59 23 * * *"),
+            MaterializationSpec(
+                schedule="0 6 * * *",
+                strategy=MaterializationStrategy.FULL,
+            ),
+        ],
+    )
+    two = _cube_declaring(MaterializationSpec(schedule="59 23 * * *"))
+    assert one == two
+    assert one.rendered_spec().diff(two) == ["materialization"]
+    assert CubeSpec.change_tier(one.rendered_spec().diff(two)) == ChangeTier.NONE
+
+
+def test_cube_spec_materialization_diff_ignores_declaration_order():
+    """
+    A cube pulled from the server lists its materializations in name order, and an
+    author is free to write them the other way round. Reading that as a change would
+    report an edit on every deploy of an untouched cube.
+    """
+    blocks = [
+        MaterializationSpec(schedule="59 23 * * *", coverage={"window": "800 DAYS"}),
+        MaterializationSpec(
+            schedule="0 6 * * *",
+            strategy=MaterializationStrategy.FULL,
+        ),
+    ]
+    assert (
+        _cube_declaring(blocks)
+        .rendered_spec()
+        .diff(
+            _cube_declaring(list(reversed(blocks))),
+        )
+        == []
+    )


### PR DESCRIPTION
### Summary

A cube often needs two materializations rather than one: an `incremental_time` build for freshness, alongside a periodic `full` rebuild that corrects late-arriving data, out-of-order events and dimension backfills. A cube with ten years of history and a slowly-changing dimension can't stay correct on incremental loads alone.

With this PR, the `materialization:` block now accepts a list as well as a single definition:
```yaml
materialization:
  - schedule: 0 9 * * *
    strategy: incremental_time
    lookback_window: 1 DAY
  - schedule: 0 3 * * 0
    strategy: full
```

Note that `strategy` is what tells two entries apart.

The declared blocks describe the materializations for their cube, so any active row with no matching YAML block is deactivated. That's a change from the single-block form, where an absent key meant "leave whatever exists alone": a materialization created through the UI or API is now superseded by a deploy that declares one. Omitting the key entirely still leaves everything alone, and none still tears everything down.

Everything downstream reconciles per entry, including declared coverage, so the full rebuild and the incremental load can maintain different spans.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
