### PR TITLE
Use worksteal distribution for parallel test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
 
           # Run tests
           export MODULE=${{ matrix.library == 'server' && 'datajunction_server' || matrix.library == 'client' && 'datajunction' || matrix.library == 'djqs' && 'djqs' || matrix.library == 'djrs' && 'datajunction_reflection'}}
-          uv run pytest ${{ (matrix.library == 'server' || matrix.library == 'client') && '-n auto --dist=loadscope' || '' }} --cov-fail-under=100 --cov=$MODULE --cov-report term-missing -vv tests/ --doctest-modules $MODULE --without-integration --without-slow-integration --ignore=datajunction_server/alembic/env.py
+          uv run pytest ${{ (matrix.library == 'server' || matrix.library == 'client') && '-n auto --dist=worksteal' || '' }} --cov-fail-under=100 --cov=$MODULE --cov-report term-missing -vv tests/ --doctest-modules $MODULE --without-integration --without-slow-integration --ignore=datajunction_server/alembic/env.py
 
   build-javascript:
     runs-on: ubuntu-latest

--- a/datajunction-server/Makefile
+++ b/datajunction-server/Makefile
@@ -9,7 +9,7 @@ docker-run:
 	docker compose up
 
 test:
-	uv run pytest -n 4 --dist=loadscope --cov-fail-under=100 --cov=datajunction_server --cov-report term-missing -vv tests/ --doctest-modules datajunction_server --without-integration --without-slow-integration --ignore=datajunction_server/alembic/env.py ${PYTEST_ARGS}
+	uv run pytest -n 4 --dist=worksteal --cov-fail-under=100 --cov=datajunction_server --cov-report term-missing -vv tests/ --doctest-modules datajunction_server --without-integration --without-slow-integration --ignore=datajunction_server/alembic/env.py ${PYTEST_ARGS}
 
 integration:
 	uv run pytest --cov=dj -vv tests/ --doctest-modules datajunction_server --with-integration --with-slow-integration --ignore=datajunction_server/alembic/env.py ${PYTEST_ARGS}


### PR DESCRIPTION
### Summary

With `--dist=loadscope`, `pytest-xdist` pins every test in a module to a single worker. Our large test modules therefore become stragglers: they keep one worker busy long after the others have drained their queues, and the run can't finish until the slowest module does. `--dist=worksteal` instead lets idle workers steal pending tests from busy ones, so the tail of the run stays balanced.

Measured on the tests/api suite at -n 4: 304s -> ~250s, roughly 19% faster, with lower total CPU time as well. Three runs were stable and reported identical pass and skip counts.

The tradeoff is that worksteal makes no promise that all tests in a module run on the same worker, so any test that depends on state created by an earlier test in its module could start failing intermittently. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
