### PR TITLE
Clone one database per module for the function type tests

### DIFF
--- a/datajunction-server/tests/sql/functions_test.py
+++ b/datajunction-server/tests/sql/functions_test.py
@@ -3,6 +3,7 @@ Tests for ``datajunction_server.sql.functions``.
 """
 
 import pytest
+import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import datajunction_server.sql.functions as F
@@ -35,6 +36,18 @@ from datajunction_server.sql.parsing.types import (
     StringType,
     WildcardType,
 )
+
+
+@pytest_asyncio.fixture(scope="module")
+async def session(module__session: AsyncSession) -> AsyncSession:
+    """
+    Override the function-scoped ``session`` fixture with a module-scoped one.
+
+    Nothing in this module writes to the database -- these tests only compile
+    expressions and assert inferred types -- so cloning a database per test is
+    wasted work.
+    """
+    return module__session
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

The function type-inference tests were each paying for a new database fixture to be spun up, but they never wrote to the db. The tests in `tests/sql/functions_test.py` just compile expressions and assert on inferred types. They need a db session because type inference takes one, but there aren't any actual changes to the session (e.g., calls to `session.add`, `commit` etc) anywhere in the module. Since every test requested the function-scoped session fixture, each one of those clones a fresh database from the template.

This PR switches it to define a module-scoped session fixture that shadows the `conftest` fixture for that module only. This way we're doing only one clone instead of hundreds.

This module is a good candidate for this approach because it's read-only.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
