### PR TITLE
Schematized custom metadata APIs

### DIFF
--- a/datajunction-server/datajunction_server/api/custom_metadata.py
+++ b/datajunction-server/datajunction_server/api/custom_metadata.py
@@ -1,0 +1,205 @@
+"""REST API for the custom_metadata schema registry."""
+
+import datetime
+
+import jsonschema
+from fastapi import Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.database.node import Node, NodeRevision
+from datajunction_server.database.custom_metadata_schema import CustomMetadataSchema
+from datajunction_server.internal.access.authentication.http import SecureAPIRouter
+from datajunction_server.internal.custom_metadata import ensure_expression_index
+from datajunction_server.models.custom_metadata import (
+    CustomMetadataSchemaCreate,
+    CustomMetadataSchemaOutput,
+    ViolationReport,
+    ViolationSample,
+)
+from datajunction_server.utils import get_session
+
+router = SecureAPIRouter(tags=["custom-metadata"])
+
+
+def _value_kind(json_schema: dict) -> str | None:
+    """Extract a single-string type from a JSON Schema, or None."""
+    t = json_schema.get("type")
+    return t if isinstance(t, str) else None
+
+
+@router.post("/custom-metadata/schemas/", response_model=CustomMetadataSchemaOutput)
+async def register_schema(
+    data: CustomMetadataSchemaCreate,
+    *,
+    session: AsyncSession = Depends(get_session),
+) -> CustomMetadataSchema:
+    """Create or upsert a custom_metadata schema registration."""
+    # Validate that json_schema is itself a valid JSON Schema
+    try:
+        jsonschema.Draft202012Validator.check_schema(data.json_schema)
+    except jsonschema.exceptions.SchemaError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid JSON Schema: {exc.message}",
+        )
+
+    node_type_val = data.node_type.value if data.node_type else None
+
+    # Upsert on (key, node_type, namespace) — use select-then-update to handle NULLs
+    node_type_clause = (
+        CustomMetadataSchema.node_type.is_(None)
+        if node_type_val is None
+        else CustomMetadataSchema.node_type == node_type_val
+    )
+    namespace_clause = (
+        CustomMetadataSchema.namespace.is_(None)
+        if data.namespace is None
+        else CustomMetadataSchema.namespace == data.namespace
+    )
+    existing = (
+        await session.execute(
+            select(CustomMetadataSchema).where(
+                CustomMetadataSchema.key == data.key,
+                node_type_clause,
+                namespace_clause,
+                CustomMetadataSchema.deactivated_at.is_(None),
+            ),
+        )
+    ).scalar_one_or_none()
+
+    if existing:
+        existing.json_schema = data.json_schema
+        existing.value_kind = _value_kind(data.json_schema)
+        existing.filterable = data.filterable
+        existing.description = data.description
+        row = existing
+    else:
+        row = CustomMetadataSchema(
+            key=data.key,
+            node_type=node_type_val,
+            namespace=data.namespace,
+            json_schema=data.json_schema,
+            value_kind=_value_kind(data.json_schema),
+            filterable=data.filterable,
+            description=data.description,
+        )
+        session.add(row)
+    await session.commit()
+    if row.filterable:
+        await ensure_expression_index(session, row.key, row.value_kind)
+        await session.commit()
+    await session.refresh(row)
+    return row
+
+
+@router.get(
+    "/custom-metadata/schemas/",
+    response_model=list[CustomMetadataSchemaOutput],
+)
+async def list_schemas(
+    namespace: str | None = None,
+    node_type: str | None = None,
+    *,
+    session: AsyncSession = Depends(get_session),
+) -> list[CustomMetadataSchema]:
+    """List active schema registrations, optionally filtered by namespace and node_type."""
+    stmt = select(CustomMetadataSchema).where(
+        CustomMetadataSchema.deactivated_at.is_(None),
+    )
+    if namespace is not None:
+        stmt = stmt.where(CustomMetadataSchema.namespace == namespace)
+    if node_type is not None:
+        stmt = stmt.where(CustomMetadataSchema.node_type == node_type)
+    return list((await session.execute(stmt)).scalars().all())
+
+
+@router.delete("/custom-metadata/schemas/{schema_id}", status_code=200)
+async def delete_schema(
+    schema_id: int,
+    *,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Soft-delete a schema registration by setting deactivated_at."""
+    row = (
+        await session.execute(
+            select(CustomMetadataSchema).where(
+                CustomMetadataSchema.id == schema_id,
+                CustomMetadataSchema.deactivated_at.is_(None),
+            ),
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Schema {schema_id} not found or already deleted",
+        )
+    row.deactivated_at = datetime.datetime.now(datetime.timezone.utc)
+    await session.commit()
+    return {"id": schema_id, "deactivated": True}
+
+
+@router.get("/custom-metadata/facets/", response_model=list[CustomMetadataSchemaOutput])
+async def list_facets(
+    *,
+    session: AsyncSession = Depends(get_session),
+) -> list[CustomMetadataSchema]:
+    """Return the curated filterable catalog (schemas with filterable=True)."""
+    stmt = select(CustomMetadataSchema).where(
+        CustomMetadataSchema.deactivated_at.is_(None),
+        CustomMetadataSchema.filterable.is_(True),
+    )
+    return list((await session.execute(stmt)).scalars().all())
+
+
+@router.get("/custom-metadata/violations/", response_model=ViolationReport)
+async def list_violations(
+    schema_id: int,
+    *,
+    session: AsyncSession = Depends(get_session),
+) -> ViolationReport:
+    """
+    Advisory read-only report: find current-revision nodes whose custom_metadata
+    violates the registered schema identified by schema_id.
+
+    Never mutates. Returns a count and a sample of violating nodes.
+    """
+    schema_row = (
+        await session.execute(
+            select(CustomMetadataSchema).where(
+                CustomMetadataSchema.id == schema_id,
+            ),
+        )
+    ).scalar_one_or_none()
+    if schema_row is None:
+        raise HTTPException(status_code=404, detail=f"Schema {schema_id} not found")
+
+    # Fetch all current-revision node revisions that have custom_metadata set
+    stmt = (
+        select(NodeRevision)
+        .join(Node, Node.id == NodeRevision.node_id)
+        .where(
+            Node.current_version == NodeRevision.version,
+            Node.deactivated_at.is_(None),
+            NodeRevision.custom_metadata.isnot(None),
+        )
+    )
+    revisions = (await session.execute(stmt)).scalars().all()
+
+    validator = jsonschema.Draft202012Validator(schema_row.json_schema)
+    key = schema_row.key
+    samples: list[ViolationSample] = []
+
+    for rev in revisions:
+        cm = rev.custom_metadata or {}
+        if key not in cm:
+            continue
+        errors = [err.message for err in validator.iter_errors(cm[key])]
+        if errors:
+            samples.append(ViolationSample(node_name=rev.name, errors=errors))
+
+    return ViolationReport(
+        schema_id=schema_id,
+        violation_count=len(samples),
+        samples=samples[:20],  # cap sample size
+    )

--- a/datajunction-server/datajunction_server/api/custom_metadata.py
+++ b/datajunction-server/datajunction_server/api/custom_metadata.py
@@ -198,7 +198,7 @@ async def delete_schema(
     else:
         access_checker.add_namespace(row.namespace, ResourceAction.WRITE)
         await access_checker.check(on_denied=AccessDenialMode.RAISE)
-    row.deactivated_at = datetime.datetime.now(datetime.timezone.utc)
+    row.deactivated_at = datetime.datetime.now(datetime.UTC)
     await session.commit()
     return {"id": schema_id, "deactivated": True}
 

--- a/datajunction-server/datajunction_server/api/custom_metadata.py
+++ b/datajunction-server/datajunction_server/api/custom_metadata.py
@@ -17,7 +17,15 @@ from datajunction_server.models.custom_metadata import (
     ViolationReport,
     ViolationSample,
 )
-from datajunction_server.utils import get_session
+from datajunction_server.database.user import User
+from datajunction_server.errors import DJAuthorizationException
+from datajunction_server.internal.access.authorization import (
+    AccessChecker,
+    AccessDenialMode,
+    get_access_checker,
+)
+from datajunction_server.models.access import ResourceAction
+from datajunction_server.utils import get_current_user, get_session
 
 router = SecureAPIRouter(tags=["custom-metadata"])
 
@@ -33,6 +41,8 @@ async def register_schema(
     data: CustomMetadataSchemaCreate,
     *,
     session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+    access_checker: AccessChecker = Depends(get_access_checker),
 ) -> CustomMetadataSchema:
     """Create or upsert a custom_metadata schema registration."""
     # Validate that json_schema is itself a valid JSON Schema
@@ -43,6 +53,42 @@ async def register_schema(
             status_code=422,
             detail=f"Invalid JSON Schema: {exc.message}",
         )
+
+    # --- Two-tier authorization ---
+    # 1. Global key (namespace is None) → require admin
+    if data.namespace is None and not current_user.is_admin:
+        raise DJAuthorizationException(
+            message="Only administrators may register global schema keys.",
+        )
+
+    # 2. reserved=True → require admin
+    if data.reserved and not current_user.is_admin:
+        raise DJAuthorizationException(
+            message="Only administrators may register reserved schema keys.",
+        )
+
+    # 3. Namespace-scoped → require write access to the namespace
+    if data.namespace is not None:
+        access_checker.add_namespace(data.namespace, ResourceAction.WRITE)
+        await access_checker.check(on_denied=AccessDenialMode.RAISE)
+
+    # 4. Check if a reserved global row exists for this key
+    if data.namespace is not None:
+        reserved_global = (
+            await session.execute(
+                select(CustomMetadataSchema).where(
+                    CustomMetadataSchema.key == data.key,
+                    CustomMetadataSchema.namespace.is_(None),
+                    CustomMetadataSchema.reserved.is_(True),
+                    CustomMetadataSchema.deactivated_at.is_(None),
+                ),
+            )
+        ).scalar_one_or_none()
+        if reserved_global is not None:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Key '{data.key}' is reserved globally and cannot be registered at namespace scope.",
+            )
 
     node_type_val = data.node_type.value if data.node_type else None
 
@@ -73,6 +119,9 @@ async def register_schema(
         existing.value_kind = _value_kind(data.json_schema)
         existing.filterable = data.filterable
         existing.description = data.description
+        existing.owner = data.owner
+        existing.reserved = data.reserved
+        existing.updated_by_id = current_user.id
         row = existing
     else:
         row = CustomMetadataSchema(
@@ -83,6 +132,10 @@ async def register_schema(
             value_kind=_value_kind(data.json_schema),
             filterable=data.filterable,
             description=data.description,
+            owner=data.owner,
+            reserved=data.reserved,
+            created_by_id=current_user.id,
+            updated_by_id=current_user.id,
         )
         session.add(row)
     await session.commit()
@@ -119,6 +172,8 @@ async def delete_schema(
     schema_id: int,
     *,
     session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+    access_checker: AccessChecker = Depends(get_access_checker),
 ) -> dict:
     """Soft-delete a schema registration by setting deactivated_at."""
     row = (
@@ -134,6 +189,15 @@ async def delete_schema(
             status_code=404,
             detail=f"Schema {schema_id} not found or already deleted",
         )
+    # Authorization
+    if row.namespace is None:
+        if not current_user.is_admin:
+            raise DJAuthorizationException(
+                message="Only administrators may delete global schema keys.",
+            )
+    else:
+        access_checker.add_namespace(row.namespace, ResourceAction.WRITE)
+        await access_checker.check(on_denied=AccessDenialMode.RAISE)
     row.deactivated_at = datetime.datetime.now(datetime.timezone.utc)
     await session.commit()
     return {"id": schema_id, "deactivated": True}

--- a/datajunction-server/datajunction_server/api/custom_metadata.py
+++ b/datajunction-server/datajunction_server/api/custom_metadata.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.custom_metadata_schema import CustomMetadataSchema
+from datajunction_server.api.helpers import check_namespace_not_git_only
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.custom_metadata import ensure_expression_index
 from datajunction_server.models.custom_metadata import (
@@ -71,6 +72,17 @@ async def register_schema(
     if data.namespace is not None:
         access_checker.add_namespace(data.namespace, ResourceAction.WRITE)
         await access_checker.check(on_denied=AccessDenialMode.RAISE)
+        # A repo-managed namespace has one writer, and it is not this endpoint.
+        # Registering here would also be undone: a deployment reconciles the
+        # namespace to exactly what its manifest declares.
+        await check_namespace_not_git_only(
+            session,
+            data.namespace,
+            remedy=(
+                "Declare it under `custom_metadata_schemas:` in the repo for this "
+                "namespace and deploy it."
+            ),
+        )
 
     # 4. Check if a reserved global row exists for this key
     if data.namespace is not None:
@@ -198,6 +210,15 @@ async def delete_schema(
     else:
         access_checker.add_namespace(row.namespace, ResourceAction.WRITE)
         await access_checker.check(on_denied=AccessDenialMode.RAISE)
+        # Same reasoning as registering: a deployment would put it straight back.
+        await check_namespace_not_git_only(
+            session,
+            row.namespace,
+            remedy=(
+                "Remove it from `custom_metadata_schemas:` in the repo for this "
+                "namespace and deploy it."
+            ),
+        )
     row.deactivated_at = datetime.datetime.now(datetime.UTC)
     await session.commit()
     return {"id": schema_id, "deactivated": True}

--- a/datajunction-server/datajunction_server/api/custom_metadata.py
+++ b/datajunction-server/datajunction_server/api/custom_metadata.py
@@ -28,7 +28,7 @@ from datajunction_server.internal.access.authorization import (
 from datajunction_server.models.access import ResourceAction
 from datajunction_server.utils import get_current_user, get_session
 
-router = SecureAPIRouter(tags=["custom-metadata"])
+router = SecureAPIRouter(tags=["metadata-schemas"])
 
 
 def _value_kind(json_schema: dict) -> str | None:
@@ -37,7 +37,7 @@ def _value_kind(json_schema: dict) -> str | None:
     return t if isinstance(t, str) else None
 
 
-@router.post("/custom-metadata/schemas/", response_model=CustomMetadataSchemaOutput)
+@router.post("/metadata-schemas/", response_model=CustomMetadataSchemaOutput)
 async def register_schema(
     data: CustomMetadataSchemaCreate,
     *,
@@ -159,19 +159,28 @@ async def register_schema(
 
 
 @router.get(
-    "/custom-metadata/schemas/",
+    "/metadata-schemas/",
     response_model=list[CustomMetadataSchemaOutput],
 )
 async def list_schemas(
+    key: str | None = None,
     namespace: str | None = None,
     node_type: str | None = None,
     *,
     session: AsyncSession = Depends(get_session),
 ) -> list[CustomMetadataSchema]:
-    """List active schema registrations, optionally filtered by namespace and node_type."""
+    """List active registrations, optionally filtered by key, namespace and node_type.
+
+    The filters match the stored scope exactly. They answer "what is registered
+    here", not "what governs a node here" -- a schema on `shared` applies to
+    `shared.finance` without being registered at it. Resolution answers the
+    second question, and exposing it as a filter can follow if callers need it.
+    """
     stmt = select(CustomMetadataSchema).where(
         CustomMetadataSchema.deactivated_at.is_(None),
     )
+    if key is not None:
+        stmt = stmt.where(CustomMetadataSchema.key == key)
     if namespace is not None:
         stmt = stmt.where(CustomMetadataSchema.namespace == namespace)
     if node_type is not None:
@@ -179,7 +188,33 @@ async def list_schemas(
     return list((await session.execute(stmt)).scalars().all())
 
 
-@router.delete("/custom-metadata/schemas/{schema_id}", status_code=200)
+@router.get(
+    "/metadata-schemas/{schema_id}",
+    response_model=CustomMetadataSchemaOutput,
+)
+async def get_schema(
+    schema_id: int,
+    *,
+    session: AsyncSession = Depends(get_session),
+) -> CustomMetadataSchema:
+    """Fetch one registration by id."""
+    row = (
+        await session.execute(
+            select(CustomMetadataSchema).where(
+                CustomMetadataSchema.id == schema_id,
+                CustomMetadataSchema.deactivated_at.is_(None),
+            ),
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Schema {schema_id} not found or deleted",
+        )
+    return row
+
+
+@router.delete("/metadata-schemas/{schema_id}", status_code=200)
 async def delete_schema(
     schema_id: int,
     *,
@@ -224,20 +259,10 @@ async def delete_schema(
     return {"id": schema_id, "deactivated": True}
 
 
-@router.get("/custom-metadata/facets/", response_model=list[CustomMetadataSchemaOutput])
-async def list_facets(
-    *,
-    session: AsyncSession = Depends(get_session),
-) -> list[CustomMetadataSchema]:
-    """Return the curated filterable catalog (schemas with filterable=True)."""
-    stmt = select(CustomMetadataSchema).where(
-        CustomMetadataSchema.deactivated_at.is_(None),
-        CustomMetadataSchema.filterable.is_(True),
-    )
-    return list((await session.execute(stmt)).scalars().all())
-
-
-@router.get("/custom-metadata/violations/", response_model=ViolationReport)
+@router.get(
+    "/metadata-schemas/{schema_id}/violations",
+    response_model=ViolationReport,
+)
 async def list_violations(
     schema_id: int,
     *,

--- a/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
@@ -356,6 +356,12 @@ async def find_nodes_paginated(
             description="Filter to dimension nodes that are not linked to by any other node",
         ),
     ] = False,
+    custom_metadata_filters: Annotated[
+        list[CustomMetadataFilterInput] | None,
+        strawberry.argument(
+            description="Filter to nodes matching ALL of these custom metadata conditions",
+        ),
+    ] = None,
     after: str | None = None,
     before: str | None = None,
     limit: Annotated[
@@ -372,6 +378,16 @@ async def find_nodes_paginated(
     """
     if not limit or limit < 0:
         limit = 100
+
+    pyd_filters = (
+        [
+            CustomMetadataFilter(key=f.key, op=f.op, value=f.value)
+            for f in custom_metadata_filters
+        ]
+        if custom_metadata_filters
+        else None
+    )
+
     nodes_list = await find_nodes_by(
         info=info,
         names=names,
@@ -395,6 +411,7 @@ async def find_nodes_paginated(
         has_materialization=has_materialization,
         orphaned_dimension=orphaned_dimension,
         search=search,
+        custom_metadata_filters=pyd_filters,
     )
 
     # Run a separate count query only when the client asked for totalCount
@@ -418,6 +435,7 @@ async def find_nodes_paginated(
             has_materialization=has_materialization,
             orphaned_dimension=orphaned_dimension,
             search=search,
+            custom_metadata_filters=pyd_filters,
         )
 
     return Connection.from_list(

--- a/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/queries/nodes.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Annotated
 
 import strawberry
+from strawberry.scalars import JSON
 from strawberry.types import Info
 
 from datajunction_server.api.graphql.resolvers.nodes import (
@@ -23,7 +24,23 @@ from datajunction_server.api.graphql.scalars.node import (
 )
 from datajunction_server.api.graphql.utils import extract_fields
 from datajunction_server.database.node import Node as DBNode
+from datajunction_server.models.custom_metadata import (
+    CustomMetadataFilter,
+    CustomMetadataOp,
+)
 from datajunction_server.models.node import NodeCursor, NodeMode, NodeStatus, NodeType
+
+CustomMetadataOpGQL = strawberry.enum(CustomMetadataOp)
+
+
+@strawberry.input
+class CustomMetadataFilterInput:
+    """Input type for filtering nodes by custom metadata."""
+
+    key: str
+    op: CustomMetadataOpGQL = CustomMetadataOp.EQ  # type: ignore[valid-type]
+    value: JSON | None = None
+
 
 DEFAULT_LIMIT = 1000
 UPPER_LIMIT = 10000
@@ -171,6 +188,12 @@ async def find_nodes(
             description="Filter to dimension nodes that are not linked to by any other node",
         ),
     ] = False,
+    custom_metadata_filters: Annotated[
+        list[CustomMetadataFilterInput] | None,
+        strawberry.argument(
+            description="Filter to nodes matching ALL of these custom metadata conditions",
+        ),
+    ] = None,
     limit: Annotated[
         int | None,
         strawberry.argument(description="Limit nodes"),
@@ -195,6 +218,15 @@ async def find_nodes(
         )
         limit = UPPER_LIMIT
 
+    pyd_filters = (
+        [
+            CustomMetadataFilter(key=f.key, op=f.op, value=f.value)
+            for f in custom_metadata_filters
+        ]
+        if custom_metadata_filters
+        else None
+    )
+
     return await find_nodes_by(  # type: ignore
         info=info,
         names=names,
@@ -212,6 +244,7 @@ async def find_nodes(
         statuses=statuses,
         has_materialization=has_materialization,
         orphaned_dimension=orphaned_dimension,
+        custom_metadata_filters=pyd_filters,
         limit=limit,
         order_by=order_by,
         ascending=ascending,

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -332,6 +332,7 @@ async def count_nodes_by(
     has_materialization: bool = False,
     orphaned_dimension: bool = False,
     search: str | None = None,
+    custom_metadata_filters: list[CustomMetadataFilter] | None = None,
 ) -> int:
     """
     Count nodes that match the same filters as ``find_nodes_by``. Used to
@@ -365,6 +366,7 @@ async def count_nodes_by(
             has_materialization=has_materialization,
             orphaned_dimension=orphaned_dimension,
             search=search,
+            custom_metadata_filters=custom_metadata_filters,
         )
 
 

--- a/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
+++ b/datajunction-server/datajunction_server/api/graphql/resolvers/nodes.py
@@ -31,6 +31,7 @@ from datajunction_server.errors import DJNodeNotFound
 from datajunction_server.internal.access.group_membership import (
     get_group_membership_service,
 )
+from datajunction_server.models.custom_metadata import CustomMetadataFilter
 from datajunction_server.models.node import NodeMode, NodeStatus, NodeType
 
 
@@ -233,6 +234,7 @@ async def find_nodes_by(
     has_materialization: bool = False,
     orphaned_dimension: bool = False,
     search: str | None = None,
+    custom_metadata_filters: list[CustomMetadataFilter] | None = None,
 ) -> list[DBNode]:
     """
     Finds nodes based on the search parameters. This function also tries to optimize
@@ -294,6 +296,7 @@ async def find_nodes_by(
             orphaned_dimension=orphaned_dimension,
             dimensions=dimensions,
             search=search,
+            custom_metadata_filters=custom_metadata_filters,
         )
 
         # For the scalar-only cube path, fetch column data as raw tuples instead

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -605,6 +605,9 @@ type Query {
 
     """Filter to dimension nodes that are not linked to by any other node"""
     orphanedDimension: Boolean! = false
+
+    """Filter to nodes matching ALL of these custom metadata conditions"""
+    customMetadataFilters: [CustomMetadataFilterInput!] = null
     after: String = null
     before: String = null
 

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -76,6 +76,23 @@ input CubeDefinition {
   orderby: [String!] = null
 }
 
+input CustomMetadataFilterInput {
+  key: String!
+  op: CustomMetadataOp! = EQ
+  value: JSON = null
+}
+
+enum CustomMetadataOp {
+  EQ
+  NE
+  EXISTS
+  GT
+  GTE
+  LT
+  LTE
+  CONTAINS
+}
+
 type DJError {
   code: ErrorCode!
   message: String
@@ -523,6 +540,9 @@ type Query {
 
     """Filter to dimension nodes that are not linked to by any other node"""
     orphanedDimension: Boolean! = false
+
+    """Filter to nodes matching ALL of these custom metadata conditions"""
+    customMetadataFilters: [CustomMetadataFilterInput!] = null
 
     """Limit nodes"""
     limit: Int = 1000

--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -95,6 +95,8 @@ async def get_node_namespace(
 async def check_namespace_not_git_only(
     session: AsyncSession,
     namespace: str,
+    *,
+    remedy: str = "Node changes must be deployed from git via the /deployments API.",
 ) -> None:
     """
     Check that a namespace (or any of its ancestors) is not git-managed.
@@ -113,6 +115,10 @@ async def check_namespace_not_git_only(
     (children with a ``parent_namespace``) are intentionally allowed — edits
     there are valid and get synced back to the git repo, so they don't trip
     this check.
+
+    ``remedy`` is the sentence appended to the error. It defaults to the node
+    wording because that is what almost every caller is guarding; anything else
+    governed by the same flag should say where *its* change belongs instead.
 
     Implementation: namespace names contain their parent path (``a.b.c``),
     so we materialize every prefix and fire a single ``IN`` query. One round
@@ -146,8 +152,7 @@ async def check_namespace_not_git_only(
                 else f"'{namespace}' (locked via ancestor '{ns.namespace}')"
             )
             raise DJInvalidInputException(
-                message=f"Namespace {scope_msg} is git-managed. "
-                "Node changes must be deployed from git via the /deployments API.",
+                message=f"Namespace {scope_msg} is git-managed. {remedy}",
             )
 
 

--- a/datajunction-server/datajunction_server/api/main.py
+++ b/datajunction-server/datajunction_server/api/main.py
@@ -22,6 +22,7 @@ from datajunction_server.api import (
     client,
     collection,
     cubes,
+    custom_metadata,
     data,
     deployments,
     dimensions,
@@ -110,6 +111,7 @@ def configure_app(app: FastAPI) -> None:
     )
     app.include_router(catalogs.router)
     app.include_router(collection.router)
+    app.include_router(custom_metadata.router)
     app.include_router(deployments.router)
     app.include_router(engines.router)
     app.include_router(metrics.router)

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -1424,6 +1424,7 @@ class Node(Base):
         has_materialization: bool = False,
         orphaned_dimension: bool = False,
         search: str | None = None,
+        custom_metadata_filters: list[CustomMetadataFilter] | None = None,
     ) -> int:
         """
         Count nodes that match the same filters as ``find_by``, ignoring
@@ -1446,6 +1447,7 @@ class Node(Base):
             has_materialization=has_materialization,
             orphaned_dimension=orphaned_dimension,
             search=search,
+            custom_metadata_filters=custom_metadata_filters,
         )
         if statement is None:
             return 0

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -84,6 +84,8 @@ from datajunction_server.models.node import (
     NodeMode,
     NodeStatus,
 )
+from datajunction_server.internal.custom_metadata import custom_metadata_clause
+from datajunction_server.models.custom_metadata import CustomMetadataFilter
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.partition import PartitionType
 from datajunction_server.models.unit import (
@@ -1051,6 +1053,7 @@ class Node(Base):
         orphaned_dimension: bool = False,
         search: str | None = None,
         order_by: MappedColumn | None = None,
+        custom_metadata_filters: list[CustomMetadataFilter] | None = None,
     ):
         """
         Build a select statement for Node rows with all listed filters applied.
@@ -1285,6 +1288,16 @@ class Node(Base):
                 ~Node.id.in_(select(linked_dimension_subquery)),
             )
 
+        # Filter by custom_metadata predicates (JSONB column on NodeRevision)
+        if custom_metadata_filters:
+            if not join_revision:
+                statement = statement.join(NodeRevisionAlias, Node.current)
+                join_revision = True
+            for f in custom_metadata_filters:
+                statement = statement.where(
+                    custom_metadata_clause(NodeRevisionAlias.custom_metadata, f),
+                )
+
         # Always ensure only nodes with valid current revisions are returned
         # This prevents GraphQL errors when current is non-nullable
         if not join_revision:
@@ -1318,6 +1331,7 @@ class Node(Base):
         has_materialization: bool = False,
         orphaned_dimension: bool = False,
         search: str | None = None,
+        custom_metadata_filters: list[CustomMetadataFilter] | None = None,
     ) -> list[Node]:
         """
         Finds a list of nodes by prefix
@@ -1348,6 +1362,7 @@ class Node(Base):
             orphaned_dimension=orphaned_dimension,
             search=search,
             order_by=order_by,
+            custom_metadata_filters=custom_metadata_filters,
         )
         if statement is None:
             return []

--- a/datajunction-server/datajunction_server/internal/custom_metadata.py
+++ b/datajunction-server/datajunction_server/internal/custom_metadata.py
@@ -159,20 +159,46 @@ async def ensure_expression_index(
     return idx_name
 
 
+def split_metadata_path(key: str) -> list[str]:
+    """Split a filter key into a JSON path on unescaped dots.
+
+    ``system.lifecycle`` addresses the nested value; ``system\\.lifecycle``
+    addresses a top-level key that itself contains a dot.
+    """
+    parts = re.split(r"(?<!\\)\.", key)
+    return [part.replace("\\.", ".") for part in parts]
+
+
+def _nest(path: list[str], value) -> dict:
+    """Wrap *value* in nested objects so containment matches at *path*."""
+    for part in reversed(path):
+        value = {part: value}
+    return value
+
+
+def _at_path(jsonb, path: list[str]):
+    """Return the JSONB expression addressing *path*."""
+    return jsonb[path[0]] if len(path) == 1 else jsonb[tuple(path)]
+
+
 def custom_metadata_clause(col, f: CustomMetadataFilter):
     """Translate one CustomMetadataFilter into a SQLAlchemy boolean over a JSONB column."""
     jsonb = type_coerce(col, JSONB)
+    path = split_metadata_path(f.key)
     if f.op == CustomMetadataOp.EXISTS:
-        return jsonb.has_key(f.key)
+        if len(path) == 1:
+            return jsonb.has_key(path[0])
+        parent = type_coerce(_at_path(jsonb, path[:-1]), JSONB)
+        return parent.has_key(path[-1])
     if f.op == CustomMetadataOp.EQ:
-        # containment => GIN-servable
-        return jsonb.contains({f.key: f.value})
+        # containment => GIN-servable, at any depth
+        return jsonb.contains(_nest(path, f.value))
     if f.op == CustomMetadataOp.NE:
-        return ~jsonb.contains({f.key: f.value})
+        return ~jsonb.contains(_nest(path, f.value))
     if f.op == CustomMetadataOp.CONTAINS:
-        return jsonb[f.key].contains(f.value)
+        return _at_path(jsonb, path).contains(f.value)
     # range operators: extract as text and cast to numeric
-    extracted = jsonb[f.key].astext
+    extracted = _at_path(jsonb, path).astext
     num = cast(extracted, Numeric)
     return {
         CustomMetadataOp.GT: num > f.value,

--- a/datajunction-server/datajunction_server/internal/custom_metadata.py
+++ b/datajunction-server/datajunction_server/internal/custom_metadata.py
@@ -1,7 +1,9 @@
 """Resolution, validation, and filter translation for custom_metadata schemas."""
 
+import re
+
 import jsonschema
-from sqlalchemy import Numeric, cast, or_, select, type_coerce
+from sqlalchemy import Numeric, cast, or_, select, text, type_coerce
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -117,6 +119,44 @@ async def validate_custom_metadata(
         raise DJInvalidInputException(
             message="custom_metadata failed schema validation:\n" + "\n".join(errors),
         )
+
+
+_NUMERIC_KINDS = {"number", "integer"}
+
+
+async def ensure_expression_index(
+    session: AsyncSession,
+    key: str,
+    value_kind: str | None,
+) -> str | None:
+    """Build a per-key expression index on noderevision for numeric-typed keys.
+
+    For ``value_kind in {"number", "integer"}`` executes:
+
+        CREATE INDEX IF NOT EXISTS ix_cm_<safe_key>
+          ON noderevision (((custom_metadata->>'<key>')::numeric))
+
+    The index name uses only ``[a-z0-9_]`` characters (safe for interpolation).
+    The raw key is embedded as a single-quoted SQL string literal via
+    ``key.replace("'", "''")`` — the standard SQL quoting escape — so that
+    special characters cannot break out of the string literal context.
+
+    Returns the index name on success, or ``None`` when no index is built.
+    """
+    if value_kind not in _NUMERIC_KINDS:
+        return None
+    safe = re.sub(r"[^a-z0-9_]", "_", key.lower())
+    idx_name = f"ix_cm_{safe}"
+    # Embed the key as a SQL string literal (single-quote escape only; no
+    # backslash sequences needed for JSONB ->> text extraction).
+    quoted_key = key.replace("'", "''")
+    await session.execute(
+        text(
+            f"CREATE INDEX IF NOT EXISTS {idx_name} ON noderevision "
+            f"(((custom_metadata->>'{quoted_key}')::numeric))",
+        ),
+    )
+    return idx_name
 
 
 def custom_metadata_clause(col, f: CustomMetadataFilter):

--- a/datajunction-server/datajunction_server/internal/custom_metadata.py
+++ b/datajunction-server/datajunction_server/internal/custom_metadata.py
@@ -1,11 +1,16 @@
 """Resolution, validation, and filter translation for custom_metadata schemas."""
 
 import jsonschema
-from sqlalchemy import or_, select
+from sqlalchemy import Numeric, cast, or_, select, type_coerce
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.database.custom_metadata_schema import CustomMetadataSchema
 from datajunction_server.errors import DJInvalidInputException
+from datajunction_server.models.custom_metadata import (
+    CustomMetadataFilter,
+    CustomMetadataOp,
+)
 from datajunction_server.models.node_type import NodeType
 
 
@@ -112,3 +117,26 @@ async def validate_custom_metadata(
         raise DJInvalidInputException(
             message="custom_metadata failed schema validation:\n" + "\n".join(errors),
         )
+
+
+def custom_metadata_clause(col, f: CustomMetadataFilter):
+    """Translate one CustomMetadataFilter into a SQLAlchemy boolean over a JSONB column."""
+    jsonb = type_coerce(col, JSONB)
+    if f.op == CustomMetadataOp.EXISTS:
+        return jsonb.has_key(f.key)
+    if f.op == CustomMetadataOp.EQ:
+        # containment => GIN-servable
+        return jsonb.contains({f.key: f.value})
+    if f.op == CustomMetadataOp.NE:
+        return ~jsonb.contains({f.key: f.value})
+    if f.op == CustomMetadataOp.CONTAINS:
+        return jsonb[f.key].contains(f.value)
+    # range operators: extract as text and cast to numeric
+    extracted = jsonb[f.key].astext
+    num = cast(extracted, Numeric)
+    return {
+        CustomMetadataOp.GT: num > f.value,
+        CustomMetadataOp.GTE: num >= f.value,
+        CustomMetadataOp.LT: num < f.value,
+        CustomMetadataOp.LTE: num <= f.value,
+    }[f.op]

--- a/datajunction-server/datajunction_server/models/custom_metadata.py
+++ b/datajunction-server/datajunction_server/models/custom_metadata.py
@@ -5,6 +5,8 @@ from typing import Any, Optional
 
 from pydantic import BaseModel
 
+from datajunction_server.models.node_type import NodeType
+
 
 class CustomMetadataOp(str, Enum):
     EQ = "eq"
@@ -21,3 +23,37 @@ class CustomMetadataFilter(BaseModel):
     key: str
     op: CustomMetadataOp = CustomMetadataOp.EQ
     value: Optional[Any] = None
+
+
+class CustomMetadataSchemaCreate(BaseModel):
+    key: str
+    node_type: Optional[NodeType] = None
+    namespace: Optional[str] = None
+    json_schema: dict
+    filterable: bool = True
+    description: Optional[str] = None
+
+
+class CustomMetadataSchemaOutput(BaseModel):
+    id: int
+    key: str
+    node_type: Optional[NodeType] = None
+    namespace: Optional[str] = None
+    json_schema: dict
+    value_kind: Optional[str] = None
+    filterable: bool
+    description: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class ViolationSample(BaseModel):
+    node_name: str
+    errors: list[str]
+
+
+class ViolationReport(BaseModel):
+    schema_id: int
+    violation_count: int
+    samples: list[ViolationSample]

--- a/datajunction-server/datajunction_server/models/custom_metadata.py
+++ b/datajunction-server/datajunction_server/models/custom_metadata.py
@@ -1,0 +1,23 @@
+"""API models for custom_metadata schema registry and filtering."""
+
+from enum import Enum
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+
+class CustomMetadataOp(str, Enum):
+    EQ = "eq"
+    NE = "ne"
+    EXISTS = "exists"
+    GT = "gt"
+    GTE = "gte"
+    LT = "lt"
+    LTE = "lte"
+    CONTAINS = "contains"  # array/object containment
+
+
+class CustomMetadataFilter(BaseModel):
+    key: str
+    op: CustomMetadataOp = CustomMetadataOp.EQ
+    value: Optional[Any] = None

--- a/datajunction-server/datajunction_server/models/custom_metadata.py
+++ b/datajunction-server/datajunction_server/models/custom_metadata.py
@@ -47,6 +47,7 @@ class CustomMetadataSchemaOutput(BaseModel):
     description: Optional[str] = None
     owner: str | None = None
     reserved: bool = False
+    created_by_id: int | None = None
     updated_by_id: int | None = None
 
     class Config:

--- a/datajunction-server/datajunction_server/models/custom_metadata.py
+++ b/datajunction-server/datajunction_server/models/custom_metadata.py
@@ -32,6 +32,8 @@ class CustomMetadataSchemaCreate(BaseModel):
     json_schema: dict
     filterable: bool = True
     description: Optional[str] = None
+    owner: str | None = None
+    reserved: bool = False
 
 
 class CustomMetadataSchemaOutput(BaseModel):
@@ -43,6 +45,9 @@ class CustomMetadataSchemaOutput(BaseModel):
     value_kind: Optional[str] = None
     filterable: bool
     description: Optional[str] = None
+    owner: str | None = None
+    reserved: bool = False
+    updated_by_id: int | None = None
 
     class Config:
         from_attributes = True

--- a/datajunction-server/datajunction_server/models/custom_metadata.py
+++ b/datajunction-server/datajunction_server/models/custom_metadata.py
@@ -20,6 +20,7 @@ class CustomMetadataOp(str, Enum):
 
 
 class CustomMetadataFilter(BaseModel):
+    # Dots address nested values (`system.lifecycle`); `\.` escapes a literal dot.
     key: str
     op: CustomMetadataOp = CustomMetadataOp.EQ
     value: Any | None = None

--- a/datajunction-server/datajunction_server/models/custom_metadata.py
+++ b/datajunction-server/datajunction_server/models/custom_metadata.py
@@ -1,7 +1,7 @@
 """API models for custom_metadata schema registry and filtering."""
 
 from enum import Enum
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -22,16 +22,16 @@ class CustomMetadataOp(str, Enum):
 class CustomMetadataFilter(BaseModel):
     key: str
     op: CustomMetadataOp = CustomMetadataOp.EQ
-    value: Optional[Any] = None
+    value: Any | None = None
 
 
 class CustomMetadataSchemaCreate(BaseModel):
     key: str
-    node_type: Optional[NodeType] = None
-    namespace: Optional[str] = None
+    node_type: NodeType | None = None
+    namespace: str | None = None
     json_schema: dict
     filterable: bool = True
-    description: Optional[str] = None
+    description: str | None = None
     owner: str | None = None
     reserved: bool = False
 
@@ -39,12 +39,12 @@ class CustomMetadataSchemaCreate(BaseModel):
 class CustomMetadataSchemaOutput(BaseModel):
     id: int
     key: str
-    node_type: Optional[NodeType] = None
-    namespace: Optional[str] = None
+    node_type: NodeType | None = None
+    namespace: str | None = None
     json_schema: dict
-    value_kind: Optional[str] = None
+    value_kind: str | None = None
     filterable: bool
-    description: Optional[str] = None
+    description: str | None = None
     owner: str | None = None
     reserved: bool = False
     created_by_id: int | None = None

--- a/datajunction-server/tests/api/graphql/test_find_nodes_custom_metadata.py
+++ b/datajunction-server/tests/api/graphql/test_find_nodes_custom_metadata.py
@@ -1,0 +1,50 @@
+"""
+Tests for customMetadataFilters on the GraphQL findNodes query.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_by_custom_metadata_matching(client_with_roads: AsyncClient):
+    """findNodes with a matching customMetadataFilter returns the node."""
+    # default.repair_orders_fact seeds custom_metadata {"foo": "bar"}
+    query = """
+    {
+      findNodes(customMetadataFilters: [{key: "foo", op: EQ, value: "bar"}]) {
+        name
+        current { customMetadata }
+      }
+    }
+    """
+    resp = await client_with_roads.post("/graphql", json={"query": query})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("errors") is None
+    names = {n["name"] for n in data["data"]["findNodes"]}
+    assert names == {
+        "default.repair_orders_fact",
+        "default.num_repair_orders",
+        "default.large_revenue_payments_only_custom",
+    }
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_by_custom_metadata_non_matching(
+    client_with_roads: AsyncClient,
+):
+    """findNodes with a non-matching customMetadataFilter excludes the node."""
+    query = """
+    {
+      findNodes(customMetadataFilters: [{key: "foo", op: EQ, value: "notbar"}]) {
+        name
+      }
+    }
+    """
+    resp = await client_with_roads.post("/graphql", json={"query": query})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("errors") is None
+    names = {n["name"] for n in data["data"]["findNodes"]}
+    assert "default.repair_orders_fact" not in names

--- a/datajunction-server/tests/api/graphql/test_find_nodes_custom_metadata.py
+++ b/datajunction-server/tests/api/graphql/test_find_nodes_custom_metadata.py
@@ -48,3 +48,58 @@ async def test_find_nodes_by_custom_metadata_non_matching(
     assert data.get("errors") is None
     names = {n["name"] for n in data["data"]["findNodes"]}
     assert "default.repair_orders_fact" not in names
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_paginated_by_custom_metadata_matching(
+    client_with_roads: AsyncClient,
+):
+    """findNodesPaginated filters edges and totalCount by custom metadata."""
+    query = """
+    {
+      findNodesPaginated(
+        customMetadataFilters: [{key: "foo", op: EQ, value: "bar"}]
+        limit: 100
+      ) {
+        edges { node { name } }
+        totalCount
+      }
+    }
+    """
+    resp = await client_with_roads.post("/graphql", json={"query": query})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("errors") is None
+    results = data["data"]["findNodesPaginated"]
+    names = {edge["node"]["name"] for edge in results["edges"]}
+    assert names == {
+        "default.repair_orders_fact",
+        "default.num_repair_orders",
+        "default.large_revenue_payments_only_custom",
+    }
+    assert results["totalCount"] == 3
+
+
+@pytest.mark.asyncio
+async def test_find_nodes_paginated_by_custom_metadata_non_matching(
+    client_with_roads: AsyncClient,
+):
+    """findNodesPaginated with a non-matching filter returns no edges."""
+    query = """
+    {
+      findNodesPaginated(
+        customMetadataFilters: [{key: "foo", op: EQ, value: "notbar"}]
+        limit: 100
+      ) {
+        edges { node { name } }
+        totalCount
+      }
+    }
+    """
+    resp = await client_with_roads.post("/graphql", json={"query": query})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("errors") is None
+    results = data["data"]["findNodesPaginated"]
+    assert results["edges"] == []
+    assert results["totalCount"] == 0

--- a/datajunction-server/tests/api/test_custom_metadata_api.py
+++ b/datajunction-server/tests/api/test_custom_metadata_api.py
@@ -1,0 +1,332 @@
+"""
+Tests for the custom_metadata schema registry REST API.
+
+Covers:
+- POST /custom-metadata/schemas/ (create + upsert)
+- GET /custom-metadata/schemas/ (list with optional filters)
+- DELETE /custom-metadata/schemas/{id} (soft-delete)
+- GET /custom-metadata/facets/ (filterable-only catalog)
+- GET /custom-metadata/violations/ (advisory report)
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+# ---------------------------------------------------------------------------
+# POST /custom-metadata/schemas/ — create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_and_list_schema(client: AsyncClient) -> None:
+    """Creating a schema and listing it should return the correct data."""
+    resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={
+            "key": "table_group",
+            "json_schema": {"type": "string"},
+            "description": "arc",
+        },
+    )
+    assert resp.status_code in (200, 201)
+    body = resp.json()
+    assert body["key"] == "table_group"
+    assert body["value_kind"] == "string"
+    assert body["filterable"] is True
+    assert body["description"] == "arc"
+
+    listed = await client.get("/custom-metadata/schemas/")
+    assert listed.status_code == 200
+    assert any(s["key"] == "table_group" for s in listed.json())
+
+
+@pytest.mark.asyncio
+async def test_register_schema_with_node_type_and_namespace(
+    client: AsyncClient,
+) -> None:
+    """Creating a schema with node_type and namespace stores them."""
+    resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={
+            "key": "owner",
+            "node_type": "metric",
+            "namespace": "default",
+            "json_schema": {"type": "string"},
+        },
+    )
+    assert resp.status_code in (200, 201)
+    body = resp.json()
+    assert body["node_type"] == "metric"
+    assert body["namespace"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_register_schema_reject_invalid_json_schema(client: AsyncClient) -> None:
+    """Posting an invalid JSON Schema must return 422."""
+    resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={
+            "key": "bad",
+            "json_schema": {"type": "not-a-real-type"},
+        },
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_register_schema_upsert_updates_existing(client: AsyncClient) -> None:
+    """POSTing the same (key, node_type, namespace) twice should upsert, not duplicate."""
+    payload = {
+        "key": "grain",
+        "json_schema": {"type": "string"},
+        "description": "first",
+    }
+    resp1 = await client.post("/custom-metadata/schemas/", json=payload)
+    assert resp1.status_code in (200, 201)
+    id1 = resp1.json()["id"]
+
+    # Update description via another POST (upsert)
+    resp2 = await client.post(
+        "/custom-metadata/schemas/",
+        json={
+            "key": "grain",
+            "json_schema": {"type": "integer"},
+            "description": "updated",
+        },
+    )
+    assert resp2.status_code in (200, 201)
+    body2 = resp2.json()
+    assert body2["id"] == id1  # same row
+    assert body2["description"] == "updated"
+    assert body2["value_kind"] == "integer"
+
+    # Only one active row in list
+    listed = await client.get("/custom-metadata/schemas/")
+    grains = [s for s in listed.json() if s["key"] == "grain"]
+    assert len(grains) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_schemas_filter_by_namespace(client: AsyncClient) -> None:
+    """GET /custom-metadata/schemas/?namespace= filters to matching rows."""
+    await client.post(
+        "/custom-metadata/schemas/",
+        json={"key": "k1", "namespace": "ns_a", "json_schema": {"type": "string"}},
+    )
+    await client.post(
+        "/custom-metadata/schemas/",
+        json={"key": "k2", "namespace": "ns_b", "json_schema": {"type": "string"}},
+    )
+    resp = await client.get("/custom-metadata/schemas/?namespace=ns_a")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all(s["namespace"] == "ns_a" for s in data)
+    assert any(s["key"] == "k1" for s in data)
+    assert not any(s["key"] == "k2" for s in data)
+
+
+# ---------------------------------------------------------------------------
+# DELETE /custom-metadata/schemas/{id} — soft delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_schema_soft_deletes(client: AsyncClient) -> None:
+    """DELETE sets deactivated_at and removes the schema from active listing."""
+    create_resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={"key": "to_delete", "json_schema": {"type": "string"}},
+    )
+    assert create_resp.status_code in (200, 201)
+    schema_id = create_resp.json()["id"]
+
+    del_resp = await client.delete(f"/custom-metadata/schemas/{schema_id}")
+    assert del_resp.status_code in (200, 204)
+
+    # Should no longer appear in list
+    listed = await client.get("/custom-metadata/schemas/")
+    assert not any(s["id"] == schema_id for s in listed.json())
+
+
+@pytest.mark.asyncio
+async def test_delete_schema_not_found(client: AsyncClient) -> None:
+    """DELETE for a nonexistent schema_id returns 404."""
+    resp = await client.delete("/custom-metadata/schemas/999999")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /custom-metadata/facets/ — filterable-only catalog
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_facets_only_lists_filterable(client: AsyncClient) -> None:
+    """GET /custom-metadata/facets/ excludes schemas with filterable=False."""
+    await client.post(
+        "/custom-metadata/schemas/",
+        json={"key": "notes", "json_schema": {"type": "string"}, "filterable": False},
+    )
+    await client.post(
+        "/custom-metadata/schemas/",
+        json={"key": "score", "json_schema": {"type": "number"}, "filterable": True},
+    )
+    facets = await client.get("/custom-metadata/facets/")
+    assert facets.status_code == 200
+    data = facets.json()
+    assert not any(f["key"] == "notes" for f in data)
+    assert any(f["key"] == "score" for f in data)
+
+
+# ---------------------------------------------------------------------------
+# GET /custom-metadata/violations/ — advisory report
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_violations_missing_schema_id_returns_422(client: AsyncClient) -> None:
+    """GET /custom-metadata/violations/ without schema_id returns 422."""
+    resp = await client.get("/custom-metadata/violations/")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_violations_nonexistent_schema_id_returns_404(
+    client: AsyncClient,
+) -> None:
+    """GET /custom-metadata/violations/?schema_id=9999 with nonexistent id returns 404."""
+    resp = await client.get("/custom-metadata/violations/?schema_id=9999")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_violations_returns_report_for_clean_nodes(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """Violation report returns count=0 when no nodes violate the schema."""
+    # Register schema
+    create_resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={"key": "grain", "json_schema": {"type": "string"}},
+    )
+    assert create_resp.status_code in (200, 201)
+    schema_id = create_resp.json()["id"]
+
+    resp = await client.get(f"/custom-metadata/violations/?schema_id={schema_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "violation_count" in body
+    assert body["violation_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_schemas_filter_by_node_type(client: AsyncClient) -> None:
+    """GET /custom-metadata/schemas/?node_type= filters to matching rows."""
+    await client.post(
+        "/custom-metadata/schemas/",
+        json={
+            "key": "nt_metric",
+            "node_type": "metric",
+            "json_schema": {"type": "string"},
+        },
+    )
+    await client.post(
+        "/custom-metadata/schemas/",
+        json={
+            "key": "nt_source",
+            "node_type": "source",
+            "json_schema": {"type": "string"},
+        },
+    )
+    resp = await client.get("/custom-metadata/schemas/?node_type=metric")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all(s["node_type"] == "metric" for s in data if s["node_type"] is not None)
+    assert any(s["key"] == "nt_metric" for s in data)
+    assert not any(s["key"] == "nt_source" for s in data)
+
+
+@pytest.mark.asyncio
+async def test_violations_node_has_key_but_passes(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """Violation report: node with the key but a valid value should not be counted."""
+    from datajunction_server.database.node import Node, NodeRevision
+    from sqlalchemy import select
+
+    create_resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={"key": "grain", "json_schema": {"type": "string"}},
+    )
+    assert create_resp.status_code in (200, 201)
+    schema_id = create_resp.json()["id"]
+
+    # Set a valid string value
+    nr = (
+        await session.execute(
+            select(NodeRevision)
+            .join(Node, Node.id == NodeRevision.node_id)
+            .where(
+                Node.current_version == NodeRevision.version,
+                Node.deactivated_at.is_(None),
+            )
+            .limit(1),
+        )
+    ).scalar_one_or_none()
+    if nr is not None:
+        nr.custom_metadata = {"grain": "daily"}  # valid string
+        await session.commit()
+
+    resp = await client.get(f"/custom-metadata/violations/?schema_id={schema_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["violation_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_violations_detects_violating_nodes(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """Violation report detects nodes whose custom_metadata violates the schema."""
+    from datajunction_server.database.node import Node, NodeRevision
+
+    # Create a schema requiring "grain" to be a string
+    create_resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={"key": "grain", "json_schema": {"type": "string"}},
+    )
+    assert create_resp.status_code in (200, 201)
+    schema_id = create_resp.json()["id"]
+
+    # Directly inject a violating node revision (custom_metadata.grain = 123, not string)
+    # Use existing default.repair_orders source node
+    from sqlalchemy import select
+
+    nr = (
+        await session.execute(
+            select(NodeRevision)
+            .join(Node, Node.id == NodeRevision.node_id)
+            .where(
+                Node.current_version == NodeRevision.version,
+                Node.deactivated_at.is_(None),
+            )
+            .limit(1),
+        )
+    ).scalar_one_or_none()
+    if nr is not None:
+        nr.custom_metadata = {"grain": 123}  # violates {type: string}
+        await session.commit()
+
+        resp = await client.get(f"/custom-metadata/violations/?schema_id={schema_id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["violation_count"] >= 1
+        assert len(body["samples"]) >= 1
+        sample = body["samples"][0]
+        assert "node_name" in sample
+        assert "errors" in sample

--- a/datajunction-server/tests/api/test_custom_metadata_api.py
+++ b/datajunction-server/tests/api/test_custom_metadata_api.py
@@ -26,6 +26,7 @@ async def test_register_and_list_schema(client: AsyncClient) -> None:
         "/custom-metadata/schemas/",
         json={
             "key": "table_group",
+            "namespace": "test.ns",
             "json_schema": {"type": "string"},
             "description": "arc",
         },
@@ -69,6 +70,7 @@ async def test_register_schema_reject_invalid_json_schema(client: AsyncClient) -
         "/custom-metadata/schemas/",
         json={
             "key": "bad",
+            "namespace": "test.ns",
             "json_schema": {"type": "not-a-real-type"},
         },
     )
@@ -80,6 +82,7 @@ async def test_register_schema_upsert_updates_existing(client: AsyncClient) -> N
     """POSTing the same (key, node_type, namespace) twice should upsert, not duplicate."""
     payload = {
         "key": "grain",
+        "namespace": "test.ns",
         "json_schema": {"type": "string"},
         "description": "first",
     }
@@ -92,6 +95,7 @@ async def test_register_schema_upsert_updates_existing(client: AsyncClient) -> N
         "/custom-metadata/schemas/",
         json={
             "key": "grain",
+            "namespace": "test.ns",
             "json_schema": {"type": "integer"},
             "description": "updated",
         },
@@ -137,7 +141,11 @@ async def test_delete_schema_soft_deletes(client: AsyncClient) -> None:
     """DELETE sets deactivated_at and removes the schema from active listing."""
     create_resp = await client.post(
         "/custom-metadata/schemas/",
-        json={"key": "to_delete", "json_schema": {"type": "string"}},
+        json={
+            "key": "to_delete",
+            "namespace": "test.ns",
+            "json_schema": {"type": "string"},
+        },
     )
     assert create_resp.status_code in (200, 201)
     schema_id = create_resp.json()["id"]
@@ -167,11 +175,21 @@ async def test_facets_only_lists_filterable(client: AsyncClient) -> None:
     """GET /custom-metadata/facets/ excludes schemas with filterable=False."""
     await client.post(
         "/custom-metadata/schemas/",
-        json={"key": "notes", "json_schema": {"type": "string"}, "filterable": False},
+        json={
+            "key": "notes",
+            "namespace": "test.ns",
+            "json_schema": {"type": "string"},
+            "filterable": False,
+        },
     )
     await client.post(
         "/custom-metadata/schemas/",
-        json={"key": "score", "json_schema": {"type": "number"}, "filterable": True},
+        json={
+            "key": "score",
+            "namespace": "test.ns",
+            "json_schema": {"type": "number"},
+            "filterable": True,
+        },
     )
     facets = await client.get("/custom-metadata/facets/")
     assert facets.status_code == 200
@@ -210,7 +228,11 @@ async def test_violations_returns_report_for_clean_nodes(
     # Register schema
     create_resp = await client.post(
         "/custom-metadata/schemas/",
-        json={"key": "grain", "json_schema": {"type": "string"}},
+        json={
+            "key": "grain",
+            "namespace": "test.ns",
+            "json_schema": {"type": "string"},
+        },
     )
     assert create_resp.status_code in (200, 201)
     schema_id = create_resp.json()["id"]
@@ -230,6 +252,7 @@ async def test_list_schemas_filter_by_node_type(client: AsyncClient) -> None:
         json={
             "key": "nt_metric",
             "node_type": "metric",
+            "namespace": "test.ns",
             "json_schema": {"type": "string"},
         },
     )
@@ -238,6 +261,7 @@ async def test_list_schemas_filter_by_node_type(client: AsyncClient) -> None:
         json={
             "key": "nt_source",
             "node_type": "source",
+            "namespace": "test.ns",
             "json_schema": {"type": "string"},
         },
     )
@@ -260,7 +284,11 @@ async def test_violations_node_has_key_but_passes(
 
     create_resp = await client.post(
         "/custom-metadata/schemas/",
-        json={"key": "grain", "json_schema": {"type": "string"}},
+        json={
+            "key": "grain",
+            "namespace": "test.ns",
+            "json_schema": {"type": "string"},
+        },
     )
     assert create_resp.status_code in (200, 201)
     schema_id = create_resp.json()["id"]
@@ -298,7 +326,11 @@ async def test_violations_detects_violating_nodes(
     # Create a schema requiring "grain" to be a string
     create_resp = await client.post(
         "/custom-metadata/schemas/",
-        json={"key": "grain", "json_schema": {"type": "string"}},
+        json={
+            "key": "grain",
+            "namespace": "test.ns",
+            "json_schema": {"type": "string"},
+        },
     )
     assert create_resp.status_code in (200, 201)
     schema_id = create_resp.json()["id"]
@@ -330,3 +362,242 @@ async def test_violations_detects_violating_nodes(
         sample = body["samples"][0]
         assert "node_name" in sample
         assert "errors" in sample
+
+
+# ---------------------------------------------------------------------------
+# Authorization tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_global_key_non_admin_forbidden(client: AsyncClient) -> None:
+    """Non-admin registering a global key (namespace=None) → 403."""
+    resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={"key": "global_key", "json_schema": {"type": "string"}},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_register_global_key_admin_succeeds(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """Admin registering a global key → success."""
+    from datajunction_server.database.user import User
+    from datajunction_server.models.user import OAuthProvider
+    from datajunction_server.internal.access.authentication.tokens import create_token
+    from datetime import timedelta
+    import httpx
+    from datajunction_server.api.main import app
+
+    admin_user = User(
+        username="admin_test_global",
+        email=None,
+        name=None,
+        oauth_provider=OAuthProvider.BASIC,
+        is_admin=True,
+    )
+    session.add(admin_user)
+    await session.commit()
+    admin_token = create_token(
+        {"username": "admin_test_global"},
+        secret="a-fake-secretkey",
+        iss="http://localhost:8000/",
+        expires_delta=timedelta(hours=24),
+    )
+    async with AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    ) as admin_client:
+        resp = await admin_client.post(
+            "/custom-metadata/schemas/",
+            json={"key": "admin_global_key", "json_schema": {"type": "string"}},
+        )
+    assert resp.status_code in (200, 201)
+    body = resp.json()
+    assert body["key"] == "admin_global_key"
+    assert body["namespace"] is None
+
+
+@pytest.mark.asyncio
+async def test_register_namespace_key_with_access_succeeds(
+    client: AsyncClient,
+) -> None:
+    """Namespace-scoped key with access (PassthroughAuth approves all) → success."""
+    resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={
+            "key": "ns_key",
+            "namespace": "my.namespace",
+            "json_schema": {"type": "string"},
+        },
+    )
+    assert resp.status_code in (200, 201)
+    body = resp.json()
+    assert body["namespace"] == "my.namespace"
+
+
+@pytest.mark.asyncio
+async def test_register_reserved_true_non_admin_forbidden(
+    client: AsyncClient,
+) -> None:
+    """Non-admin setting reserved=True → 403."""
+    resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={
+            "key": "some_ns_key",
+            "namespace": "my.namespace",
+            "reserved": True,
+            "json_schema": {"type": "string"},
+        },
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_register_namespace_key_blocked_by_reserved_global(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """Namespace registration of a key with a reserved global row → 409."""
+    from datajunction_server.database.user import User
+    from datajunction_server.models.user import OAuthProvider
+    from datajunction_server.internal.access.authentication.tokens import create_token
+    from datetime import timedelta
+    import httpx
+    from datajunction_server.api.main import app
+
+    # First, create the reserved global schema as admin
+    admin_user = User(
+        username="admin_reserved",
+        email=None,
+        name=None,
+        oauth_provider=OAuthProvider.BASIC,
+        is_admin=True,
+    )
+    session.add(admin_user)
+    await session.commit()
+    admin_token = create_token(
+        {"username": "admin_reserved"},
+        secret="a-fake-secretkey",
+        iss="http://localhost:8000/",
+        expires_delta=timedelta(hours=24),
+    )
+    async with AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    ) as admin_client:
+        resp = await admin_client.post(
+            "/custom-metadata/schemas/",
+            json={
+                "key": "reserved_key",
+                "reserved": True,
+                "json_schema": {"type": "string"},
+            },
+        )
+    assert resp.status_code in (200, 201)
+
+    # Now try to register namespace-scoped (non-admin, namespace write OK via Passthrough)
+    resp2 = await client.post(
+        "/custom-metadata/schemas/",
+        json={
+            "key": "reserved_key",
+            "namespace": "some.namespace",
+            "json_schema": {"type": "string"},
+        },
+    )
+    assert resp2.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_created_by_id_and_updated_by_id_populated(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """created_by_id and updated_by_id are set from the current user."""
+    from datajunction_server.database.user import User
+    from datajunction_server.models.user import OAuthProvider
+    from datajunction_server.internal.access.authentication.tokens import create_token
+    from datetime import timedelta
+    import httpx
+    from datajunction_server.api.main import app
+
+    admin_user = User(
+        username="admin_audit",
+        email=None,
+        name=None,
+        oauth_provider=OAuthProvider.BASIC,
+        is_admin=True,
+    )
+    session.add(admin_user)
+    await session.commit()
+    await session.refresh(admin_user)
+    admin_id = admin_user.id
+    admin_token = create_token(
+        {"username": "admin_audit"},
+        secret="a-fake-secretkey",
+        iss="http://localhost:8000/",
+        expires_delta=timedelta(hours=24),
+    )
+    async with AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    ) as admin_client:
+        resp = await admin_client.post(
+            "/custom-metadata/schemas/",
+            json={"key": "audit_key", "json_schema": {"type": "string"}},
+        )
+    assert resp.status_code in (200, 201)
+    body = resp.json()
+    assert body["updated_by_id"] == admin_id
+
+
+@pytest.mark.asyncio
+async def test_owner_round_trips(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """owner field is persisted and returned in output."""
+    from datajunction_server.database.user import User
+    from datajunction_server.models.user import OAuthProvider
+    from datajunction_server.internal.access.authentication.tokens import create_token
+    from datetime import timedelta
+    import httpx
+    from datajunction_server.api.main import app
+
+    admin_user = User(
+        username="admin_owner",
+        email=None,
+        name=None,
+        oauth_provider=OAuthProvider.BASIC,
+        is_admin=True,
+    )
+    session.add(admin_user)
+    await session.commit()
+    admin_token = create_token(
+        {"username": "admin_owner"},
+        secret="a-fake-secretkey",
+        iss="http://localhost:8000/",
+        expires_delta=timedelta(hours=24),
+    )
+    async with AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    ) as admin_client:
+        resp = await admin_client.post(
+            "/custom-metadata/schemas/",
+            json={
+                "key": "owner_key",
+                "json_schema": {"type": "string"},
+                "owner": "team-data-eng",
+            },
+        )
+    assert resp.status_code in (200, 201)
+    body = resp.json()
+    assert body["owner"] == "team-data-eng"

--- a/datajunction-server/tests/api/test_custom_metadata_api.py
+++ b/datajunction-server/tests/api/test_custom_metadata_api.py
@@ -9,9 +9,18 @@ Covers:
 - GET /custom-metadata/violations/ (advisory report)
 """
 
+from datetime import timedelta
+
+import httpx
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.api.main import app
+from datajunction_server.database.user import User
+from datajunction_server.internal.access.authentication.tokens import create_token
+from datajunction_server.models.user import OAuthProvider
 
 
 # ---------------------------------------------------------------------------
@@ -632,3 +641,128 @@ async def test_owner_round_trips(
     assert resp.status_code in (200, 201)
     body = resp.json()
     assert body["owner"] == "team-data-eng"
+
+
+# ---------------------------------------------------------------------------
+# Repo-managed namespaces — the API is not a second writer
+# ---------------------------------------------------------------------------
+
+
+async def _make_git_managed(client: AsyncClient, namespace: str) -> None:
+    """Create a namespace and mark it as owning a repo."""
+    await client.post(f"/namespaces/{namespace}")
+    resp = await client.patch(
+        f"/namespaces/{namespace}/git",
+        json={"github_repo_path": "myorg/myrepo"},
+    )
+    assert resp.status_code in (200, 201), resp.text
+
+
+@pytest.mark.asyncio
+async def test_registering_into_a_repo_managed_namespace_is_refused(
+    client: AsyncClient,
+) -> None:
+    """
+    A repo-managed namespace has one writer, and it is not this endpoint.
+
+    Beyond being unreviewed, a registration here does not survive: a deployment
+    reconciles the namespace to exactly what its manifest declares, so the row
+    would disappear at the next push with nothing to explain it. Better to
+    refuse and say where the change belongs.
+    """
+    await _make_git_managed(client, "gitmanaged")
+
+    resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={
+            "key": "system",
+            "namespace": "gitmanaged",
+            "json_schema": {"type": "object"},
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    assert "is git-managed" in resp.text
+    assert "custom_metadata_schemas:" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_repo_managed_schema_is_refused(client: AsyncClient) -> None:
+    """Deleting has the same problem in reverse: the next deploy re-creates it."""
+    resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={
+            "key": "system",
+            "namespace": "gitlater",
+            "json_schema": {"type": "object"},
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    schema_id = resp.json()["id"]
+
+    # The namespace becomes repo-managed after the fact, as it would in practice.
+    await _make_git_managed(client, "gitlater")
+
+    resp = await client.delete(f"/custom-metadata/schemas/{schema_id}")
+    assert resp.status_code == 422, resp.text
+    assert "is git-managed" in resp.text
+
+
+@pytest_asyncio.fixture
+async def admin_client(client: AsyncClient, session: AsyncSession):
+    """An AsyncClient authenticated as an admin, which registering a global key needs.
+
+    Depends on ``client`` so its app-level get_session override is installed first.
+    """
+    admin_user = User(
+        username="admin_git_gate",
+        email=None,
+        name=None,
+        oauth_provider=OAuthProvider.BASIC,
+        is_admin=True,
+    )
+    session.add(admin_user)
+    await session.commit()
+    token = create_token(
+        {"username": "admin_git_gate"},
+        secret="a-fake-secretkey",
+        iss="http://localhost:8000/",
+        expires_delta=timedelta(hours=24),
+    )
+    async with AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {token}"},
+    ) as authed:
+        yield authed
+
+
+@pytest.mark.asyncio
+async def test_a_global_key_is_unaffected(
+    client: AsyncClient,
+    admin_client: AsyncClient,
+) -> None:
+    """No repository owns a global key, so no repository can be told to own it."""
+    await _make_git_managed(client, "gitglobal")
+
+    resp = await admin_client.post(
+        "/custom-metadata/schemas/",
+        json={"key": "global_only_key", "json_schema": {"type": "string"}},
+    )
+    assert resp.status_code in (200, 201), resp.text
+    assert resp.json()["namespace"] is None
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_namespace_is_unaffected(client: AsyncClient) -> None:
+    """The gate is about repo-managed namespaces, not about the API."""
+    await client.post("/namespaces/plain_ns")
+
+    resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={
+            "key": "system",
+            "namespace": "plain_ns",
+            "json_schema": {"type": "object"},
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text

--- a/datajunction-server/tests/api/test_custom_metadata_api.py
+++ b/datajunction-server/tests/api/test_custom_metadata_api.py
@@ -2,11 +2,10 @@
 Tests for the custom_metadata schema registry REST API.
 
 Covers:
-- POST /custom-metadata/schemas/ (create + upsert)
-- GET /custom-metadata/schemas/ (list with optional filters)
-- DELETE /custom-metadata/schemas/{id} (soft-delete)
-- GET /custom-metadata/facets/ (filterable-only catalog)
-- GET /custom-metadata/violations/ (advisory report)
+- POST /metadata-schemas/ (create + upsert)
+- GET /metadata-schemas/ (list with optional filters)
+- DELETE /metadata-schemas/{id} (soft-delete)
+- GET /metadata-schemas/{id}/violations (advisory report)
 """
 
 from datetime import timedelta
@@ -24,7 +23,7 @@ from datajunction_server.models.user import OAuthProvider
 
 
 # ---------------------------------------------------------------------------
-# POST /custom-metadata/schemas/ — create
+# POST /metadata-schemas/ — create
 # ---------------------------------------------------------------------------
 
 
@@ -32,7 +31,7 @@ from datajunction_server.models.user import OAuthProvider
 async def test_register_and_list_schema(client: AsyncClient) -> None:
     """Creating a schema and listing it should return the correct data."""
     resp = await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "table_group",
             "namespace": "test.ns",
@@ -47,7 +46,7 @@ async def test_register_and_list_schema(client: AsyncClient) -> None:
     assert body["filterable"] is True
     assert body["description"] == "arc"
 
-    listed = await client.get("/custom-metadata/schemas/")
+    listed = await client.get("/metadata-schemas/")
     assert listed.status_code == 200
     assert any(s["key"] == "table_group" for s in listed.json())
 
@@ -58,7 +57,7 @@ async def test_register_schema_with_node_type_and_namespace(
 ) -> None:
     """Creating a schema with node_type and namespace stores them."""
     resp = await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "owner",
             "node_type": "metric",
@@ -76,7 +75,7 @@ async def test_register_schema_with_node_type_and_namespace(
 async def test_register_schema_reject_invalid_json_schema(client: AsyncClient) -> None:
     """Posting an invalid JSON Schema must return 422."""
     resp = await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "bad",
             "namespace": "test.ns",
@@ -95,13 +94,13 @@ async def test_register_schema_upsert_updates_existing(client: AsyncClient) -> N
         "json_schema": {"type": "string"},
         "description": "first",
     }
-    resp1 = await client.post("/custom-metadata/schemas/", json=payload)
+    resp1 = await client.post("/metadata-schemas/", json=payload)
     assert resp1.status_code in (200, 201)
     id1 = resp1.json()["id"]
 
     # Update description via another POST (upsert)
     resp2 = await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "grain",
             "namespace": "test.ns",
@@ -116,23 +115,23 @@ async def test_register_schema_upsert_updates_existing(client: AsyncClient) -> N
     assert body2["value_kind"] == "integer"
 
     # Only one active row in list
-    listed = await client.get("/custom-metadata/schemas/")
+    listed = await client.get("/metadata-schemas/")
     grains = [s for s in listed.json() if s["key"] == "grain"]
     assert len(grains) == 1
 
 
 @pytest.mark.asyncio
 async def test_list_schemas_filter_by_namespace(client: AsyncClient) -> None:
-    """GET /custom-metadata/schemas/?namespace= filters to matching rows."""
+    """GET /metadata-schemas/?namespace= filters to matching rows."""
     await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={"key": "k1", "namespace": "ns_a", "json_schema": {"type": "string"}},
     )
     await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={"key": "k2", "namespace": "ns_b", "json_schema": {"type": "string"}},
     )
-    resp = await client.get("/custom-metadata/schemas/?namespace=ns_a")
+    resp = await client.get("/metadata-schemas/?namespace=ns_a")
     assert resp.status_code == 200
     data = resp.json()
     assert all(s["namespace"] == "ns_a" for s in data)
@@ -141,7 +140,7 @@ async def test_list_schemas_filter_by_namespace(client: AsyncClient) -> None:
 
 
 # ---------------------------------------------------------------------------
-# DELETE /custom-metadata/schemas/{id} — soft delete
+# DELETE /metadata-schemas/{id} — soft delete
 # ---------------------------------------------------------------------------
 
 
@@ -149,7 +148,7 @@ async def test_list_schemas_filter_by_namespace(client: AsyncClient) -> None:
 async def test_delete_schema_soft_deletes(client: AsyncClient) -> None:
     """DELETE sets deactivated_at and removes the schema from active listing."""
     create_resp = await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "to_delete",
             "namespace": "test.ns",
@@ -159,18 +158,18 @@ async def test_delete_schema_soft_deletes(client: AsyncClient) -> None:
     assert create_resp.status_code in (200, 201)
     schema_id = create_resp.json()["id"]
 
-    del_resp = await client.delete(f"/custom-metadata/schemas/{schema_id}")
+    del_resp = await client.delete(f"/metadata-schemas/{schema_id}")
     assert del_resp.status_code in (200, 204)
 
     # Should no longer appear in list
-    listed = await client.get("/custom-metadata/schemas/")
+    listed = await client.get("/metadata-schemas/")
     assert not any(s["id"] == schema_id for s in listed.json())
 
 
 @pytest.mark.asyncio
 async def test_delete_schema_not_found(client: AsyncClient) -> None:
     """DELETE for a nonexistent schema_id returns 404."""
-    resp = await client.delete("/custom-metadata/schemas/999999")
+    resp = await client.delete("/metadata-schemas/999999")
     assert resp.status_code == 404
 
 
@@ -194,20 +193,25 @@ async def test_delete_global_key_non_admin_forbidden(
     session.add(row)
     await session.commit()
 
-    resp = await client.delete(f"/custom-metadata/schemas/{row.id}")
+    resp = await client.delete(f"/metadata-schemas/{row.id}")
     assert resp.status_code == 403
 
 
 # ---------------------------------------------------------------------------
-# GET /custom-metadata/facets/ — filterable-only catalog
+# `filterable` on the list response
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_facets_only_lists_filterable(client: AsyncClient) -> None:
-    """GET /custom-metadata/facets/ excludes schemas with filterable=False."""
+async def test_list_reports_filterable_per_schema(client: AsyncClient) -> None:
+    """The filterable subset is a read off the list, not an endpoint of its own.
+
+    `filterable` curates which keys a UI offers as filter controls; it does not
+    gate filtering, which goes through `customMetadataFilters` and never consults
+    the registry. A caller wanting the subset filters the list itself.
+    """
     await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "notes",
             "namespace": "test.ns",
@@ -216,7 +220,7 @@ async def test_facets_only_lists_filterable(client: AsyncClient) -> None:
         },
     )
     await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "score",
             "namespace": "test.ns",
@@ -224,31 +228,24 @@ async def test_facets_only_lists_filterable(client: AsyncClient) -> None:
             "filterable": True,
         },
     )
-    facets = await client.get("/custom-metadata/facets/")
-    assert facets.status_code == 200
-    data = facets.json()
-    assert not any(f["key"] == "notes" for f in data)
-    assert any(f["key"] == "score" for f in data)
+    resp = await client.get("/metadata-schemas/?namespace=test.ns")
+    assert resp.status_code == 200
+    by_key = {row["key"]: row["filterable"] for row in resp.json()}
+    assert by_key["notes"] is False
+    assert by_key["score"] is True
 
 
 # ---------------------------------------------------------------------------
-# GET /custom-metadata/violations/ — advisory report
+# GET /metadata-schemas/{id}/violations — advisory report
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_violations_missing_schema_id_returns_422(client: AsyncClient) -> None:
-    """GET /custom-metadata/violations/ without schema_id returns 422."""
-    resp = await client.get("/custom-metadata/violations/")
-    assert resp.status_code == 422
 
 
 @pytest.mark.asyncio
 async def test_violations_nonexistent_schema_id_returns_404(
     client: AsyncClient,
 ) -> None:
-    """GET /custom-metadata/violations/?schema_id=9999 with nonexistent id returns 404."""
-    resp = await client.get("/custom-metadata/violations/?schema_id=9999")
+    """An id that matches no live registration is a 404."""
+    resp = await client.get("/metadata-schemas/9999/violations")
     assert resp.status_code == 404
 
 
@@ -260,7 +257,7 @@ async def test_violations_returns_report_for_clean_nodes(
     """Violation report returns count=0 when no nodes violate the schema."""
     # Register schema
     create_resp = await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "grain",
             "namespace": "test.ns",
@@ -270,7 +267,7 @@ async def test_violations_returns_report_for_clean_nodes(
     assert create_resp.status_code in (200, 201)
     schema_id = create_resp.json()["id"]
 
-    resp = await client.get(f"/custom-metadata/violations/?schema_id={schema_id}")
+    resp = await client.get(f"/metadata-schemas/{schema_id}/violations")
     assert resp.status_code == 200
     body = resp.json()
     assert "violation_count" in body
@@ -279,9 +276,9 @@ async def test_violations_returns_report_for_clean_nodes(
 
 @pytest.mark.asyncio
 async def test_list_schemas_filter_by_node_type(client: AsyncClient) -> None:
-    """GET /custom-metadata/schemas/?node_type= filters to matching rows."""
+    """GET /metadata-schemas/?node_type= filters to matching rows."""
     await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "nt_metric",
             "node_type": "metric",
@@ -290,7 +287,7 @@ async def test_list_schemas_filter_by_node_type(client: AsyncClient) -> None:
         },
     )
     await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "nt_source",
             "node_type": "source",
@@ -298,7 +295,7 @@ async def test_list_schemas_filter_by_node_type(client: AsyncClient) -> None:
             "json_schema": {"type": "string"},
         },
     )
-    resp = await client.get("/custom-metadata/schemas/?node_type=metric")
+    resp = await client.get("/metadata-schemas/?node_type=metric")
     assert resp.status_code == 200
     data = resp.json()
     assert all(s["node_type"] == "metric" for s in data if s["node_type"] is not None)
@@ -316,7 +313,7 @@ async def test_violations_node_has_key_but_passes(
     from sqlalchemy import select
 
     create_resp = await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "grain",
             "namespace": "test.ns",
@@ -342,7 +339,7 @@ async def test_violations_node_has_key_but_passes(
         nr.custom_metadata = {"grain": "daily"}  # valid string
         await session.commit()
 
-    resp = await client.get(f"/custom-metadata/violations/?schema_id={schema_id}")
+    resp = await client.get(f"/metadata-schemas/{schema_id}/violations")
     assert resp.status_code == 200
     body = resp.json()
     assert body["violation_count"] == 0
@@ -358,7 +355,7 @@ async def test_violations_detects_violating_nodes(
 
     # Create a schema requiring "grain" to be a string
     create_resp = await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "grain",
             "namespace": "test.ns",
@@ -387,7 +384,7 @@ async def test_violations_detects_violating_nodes(
         nr.custom_metadata = {"grain": 123}  # violates {type: string}
         await session.commit()
 
-        resp = await client.get(f"/custom-metadata/violations/?schema_id={schema_id}")
+        resp = await client.get(f"/metadata-schemas/{schema_id}/violations")
         assert resp.status_code == 200
         body = resp.json()
         assert body["violation_count"] >= 1
@@ -406,7 +403,7 @@ async def test_violations_detects_violating_nodes(
 async def test_register_global_key_non_admin_forbidden(client: AsyncClient) -> None:
     """Non-admin registering a global key (namespace=None) → 403."""
     resp = await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={"key": "global_key", "json_schema": {"type": "string"}},
     )
     assert resp.status_code == 403
@@ -446,7 +443,7 @@ async def test_register_global_key_admin_succeeds(
         headers={"Authorization": f"Bearer {admin_token}"},
     ) as admin_client:
         resp = await admin_client.post(
-            "/custom-metadata/schemas/",
+            "/metadata-schemas/",
             json={"key": "admin_global_key", "json_schema": {"type": "string"}},
         )
         assert resp.status_code in (200, 201)
@@ -456,7 +453,7 @@ async def test_register_global_key_admin_succeeds(
 
         # Admin can also delete a global key (covers the admin-delete-global path).
         del_resp = await admin_client.delete(
-            f"/custom-metadata/schemas/{body['id']}",
+            f"/metadata-schemas/{body['id']}",
         )
         assert del_resp.status_code == 200
 
@@ -467,7 +464,7 @@ async def test_register_namespace_key_with_access_succeeds(
 ) -> None:
     """Namespace-scoped key with access (PassthroughAuth approves all) → success."""
     resp = await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "ns_key",
             "namespace": "my.namespace",
@@ -485,7 +482,7 @@ async def test_register_reserved_true_non_admin_forbidden(
 ) -> None:
     """Non-admin setting reserved=True → 403."""
     resp = await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "some_ns_key",
             "namespace": "my.namespace",
@@ -531,7 +528,7 @@ async def test_register_namespace_key_blocked_by_reserved_global(
         headers={"Authorization": f"Bearer {admin_token}"},
     ) as admin_client:
         resp = await admin_client.post(
-            "/custom-metadata/schemas/",
+            "/metadata-schemas/",
             json={
                 "key": "reserved_key",
                 "reserved": True,
@@ -542,7 +539,7 @@ async def test_register_namespace_key_blocked_by_reserved_global(
 
     # Now try to register namespace-scoped (non-admin, namespace write OK via Passthrough)
     resp2 = await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "reserved_key",
             "namespace": "some.namespace",
@@ -588,7 +585,7 @@ async def test_created_by_id_and_updated_by_id_populated(
         headers={"Authorization": f"Bearer {admin_token}"},
     ) as admin_client:
         resp = await admin_client.post(
-            "/custom-metadata/schemas/",
+            "/metadata-schemas/",
             json={"key": "audit_key", "json_schema": {"type": "string"}},
         )
     assert resp.status_code in (200, 201)
@@ -631,7 +628,7 @@ async def test_owner_round_trips(
         headers={"Authorization": f"Bearer {admin_token}"},
     ) as admin_client:
         resp = await admin_client.post(
-            "/custom-metadata/schemas/",
+            "/metadata-schemas/",
             json={
                 "key": "owner_key",
                 "json_schema": {"type": "string"},
@@ -673,7 +670,7 @@ async def test_registering_into_a_repo_managed_namespace_is_refused(
     await _make_git_managed(client, "gitmanaged")
 
     resp = await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "system",
             "namespace": "gitmanaged",
@@ -689,7 +686,7 @@ async def test_registering_into_a_repo_managed_namespace_is_refused(
 async def test_deleting_a_repo_managed_schema_is_refused(client: AsyncClient) -> None:
     """Deleting has the same problem in reverse: the next deploy re-creates it."""
     resp = await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "system",
             "namespace": "gitlater",
@@ -702,7 +699,7 @@ async def test_deleting_a_repo_managed_schema_is_refused(client: AsyncClient) ->
     # The namespace becomes repo-managed after the fact, as it would in practice.
     await _make_git_managed(client, "gitlater")
 
-    resp = await client.delete(f"/custom-metadata/schemas/{schema_id}")
+    resp = await client.delete(f"/metadata-schemas/{schema_id}")
     assert resp.status_code == 422, resp.text
     assert "is git-managed" in resp.text
 
@@ -745,7 +742,7 @@ async def test_a_global_key_is_unaffected(
     await _make_git_managed(client, "gitglobal")
 
     resp = await admin_client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={"key": "global_only_key", "json_schema": {"type": "string"}},
     )
     assert resp.status_code in (200, 201), resp.text
@@ -758,7 +755,7 @@ async def test_an_ordinary_namespace_is_unaffected(client: AsyncClient) -> None:
     await client.post("/namespaces/plain_ns")
 
     resp = await client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "system",
             "namespace": "plain_ns",
@@ -766,3 +763,65 @@ async def test_an_ordinary_namespace_is_unaffected(client: AsyncClient) -> None:
         },
     )
     assert resp.status_code in (200, 201), resp.text
+
+
+@pytest.mark.asyncio
+async def test_get_one_schema_by_id(client: AsyncClient) -> None:
+    """An id you cannot fetch with is half an identifier.
+
+    Delete has always taken one; without a matching read there was no way to
+    confirm what you were about to remove.
+    """
+    created = await client.post(
+        "/metadata-schemas/",
+        json={
+            "key": "grain",
+            "namespace": "byid.ns",
+            "json_schema": {"type": "string"},
+        },
+    )
+    schema_id = created.json()["id"]
+
+    resp = await client.get(f"/metadata-schemas/{schema_id}")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["key"] == "grain"
+    assert resp.json()["namespace"] == "byid.ns"
+
+
+@pytest.mark.asyncio
+async def test_get_a_deleted_schema_is_a_404(client: AsyncClient) -> None:
+    """Soft-deleted rows are invisible to reads, as they are to resolution."""
+    created = await client.post(
+        "/metadata-schemas/",
+        json={
+            "key": "gone",
+            "namespace": "byid.ns",
+            "json_schema": {"type": "string"},
+        },
+    )
+    schema_id = created.json()["id"]
+    assert (await client.delete(f"/metadata-schemas/{schema_id}")).status_code == 200
+
+    assert (await client.get(f"/metadata-schemas/{schema_id}")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_filters_by_key(client: AsyncClient) -> None:
+    """Resolving an id for a key you already know should be one precise call.
+
+    Without this the only route to a schema's id was listing everything and
+    scanning, which is the friction that made ids feel like the wrong handle.
+    """
+    for key in ("wanted", "unwanted"):
+        await client.post(
+            "/metadata-schemas/",
+            json={
+                "key": key,
+                "namespace": "bykey.ns",
+                "json_schema": {"type": "string"},
+            },
+        )
+
+    resp = await client.get("/metadata-schemas/?key=wanted&namespace=bykey.ns")
+    assert resp.status_code == 200, resp.text
+    assert [row["key"] for row in resp.json()] == ["wanted"]

--- a/datajunction-server/tests/api/test_custom_metadata_api.py
+++ b/datajunction-server/tests/api/test_custom_metadata_api.py
@@ -554,6 +554,7 @@ async def test_created_by_id_and_updated_by_id_populated(
         )
     assert resp.status_code in (200, 201)
     body = resp.json()
+    assert body["created_by_id"] == admin_id
     assert body["updated_by_id"] == admin_id
 
 

--- a/datajunction-server/tests/api/test_custom_metadata_api.py
+++ b/datajunction-server/tests/api/test_custom_metadata_api.py
@@ -19,7 +19,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from datajunction_server.api.main import app
 from datajunction_server.database.user import User
 from datajunction_server.internal.access.authentication.tokens import create_token
+from datajunction_server.models.access import ResourceAction
 from datajunction_server.models.user import OAuthProvider
+from tests.authz import VALIDATOR_AUTH_SERVICE, deny
 
 
 # ---------------------------------------------------------------------------
@@ -825,3 +827,36 @@ async def test_list_filters_by_key(client: AsyncClient) -> None:
     resp = await client.get("/metadata-schemas/?key=wanted&namespace=bykey.ns")
     assert resp.status_code == 200, resp.text
     assert [row["key"] for row in resp.json()] == ["wanted"]
+
+
+@pytest.mark.asyncio
+async def test_delete_denies_without_write_on_the_namespace(
+    client: AsyncClient,
+    mocker,
+) -> None:
+    """The delete gate has to bite, not merely be reached.
+
+    Registered in `write_enforcement_test.DENIAL_TESTED_ELSEWHERE` rather than its
+    Case table: the route addresses an integer id and authorizes the row's own
+    namespace, so a row has to exist before the check runs. The generic cases fill
+    every path parameter with a string stub, which would fail validation first.
+
+    Setup runs with normal access; the denial is applied afterwards so the 403
+    comes from the delete rather than from creating the row.
+    """
+    created = await client.post(
+        "/metadata-schemas/",
+        json={
+            "key": "denied",
+            "namespace": "denial.ns",
+            "json_schema": {"type": "string"},
+        },
+    )
+    assert created.status_code in (200, 201), created.text
+    schema_id = created.json()["id"]
+
+    mocker.patch(VALIDATOR_AUTH_SERVICE, deny(ResourceAction.WRITE))
+
+    resp = await client.delete(f"/metadata-schemas/{schema_id}")
+    assert resp.status_code == 403, resp.text
+    assert "Access denied" in resp.json()["message"]

--- a/datajunction-server/tests/api/test_custom_metadata_api.py
+++ b/datajunction-server/tests/api/test_custom_metadata_api.py
@@ -165,6 +165,30 @@ async def test_delete_schema_not_found(client: AsyncClient) -> None:
     assert resp.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_delete_global_key_non_admin_forbidden(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """A non-admin deleting a global (namespace=None) schema key → 403."""
+    from datajunction_server.database.custom_metadata_schema import (
+        CustomMetadataSchema,
+    )
+
+    row = CustomMetadataSchema(
+        key="global_del_key",
+        node_type=None,
+        namespace=None,
+        json_schema={"type": "string"},
+        value_kind="string",
+    )
+    session.add(row)
+    await session.commit()
+
+    resp = await client.delete(f"/custom-metadata/schemas/{row.id}")
+    assert resp.status_code == 403
+
+
 # ---------------------------------------------------------------------------
 # GET /custom-metadata/facets/ — filterable-only catalog
 # ---------------------------------------------------------------------------
@@ -416,10 +440,16 @@ async def test_register_global_key_admin_succeeds(
             "/custom-metadata/schemas/",
             json={"key": "admin_global_key", "json_schema": {"type": "string"}},
         )
-    assert resp.status_code in (200, 201)
-    body = resp.json()
-    assert body["key"] == "admin_global_key"
-    assert body["namespace"] is None
+        assert resp.status_code in (200, 201)
+        body = resp.json()
+        assert body["key"] == "admin_global_key"
+        assert body["namespace"] is None
+
+        # Admin can also delete a global key (covers the admin-delete-global path).
+        del_resp = await admin_client.delete(
+            f"/custom-metadata/schemas/{body['id']}",
+        )
+        assert del_resp.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/api/test_custom_metadata_expression_index.py
+++ b/datajunction-server/tests/api/test_custom_metadata_expression_index.py
@@ -1,0 +1,106 @@
+"""Tests for per-key expression index creation on schema registration.
+
+Tier-1 index: numeric-typed schemas (type='number' or type='integer') get a
+functional index on (custom_metadata->>'key')::numeric for range/sort queries.
+String and other types do NOT get an index (equality served by GIN).
+
+Key names chosen to be unique to this file to avoid cross-test index leakage
+when the testcontainer DB persists across the session.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.mark.asyncio
+async def test_numeric_schema_builds_expression_index(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """Registering a filterable numeric schema must create ix_cm_threshold_num."""
+    resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={"key": "threshold_num", "json_schema": {"type": "number"}},
+    )
+    assert resp.status_code in (200, 201)
+
+    result = await session.execute(
+        text(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE tablename='noderevision' "
+            "AND indexname='ix_cm_threshold_num'",
+        ),
+    )
+    assert result.scalar() == "ix_cm_threshold_num"
+
+
+@pytest.mark.asyncio
+async def test_integer_schema_builds_expression_index(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """Registering a filterable integer schema must create ix_cm_priority_int."""
+    resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={"key": "priority_int", "json_schema": {"type": "integer"}},
+    )
+    assert resp.status_code in (200, 201)
+
+    result = await session.execute(
+        text(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE tablename='noderevision' "
+            "AND indexname='ix_cm_priority_int'",
+        ),
+    )
+    assert result.scalar() == "ix_cm_priority_int"
+
+
+@pytest.mark.asyncio
+async def test_string_schema_builds_no_expression_index(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """Registering a string schema must NOT create an expression index (GIN covers equality)."""
+    resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={"key": "label_str", "json_schema": {"type": "string"}},
+    )
+    assert resp.status_code in (200, 201)
+
+    result = await session.execute(
+        text(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE tablename='noderevision' "
+            "AND indexname='ix_cm_label_str'",
+        ),
+    )
+    assert result.scalar() is None
+
+
+@pytest.mark.asyncio
+async def test_non_filterable_numeric_schema_builds_no_index(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    """A numeric schema with filterable=False must NOT build an expression index."""
+    resp = await client.post(
+        "/custom-metadata/schemas/",
+        json={
+            "key": "hidden_score",
+            "json_schema": {"type": "number"},
+            "filterable": False,
+        },
+    )
+    assert resp.status_code in (200, 201)
+
+    result = await session.execute(
+        text(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE tablename='noderevision' "
+            "AND indexname='ix_cm_hidden_score'",
+        ),
+    )
+    assert result.scalar() is None

--- a/datajunction-server/tests/api/test_custom_metadata_expression_index.py
+++ b/datajunction-server/tests/api/test_custom_metadata_expression_index.py
@@ -6,21 +6,63 @@ String and other types do NOT get an index (equality served by GIN).
 
 Key names chosen to be unique to this file to avoid cross-test index leakage
 when the testcontainer DB persists across the session.
+
+These register global keys (namespace omitted), which requires an admin caller,
+so the tests use an authenticated admin client.
 """
 
+from datetime import timedelta
+
+import httpx
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from datajunction_server.api.main import app
+from datajunction_server.database.user import User
+from datajunction_server.internal.access.authentication.tokens import create_token
+from datajunction_server.models.user import OAuthProvider
+
+
+@pytest_asyncio.fixture
+async def admin_client(client: AsyncClient, session: AsyncSession):
+    """An AsyncClient authenticated as an admin user (needed for global keys).
+
+    Depends on ``client`` so its app-level get_session override (pointing at the
+    test database) is installed before we build the admin-authenticated client.
+    """
+    admin_user = User(
+        username="admin_expr_index",
+        email=None,
+        name=None,
+        oauth_provider=OAuthProvider.BASIC,
+        is_admin=True,
+    )
+    session.add(admin_user)
+    await session.commit()
+    admin_token = create_token(
+        {"username": "admin_expr_index"},
+        secret="a-fake-secretkey",
+        iss="http://localhost:8000/",
+        expires_delta=timedelta(hours=24),
+    )
+    async with AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    ) as authed:
+        yield authed
+
 
 @pytest.mark.asyncio
 async def test_numeric_schema_builds_expression_index(
-    client: AsyncClient,
+    admin_client: AsyncClient,
     session: AsyncSession,
 ) -> None:
     """Registering a filterable numeric schema must create ix_cm_threshold_num."""
-    resp = await client.post(
+    resp = await admin_client.post(
         "/custom-metadata/schemas/",
         json={"key": "threshold_num", "json_schema": {"type": "number"}},
     )
@@ -38,11 +80,11 @@ async def test_numeric_schema_builds_expression_index(
 
 @pytest.mark.asyncio
 async def test_integer_schema_builds_expression_index(
-    client: AsyncClient,
+    admin_client: AsyncClient,
     session: AsyncSession,
 ) -> None:
     """Registering a filterable integer schema must create ix_cm_priority_int."""
-    resp = await client.post(
+    resp = await admin_client.post(
         "/custom-metadata/schemas/",
         json={"key": "priority_int", "json_schema": {"type": "integer"}},
     )
@@ -60,11 +102,11 @@ async def test_integer_schema_builds_expression_index(
 
 @pytest.mark.asyncio
 async def test_string_schema_builds_no_expression_index(
-    client: AsyncClient,
+    admin_client: AsyncClient,
     session: AsyncSession,
 ) -> None:
     """Registering a string schema must NOT create an expression index (GIN covers equality)."""
-    resp = await client.post(
+    resp = await admin_client.post(
         "/custom-metadata/schemas/",
         json={"key": "label_str", "json_schema": {"type": "string"}},
     )
@@ -82,11 +124,11 @@ async def test_string_schema_builds_no_expression_index(
 
 @pytest.mark.asyncio
 async def test_non_filterable_numeric_schema_builds_no_index(
-    client: AsyncClient,
+    admin_client: AsyncClient,
     session: AsyncSession,
 ) -> None:
     """A numeric schema with filterable=False must NOT build an expression index."""
-    resp = await client.post(
+    resp = await admin_client.post(
         "/custom-metadata/schemas/",
         json={
             "key": "hidden_score",

--- a/datajunction-server/tests/api/test_custom_metadata_expression_index.py
+++ b/datajunction-server/tests/api/test_custom_metadata_expression_index.py
@@ -63,7 +63,7 @@ async def test_numeric_schema_builds_expression_index(
 ) -> None:
     """Registering a filterable numeric schema must create ix_cm_threshold_num."""
     resp = await admin_client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={"key": "threshold_num", "json_schema": {"type": "number"}},
     )
     assert resp.status_code in (200, 201)
@@ -85,7 +85,7 @@ async def test_integer_schema_builds_expression_index(
 ) -> None:
     """Registering a filterable integer schema must create ix_cm_priority_int."""
     resp = await admin_client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={"key": "priority_int", "json_schema": {"type": "integer"}},
     )
     assert resp.status_code in (200, 201)
@@ -107,7 +107,7 @@ async def test_string_schema_builds_no_expression_index(
 ) -> None:
     """Registering a string schema must NOT create an expression index (GIN covers equality)."""
     resp = await admin_client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={"key": "label_str", "json_schema": {"type": "string"}},
     )
     assert resp.status_code in (200, 201)
@@ -129,7 +129,7 @@ async def test_non_filterable_numeric_schema_builds_no_index(
 ) -> None:
     """A numeric schema with filterable=False must NOT build an expression index."""
     resp = await admin_client.post(
-        "/custom-metadata/schemas/",
+        "/metadata-schemas/",
         json={
             "key": "hidden_score",
             "json_schema": {"type": "number"},

--- a/datajunction-server/tests/api/write_enforcement_test.py
+++ b/datajunction-server/tests/api/write_enforcement_test.py
@@ -93,6 +93,13 @@ CASES = [
         "/nodes/{node_name}/materializations/{materialization_name}/backfill",
         [],
     ),
+    # metadata schemas -- WRITE is on the namespace named in the body
+    Case(
+        "POST",
+        "/metadata-schemas",
+        {"key": "k", "namespace": STUB, "json_schema": {"type": "string"}},
+        resource=ResourceType.NAMESPACE,
+    ),
     # cubes
     Case("POST", "/cubes/{name}/materialize", {"schedule": "0 0 * * *"}),
     Case("DELETE", "/cubes/{name}/materialize"),
@@ -143,6 +150,7 @@ DENIAL_TESTED_ELSEWHERE: dict[tuple[str, str], str] = {
     ("POST", "/preaggs/{preagg_id}/backfill"): "preaggregations_test.py",
     ("POST", "/preaggs/plan"): "preaggregations_test.py",
     ("POST", "/preaggs/register"): "preaggregations_test.py",
+    ("DELETE", "/metadata-schemas/{schema_id}"): "test_custom_metadata_api.py",
 }
 
 # PENDING_DENIAL_TESTS: routes that reach check() (so the coverage guard is green)

--- a/datajunction-server/tests/database/test_custom_metadata_node_filter.py
+++ b/datajunction-server/tests/database/test_custom_metadata_node_filter.py
@@ -1,0 +1,117 @@
+"""Tests for filtering nodes by custom_metadata predicates via find_by."""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from datajunction_server.database.node import Node, NodeRevision, NodeType
+from datajunction_server.database.user import OAuthProvider, User
+from datajunction_server.models.custom_metadata import (
+    CustomMetadataFilter,
+    CustomMetadataOp,
+)
+
+
+@pytest_asyncio.fixture
+async def _user(session: AsyncSession) -> User:
+    """A minimal user needed for node creation."""
+    user = User(username="cm_filter_test_user", oauth_provider=OAuthProvider.BASIC)
+    session.add(user)
+    await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def nodes_with_metadata(session: AsyncSession, _user: User):
+    """Seed two metric nodes with different custom_metadata values."""
+    ads_node = Node(
+        name="default.ads_metric",
+        type=NodeType.METRIC,
+        current_version="v1",
+        created_by_id=_user.id,
+    )
+    ads_revision = NodeRevision(
+        node=ads_node,
+        name=ads_node.name,
+        type=ads_node.type,
+        version="v1",
+        query="SELECT COUNT(1) FROM ads",
+        custom_metadata={"table_group": "ads"},
+        created_by_id=_user.id,
+    )
+
+    growth_node = Node(
+        name="default.growth_metric",
+        type=NodeType.METRIC,
+        current_version="v1",
+        created_by_id=_user.id,
+    )
+    growth_revision = NodeRevision(
+        node=growth_node,
+        name=growth_node.name,
+        type=growth_node.type,
+        version="v1",
+        query="SELECT COUNT(1) FROM growth",
+        custom_metadata={"table_group": "growth"},
+        created_by_id=_user.id,
+    )
+
+    session.add_all([ads_node, ads_revision, growth_node, growth_revision])
+    await session.commit()
+    return ads_node, growth_node
+
+
+@pytest.mark.asyncio
+async def test_find_by_custom_metadata_eq(session: AsyncSession, nodes_with_metadata):
+    """Filtering by EQ returns only the node with the matching custom_metadata value."""
+    results = await Node.find_by(
+        session,
+        custom_metadata_filters=[
+            CustomMetadataFilter(
+                key="table_group",
+                op=CustomMetadataOp.EQ,
+                value="ads",
+            ),
+        ],
+    )
+    names = {n.name for n in results}
+    assert names == {"default.ads_metric"}
+    assert "default.growth_metric" not in names
+
+
+@pytest.mark.asyncio
+async def test_find_by_custom_metadata_exists(
+    session: AsyncSession,
+    nodes_with_metadata,
+):
+    """Filtering by EXISTS returns all nodes that have the key regardless of value."""
+    results = await Node.find_by(
+        session,
+        custom_metadata_filters=[
+            CustomMetadataFilter(key="table_group", op=CustomMetadataOp.EXISTS),
+        ],
+    )
+    names = {n.name for n in results}
+    assert "default.ads_metric" in names
+    assert "default.growth_metric" in names
+
+
+@pytest.mark.asyncio
+async def test_find_by_custom_metadata_no_match(
+    session: AsyncSession,
+    nodes_with_metadata,
+):
+    """Filtering by a non-existent value returns an empty list."""
+    results = await Node.find_by(
+        session,
+        custom_metadata_filters=[
+            CustomMetadataFilter(
+                key="table_group",
+                op=CustomMetadataOp.EQ,
+                value="unknown",
+            ),
+        ],
+    )
+    names = {n.name for n in results}
+    assert "default.ads_metric" not in names
+    assert "default.growth_metric" not in names

--- a/datajunction-server/tests/database/test_custom_metadata_node_filter.py
+++ b/datajunction-server/tests/database/test_custom_metadata_node_filter.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.database.node import Node, NodeRevision, NodeType
 from datajunction_server.database.user import OAuthProvider, User
+from datajunction_server.models.node import NodeMode
 from datajunction_server.models.custom_metadata import (
     CustomMetadataFilter,
     CustomMetadataOp,
@@ -115,3 +116,30 @@ async def test_find_by_custom_metadata_no_match(
     names = {n.name for n in results}
     assert "default.ads_metric" not in names
     assert "default.growth_metric" not in names
+
+
+@pytest.mark.asyncio
+async def test_find_by_custom_metadata_with_an_already_joined_revision(
+    session: AsyncSession,
+    nodes_with_metadata,
+):
+    """A custom_metadata filter must not re-join the revision another filter joined.
+
+    `find_by` joins the current revision once and tracks it, because a second join
+    of the same alias is a SQLAlchemy error rather than a slower query. Every other
+    revision-dependent filter shares that flag, so the case worth pinning is a
+    custom_metadata filter arriving *after* something else has already joined --
+    here a `mode` filter, which joins up front.
+    """
+    results = await Node.find_by(
+        session,
+        mode=NodeMode.PUBLISHED,
+        custom_metadata_filters=[
+            CustomMetadataFilter(
+                key="table_group",
+                op=CustomMetadataOp.EQ,
+                value="ads",
+            ),
+        ],
+    )
+    assert {n.name for n in results} == {"default.ads_metric"}

--- a/datajunction-server/tests/database/test_custom_metadata_node_filter.py
+++ b/datajunction-server/tests/database/test_custom_metadata_node_filter.py
@@ -57,9 +57,37 @@ async def nodes_with_metadata(session: AsyncSession, _user: User):
         created_by_id=_user.id,
     )
 
-    session.add_all([ads_node, ads_revision, growth_node, growth_revision])
+    nested_node = Node(
+        name="default.nested_metric",
+        type=NodeType.METRIC,
+        current_version="v1",
+        created_by_id=_user.id,
+    )
+    nested_revision = NodeRevision(
+        node=nested_node,
+        name=nested_node.name,
+        type=nested_node.type,
+        version="v1",
+        query="SELECT COUNT(1) FROM nested",
+        custom_metadata={
+            "system": {"lifecycle": "actively_maintained", "score": 7},
+            "odd.key": "literal",
+        },
+        created_by_id=_user.id,
+    )
+
+    session.add_all(
+        [
+            ads_node,
+            ads_revision,
+            growth_node,
+            growth_revision,
+            nested_node,
+            nested_revision,
+        ],
+    )
     await session.commit()
-    return ads_node, growth_node
+    return ads_node, growth_node, nested_node
 
 
 @pytest.mark.asyncio
@@ -92,9 +120,10 @@ async def test_find_by_custom_metadata_exists(
             CustomMetadataFilter(key="table_group", op=CustomMetadataOp.EXISTS),
         ],
     )
-    names = {n.name for n in results}
-    assert "default.ads_metric" in names
-    assert "default.growth_metric" in names
+    assert {n.name for n in results} == {
+        "default.ads_metric",
+        "default.growth_metric",
+    }
 
 
 @pytest.mark.asyncio
@@ -143,3 +172,139 @@ async def test_find_by_custom_metadata_with_an_already_joined_revision(
         ],
     )
     assert {n.name for n in results} == {"default.ads_metric"}
+
+
+@pytest.mark.asyncio
+async def test_find_by_nested_path_eq(session: AsyncSession, nodes_with_metadata):
+    """A dotted key addresses a nested value via JSONB containment."""
+    results = await Node.find_by(
+        session,
+        custom_metadata_filters=[
+            CustomMetadataFilter(
+                key="system.lifecycle",
+                op=CustomMetadataOp.EQ,
+                value="actively_maintained",
+            ),
+        ],
+    )
+    assert {n.name for n in results} == {"default.nested_metric"}
+
+
+@pytest.mark.asyncio
+async def test_find_by_nested_path_eq_no_match(
+    session: AsyncSession,
+    nodes_with_metadata,
+):
+    """A dotted key with the wrong nested value matches nothing."""
+    results = await Node.find_by(
+        session,
+        custom_metadata_filters=[
+            CustomMetadataFilter(
+                key="system.lifecycle",
+                op=CustomMetadataOp.EQ,
+                value="deprecated",
+            ),
+        ],
+    )
+    assert {n.name for n in results} == set()
+
+
+@pytest.mark.asyncio
+async def test_find_by_nested_path_exists(session: AsyncSession, nodes_with_metadata):
+    """EXISTS on a dotted key tests the nested key, not the top-level one."""
+    present = await Node.find_by(
+        session,
+        custom_metadata_filters=[
+            CustomMetadataFilter(key="system.lifecycle", op=CustomMetadataOp.EXISTS),
+        ],
+    )
+    assert {n.name for n in present} == {"default.nested_metric"}
+
+    absent = await Node.find_by(
+        session,
+        custom_metadata_filters=[
+            CustomMetadataFilter(key="system.owner", op=CustomMetadataOp.EXISTS),
+        ],
+    )
+    assert {n.name for n in absent} == set()
+
+
+@pytest.mark.asyncio
+async def test_find_by_nested_path_range(session: AsyncSession, nodes_with_metadata):
+    """Range operators extract a nested number and compare it numerically."""
+    matches = await Node.find_by(
+        session,
+        custom_metadata_filters=[
+            CustomMetadataFilter(
+                key="system.score",
+                op=CustomMetadataOp.GT,
+                value=5,
+            ),
+        ],
+    )
+    assert {n.name for n in matches} == {"default.nested_metric"}
+
+    misses = await Node.find_by(
+        session,
+        custom_metadata_filters=[
+            CustomMetadataFilter(
+                key="system.score",
+                op=CustomMetadataOp.LT,
+                value=5,
+            ),
+        ],
+    )
+    assert {n.name for n in misses} == set()
+
+
+@pytest.mark.asyncio
+async def test_find_by_escaped_dot_is_a_literal_key(
+    session: AsyncSession,
+    nodes_with_metadata,
+):
+    r"""``odd\.key`` addresses a top-level key that contains a dot."""
+    escaped = await Node.find_by(
+        session,
+        custom_metadata_filters=[
+            CustomMetadataFilter(
+                key=r"odd\.key",
+                op=CustomMetadataOp.EQ,
+                value="literal",
+            ),
+        ],
+    )
+    assert {n.name for n in escaped} == {"default.nested_metric"}
+
+    # Unescaped, the same text is a path into a non-existent "odd" object.
+    as_path = await Node.find_by(
+        session,
+        custom_metadata_filters=[
+            CustomMetadataFilter(
+                key="odd.key",
+                op=CustomMetadataOp.EQ,
+                value="literal",
+            ),
+        ],
+    )
+    assert {n.name for n in as_path} == set()
+
+
+@pytest.mark.asyncio
+async def test_count_by_applies_custom_metadata_filters(
+    session: AsyncSession,
+    nodes_with_metadata,
+):
+    """``count_by`` backs GraphQL totalCount, so it must honour the same filters."""
+    assert (
+        await Node.count_by(
+            session,
+            custom_metadata_filters=[
+                CustomMetadataFilter(
+                    key="system.lifecycle",
+                    op=CustomMetadataOp.EQ,
+                    value="actively_maintained",
+                ),
+            ],
+        )
+        == 1
+    )

--- a/datajunction-server/tests/internal/test_custom_metadata_filter_sql.py
+++ b/datajunction-server/tests/internal/test_custom_metadata_filter_sql.py
@@ -1,0 +1,75 @@
+"""Tests for custom_metadata_clause SQL translation (no DB required)."""
+
+from sqlalchemy.dialects import postgresql
+
+from datajunction_server.database.node import NodeRevision
+from datajunction_server.internal.custom_metadata import custom_metadata_clause
+from datajunction_server.models.custom_metadata import (
+    CustomMetadataFilter,
+    CustomMetadataOp,
+)
+
+_PG_DIALECT = postgresql.dialect()
+
+
+def _sql(clause):
+    return str(clause.compile(dialect=_PG_DIALECT))
+
+
+def test_eq_uses_containment():
+    f = CustomMetadataFilter(key="table_group", op=CustomMetadataOp.EQ, value="ads")
+    sql = _sql(custom_metadata_clause(NodeRevision.custom_metadata, f))
+    assert "@>" in sql  # GIN-served containment
+    assert "CAST" not in sql.upper()  # no cast — GIN index must be usable
+
+
+def test_ne_uses_negated_containment():
+    f = CustomMetadataFilter(key="table_group", op=CustomMetadataOp.NE, value="ads")
+    sql = _sql(custom_metadata_clause(NodeRevision.custom_metadata, f))
+    assert "@>" in sql
+    assert "NOT" in sql
+    assert "CAST" not in sql.upper()
+
+
+def test_exists_uses_question_operator():
+    f = CustomMetadataFilter(key="grain", op=CustomMetadataOp.EXISTS)
+    sql = _sql(custom_metadata_clause(NodeRevision.custom_metadata, f))
+    assert "?" in sql
+    assert "CAST" not in sql.upper()
+
+
+def test_gt_uses_text_extraction_cast():
+    f = CustomMetadataFilter(key="threshold", op=CustomMetadataOp.GT, value=5)
+    sql = _sql(custom_metadata_clause(NodeRevision.custom_metadata, f))
+    assert "->>" in sql
+    assert " > " in sql
+    assert " >= " not in sql
+
+
+def test_gte_uses_text_extraction_cast():
+    f = CustomMetadataFilter(key="threshold", op=CustomMetadataOp.GTE, value=5)
+    sql = _sql(custom_metadata_clause(NodeRevision.custom_metadata, f))
+    assert "->>" in sql
+    assert " >= " in sql
+
+
+def test_lt_uses_text_extraction_cast():
+    f = CustomMetadataFilter(key="threshold", op=CustomMetadataOp.LT, value=10)
+    sql = _sql(custom_metadata_clause(NodeRevision.custom_metadata, f))
+    assert "->>" in sql
+    assert " < " in sql
+    assert " <= " not in sql
+
+
+def test_lte_uses_text_extraction_cast():
+    f = CustomMetadataFilter(key="threshold", op=CustomMetadataOp.LTE, value=10)
+    sql = _sql(custom_metadata_clause(NodeRevision.custom_metadata, f))
+    assert "->>" in sql
+    assert " <= " in sql
+
+
+def test_contains_uses_jsonb_containment_on_element():
+    f = CustomMetadataFilter(key="tags", op=CustomMetadataOp.CONTAINS, value=["a", "b"])
+    sql = _sql(custom_metadata_clause(NodeRevision.custom_metadata, f))
+    assert "@>" in sql
+    assert "CAST" not in sql.upper()


### PR DESCRIPTION
### Summary

The custom metadata schema registry was added in #2456. This PR adds endpoints for registering and retiring schemas, along with discovery endpoints so that nodes can be filtered by their `custom_metadata` entries.

**Managing schemas**
```
POST   /metadata-schemas/
GET    /metadata-schemas/            ?key= &namespace= &node_type=
GET    /metadata-schemas/{schema_id}
DELETE /metadata-schemas/{schema_id}
GET    /metadata-schemas/{schema_id}/violations
```

**Authorization:**
- A global or reserved key is scoped to admin-only (registering a key that a reserved global already owns is a 409).
- A namespace-scoped key needs write access to that namespace.
- Registering a schema against a repo-managed namespace is refused, using the same `check_namespace_not_git_only` guard node mutations already use.

**Finding nodes by metadata**

`findNodes` accepts `customMetadataFilters`, a list of `{key, op, value}` with `EQ`, `NE`, `EXISTS`, `CONTAINS` and numeric comparisons. Equality compiles to JSONB containment (`@>`) so it can be served by the global GIN index from #2337, and containment is recursive, so filtering on a nested value works without a path syntax.

### Test Plan

- [x] PR has an associated issue: #1352
- [x] make check passes
- [x] make test shows 100% unit test coverage

### Deployment Plan

Additive -- new endpoints and a new optional GraphQL argument