### PR TITLE
Enable declarative custom metadata schemas for repo-backed namespaces

### DIFF
--- a/datajunction-server/datajunction_server/api/custom_metadata.py
+++ b/datajunction-server/datajunction_server/api/custom_metadata.py
@@ -11,7 +11,12 @@ from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.custom_metadata_schema import CustomMetadataSchema
 from datajunction_server.api.helpers import check_namespace_not_git_only
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
-from datajunction_server.internal.custom_metadata import ensure_expression_index
+from datajunction_server.internal.custom_metadata import (
+    assert_not_reserved_globally,
+    check_json_schema,
+    ensure_expression_index,
+    upsert_schema_row,
+)
 from datajunction_server.models.custom_metadata import (
     CustomMetadataSchemaCreate,
     CustomMetadataSchemaOutput,
@@ -31,12 +36,6 @@ from datajunction_server.utils import get_current_user, get_session
 router = SecureAPIRouter(tags=["metadata-schemas"])
 
 
-def _value_kind(json_schema: dict) -> str | None:
-    """Extract a single-string type from a JSON Schema, or None."""
-    t = json_schema.get("type")
-    return t if isinstance(t, str) else None
-
-
 @router.post("/metadata-schemas/", response_model=CustomMetadataSchemaOutput)
 async def register_schema(
     data: CustomMetadataSchemaCreate,
@@ -46,29 +45,18 @@ async def register_schema(
     access_checker: AccessChecker = Depends(get_access_checker),
 ) -> CustomMetadataSchema:
     """Create or upsert a custom_metadata schema registration."""
-    # Validate that json_schema is itself a valid JSON Schema
-    try:
-        jsonschema.Draft202012Validator.check_schema(data.json_schema)
-    except jsonschema.exceptions.SchemaError as exc:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Invalid JSON Schema: {exc.message}",
-        )
+    check_json_schema(data.key, data.json_schema)
 
-    # --- Two-tier authorization ---
-    # 1. Global key (namespace is None) → require admin
+    # Two-tier authorization: a global key or a reserved one is an admin's to
+    # register; a namespace-scoped one needs write access to that namespace.
     if data.namespace is None and not current_user.is_admin:
         raise DJAuthorizationException(
             message="Only administrators may register global schema keys.",
         )
-
-    # 2. reserved=True → require admin
     if data.reserved and not current_user.is_admin:
         raise DJAuthorizationException(
             message="Only administrators may register reserved schema keys.",
         )
-
-    # 3. Namespace-scoped → require write access to the namespace
     if data.namespace is not None:
         access_checker.add_namespace(data.namespace, ResourceAction.WRITE)
         await access_checker.check(on_denied=AccessDenialMode.RAISE)
@@ -84,72 +72,20 @@ async def register_schema(
             ),
         )
 
-    # 4. Check if a reserved global row exists for this key
-    if data.namespace is not None:
-        reserved_global = (
-            await session.execute(
-                select(CustomMetadataSchema).where(
-                    CustomMetadataSchema.key == data.key,
-                    CustomMetadataSchema.namespace.is_(None),
-                    CustomMetadataSchema.reserved.is_(True),
-                    CustomMetadataSchema.deactivated_at.is_(None),
-                ),
-            )
-        ).scalar_one_or_none()
-        if reserved_global is not None:
-            raise HTTPException(
-                status_code=409,
-                detail=f"Key '{data.key}' is reserved globally and cannot be registered at namespace scope.",
-            )
+    await assert_not_reserved_globally(session, data.key, data.namespace)
 
-    node_type_val = data.node_type.value if data.node_type else None
-
-    # Upsert on (key, node_type, namespace) — use select-then-update to handle NULLs
-    node_type_clause = (
-        CustomMetadataSchema.node_type.is_(None)
-        if node_type_val is None
-        else CustomMetadataSchema.node_type == node_type_val
+    row = await upsert_schema_row(
+        session,
+        key=data.key,
+        namespace=data.namespace,
+        node_type=data.node_type.value if data.node_type else None,
+        json_schema=data.json_schema,
+        filterable=data.filterable,
+        description=data.description,
+        owner=data.owner,
+        reserved=data.reserved,
+        current_user_id=current_user.id,
     )
-    namespace_clause = (
-        CustomMetadataSchema.namespace.is_(None)
-        if data.namespace is None
-        else CustomMetadataSchema.namespace == data.namespace
-    )
-    existing = (
-        await session.execute(
-            select(CustomMetadataSchema).where(
-                CustomMetadataSchema.key == data.key,
-                node_type_clause,
-                namespace_clause,
-                CustomMetadataSchema.deactivated_at.is_(None),
-            ),
-        )
-    ).scalar_one_or_none()
-
-    if existing:
-        existing.json_schema = data.json_schema
-        existing.value_kind = _value_kind(data.json_schema)
-        existing.filterable = data.filterable
-        existing.description = data.description
-        existing.owner = data.owner
-        existing.reserved = data.reserved
-        existing.updated_by_id = current_user.id
-        row = existing
-    else:
-        row = CustomMetadataSchema(
-            key=data.key,
-            node_type=node_type_val,
-            namespace=data.namespace,
-            json_schema=data.json_schema,
-            value_kind=_value_kind(data.json_schema),
-            filterable=data.filterable,
-            description=data.description,
-            owner=data.owner,
-            reserved=data.reserved,
-            created_by_id=current_user.id,
-            updated_by_id=current_user.id,
-        )
-        session.add(row)
     await session.commit()
     if row.filterable:
         await ensure_expression_index(session, row.key, row.value_kind)

--- a/datajunction-server/datajunction_server/internal/custom_metadata.py
+++ b/datajunction-server/datajunction_server/internal/custom_metadata.py
@@ -1,5 +1,6 @@
 """Resolution, validation, and filter translation for custom_metadata schemas."""
 
+import datetime
 import re
 
 import jsonschema
@@ -8,11 +9,15 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datajunction_server.database.custom_metadata_schema import CustomMetadataSchema
-from datajunction_server.errors import DJInvalidInputException
+from datajunction_server.errors import (
+    DJAlreadyExistsException,
+    DJInvalidInputException,
+)
 from datajunction_server.models.custom_metadata import (
     CustomMetadataFilter,
     CustomMetadataOp,
 )
+from datajunction_server.models.deployment import CustomMetadataSchemaSpec
 from datajunction_server.models.node_type import NodeType
 
 
@@ -179,6 +184,184 @@ def _nest(path: list[str], value) -> dict:
 def _at_path(jsonb, path: list[str]):
     """Return the JSONB expression addressing *path*."""
     return jsonb[path[0]] if len(path) == 1 else jsonb[tuple(path)]
+
+
+def value_kind(json_schema: dict) -> str | None:
+    """The single string ``type`` a JSON Schema declares, or None."""
+    declared = json_schema.get("type")
+    return declared if isinstance(declared, str) else None
+
+
+def check_json_schema(key: str, json_schema: dict) -> None:
+    """Raise if *json_schema* is not itself a valid JSON Schema."""
+    try:
+        jsonschema.Draft202012Validator.check_schema(json_schema)
+    except jsonschema.exceptions.SchemaError as exc:
+        raise DJInvalidInputException(
+            message=(
+                f"Invalid JSON Schema for custom_metadata key '{key}': {exc.message}"
+            ),
+        ) from exc
+
+
+def scope_clause(key: str, namespace: str | None, node_type: str | None):
+    """Where-clauses selecting the one row that owns (key, namespace, node_type).
+
+    Deliberately does not filter on ``deactivated_at``: the unique index spans
+    soft-deleted rows, so a caller that hides them would insert into a collision.
+    """
+    return [
+        CustomMetadataSchema.key == key,
+        CustomMetadataSchema.namespace.is_(None)
+        if namespace is None
+        else CustomMetadataSchema.namespace == namespace,
+        CustomMetadataSchema.node_type.is_(None)
+        if node_type is None
+        else CustomMetadataSchema.node_type == node_type,
+    ]
+
+
+async def assert_not_reserved_globally(
+    session: AsyncSession,
+    key: str,
+    namespace: str | None,
+) -> None:
+    """Refuse a namespace registration of a key an admin reserved globally."""
+    if namespace is None:
+        return
+    reserved = (
+        await session.execute(
+            select(CustomMetadataSchema).where(
+                CustomMetadataSchema.key == key,
+                CustomMetadataSchema.namespace.is_(None),
+                CustomMetadataSchema.reserved.is_(True),
+                CustomMetadataSchema.deactivated_at.is_(None),
+            ),
+        )
+    ).scalar_one_or_none()
+    if reserved is not None:
+        raise DJAlreadyExistsException(
+            message=(
+                f"Key '{key}' is reserved globally and cannot be registered at "
+                "namespace scope."
+            ),
+        )
+
+
+async def upsert_schema_row(
+    session: AsyncSession,
+    *,
+    key: str,
+    namespace: str | None,
+    node_type: str | None,
+    json_schema: dict,
+    filterable: bool,
+    description: str | None,
+    owner: str | None,
+    reserved: bool,
+    current_user_id: int,
+) -> CustomMetadataSchema:
+    """Create, update, or revive the single row owning this scope.
+
+    Reviving rather than inserting alongside: the unique index counts
+    soft-deleted rows while every read hides them, so an insert beside a
+    tombstone violates the constraint. The row keeps its id and created_at, so
+    a retired key that comes back is the same registration, not a new one.
+
+    Does not commit -- the caller owns the transaction, which is what lets a
+    dry-run deployment roll the registration back.
+    """
+    row = (
+        await session.execute(
+            select(CustomMetadataSchema).where(
+                *scope_clause(key, namespace, node_type),
+            ),
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        row = CustomMetadataSchema(
+            key=key,
+            namespace=namespace,
+            node_type=node_type,
+            created_by_id=current_user_id,
+        )
+        session.add(row)
+    row.json_schema = json_schema
+    row.value_kind = value_kind(json_schema)
+    row.filterable = filterable
+    row.description = description
+    row.owner = owner
+    row.reserved = reserved
+    row.updated_by_id = current_user_id
+    row.deactivated_at = None
+    return row
+
+
+async def upsert_schema_specs(
+    session: AsyncSession,
+    namespace: str,
+    specs: list[CustomMetadataSchemaSpec],
+    *,
+    current_user_id: int,
+    build_indexes: bool = True,
+) -> None:
+    """Reconcile *namespace*'s schema rows to exactly *specs*.
+
+    Declared keys are upserted; namespace-scoped rows the specs no longer
+    declare are soft-deleted. Global rows are never touched -- no namespace
+    owns them, so no deployment can retire one.
+
+    Every schema is checked before anything is written, so a malformed spec
+    fails the deployment rather than half-applying it. ``build_indexes=False``
+    skips index DDL for a dry run.
+    """
+    for spec in specs:
+        check_json_schema(spec.key, spec.json_schema)
+        await assert_not_reserved_globally(session, spec.key, namespace)
+
+    declared: set[tuple[str, str | None]] = set()
+    for spec in specs:
+        node_type_val = spec.node_type.value if spec.node_type is not None else None
+        declared.add((spec.key, node_type_val))
+        await upsert_schema_row(
+            session,
+            key=spec.key,
+            namespace=namespace,
+            node_type=node_type_val,
+            json_schema=spec.json_schema,
+            filterable=spec.filterable,
+            description=spec.description,
+            owner=spec.owner,
+            reserved=False,
+            current_user_id=current_user_id,
+        )
+
+    existing = (
+        (
+            await session.execute(
+                select(CustomMetadataSchema).where(
+                    CustomMetadataSchema.namespace == namespace,
+                    CustomMetadataSchema.deactivated_at.is_(None),
+                ),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    now = datetime.datetime.now(datetime.UTC)
+    for row in existing:
+        if (row.key, row.node_type) not in declared:
+            row.deactivated_at = now
+
+    if build_indexes:
+        await session.flush()
+        for spec in specs:
+            if spec.filterable:
+                await ensure_expression_index(
+                    session,
+                    spec.key,
+                    value_kind(spec.json_schema),
+                )
 
 
 def custom_metadata_clause(col, f: CustomMetadataFilter):

--- a/datajunction-server/datajunction_server/internal/custom_metadata.py
+++ b/datajunction-server/datajunction_server/internal/custom_metadata.py
@@ -305,28 +305,41 @@ async def upsert_schema_specs(
     current_user_id: int,
     build_indexes: bool = True,
 ) -> None:
-    """Reconcile *namespace*'s schema rows to exactly *specs*.
+    """Reconcile schema rows to exactly *specs*.
 
-    Declared keys are upserted; namespace-scoped rows the specs no longer
-    declare are soft-deleted. Global rows are never touched -- no namespace
-    owns them, so no deployment can retire one.
+    Declared keys are upserted; rows in scope the specs no longer declare are
+    soft-deleted. Global rows are never touched -- no namespace owns them, so no
+    deployment can retire one.
 
-    Every schema is checked before anything is written, so a malformed spec
-    fails the deployment rather than half-applying it. ``build_indexes=False``
-    skips index DDL for a dry run.
+    A spec carries its own namespace, defaulted to the deployment's by
+    `DeploymentSpec.set_namespaces` and constrained there to that namespace or one
+    beneath it. Reconciliation covers the deploying namespace plus whatever
+    sub-namespaces the specs name, and nothing else: declaring a schema for
+    `shared.conformed` must not retire rows for `shared.finance`, which a different
+    deployment owns, while an empty spec list still retires the deploying
+    namespace's own rows.
+
+    Every schema is checked before anything is written, so a malformed spec fails
+    the deployment rather than half-applying it. ``build_indexes=False`` skips
+    index DDL for a dry run.
     """
     for spec in specs:
         check_json_schema(spec.key, spec.json_schema)
-        await assert_not_reserved_globally(session, spec.key, namespace)
+        await assert_not_reserved_globally(
+            session,
+            spec.key,
+            spec.namespace or namespace,
+        )
 
-    declared: set[tuple[str, str | None]] = set()
+    declared: set[tuple[str, str | None, str]] = set()
     for spec in specs:
         node_type_val = spec.node_type.value if spec.node_type is not None else None
-        declared.add((spec.key, node_type_val))
+        scope = spec.namespace or namespace
+        declared.add((spec.key, node_type_val, scope))
         await upsert_schema_row(
             session,
             key=spec.key,
-            namespace=namespace,
+            namespace=scope,
             node_type=node_type_val,
             json_schema=spec.json_schema,
             filterable=spec.filterable,
@@ -336,11 +349,12 @@ async def upsert_schema_specs(
             current_user_id=current_user_id,
         )
 
+    scopes = {namespace} | {scope for _, _, scope in declared}
     existing = (
         (
             await session.execute(
                 select(CustomMetadataSchema).where(
-                    CustomMetadataSchema.namespace == namespace,
+                    CustomMetadataSchema.namespace.in_(scopes),
                     CustomMetadataSchema.deactivated_at.is_(None),
                 ),
             )
@@ -350,7 +364,7 @@ async def upsert_schema_specs(
     )
     now = datetime.datetime.now(datetime.UTC)
     for row in existing:
-        if (row.key, row.node_type) not in declared:
+        if (row.key, row.node_type, row.namespace) not in declared:
             row.deactivated_at = now
 
     if build_indexes:

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -47,6 +47,7 @@ from datajunction_server.internal.access.authorization import (
     AccessDenialMode,
 )
 from datajunction_server.internal.access.authorization.context import AuthContext
+from datajunction_server.internal.custom_metadata import upsert_schema_specs
 from datajunction_server.internal.deployment.dimension_reachability import (
     DimensionReachability,
 )
@@ -594,6 +595,19 @@ class DeploymentOrchestrator:
         self.registry.add_owners(await self._setup_owners())
         self.registry.add_catalogs(await self._setup_catalogs())
         self.registry.add_attributes(await self._setup_attributes())
+        # `is not None`, not truthiness: an empty list is a manifest that manages
+        # schemas and declares none, which retires them. Omitting the section
+        # leaves them alone.
+        if self.deployment_spec.custom_metadata_schemas is not None:
+            await upsert_schema_specs(
+                self.session,
+                self.deployment_spec.namespace,
+                self.deployment_spec.custom_metadata_schemas,
+                current_user_id=self.context.current_user.id,
+                # Index DDL is the one part a rolled-back SAVEPOINT would do for
+                # nothing, and a dry run needs no index to report impact.
+                build_indexes=not self.dry_run,
+            )
         logger.info(
             "Set up deployment resources: %d namespaces, %d tags, %d owners, %d catalogs, %d attributes",
             len(self.registry.namespaces),

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -1374,6 +1374,23 @@ def diff(
     ]
 
 
+class CustomMetadataSchemaSpec(BaseModel):
+    """
+    Specification for a custom_metadata JSON Schema to register for a namespace.
+
+    The namespace is implicit: it comes from the enclosing DeploymentSpec.
+    """
+
+    key: str
+    node_type: NodeType | None = None
+    json_schema: dict
+    filterable: bool = True
+    description: str | None = None
+    # Advisory team ownership, not authorization: registering through a
+    # deployment is already gated on WRITE for the namespace.
+    owner: str | None = None
+
+
 class GitDeploymentSource(BaseModel):
     """
     Deployment from a tracked git repository.
@@ -1473,6 +1490,11 @@ class DeploymentSpec(BaseModel):
     tags: list[TagSpec] = Field(default_factory=list)
     hierarchies: list[HierarchySpec] = Field(default_factory=list)
     preaggregations: list[PreAggSpec] = Field(default_factory=list)
+    # None and [] mean different things: None is "this manifest does not manage
+    # schemas", [] is "it manages them and declares none", which retires the
+    # namespace's rows. A list default would make every deployment that omits
+    # the section look like the latter.
+    custom_metadata_schemas: list[CustomMetadataSchemaSpec] | None = None
     source: DeploymentSource | None = None  # CI/CD provenance tracking
     git_config: NamespaceGitConfig | None = None  # Git branch management config
     force: bool = Field(

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -1378,11 +1378,16 @@ class CustomMetadataSchemaSpec(BaseModel):
     """
     Specification for a custom_metadata JSON Schema to register for a namespace.
 
-    The namespace is implicit: it comes from the enclosing DeploymentSpec.
+    The namespace defaults to the enclosing DeploymentSpec's. Naming one narrows the
+    schema to a sub-namespace, which is how a vocabulary can be rolled out to part of
+    a repo's graph -- conformed dimensions first, say -- before it governs all of it.
+    A namespace outside the deploying one is rejected: a manifest may scope narrower
+    than itself, never wider.
     """
 
     key: str
     node_type: NodeType | None = None
+    namespace: str | None = None
     json_schema: dict
     filterable: bool = True
     description: str | None = None
@@ -1564,6 +1569,22 @@ class DeploymentSpec(BaseModel):
         for preagg in self.preaggregations:
             if not preagg.namespace:
                 preagg.namespace = self.namespace
+        for schema in self.custom_metadata_schemas or []:
+            if not schema.namespace:
+                schema.namespace = self.namespace
+            elif schema.namespace != self.namespace and not schema.namespace.startswith(
+                f"{self.namespace}.",
+            ):
+                # Narrower than the deploying namespace is a rollout choice;
+                # wider, or sideways, would let one repo govern another's nodes.
+                raise DJInvalidDeploymentConfig(
+                    message=(
+                        f"custom_metadata schema '{schema.key}' declares namespace "
+                        f"'{schema.namespace}', which is not '{self.namespace}' or "
+                        "beneath it. A deployment may scope a schema to its own "
+                        "namespace or a sub-namespace, never to another."
+                    ),
+                )
         return self
 
 

--- a/datajunction-server/tests/internal/test_custom_metadata_deploy.py
+++ b/datajunction-server/tests/internal/test_custom_metadata_deploy.py
@@ -1,0 +1,508 @@
+"""Tests for upsert_schema_specs — namespace-scoped schema registration via deploy."""
+
+import datetime
+
+import pytest
+from sqlalchemy import select, text
+from unittest.mock import MagicMock
+
+from datajunction_server.database.custom_metadata_schema import CustomMetadataSchema
+from datajunction_server.errors import (
+    DJAlreadyExistsException,
+    DJInvalidInputException,
+)
+from datajunction_server.internal.custom_metadata import upsert_schema_specs
+from datajunction_server.internal.deployment.orchestrator import DeploymentOrchestrator
+from datajunction_server.internal.deployment.utils import DeploymentContext
+from datajunction_server.models.deployment import (
+    CustomMetadataSchemaSpec,
+    DeploymentSpec,
+)
+from datajunction_server.models.node_type import NodeType
+
+
+@pytest.mark.asyncio
+async def test_deploy_registers_namespace_scoped_schema(session, current_user):
+    """Insert path: a new schema spec creates a namespace-scoped row."""
+    await upsert_schema_specs(
+        session,
+        namespace="finance",
+        specs=[
+            CustomMetadataSchemaSpec(key="grain", json_schema={"type": "string"}),
+        ],
+        current_user_id=current_user.id,
+    )
+    row = (
+        await session.execute(
+            select(CustomMetadataSchema).where(CustomMetadataSchema.key == "grain"),
+        )
+    ).scalar_one()
+    assert row.namespace == "finance"
+    assert row.value_kind == "string"
+
+
+@pytest.mark.asyncio
+async def test_deploy_updates_existing_schema(session, current_user):
+    """Update path: a pre-existing row is updated in-place, not duplicated."""
+    # Pre-seed a row for the same key/namespace/node_type=None
+    session.add(
+        CustomMetadataSchema(
+            key="grain",
+            namespace="finance",
+            json_schema={"type": "string"},
+            value_kind="string",
+            filterable=True,
+        ),
+    )
+    await session.commit()
+
+    # Call upsert again with a changed schema (now integer)
+    await upsert_schema_specs(
+        session,
+        namespace="finance",
+        specs=[
+            CustomMetadataSchemaSpec(
+                key="grain",
+                json_schema={"type": "integer"},
+                filterable=False,
+                description="updated",
+            ),
+        ],
+        current_user_id=current_user.id,
+    )
+
+    rows = (
+        (
+            await session.execute(
+                select(CustomMetadataSchema).where(
+                    CustomMetadataSchema.key == "grain",
+                    CustomMetadataSchema.namespace == "finance",
+                ),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    # Should still be exactly one row (updated, not duplicated)
+    assert len(rows) == 1
+    assert rows[0].value_kind == "integer"
+    assert rows[0].filterable is False
+    assert rows[0].description == "updated"
+
+
+@pytest.mark.asyncio
+async def test_deploy_node_type_scoped_schema(session, current_user):
+    """Node-type-scoped spec creates a row with node_type set."""
+    await upsert_schema_specs(
+        session,
+        namespace="eng",
+        specs=[
+            CustomMetadataSchemaSpec(
+                key="owner_team",
+                node_type=NodeType.METRIC,
+                json_schema={"type": "string"},
+            ),
+        ],
+        current_user_id=current_user.id,
+    )
+    row = (
+        await session.execute(
+            select(CustomMetadataSchema).where(
+                CustomMetadataSchema.key == "owner_team",
+                CustomMetadataSchema.namespace == "eng",
+            ),
+        )
+    ).scalar_one()
+    assert row.node_type == NodeType.METRIC.value
+    assert row.value_kind == "string"
+
+
+@pytest.mark.asyncio
+async def test_deploy_empty_specs_on_an_empty_namespace(session, current_user):
+    """An empty spec list against a namespace with no rows registers nothing.
+
+    `[]` means "this manifest manages schemas and declares none", so it retires
+    whatever the namespace had -- which here is nothing.
+    """
+    await upsert_schema_specs(
+        session,
+        namespace="empty_ns",
+        specs=[],
+        current_user_id=current_user.id,
+    )
+    rows = (
+        (
+            await session.execute(
+                select(CustomMetadataSchema).where(
+                    CustomMetadataSchema.namespace == "empty_ns",
+                ),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_upsert_invalid_json_schema_raises(session, current_user):
+    """upsert_schema_specs raises DJInvalidInputException for an invalid JSON Schema."""
+    with pytest.raises(DJInvalidInputException) as exc_info:
+        await upsert_schema_specs(
+            session,
+            namespace="validation_test",
+            specs=[
+                CustomMetadataSchemaSpec(
+                    key="bad_schema_key",
+                    json_schema={"type": "not-a-type"},
+                ),
+            ],
+            current_user_id=current_user.id,
+        )
+    assert "bad_schema_key" in exc_info.value.message
+    assert "Invalid JSON Schema" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_upsert_filterable_numeric_builds_index(session, current_user):
+    """upsert_schema_specs with a filterable numeric spec creates the expression index."""
+    unique_key = "deploy_numeric_score_idx_test"
+    await upsert_schema_specs(
+        session,
+        namespace="index_test_ns",
+        specs=[
+            CustomMetadataSchemaSpec(
+                key=unique_key,
+                json_schema={"type": "number"},
+                filterable=True,
+            ),
+        ],
+        current_user_id=current_user.id,
+    )
+    # Verify the index was created in pg_indexes
+    result = await session.execute(
+        text(
+            "SELECT indexname FROM pg_indexes WHERE indexname = :idx",
+        ),
+        {"idx": f"ix_cm_{unique_key}"},
+    )
+    row = result.fetchone()
+    assert row is not None, f"Expected index ix_cm_{unique_key} to exist in pg_indexes"
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_setup_calls_upsert_schema_specs(session, current_user):
+    """The deploy wiring: _setup_deployment_resources calls upsert_schema_specs
+    when custom_metadata_schemas is non-empty, registering the row in the DB."""
+    spec = DeploymentSpec(
+        namespace="wiring_test",
+        nodes=[],
+        custom_metadata_schemas=[
+            CustomMetadataSchemaSpec(key="region", json_schema={"type": "string"}),
+        ],
+    )
+    mock_context = MagicMock(spec=DeploymentContext)
+    mock_context.current_user = current_user
+    orchestrator = DeploymentOrchestrator(
+        deployment_spec=spec,
+        deployment_id="wiring-test-id",
+        session=session,
+        context=mock_context,
+    )
+    await orchestrator._setup_deployment_resources()
+
+    row = (
+        await session.execute(
+            select(CustomMetadataSchema).where(
+                CustomMetadataSchema.key == "region",
+                CustomMetadataSchema.namespace == "wiring_test",
+            ),
+        )
+    ).scalar_one()
+    assert row.value_kind == "string"
+
+
+@pytest.mark.asyncio
+async def test_a_retired_key_can_be_registered_again(session, current_user):
+    """
+    Soft-deleting a key must not make its scope permanently unusable.
+
+    The unique index spans deactivated rows while every read hides them, so an
+    insert beside a tombstone violates the constraint. The upsert revives the
+    row instead, which also keeps its id and created_at: a key that comes back
+    is the same registration, not a new one.
+    """
+    spec = CustomMetadataSchemaSpec(key="lifecycle", json_schema={"type": "string"})
+    await upsert_schema_specs(
+        session,
+        namespace="revive_ns",
+        specs=[spec],
+        current_user_id=current_user.id,
+    )
+    original = (
+        await session.execute(
+            select(CustomMetadataSchema).where(
+                CustomMetadataSchema.key == "lifecycle",
+                CustomMetadataSchema.namespace == "revive_ns",
+            ),
+        )
+    ).scalar_one()
+    original_id, original_created = original.id, original.created_at
+
+    original.deactivated_at = datetime.datetime.now(datetime.UTC)
+    await session.commit()
+
+    await upsert_schema_specs(
+        session,
+        namespace="revive_ns",
+        specs=[spec],
+        current_user_id=current_user.id,
+    )
+    revived = (
+        (
+            await session.execute(
+                select(CustomMetadataSchema).where(
+                    CustomMetadataSchema.key == "lifecycle",
+                    CustomMetadataSchema.namespace == "revive_ns",
+                ),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(revived) == 1
+    assert revived[0].id == original_id
+    assert revived[0].created_at == original_created
+    assert revived[0].deactivated_at is None
+
+
+@pytest.mark.asyncio
+async def test_a_key_the_manifest_drops_is_retired(session, current_user):
+    """Reconciliation: the manifest is the whole truth for its own namespace."""
+    await upsert_schema_specs(
+        session,
+        namespace="reconcile_ns",
+        specs=[
+            CustomMetadataSchemaSpec(key="keep", json_schema={"type": "string"}),
+            CustomMetadataSchemaSpec(key="drop", json_schema={"type": "string"}),
+        ],
+        current_user_id=current_user.id,
+    )
+    await upsert_schema_specs(
+        session,
+        namespace="reconcile_ns",
+        specs=[
+            CustomMetadataSchemaSpec(key="keep", json_schema={"type": "string"}),
+        ],
+        current_user_id=current_user.id,
+    )
+    live = sorted(
+        row.key
+        for row in (
+            await session.execute(
+                select(CustomMetadataSchema).where(
+                    CustomMetadataSchema.namespace == "reconcile_ns",
+                    CustomMetadataSchema.deactivated_at.is_(None),
+                ),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert live == ["keep"]
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_leaves_global_rows_alone(session, current_user):
+    """No namespace owns a global key, so no deployment may retire one."""
+    session.add(
+        CustomMetadataSchema(
+            key="global_key",
+            namespace=None,
+            json_schema={"type": "string"},
+            value_kind="string",
+        ),
+    )
+    await session.commit()
+
+    await upsert_schema_specs(
+        session,
+        namespace="some_ns",
+        specs=[],
+        current_user_id=current_user.id,
+    )
+    row = (
+        await session.execute(
+            select(CustomMetadataSchema).where(
+                CustomMetadataSchema.key == "global_key",
+            ),
+        )
+    ).scalar_one()
+    assert row.deactivated_at is None
+
+
+@pytest.mark.asyncio
+async def test_a_deploy_cannot_shadow_a_reserved_global_key(session, current_user):
+    """
+    The API refuses this; the deploy path used to be the way around it.
+
+    Both writers hit the same table, so a check only one of them makes is not a
+    check at all.
+    """
+    session.add(
+        CustomMetadataSchema(
+            key="lifecycle",
+            namespace=None,
+            reserved=True,
+            json_schema={"type": "string", "enum": ["beta"]},
+            value_kind="string",
+        ),
+    )
+    await session.commit()
+
+    with pytest.raises(DJAlreadyExistsException) as exc_info:
+        await upsert_schema_specs(
+            session,
+            namespace="sneaky_ns",
+            specs=[
+                CustomMetadataSchemaSpec(
+                    key="lifecycle",
+                    json_schema={"type": "string"},
+                ),
+            ],
+            current_user_id=current_user.id,
+        )
+    assert "reserved globally" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_a_deploy_records_who_registered_the_schema(session, current_user):
+    """Ownership and provenance, which the deploy path was not setting at all."""
+    await upsert_schema_specs(
+        session,
+        namespace="prov_ns",
+        specs=[
+            CustomMetadataSchemaSpec(
+                key="grain",
+                json_schema={"type": "string"},
+                owner="@corp/some-team",
+            ),
+        ],
+        current_user_id=current_user.id,
+    )
+    row = (
+        await session.execute(
+            select(CustomMetadataSchema).where(
+                CustomMetadataSchema.namespace == "prov_ns",
+            ),
+        )
+    ).scalar_one()
+    assert row.created_by_id == current_user.id
+    assert row.updated_by_id == current_user.id
+    assert row.owner == "@corp/some-team"
+    assert row.reserved is False
+
+
+@pytest.mark.asyncio
+async def test_upsert_leaves_the_transaction_to_its_caller(session, current_user):
+    """
+    Registration must be rollback-able, which is what makes a dry run safe.
+
+    `POST /deployments/impact` runs the whole orchestrator inside a SAVEPOINT
+    purely to report what a deployment would do, then unwinds it. A commit in
+    here releases that SAVEPOINT, so analysing a spec would permanently
+    register its schemas.
+    """
+    await upsert_schema_specs(
+        session,
+        namespace="rollback_ns",
+        specs=[
+            CustomMetadataSchemaSpec(key="grain", json_schema={"type": "string"}),
+        ],
+        current_user_id=current_user.id,
+    )
+    await session.rollback()
+
+    rows = (
+        (
+            await session.execute(
+                select(CustomMetadataSchema).where(
+                    CustomMetadataSchema.namespace == "rollback_ns",
+                ),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_a_dry_run_builds_no_index(session, current_user):
+    """
+    Index DDL is the one thing a rolled-back SAVEPOINT would do for nothing,
+    and impact analysis needs no index to report impact.
+    """
+    unique_key = "dry_run_no_index_probe"
+    await upsert_schema_specs(
+        session,
+        namespace="dry_run_ns",
+        specs=[
+            CustomMetadataSchemaSpec(
+                key=unique_key,
+                json_schema={"type": "number"},
+                filterable=True,
+            ),
+        ],
+        current_user_id=current_user.id,
+        build_indexes=False,
+    )
+    found = (
+        await session.execute(
+            text("SELECT indexname FROM pg_indexes WHERE indexname = :idx"),
+            {"idx": f"ix_cm_{unique_key}"},
+        )
+    ).fetchone()
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_an_omitted_section_leaves_schemas_alone(session, current_user):
+    """
+    None and [] are different manifests.
+
+    Every deployment that predates this field sends no section at all. If that
+    read as "declares none", the next deploy of any existing repo would retire
+    every schema it had.
+    """
+    session.add(
+        CustomMetadataSchema(
+            key="pre_existing",
+            namespace="untouched_ns",
+            json_schema={"type": "string"},
+            value_kind="string",
+        ),
+    )
+    await session.commit()
+
+    spec = DeploymentSpec(namespace="untouched_ns", nodes=[])
+    assert spec.custom_metadata_schemas is None
+
+    mock_context = MagicMock(spec=DeploymentContext)
+    mock_context.current_user = current_user
+    orchestrator = DeploymentOrchestrator(
+        deployment_spec=spec,
+        deployment_id="omitted-section-id",
+        session=session,
+        context=mock_context,
+    )
+    await orchestrator._setup_deployment_resources()
+
+    row = (
+        await session.execute(
+            select(CustomMetadataSchema).where(
+                CustomMetadataSchema.key == "pre_existing",
+            ),
+        )
+    ).scalar_one()
+    assert row.deactivated_at is None

--- a/datajunction-server/tests/internal/test_custom_metadata_deploy.py
+++ b/datajunction-server/tests/internal/test_custom_metadata_deploy.py
@@ -506,3 +506,116 @@ async def test_an_omitted_section_leaves_schemas_alone(session, current_user):
         )
     ).scalar_one()
     assert row.deactivated_at is None
+
+
+@pytest.mark.asyncio
+async def test_a_schema_can_be_scoped_to_a_sub_namespace(session, current_user):
+    """
+    Rolling a vocabulary out to part of a repo's graph before all of it.
+
+    The USG rollout gates conformed dimensions first, which needs a schema scoped
+    narrower than the namespace being deployed.
+    """
+    await upsert_schema_specs(
+        session,
+        namespace="shared",
+        specs=[
+            CustomMetadataSchemaSpec(
+                key="system",
+                namespace="shared.conformed",
+                json_schema={"type": "object"},
+            ),
+        ],
+        current_user_id=current_user.id,
+    )
+    row = (
+        await session.execute(
+            select(CustomMetadataSchema).where(CustomMetadataSchema.key == "system"),
+        )
+    ).scalar_one()
+    assert row.namespace == "shared.conformed"
+
+
+@pytest.mark.asyncio
+async def test_a_sub_namespace_declaration_spares_its_siblings(session, current_user):
+    """
+    Reconciliation covers what the specs name, not the whole subtree.
+
+    `shared.finance` is deployed by whoever owns it. A deployment of `shared` that
+    declares a schema for `shared.conformed` says nothing about it, so retiring it
+    would be one repo reaching into another's rows.
+    """
+    session.add(
+        CustomMetadataSchema(
+            key="system",
+            namespace="shared.finance",
+            json_schema={"type": "object"},
+            value_kind="object",
+        ),
+    )
+    await session.commit()
+
+    await upsert_schema_specs(
+        session,
+        namespace="shared",
+        specs=[
+            CustomMetadataSchemaSpec(
+                key="system",
+                namespace="shared.conformed",
+                json_schema={"type": "object"},
+            ),
+        ],
+        current_user_id=current_user.id,
+    )
+    live = sorted(
+        row.namespace
+        for row in (
+            await session.execute(
+                select(CustomMetadataSchema).where(
+                    CustomMetadataSchema.key == "system",
+                    CustomMetadataSchema.deactivated_at.is_(None),
+                ),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert live == ["shared.conformed", "shared.finance"]
+
+
+@pytest.mark.asyncio
+async def test_an_empty_list_still_retires_the_deploying_namespace(
+    session,
+    current_user,
+):
+    """
+    The deploying namespace stays in scope even when no spec names it, so `[]`
+    keeps meaning "manages schemas, declares none".
+    """
+    await upsert_schema_specs(
+        session,
+        namespace="retire_ns",
+        specs=[
+            CustomMetadataSchemaSpec(key="system", json_schema={"type": "object"}),
+        ],
+        current_user_id=current_user.id,
+    )
+    await upsert_schema_specs(
+        session,
+        namespace="retire_ns",
+        specs=[],
+        current_user_id=current_user.id,
+    )
+    live = (
+        (
+            await session.execute(
+                select(CustomMetadataSchema).where(
+                    CustomMetadataSchema.namespace == "retire_ns",
+                    CustomMetadataSchema.deactivated_at.is_(None),
+                ),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert live == []

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -263,6 +263,7 @@ def test_deployment_spec():
         "tags": [],
         "hierarchies": [],
         "preaggregations": [],
+        "custom_metadata_schemas": None,
         "source": None,
         "auto_register_sources": True,
         "force": False,

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -12,6 +12,7 @@ from datajunction_server.models.deployment import (
     ChangeTier,
     ColumnSpec,
     CubeSpec,
+    CustomMetadataSchemaSpec,
     DeploymentSpec,
     DimensionJoinLinkSpec,
     DimensionReferenceLinkSpec,
@@ -1575,3 +1576,56 @@ def test_cube_spec_materialization_diff_ignores_declaration_order():
         )
         == []
     )
+
+
+def test_a_schema_namespace_defaults_to_the_deployment():
+    """Omitting it keeps the existing behaviour: the deploying namespace."""
+    spec = DeploymentSpec(
+        namespace="shared",
+        nodes=[],
+        custom_metadata_schemas=[
+            CustomMetadataSchemaSpec(key="system", json_schema={"type": "object"}),
+        ],
+    )
+    assert spec.custom_metadata_schemas[0].namespace == "shared"
+
+
+def test_a_schema_may_be_scoped_to_a_sub_namespace():
+    """Narrower than the deployment is how a vocabulary rolls out in stages."""
+    spec = DeploymentSpec(
+        namespace="shared",
+        nodes=[],
+        custom_metadata_schemas=[
+            CustomMetadataSchemaSpec(
+                key="system",
+                namespace="shared.conformed",
+                json_schema={"type": "object"},
+            ),
+        ],
+    )
+    assert spec.custom_metadata_schemas[0].namespace == "shared.conformed"
+
+
+@pytest.mark.parametrize(
+    "outside",
+    ["arc", "shared_other", "other.shared", "sharedx"],
+)
+def test_a_schema_namespace_outside_the_deployment_is_rejected(outside):
+    """
+    A manifest may scope a schema narrower than itself, never wider or sideways --
+    otherwise one repo governs another repo's nodes. `shared_other` and `sharedx`
+    are the prefix trap: they start with the namespace but are not beneath it.
+    """
+    with pytest.raises(DJInvalidDeploymentConfig) as exc_info:
+        DeploymentSpec(
+            namespace="shared",
+            nodes=[],
+            custom_metadata_schemas=[
+                CustomMetadataSchemaSpec(
+                    key="system",
+                    namespace=outside,
+                    json_schema={"type": "object"},
+                ),
+            ],
+        )
+    assert "not 'shared' or beneath it" in str(exc_info.value)


### PR DESCRIPTION
### Summary

A namespace's `custom_metadata` vocabulary can now be declared in the deployment manifest, next to the nodes it governs, instead of only through admin API calls:
```yaml
namespace: analytics.sales
custom_metadata_schemas:
  - key: sla
    description: Freshness commitment for scheduled outputs.
    owner: 'foobar'
    json_schema:
      type: object
      properties:
        max_staleness_hours:
          type: integer
          minimum: 1
        pager_rotation:
          type: string
      required: [max_staleness_hours]

  - key: review_status
    node_type: metric
    description: Where a metric definition sits in review.
    json_schema:
      type: string
      enum: [draft, in_review, approved]

  - key: pii_reviewed
    namespace: analytics.sales.customer
    description: Whether a privacy review has been recorded.
    json_schema:
      type: boolean
```

A deployment manages the complete set of schemas for the namespace it's scoped to. Any declared keys here are created, updated, or revived if previously retired. Omitting the section leaves existing schemas alone, but declaring an empty list `[]` will make DJ match the (empty-list) manifest and retire any existing schemas.

The schema defaults to the deploying namespace, but you can also name one to narrow it to a sub-namespace. Anything outside of the deploying namespace is rejected at spec validation, so one repo can't register schemas that govern another's nodes. Globally reserved keys remain untouchable from a deployment.

### Test Plan

Last of the custom metadata schema registry stack, following #2456 and #2461.

- [ ] PR has an associated issue: #1352
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
