### PR TITLE
add display_name to semantic metadata

### DIFF
--- a/datajunction-server/datajunction_server/api/semantic_layer.py
+++ b/datajunction-server/datajunction_server/api/semantic_layer.py
@@ -98,10 +98,18 @@ def _cube_column_type_map(cube: NodeRevision) -> dict[str, str | None]:
         for column in cube.columns
     }
 
+def _cube_metadata_map(cube: NodeRevision) -> dict[str, dict[str, str | None]]:
+    """Return column metadata for the metric/dimension ids exposed by a cube."""
+    return {
+            column.cube_element_name: {"display_name": column.display_name}
+        for column in cube.columns
+    }
+
 
 def _metrics_payload(cube: NodeRevision) -> list["MetricInfo"]:
     """Spec ``metrics`` list. ``definition`` is display-only."""
     type_by_name = _cube_column_type_map(cube)
+    metadata_by_name = _cube_metadata_map(cube)
     return [
         MetricInfo(
             id=metric_name,
@@ -110,6 +118,7 @@ def _metrics_payload(cube: NodeRevision) -> list["MetricInfo"]:
             definition=metric_name,
             description=None,
             aggregation="OTHER",
+            metadata=MetricsMetadata(display_name=metadata_by_name.get(metric_name, {}).get("display_name", "")),
         )
         for metric_name in cube.cube_node_metrics
     ]
@@ -118,6 +127,7 @@ def _metrics_payload(cube: NodeRevision) -> list["MetricInfo"]:
 def _dimensions_payload(cube: NodeRevision) -> list["DimensionInfo"]:
     """Spec ``dimensions`` list. Grain detection is deferred."""
     type_by_name = _cube_column_type_map(cube)
+    metadata_by_name = _cube_metadata_map(cube)
     return [
         DimensionInfo(
             id=dim_ref,
@@ -126,6 +136,7 @@ def _dimensions_payload(cube: NodeRevision) -> list["DimensionInfo"]:
             definition=dim_ref,
             description=None,
             grain=None,
+            metadata=DimensionMetadata(display_name=metadata_by_name.get(dim_ref, {}).get("display_name", "")),
         )
         for dim_ref in cube.cube_node_dimensions
     ]
@@ -234,6 +245,11 @@ class QueryRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class MetricsMetadata(BaseModel):
+    """Metric-specific field metadata"""
+
+    display_name: str
+
 class MetricInfo(BaseModel):
     """A metric exposed by a semantic view."""
 
@@ -243,7 +259,13 @@ class MetricInfo(BaseModel):
     definition: str
     description: str | None
     aggregation: str
+    metadata: MetricsMetadata
 
+
+class DimensionMetadata(BaseModel):
+    """Dimension-specific field metadata"""
+
+    display_name: str
 
 class DimensionInfo(BaseModel):
     """A dimension exposed by a semantic view."""
@@ -254,6 +276,7 @@ class DimensionInfo(BaseModel):
     definition: str
     description: str | None
     grain: str | None
+    metadata: DimensionMetadata
 
 
 class ViewSummary(BaseModel):

--- a/datajunction-server/datajunction_server/api/semantic_layer.py
+++ b/datajunction-server/datajunction_server/api/semantic_layer.py
@@ -98,10 +98,11 @@ def _cube_column_type_map(cube: NodeRevision) -> dict[str, str | None]:
         for column in cube.columns
     }
 
+
 def _cube_metadata_map(cube: NodeRevision) -> dict[str, dict[str, str | None]]:
     """Return column metadata for the metric/dimension ids exposed by a cube."""
     return {
-            column.cube_element_name: {"display_name": column.display_name}
+        column.cube_element_name: {"display_name": column.display_name}
         for column in cube.columns
     }
 
@@ -118,7 +119,12 @@ def _metrics_payload(cube: NodeRevision) -> list["MetricInfo"]:
             definition=metric_name,
             description=None,
             aggregation="OTHER",
-            metadata=MetricsMetadata(display_name=metadata_by_name.get(metric_name, {}).get("display_name", "")),
+            metadata=MetricsMetadata(
+                display_name=metadata_by_name.get(metric_name, {}).get(
+                    "display_name",
+                    "",
+                ),
+            ),
         )
         for metric_name in cube.cube_node_metrics
     ]
@@ -136,7 +142,9 @@ def _dimensions_payload(cube: NodeRevision) -> list["DimensionInfo"]:
             definition=dim_ref,
             description=None,
             grain=None,
-            metadata=DimensionMetadata(display_name=metadata_by_name.get(dim_ref, {}).get("display_name", "")),
+            metadata=DimensionMetadata(
+                display_name=metadata_by_name.get(dim_ref, {}).get("display_name", ""),
+            ),
         )
         for dim_ref in cube.cube_node_dimensions
     ]
@@ -250,6 +258,7 @@ class MetricsMetadata(BaseModel):
 
     display_name: str
 
+
 class MetricInfo(BaseModel):
     """A metric exposed by a semantic view."""
 
@@ -266,6 +275,7 @@ class DimensionMetadata(BaseModel):
     """Dimension-specific field metadata"""
 
     display_name: str
+
 
 class DimensionInfo(BaseModel):
     """A dimension exposed by a semantic view."""

--- a/datajunction-server/tests/api/semantic_layer_test.py
+++ b/datajunction-server/tests/api/semantic_layer_test.py
@@ -83,14 +83,17 @@ class TestSemanticViewPayloadTypes:
                 SimpleNamespace(
                     cube_element_name="sem.total_amount",
                     type="decimal(18,2)",
+                    display_name="Total amount",
                 ),
                 SimpleNamespace(
                     cube_element_name="sem.region.region_id",
                     type="bigint",
+                    display_name="Region ID",
                 ),
                 SimpleNamespace(
                     cube_element_name="sem.region.region_name[home]",
                     type="varchar(255)",
+                    display_name="Home region name",
                 ),
             ],
             cube_node_metrics=["sem.total_amount"],
@@ -103,11 +106,44 @@ class TestSemanticViewPayloadTypes:
         metrics = _metrics_payload(cube)  # type: ignore[arg-type]
         dimensions = _dimensions_payload(cube)  # type: ignore[arg-type]
 
-        assert metrics[0].type == "decimal"
-        assert {dimension.id: dimension.type for dimension in dimensions} == {
-            "sem.region.region_id": "int",
-            "sem.region.region_name[home]": "utf8",
-        }
+        assert [ metric.model_dump() for metric in metrics ] == [
+            {
+                "id": "sem.total_amount",
+                "name": "total_amount",
+                "type": "decimal",
+                "definition": "sem.total_amount",
+                "description": None,
+                "aggregation": "OTHER",
+                "metadata": {
+                    "display_name": "Total amount",
+                },
+            },
+        ]
+
+        assert [ dim.model_dump() for dim in dimensions ] == [
+            {
+                "id": "sem.region.region_id",
+                "name": "region_id",
+                "type": "int",
+                "definition": "sem.region.region_id",
+                "description": None,
+                "grain": None,
+                "metadata": {
+                    "display_name": "Region ID",
+                },
+            },
+            {
+                "id": "sem.region.region_name[home]",
+                "name": "region_name[home]",
+                "type": "utf8",
+                "definition": "sem.region.region_name[home]",
+                "description": None,
+                "grain": None,
+                "metadata": {
+                    "display_name": "Home region name",
+                },
+            },
+        ]
 
     def test_metric_and_dimension_payloads_fallback_when_type_is_unknown(self):
         cube = SimpleNamespace(
@@ -115,10 +151,12 @@ class TestSemanticViewPayloadTypes:
                 SimpleNamespace(
                     cube_element_name="sem.total_amount",
                     type=None,
+                    display_name="Total amount",
                 ),
                 SimpleNamespace(
                     cube_element_name="sem.region.region_name",
                     type="unknown_type",
+                    display_name="Region name",
                 ),
             ],
             cube_node_metrics=["sem.total_amount"],

--- a/datajunction-server/tests/api/semantic_layer_test.py
+++ b/datajunction-server/tests/api/semantic_layer_test.py
@@ -106,7 +106,7 @@ class TestSemanticViewPayloadTypes:
         metrics = _metrics_payload(cube)  # type: ignore[arg-type]
         dimensions = _dimensions_payload(cube)  # type: ignore[arg-type]
 
-        assert [ metric.model_dump() for metric in metrics ] == [
+        assert [metric.model_dump() for metric in metrics] == [
             {
                 "id": "sem.total_amount",
                 "name": "total_amount",
@@ -120,7 +120,7 @@ class TestSemanticViewPayloadTypes:
             },
         ]
 
-        assert [ dim.model_dump() for dim in dimensions ] == [
+        assert [dim.model_dump() for dim in dimensions] == [
             {
                 "id": "sem.region.region_id",
                 "name": "region_id",


### PR DESCRIPTION
### Summary

Add `metadata` field to `metrics` and `dimensions` response for `POST /semantic/views/{view_name}` based on [API spec](https://github.com/betodealmeida/sl-rest-api/blob/main/SPEC.md#post-viewsview_name).

Currently only populates `display_name` field of `metadata`.

