### PR TITLE
Persist workflows the query service creates

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2026_08_26_0000-wf0001names_add_workflow_names_to_materialization.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_08_26_0000-wf0001names_add_workflow_names_to_materialization.py
@@ -1,0 +1,26 @@
+"""add workflow_names to materialization
+
+Revision ID: wf0001names
+Revises: cm0002schematable
+Create Date: 2026-08-26 00:00:00.000000+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "wf0001names"
+down_revision = "cm0002schematable"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "materialization",
+        sa.Column("workflow_names", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("materialization", "workflow_names")

--- a/datajunction-server/datajunction_server/database/materialization.py
+++ b/datajunction-server/datajunction_server/database/materialization.py
@@ -97,6 +97,13 @@ class Materialization(Base):
         default="MaterializationJob",
     )
 
+    # Workflows the query service reported when it scheduled this
+    workflow_names: Mapped[list[str] | None] = mapped_column(
+        JSON,
+        nullable=True,
+        default=None,
+    )
+
     deactivated_at: Mapped[UTCDatetime] = mapped_column(
         DateTime(timezone=True),
         nullable=True,
@@ -109,6 +116,22 @@ class Materialization(Base):
         cascade="all, delete",
         lazy="selectin",
     )
+
+    @property
+    def backfill_workflow(self) -> str | None:
+        """
+        The recorded workflow a backfill run belongs to, if the query service made
+        one.
+
+        Picked by its `.backfill` suffix rather than by position: the scheduled
+        workflow is always reported, the backfill one only for an incremental
+        strategy, so a one-element list is the ordinary shape and indexing into it
+        would hand the scheduler its own scheduled workflow to backfill on.
+        """
+        return next(
+            (name for name in self.workflow_names or [] if name.endswith(".backfill")),
+            None,
+        )
 
     @property
     def is_cube_planner(self) -> bool:

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -824,8 +824,16 @@ async def _launch_backfill(
     deploy. The span is written down only once the query service takes it, so a
     refused launch is asked for again next deploy. Never raises, and records on
     the outcome what the caller reports.
+
+    The recorded backfill workflow goes with the request when the materialization
+    has one. Without it the query service derives a name of its own, which is what
+    a row written before DJ recorded any has to fall back on.
     """
     span = backfill.span
+    materialization = await session.get(
+        Materialization,
+        backfill.materialization_id,
+    )
     try:
         result = query_service_client.run_cube_backfill(
             CubeBackfillInput(
@@ -833,6 +841,9 @@ async def _launch_backfill(
                 cube_version=swap.new_version,
                 start_date=span[0],
                 end_date=span[1],
+                workflow_name=materialization.backfill_workflow
+                if materialization
+                else None,
             ),
             request_headers=request_headers,
         )
@@ -1002,10 +1013,11 @@ def stop_cube_materialization_workflows(
     """
     Ask the query service to stop the workflows behind cube materializations.
 
-    Workflow names recorded on the materialization configs are stopped together in
-    one call. Materializations predating persisted workflow names fall back to the
-    cube name + version endpoint, whose arguments are identical for every
-    materialization on a revision, so it is called at most once.
+    Workflow names recorded on the materialization rows are stopped together in one
+    call. A cube planner row keeps its names in its config instead, which nothing
+    rebuilds, so those are read too. Materializations predating persisted workflow
+    names fall back to the cube name + version endpoint, whose arguments are
+    identical for every materialization on a revision, so it is called at most once.
 
     Never raises: a query service that is unreachable, or that has already forgotten
     the workflow, must not block the DJ-side operation that triggered the teardown.
@@ -1020,7 +1032,7 @@ def stop_cube_materialization_workflows(
         config = (
             materialization.config if isinstance(materialization.config, dict) else {}
         )
-        names = config.get("workflow_names", [])
+        names = materialization.workflow_names or config.get("workflow_names") or []
         if names:
             workflow_names.extend(names)
         else:
@@ -1098,7 +1110,7 @@ async def collect_materialization_teardowns(
     them because it cannot rebuild what it stops. A deletion rebuilds nothing, and
     the planner's row is the only place its workflow names are written down.
 
-    What comes back are copies holding just the name and config the teardown reads,
+    What comes back are copies holding just the fields the teardown reads,
     never rows attached to the session: the workflows are stopped after the commit
     that deleted them, where a real row would either be expired and unable to answer
     or gone from the database entirely.
@@ -1110,6 +1122,7 @@ async def collect_materialization_teardowns(
             select(
                 Materialization.name,
                 Materialization.config,
+                Materialization.workflow_names,
                 NodeRevision.name.label("node_name"),
                 NodeRevision.version,
                 Node.type,
@@ -1135,7 +1148,11 @@ async def collect_materialization_teardowns(
             ),
         )
         teardown.materializations.append(
-            Materialization(name=row.name, config=row.config),
+            Materialization(
+                name=row.name,
+                config=row.config,
+                workflow_names=row.workflow_names,
+            ),
         )
     return list(teardowns.values())
 
@@ -1238,7 +1255,41 @@ async def schedule_materialization_jobs(
                 query_service_client,
                 request_headers=request_headers,
             )
+    await record_workflow_names(session, materializations, materialization_to_output)
     return materialization_to_output
+
+
+async def record_workflow_names(
+    session: AsyncSession,
+    materializations: list[Materialization],
+    scheduled: dict[str, MaterializationInfo],
+) -> None:
+    """
+    Write down the workflows the query service just started.
+
+    Kept on the row rather than in the config, which every deploy rebuilds from the
+    revision and compares to decide whether anything moved. Runs after the deploy
+    commits, so it commits on its own, and never raises: a name DJ failed to record
+    costs the next teardown its precision, not the deploy its result.
+    """
+    recorded = False
+    for materialization in materializations:
+        info = scheduled.get(materialization.name)
+        if info and info.workflow_names:
+            materialization.workflow_names = list(info.workflow_names)
+            recorded = True
+    if not recorded:
+        return
+    try:
+        await session.commit()
+    except Exception as exc:
+        _logger.warning(
+            "Failed to record workflow names for %s: %s (continuing)",
+            [mat.name for mat in materializations],
+            str(exc),
+            exc_info=True,
+        )
+        await session.rollback()
 
 
 async def schedule_materialization_jobs_bg(

--- a/datajunction-server/datajunction_server/models/preaggregation.py
+++ b/datajunction-server/datajunction_server/models/preaggregation.py
@@ -520,7 +520,8 @@ class CubeBackfillInput(BaseModel):
     Input for running a cube backfill in query service.
 
     The cube workflow must already exist (created via POST /cubes/{name}/materialize).
-    Query Service uses cube_name and cube_version to derive workflow names via checksum.
+    Query Service runs `workflow_name` when DJ recorded one, and otherwise derives a
+    name from cube_name and cube_version via checksum.
     """
 
     cube_name: str = Field(description="Cube name (e.g., 'ads.my_cube')")
@@ -529,6 +530,10 @@ class CubeBackfillInput(BaseModel):
     )
     start_date: date = Field(description="Backfill start date")
     end_date: date = Field(description="Backfill end date")
+    workflow_name: str | None = Field(
+        default=None,
+        description="Backfill workflow DJ recorded when the cube was materialized",
+    )
 
 
 # Forward reference update

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -5656,6 +5656,90 @@ class TestDeclaredCubeMaterializations:
         ]
 
     @pytest.mark.asyncio
+    async def test_recorded_workflow_names_outlive_a_redeploy(
+        self,
+        session,
+        client,
+        upstreams,
+        mock_qs,
+    ):
+        """
+        DJ writes down the workflows the query service names and backfills the one
+        called `.backfill`, rather than letting the query service derive a name that
+        does not match what the materialize call pushed.
+
+        The names go on the materialization row, not in its config, which every
+        deploy rebuilds from the revision and compares to decide whether anything
+        moved -- so a second push that changes nothing still finds them there.
+        """
+        namespace = "cube_mat_workflow_names"
+        cube_name = f"{namespace}.default.repairs_cube"
+        workflow_names = [
+            f"dj.{cube_name}.v1_0.main",
+            f"dj.{cube_name}.v1_0.backfill",
+        ]
+        mock_qs.materialize_cube.return_value = MaterializationInfo(
+            urls=["http://fake.url/job"],
+            output_tables=[],
+            workflow_names=workflow_names,
+        )
+        cube = self._cube(
+            materialization=MaterializationSpec(
+                schedule="0 6 * * *",
+                lookback_window="1 DAY",
+                coverage={"from": "2024-01-01", "to": "2024-01-05"},
+            ),
+        )
+        nodes = [*upstreams, cube]
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert mock_qs.run_cube_backfill.call_args_list == [
+            mock.call(
+                CubeBackfillInput(
+                    cube_name=cube_name,
+                    cube_version="v1.0",
+                    start_date=date(2024, 1, 1),
+                    end_date=date(2024, 1, 5),
+                    workflow_name=f"dj.{cube_name}.v1_0.backfill",
+                ),
+                request_headers=mock.ANY,
+            ),
+        ]
+
+        session.expire_all()
+        deployed = await Node.get_by_name(
+            session,
+            cube_name,
+            options=Node.cube_load_options(),
+        )
+        assert [
+            materialization.workflow_names
+            for materialization in deployed.current.materializations
+        ] == [workflow_names]
+
+        mock_qs.reset_mock()
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert mock_qs.method_calls == []
+
+        session.expire_all()
+        deployed = await Node.get_by_name(
+            session,
+            cube_name,
+            options=Node.cube_load_options(),
+        )
+        assert [
+            materialization.workflow_names
+            for materialization in deployed.current.materializations
+        ] == [workflow_names]
+
+    @pytest.mark.asyncio
     async def test_unchanged_declaration_touches_nothing(
         self,
         client,

--- a/datajunction-server/tests/internal/materializations_test.py
+++ b/datajunction-server/tests/internal/materializations_test.py
@@ -25,9 +25,11 @@ from datajunction_server.internal.materializations import (
     coverage_gap,
     coverage_partition,
     record_backfill,
+    record_workflow_names,
     stop_cube_materialization_workflows,
     stop_materialization_workflows,
 )
+from datajunction_server.models.materialization import MaterializationInfo
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.partition import Granularity, PartitionType
 from datajunction_server.models.preaggregation import CubeBackfillInput
@@ -121,6 +123,34 @@ def test_stop_cube_workflows_batches_across_materializations():
     assert query_service_client.deactivate_cube_workflow.call_args_list == [
         mock.call("default.a_cube", version="v1.0", request_headers=None),
     ]
+
+
+def test_stop_cube_workflows_uses_recorded_names():
+    """
+    Names DJ recorded on the row when it scheduled the workflow stop exactly those
+    workflows, so the cube name + version endpoint is never called.
+    """
+    query_service_client = mock.MagicMock()
+    materialization = Materialization(
+        name="druid_cube__incremental_time__a_cube.date",
+        config={},
+        workflow_names=["dj.a_cube.v1_0.main", "dj.a_cube.v1_0.backfill"],
+    )
+
+    stop_cube_materialization_workflows(
+        query_service_client=query_service_client,
+        cube_name="default.a_cube",
+        cube_version="v1.0",
+        materializations=[materialization],
+    )
+
+    assert query_service_client.deactivate_workflows.call_args_list == [
+        mock.call(
+            workflow_names=["dj.a_cube.v1_0.main", "dj.a_cube.v1_0.backfill"],
+            request_headers=None,
+        ),
+    ]
+    assert query_service_client.deactivate_cube_workflow.call_args_list == []
 
 
 def test_stop_cube_workflows_without_a_config():
@@ -806,3 +836,172 @@ async def test_backfill_recorded_reads_djs_own(session, current_user, spec):
     session.add(Backfill(materialization_id=materialization.id, spec=spec))
 
     assert await backfill_recorded(session, materialization, date(2024, 1, 1)) is False
+
+
+def _scheduled(*workflow_names: str) -> dict[str, MaterializationInfo]:
+    """What the query service answered for the stored cube materialization."""
+    return {
+        "druid_cube_v3": MaterializationInfo(
+            output_tables=["druid.a_cube"],
+            urls=["http://fake.url/job"],
+            workflow_names=list(workflow_names),
+        ),
+    }
+
+
+@pytest.mark.asyncio
+async def test_record_workflow_names_keeps_both(session, current_user):
+    """
+    An incremental cube gets a scheduled workflow and a backfill one, and DJ writes
+    both down so a later teardown or backfill names them rather than guessing.
+    """
+    materialization = await _stored_materialization(session, current_user)
+
+    await record_workflow_names(
+        session,
+        [materialization],
+        _scheduled("dj.a_cube.v1_0.main", "dj.a_cube.v1_0.backfill"),
+    )
+
+    materialization_id = materialization.id
+    session.expire_all()
+    stored = await session.get(Materialization, materialization_id)
+    assert stored.workflow_names == [
+        "dj.a_cube.v1_0.main",
+        "dj.a_cube.v1_0.backfill",
+    ]
+    assert stored.backfill_workflow == "dj.a_cube.v1_0.backfill"
+
+
+@pytest.mark.asyncio
+async def test_record_workflow_names_keeps_one(session, current_user):
+    """
+    A full-strategy cube has no backfill workflow, so the one name reported is the
+    scheduled one and nothing reads it as a backfill.
+    """
+    materialization = await _stored_materialization(session, current_user)
+
+    await record_workflow_names(
+        session,
+        [materialization],
+        _scheduled("dj.a_cube.v1_0.main"),
+    )
+
+    materialization_id = materialization.id
+    session.expire_all()
+    stored = await session.get(Materialization, materialization_id)
+    assert stored.workflow_names == ["dj.a_cube.v1_0.main"]
+    assert stored.backfill_workflow is None
+
+
+@pytest.mark.asyncio
+async def test_record_workflow_names_with_nothing_named(session, current_user):
+    """
+    A query service that names no workflow leaves the row as it was, and the
+    teardown falls back to the cube name + version endpoint.
+    """
+    materialization = await _stored_materialization(session, current_user)
+
+    await record_workflow_names(session, [materialization], _scheduled())
+
+    materialization_id = materialization.id
+    session.expire_all()
+    stored = await session.get(Materialization, materialization_id)
+    assert stored.workflow_names is None
+
+
+@pytest.mark.asyncio
+async def test_record_workflow_names_survives_a_failure(session, current_user):
+    """
+    The workflow is already running by the time DJ writes its name down, and the
+    deploy has committed, so a write that fails is logged rather than raised.
+    """
+    materialization = await _stored_materialization(session, current_user)
+    materialization_id = materialization.id
+
+    with mock.patch.object(
+        session,
+        "commit",
+        new=mock.AsyncMock(side_effect=Exception("connection reset")),
+    ):
+        await record_workflow_names(
+            session,
+            [materialization],
+            _scheduled("dj.a_cube.v1_0.main"),
+        )
+
+    session.expire_all()
+    stored = await session.get(Materialization, materialization_id)
+    assert stored.workflow_names is None
+
+
+@pytest.mark.asyncio
+async def test_apply_cube_swap_backfills_by_recorded_name(session, current_user):
+    """
+    The backfill runs the workflow DJ recorded, not one the query service derives
+    from the cube name and version -- those disagree, and the derived one 404s.
+    """
+    materialization = await _stored_materialization(session, current_user)
+    materialization.workflow_names = [
+        "dj.a_cube.v1_0.main",
+        "dj.a_cube.v1_0.backfill",
+    ]
+    await session.commit()
+    query_service_client = mock.MagicMock()
+    query_service_client.run_cube_backfill.return_value = {"job_url": "http://job1"}
+
+    await _apply_with_backfill(
+        session,
+        query_service_client,
+        coverage_backfill(
+            materialization,
+            _cube_revision().columns[0],
+            (date(2024, 1, 1), date(2024, 1, 2)),
+        ),
+    )
+
+    assert query_service_client.run_cube_backfill.call_args_list == [
+        mock.call(
+            CubeBackfillInput(
+                cube_name="default.a_cube",
+                cube_version="v1.1",
+                start_date=date(2024, 1, 1),
+                end_date=date(2024, 1, 2),
+                workflow_name="dj.a_cube.v1_0.backfill",
+            ),
+            request_headers=None,
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_apply_cube_swap_backfills_a_missing_row(session):
+    """
+    A materialization the deploy has since dropped names no workflow, so the query
+    service derives one, which is all a row written before DJ recorded any can do.
+    """
+    query_service_client = mock.MagicMock()
+    query_service_client.run_cube_backfill.return_value = {"job_url": "http://job1"}
+
+    await _apply_with_backfill(
+        session,
+        query_service_client,
+        CoverageBackfill(
+            span=(date(2024, 1, 1), date(2024, 1, 2)),
+            materialization_id=987654,
+            column_name="date_0",
+        ),
+    )
+
+    assert query_service_client.run_cube_backfill.call_args_list == [
+        mock.call(
+            CubeBackfillInput(
+                cube_name="default.a_cube",
+                cube_version="v1.1",
+                start_date=date(2024, 1, 1),
+                end_date=date(2024, 1, 2),
+                workflow_name=None,
+            ),
+            request_headers=None,
+        ),
+    ]


### PR DESCRIPTION
### Summary

Store `workflow_names` per materialization

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
