### PR TITLE
Seed test fixtures once per module instead of once per test

### DIFF
--- a/datajunction-server/tests/api/graphql/tags_test.py
+++ b/datajunction-server/tests/api/graphql/tags_test.py
@@ -7,14 +7,14 @@ import pytest_asyncio
 from httpx import AsyncClient
 
 
-@pytest_asyncio.fixture
+@pytest_asyncio.fixture(scope="module")
 async def client_with_tags(
-    client_with_roads: AsyncClient,
+    module__client_with_roads: AsyncClient,
 ) -> AsyncClient:
     """
     Provides a DJ client fixture seeded with tags
     """
-    await client_with_roads.post(
+    await module__client_with_roads.post(
         "/tags/",
         json={
             "name": "sales_report",
@@ -24,7 +24,7 @@ async def client_with_tags(
             "tag_metadata": {},
         },
     )
-    await client_with_roads.post(
+    await module__client_with_roads.post(
         "/tags/",
         json={
             "name": "other_report",
@@ -34,7 +34,7 @@ async def client_with_tags(
             "tag_metadata": {},
         },
     )
-    await client_with_roads.post(
+    await module__client_with_roads.post(
         "/tags/",
         json={
             "name": "coffee",
@@ -44,7 +44,7 @@ async def client_with_tags(
             "tag_metadata": {},
         },
     )
-    await client_with_roads.post(
+    await module__client_with_roads.post(
         "/tags/",
         json={
             "name": "tea",
@@ -55,16 +55,16 @@ async def client_with_tags(
         },
     )
 
-    await client_with_roads.post(
+    await module__client_with_roads.post(
         "/nodes/default.total_repair_cost/tags/?tag_names=sales_report",
     )
-    await client_with_roads.post(
+    await module__client_with_roads.post(
         "/nodes/default.avg_repair_price/tags/?tag_names=sales_report",
     )
-    await client_with_roads.post(
+    await module__client_with_roads.post(
         "/nodes/default.num_repair_orders/tags/?tag_names=other_report",
     )
-    return client_with_roads
+    return module__client_with_roads
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/construction/build_v3/fanout_guard_test.py
+++ b/datajunction-server/tests/construction/build_v3/fanout_guard_test.py
@@ -14,6 +14,7 @@ These tests exercise that guard end-to-end through the /sql/measures/v3/ and
 """
 
 import pytest
+import pytest_asyncio
 
 
 def fanout_warnings(payload: dict) -> list[dict]:
@@ -25,8 +26,8 @@ def fanout_warnings(payload: dict) -> list[dict]:
     ]
 
 
-@pytest.fixture
-async def setup_fanout_links(client_with_build_v3):
+@pytest_asyncio.fixture(scope="module")
+async def setup_fanout_links(module__client_with_build_v3):
     """
     Add a dimension that fans out from ``v3.order_details``.
 
@@ -38,7 +39,7 @@ async def setup_fanout_links(client_with_build_v3):
     Defined locally so only the fan-out tests pay the setup cost; the global
     BUILD_V3 fixture is unaffected.
     """
-    response = await client_with_build_v3.post(
+    response = await module__client_with_build_v3.post(
         "/nodes/source/",
         json={
             "name": "v3.src_order_promotions",
@@ -57,7 +58,7 @@ async def setup_fanout_links(client_with_build_v3):
     )
     assert response.status_code in (200, 201, 409), response.json()
 
-    response = await client_with_build_v3.post(
+    response = await module__client_with_build_v3.post(
         "/nodes/dimension/",
         json={
             "name": "v3.order_promotion",
@@ -73,7 +74,7 @@ async def setup_fanout_links(client_with_build_v3):
     assert response.status_code in (200, 201, 409), response.json()
 
     # order_details -> order_promotion: one order line maps to many promotions.
-    response = await client_with_build_v3.post(
+    response = await module__client_with_build_v3.post(
         "/nodes/v3.order_details/link",
         json={
             "dimension_node": "v3.order_promotion",
@@ -85,7 +86,7 @@ async def setup_fanout_links(client_with_build_v3):
     assert response.status_code in (200, 201, 409), response.json()
 
     # A second dimension linked many_to_many, to exercise that cardinality.
-    response = await client_with_build_v3.post(
+    response = await module__client_with_build_v3.post(
         "/nodes/source/",
         json={
             "name": "v3.src_order_channels",
@@ -103,7 +104,7 @@ async def setup_fanout_links(client_with_build_v3):
     )
     assert response.status_code in (200, 201, 409), response.json()
 
-    response = await client_with_build_v3.post(
+    response = await module__client_with_build_v3.post(
         "/nodes/dimension/",
         json={
             "name": "v3.order_channel",
@@ -117,7 +118,7 @@ async def setup_fanout_links(client_with_build_v3):
     )
     assert response.status_code in (200, 201, 409), response.json()
 
-    response = await client_with_build_v3.post(
+    response = await module__client_with_build_v3.post(
         "/nodes/v3.order_details/link",
         json={
             "dimension_node": "v3.order_channel",
@@ -130,7 +131,7 @@ async def setup_fanout_links(client_with_build_v3):
 
     # A MIN metric: its merge function is MIN (non-additive), so it's
     # duplication-immune and must NOT trip the guard even across a fan-out link.
-    response = await client_with_build_v3.post(
+    response = await module__client_with_build_v3.post(
         "/nodes/metric/",
         json={
             "name": "v3.min_unit_price",
@@ -144,7 +145,7 @@ async def setup_fanout_links(client_with_build_v3):
     # A COUNT_IF metric: merge=SUM (additive), so it inflates under fan-out exactly
     # like SUM/COUNT. Its phase-1 aggregation name is "COUNT_IF" (not SUM/COUNT/AVG),
     # so keying on the merge function — not the aggregation name — is what catches it.
-    response = await client_with_build_v3.post(
+    response = await module__client_with_build_v3.post(
         "/nodes/metric/",
         json={
             "name": "v3.completed_order_count",
@@ -158,7 +159,7 @@ async def setup_fanout_links(client_with_build_v3):
     # A MEDIAN metric: non-decomposable (holistic), so it builds via raw
     # passthrough and is aggregated over the duplicated rows. It depends on the
     # multiset of rows, so a fan-out distorts it and the guard MUST fire.
-    response = await client_with_build_v3.post(
+    response = await module__client_with_build_v3.post(
         "/nodes/metric/",
         json={
             "name": "v3.median_unit_price",
@@ -171,7 +172,7 @@ async def setup_fanout_links(client_with_build_v3):
 
     # A MAX_BY metric: non-decomposable too, but argmax reads a single extreme
     # row, so duplication can't change it. It must NOT trip the guard.
-    response = await client_with_build_v3.post(
+    response = await module__client_with_build_v3.post(
         "/nodes/metric/",
         json={
             "name": "v3.unit_price_at_max_order",
@@ -184,7 +185,7 @@ async def setup_fanout_links(client_with_build_v3):
 
     # Non-decomposable (MAX_BY) but embeds COUNT(DISTINCT). Both terms are immune, so
     # the metric is too — the embedded-DISTINCT case that must NOT trip the guard.
-    response = await client_with_build_v3.post(
+    response = await module__client_with_build_v3.post(
         "/nodes/metric/",
         json={
             "name": "v3.price_at_max_order_per_distinct_order",
@@ -200,7 +201,7 @@ async def setup_fanout_links(client_with_build_v3):
 
     # An APPROX_COUNT_DISTINCT metric: decomposable, but its component merges via
     # hll_union_agg (not SUM), so duplication can't inflate it. Must NOT warn.
-    response = await client_with_build_v3.post(
+    response = await module__client_with_build_v3.post(
         "/nodes/metric/",
         json={
             "name": "v3.approx_order_count",
@@ -214,7 +215,7 @@ async def setup_fanout_links(client_with_build_v3):
     # A metric that SUMs a dimension attribute reachable only through the fan-out
     # link. The join is emitted even when no promotion dimension is requested, so the
     # guard must see it — this is the metric-expression-dimension fan-out case.
-    response = await client_with_build_v3.post(
+    response = await module__client_with_build_v3.post(
         "/nodes/metric/",
         json={
             "name": "v3.total_promo_discount",
@@ -232,11 +233,11 @@ class TestFanoutGuardWarns:
     @pytest.mark.asyncio
     async def test_sum_over_one_to_many_warns(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """SUM across a one_to_many link inflates → 200 with an actionable warning."""
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.total_revenue"],
@@ -268,11 +269,11 @@ class TestFanoutGuardWarns:
     @pytest.mark.asyncio
     async def test_sum_over_many_to_many_warns(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """SUM across a many_to_many link inflates → 200 with a warning."""
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.total_revenue"],
@@ -287,11 +288,11 @@ class TestFanoutGuardWarns:
     @pytest.mark.asyncio
     async def test_avg_over_one_to_many_warns(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """AVG decomposes into SUM/COUNT components, both inflate → 200 + warning."""
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.avg_unit_price"],
@@ -304,7 +305,7 @@ class TestFanoutGuardWarns:
     @pytest.mark.asyncio
     async def test_count_if_over_one_to_many_warns(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """COUNT_IF has merge=SUM (additive) → inflates → 200 + warning.
@@ -312,7 +313,7 @@ class TestFanoutGuardWarns:
         COUNT_IF's phase-1 aggregation name is not in {SUM,COUNT,AVG}, so a name-based
         guard would miss it; keying on the merge function is what catches it.
         """
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.completed_order_count"],
@@ -325,7 +326,7 @@ class TestFanoutGuardWarns:
     @pytest.mark.asyncio
     async def test_median_over_one_to_many_warns(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """A non-decomposable holistic metric (MEDIAN) inflates → 200 + warning.
@@ -333,7 +334,7 @@ class TestFanoutGuardWarns:
         MEDIAN has no components and no SUM merge, so the merge check alone can't
         see it; it's caught via the grain group's non-decomposable metrics.
         """
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.median_unit_price"],
@@ -348,7 +349,7 @@ class TestFanoutGuardWarns:
     @pytest.mark.asyncio
     async def test_metric_expression_dimension_fanout_warns(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """A dimension attribute SUM'd inside the metric expression still fans out.
@@ -357,7 +358,7 @@ class TestFanoutGuardWarns:
         v3.order_promotion.discount, so the build emits the one_to_many join anyway.
         The guard must scan the emitted join paths, not just the requested dimensions.
         """
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.total_promo_discount"],
@@ -372,11 +373,11 @@ class TestFanoutGuardWarns:
     @pytest.mark.asyncio
     async def test_metrics_endpoint_also_warns(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """The guard fires on /sql/metrics/v3/ as well, not just measures."""
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/metrics/v3/",
             params={
                 "metrics": ["v3.total_revenue"],
@@ -389,14 +390,14 @@ class TestFanoutGuardWarns:
     @pytest.mark.asyncio
     async def test_node_sql_endpoint_also_warns(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """
         /sql/{node_name}/ builds a metric node through v3 as well, so its
         TranslatedSQL response has to carry the warning too.
         """
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/v3.total_revenue/",
             params={"dimensions": ["v3.order_promotion.campaign"]},
         )
@@ -406,7 +407,7 @@ class TestFanoutGuardWarns:
     @pytest.mark.asyncio
     async def test_derived_metric_warning_names_the_requested_metric(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """
@@ -418,7 +419,7 @@ class TestFanoutGuardWarns:
         v3.avg_order_value = v3.total_revenue / v3.order_count, and only the SUM in
         v3.total_revenue inflates -- v3.order_count is COUNT(DISTINCT ...).
         """
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.avg_order_value"],
@@ -437,7 +438,7 @@ class TestFanoutGuardWarns:
     @pytest.mark.asyncio
     async def test_warning_names_only_the_inflated_metric(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """
@@ -447,7 +448,7 @@ class TestFanoutGuardWarns:
         so both land in the same grain group, but only the SUM inflates. Naming both
         would send the caller to fix a metric that is already correct.
         """
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.total_revenue", "v3.order_count"],
@@ -464,7 +465,7 @@ class TestFanoutGuardWarns:
     @pytest.mark.asyncio
     async def test_window_metric_over_one_to_many_warns(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """
@@ -477,7 +478,7 @@ class TestFanoutGuardWarns:
         grain, so the guard must fire on that grain group too (not just the base
         metric path).
         """
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.wow_revenue_change"],
@@ -502,11 +503,11 @@ class TestFanoutGuardAllows:
     @pytest.mark.asyncio
     async def test_count_distinct_over_one_to_many_ok(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """COUNT(DISTINCT) has no merge function → fan-out-immune → no warning."""
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.order_count"],
@@ -519,11 +520,11 @@ class TestFanoutGuardAllows:
     @pytest.mark.asyncio
     async def test_min_over_one_to_many_ok(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """MIN's merge function is MIN, not additive → duplication-immune → no warning."""
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.min_unit_price"],
@@ -536,11 +537,11 @@ class TestFanoutGuardAllows:
     @pytest.mark.asyncio
     async def test_max_by_over_one_to_many_ok(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """MAX_BY is non-decomposable but argmax reads one extreme row → immune → no warning."""
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.unit_price_at_max_order"],
@@ -553,11 +554,11 @@ class TestFanoutGuardAllows:
     @pytest.mark.asyncio
     async def test_approx_count_distinct_over_one_to_many_ok(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """APPROX_COUNT_DISTINCT merges via hll_union_agg (not SUM) → immune → no warning."""
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.approx_order_count"],
@@ -570,7 +571,7 @@ class TestFanoutGuardAllows:
     @pytest.mark.asyncio
     async def test_embedded_count_distinct_over_one_to_many_ok(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """
@@ -578,7 +579,7 @@ class TestFanoutGuardAllows:
         duplication-immune. Keying invariance on the Count class alone would flag it;
         reading the DISTINCT off the call keeps it quiet.
         """
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.price_at_max_order_per_distinct_order"],
@@ -591,11 +592,11 @@ class TestFanoutGuardAllows:
     @pytest.mark.asyncio
     async def test_sum_over_safe_many_to_one_ok(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """SUM across the default many_to_one customer link does not fan out → no warning."""
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.total_revenue"],
@@ -608,14 +609,14 @@ class TestFanoutGuardAllows:
     @pytest.mark.asyncio
     async def test_sum_without_fanout_dimension_ok(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """
         The same SUM metric is fine as long as the fan-out dimension is not
         requested — the unsafe link is never traversed.
         """
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/",
             params={
                 "metrics": ["v3.total_revenue"],
@@ -634,11 +635,11 @@ class TestFanoutGuardCombinedEndpoint:
     @pytest.mark.asyncio
     async def test_combined_source_path_warns(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """SUM across a one_to_many link, combined-from-source → 200 + warning."""
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/combined",
             params={
                 "metrics": ["v3.total_revenue"],
@@ -651,7 +652,7 @@ class TestFanoutGuardCombinedEndpoint:
     @pytest.mark.asyncio
     async def test_combined_preagg_path_warns(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """
@@ -661,7 +662,7 @@ class TestFanoutGuardCombinedEndpoint:
         computes measures from source internally to derive the grain groups, so the
         fan-out risk is known and must be surfaced.
         """
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/combined",
             params={
                 "use_preagg_tables": "true",
@@ -678,11 +679,11 @@ class TestFanoutGuardCombinedEndpoint:
     @pytest.mark.asyncio
     async def test_combined_preagg_path_without_fanout_ok(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """The pre-agg path does not warn when no fan-out dimension is requested."""
-        response = await client_with_build_v3.get(
+        response = await module__client_with_build_v3.get(
             "/sql/measures/v3/combined",
             params={
                 "use_preagg_tables": "true",
@@ -703,11 +704,11 @@ class TestFanoutGuardPreaggPlan:
     @pytest.mark.asyncio
     async def test_preaggs_plan_over_one_to_many_warns(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """Planning a pre-agg for SUM across a one_to_many link → 201 + warning."""
-        response = await client_with_build_v3.post(
+        response = await module__client_with_build_v3.post(
             "/preaggs/plan",
             json={
                 "metrics": ["v3.total_revenue"],
@@ -723,11 +724,11 @@ class TestFanoutGuardPreaggPlan:
     @pytest.mark.asyncio
     async def test_preaggs_plan_without_fanout_ok(
         self,
-        client_with_build_v3,
+        module__client_with_build_v3,
         setup_fanout_links,
     ):
         """Planning a pre-agg without a fan-out dimension does not warn."""
-        response = await client_with_build_v3.post(
+        response = await module__client_with_build_v3.post(
             "/preaggs/plan",
             json={
                 "metrics": ["v3.total_revenue"],

--- a/datajunction-server/tests/construction/build_v3/transform_query_shapes_test.py
+++ b/datajunction-server/tests/construction/build_v3/transform_query_shapes_test.py
@@ -15,10 +15,10 @@ from httpx import AsyncClient
 from tests.construction.build_v3 import assert_sql_equal
 
 
-@pytest_asyncio.fixture
-async def client_with_edge_shapes(client_with_build_v3: AsyncClient):
+@pytest_asyncio.fixture(scope="module")
+async def client_with_edge_shapes(module__client_with_build_v3: AsyncClient):
     """Adds transforms with unusual query shapes + metrics on top of them."""
-    r1 = await client_with_build_v3.post(
+    r1 = await module__client_with_build_v3.post(
         "/nodes/transform/",
         json={
             "name": "v3.orders_via_derived_table",
@@ -37,7 +37,7 @@ async def client_with_edge_shapes(client_with_build_v3: AsyncClient):
     )
     assert r1.status_code == 201, r1.json()
 
-    r2 = await client_with_build_v3.post(
+    r2 = await module__client_with_build_v3.post(
         "/nodes/transform/",
         json={
             "name": "v3.orders_ranked",
@@ -59,7 +59,7 @@ async def client_with_edge_shapes(client_with_build_v3: AsyncClient):
     )
     assert r2.status_code == 201, r2.json()
 
-    r3 = await client_with_build_v3.post(
+    r3 = await module__client_with_build_v3.post(
         "/nodes/transform/",
         json={
             "name": "v3.orders_self_joined",
@@ -89,12 +89,12 @@ async def client_with_edge_shapes(client_with_build_v3: AsyncClient):
         ("v3.ranked_count", "SELECT COUNT(*) FROM v3.orders_ranked"),
         ("v3.self_join_count", "SELECT COUNT(*) FROM v3.orders_self_joined"),
     ]:
-        r = await client_with_build_v3.post(
+        r = await module__client_with_build_v3.post(
             "/nodes/metric/",
             json={"name": name, "query": query, "mode": "published"},
         )
         assert r.status_code == 201, r.json()
-    return client_with_build_v3
+    return module__client_with_build_v3
 
 
 class TestTransformQueryShapes:


### PR DESCRIPTION
### Summary

Some test fixtures are declared using `@pytest.fixture` with no scope, so it defaults to the `function` scope, which causes it to rerun the entire seeding sequence per test. That seeding sequence will recreate a series of nodes over HTTP, which can get expensive across dozens of tests (e.g., 6 node creations across 23 tests in the fan-out guard file, 7 tag creations across 10 tests in the tags GraphQL file etc).

This PR widens them to module scope and then points the tests at the module-scoped client. Since neither of these modules are mutating the seeded state (the fan-out tests only read through `/sql/measures/v3/` and the tags tests issue read-only GraphQL queries), one seeding pass per module is sufficient.

When run locally:
```
fanout_guard_test.py  122.15s -> 56.14s
graphql/tags_test.py   53.64s -> 49.25s
transform_query_shapes_test.py   56.44s -> 51.79s
```

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
