### PR TITLE
Plan the preagg fixtures once into a template database

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,6 +169,24 @@ jobs:
   coverage-shard:
     needs: changes
     runs-on: ubuntu-latest
+
+    # Same shared Postgres as the build job. This matters more here: without it
+    # every one of the five shards starts its own containers and rebuilds every
+    # template, so the duplicated startup cost is paid five times over.
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: dj
+          POSTGRES_PASSWORD: dj
+          POSTGRES_DB: dj
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U dj"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     if: needs.changes.outputs.server == 'true' || needs.changes.outputs.workflow == 'true'
 
     strategy:
@@ -225,6 +243,25 @@ jobs:
           COVERAGE_FILE: .cov-shard${{ matrix.shard }}
         run: |
           uv sync --group test --python 3.13
+
+          PG="postgresql://dj:dj@localhost:5432"
+          PGX="postgresql+psycopg://dj:dj@localhost:5432"
+          export DJ_TEST_POSTGRES_URL="$PGX/dj"
+
+          # The suite creates this role for containers it starts itself; on a
+          # server it does not own, it cannot.
+          psql "$PG/dj" -c "CREATE ROLE readonly_user WITH LOGIN PASSWORD 'readonly'"
+
+          psql "$PG/dj" -c "CREATE DATABASE template_all_examples"
+          uv run python tests/helpers/populate_template.py "$PGX/template_all_examples"
+
+          psql "$PG/dj" -c "CREATE DATABASE template_preaggs TEMPLATE template_all_examples"
+          uv run python tests/helpers/populate_preaggs_template.py "$PGX/template_preaggs"
+
+          psql "$PG/dj" -c "CREATE DATABASE template_dimension_links"
+          uv run python tests/helpers/populate_template.py \
+            "$PGX/template_dimension_links" COMPLEX_DIMENSION_LINK
+
           uv run pytest -n auto --dist=loadscope \
             --cov=datajunction_server --cov-report= \
             -q ${{ matrix.paths }} \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,25 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
 
+    # One Postgres for the whole job. Without it each xdist worker starts its
+    # own container and rebuilds the same template, N times over, all at
+    # startup. Services cannot be conditional, so the non-server legs get one
+    # too; it costs a couple of seconds to start and nothing to ignore.
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: dj
+          POSTGRES_PASSWORD: dj
+          POSTGRES_DB: dj
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U dj"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     strategy:
       fail-fast: false
       matrix:
@@ -100,6 +119,28 @@ jobs:
 
           # Run linters
           uv run pre-commit run --all-files
+
+          # Build the template databases once for the whole job. Each xdist
+          # worker then clones them (~90ms) instead of building its own.
+          if [ "${{ matrix.library }}" = "server" ]; then
+            PG="postgresql://dj:dj@localhost:5432"
+            PGX="postgresql+psycopg://dj:dj@localhost:5432"
+            export DJ_TEST_POSTGRES_URL="$PGX/dj"
+
+            # The suite creates this role for containers it starts itself; on a
+            # server it does not own, it cannot.
+            psql "$PG/dj" -c "CREATE ROLE readonly_user WITH LOGIN PASSWORD 'readonly'"
+
+            psql "$PG/dj" -c "CREATE DATABASE template_all_examples"
+            uv run python tests/helpers/populate_template.py "$PGX/template_all_examples"
+
+            psql "$PG/dj" -c "CREATE DATABASE template_preaggs TEMPLATE template_all_examples"
+            uv run python tests/helpers/populate_preaggs_template.py "$PGX/template_preaggs"
+
+            psql "$PG/dj" -c "CREATE DATABASE template_dimension_links"
+            uv run python tests/helpers/populate_template.py \
+              "$PGX/template_dimension_links" COMPLEX_DIMENSION_LINK
+          fi
 
           # Run tests
           export MODULE=${{ matrix.library == 'server' && 'datajunction_server' || matrix.library == 'client' && 'datajunction' || matrix.library == 'djqs' && 'djqs' || matrix.library == 'djrs' && 'datajunction_reflection'}}

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -18,6 +18,8 @@ from testcontainers.postgres import PostgresContainer
 
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from tests.conftest import (
+    database_exists,
+    externally_managed_postgres,
     cleanup_database_for_module,
     create_database_for_module,
 )
@@ -43,6 +45,14 @@ def dim_links_template_database(
     every test still gets its own database, so the tests that mutate links stay
     isolated.
     """
+    externally_managed = externally_managed_postgres()
+    if externally_managed and database_exists(
+        postgres_container,
+        DIM_LINKS_TEMPLATE_DB_NAME,
+    ):
+        yield DIM_LINKS_TEMPLATE_DB_NAME
+        return
+
     url = create_database_for_module(postgres_container, DIM_LINKS_TEMPLATE_DB_NAME)
     script = pathlib.Path(__file__).parent.parent / "helpers" / "populate_template.py"
     project_root = pathlib.Path(__file__).parent.parent.parent
@@ -63,7 +73,8 @@ def dim_links_template_database(
             f"{result.stdout}\n{result.stderr}",
         )
     yield DIM_LINKS_TEMPLATE_DB_NAME
-    cleanup_database_for_module(postgres_container, DIM_LINKS_TEMPLATE_DB_NAME)
+    if not externally_managed:
+        cleanup_database_for_module(postgres_container, DIM_LINKS_TEMPLATE_DB_NAME)
 
 
 @pytest.fixture

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -18,8 +18,8 @@ from testcontainers.postgres import PostgresContainer
 
 from datajunction_server.sql.parsing.backends.antlr4 import parse
 from tests.conftest import (
-    database_exists,
     externally_managed_postgres,
+    require_shared_template,
     cleanup_database_for_module,
     create_database_for_module,
 )
@@ -46,10 +46,14 @@ def dim_links_template_database(
     isolated.
     """
     externally_managed = externally_managed_postgres()
-    if externally_managed and database_exists(
-        postgres_container,
-        DIM_LINKS_TEMPLATE_DB_NAME,
-    ):
+    if externally_managed:
+        require_shared_template(
+            postgres_container,
+            DIM_LINKS_TEMPLATE_DB_NAME,
+            f"psql -c 'CREATE DATABASE {DIM_LINKS_TEMPLATE_DB_NAME};' && python "
+            f"tests/helpers/populate_template.py "
+            f"<url-ending-in>/{DIM_LINKS_TEMPLATE_DB_NAME} COMPLEX_DIMENSION_LINK",
+        )
         yield DIM_LINKS_TEMPLATE_DB_NAME
         return
 

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -4,31 +4,81 @@ Dimension linking related tests.
 Each test gets its own isolated database with COMPLEX_DIMENSION_LINK data loaded fresh.
 """
 
+import os
+import pathlib
+import subprocess
+import sys
+from collections.abc import Generator
+
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 from requests import Response
+from testcontainers.postgres import PostgresContainer
 
 from datajunction_server.sql.parsing.backends.antlr4 import parse
-from tests.conftest import post_and_raise_if_error
+from tests.conftest import (
+    cleanup_database_for_module,
+    create_database_for_module,
+)
 from tests.construction.build_v3 import assert_sql_equal
-from tests.examples import COMPLEX_DIMENSION_LINK, SERVICE_SETUP
+
+
+DIM_LINKS_TEMPLATE_DB_NAME = "template_dimension_links"
+
+
+@pytest.fixture(scope="session")
+def dim_links_template_database(
+    postgres_container: PostgresContainer,
+) -> Generator[str, None, None]:
+    """
+    A template database holding just the COMPLEX_DIMENSION_LINK examples.
+
+    These tests used ``isolated_client``, which builds an empty database per
+    test -- create_all for every table, then the default attribute types,
+    catalogs and user, then the examples over HTTP. That is ~2s of setup for
+    each of the 14 tests, all of it producing identical state.
+
+    Build it once and let each test clone it instead. Cloning is ~90ms, and
+    every test still gets its own database, so the tests that mutate links stay
+    isolated.
+    """
+    url = create_database_for_module(postgres_container, DIM_LINKS_TEMPLATE_DB_NAME)
+    script = pathlib.Path(__file__).parent.parent / "helpers" / "populate_template.py"
+    project_root = pathlib.Path(__file__).parent.parent.parent
+    env = {
+        **os.environ,
+        "PYTHONPATH": f"{project_root}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
+    }
+    result = subprocess.run(
+        [sys.executable, str(script), url, "COMPLEX_DIMENSION_LINK"],
+        capture_output=True,
+        text=True,
+        cwd=str(project_root),
+        env=env,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to populate dimension links template:\n"
+            f"{result.stdout}\n{result.stderr}",
+        )
+    yield DIM_LINKS_TEMPLATE_DB_NAME
+    cleanup_database_for_module(postgres_container, DIM_LINKS_TEMPLATE_DB_NAME)
+
+
+@pytest.fixture
+def isolated_client_template(dim_links_template_database: str) -> str:
+    """Have ``isolated_client`` clone the dimension-links template."""
+    return dim_links_template_database
 
 
 @pytest_asyncio.fixture
 async def dimensions_link_client(isolated_client: AsyncClient) -> AsyncClient:
     """
-    Function-scoped fixture that provides a client with COMPLEX_DIMENSION_LINK data.
+    Client whose database already has the COMPLEX_DIMENSION_LINK examples.
 
-    Uses isolated_client for complete isolation - each test gets its own fresh
-    database with the dimension link examples loaded.
+    They arrive with the template clone, so there is nothing to load here.
     """
-    for endpoint, json in SERVICE_SETUP + COMPLEX_DIMENSION_LINK:
-        await post_and_raise_if_error(
-            client=isolated_client,
-            endpoint=endpoint,
-            json=json,  # type: ignore
-        )
     return isolated_client
 
 

--- a/datajunction-server/tests/api/preaggregations_test.py
+++ b/datajunction-server/tests/api/preaggregations_test.py
@@ -9,11 +9,14 @@ import subprocess
 import sys
 from collections.abc import Generator
 
+from urllib.parse import urlparse
+
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from psycopg import connect
 from testcontainers.postgres import PostgresContainer
 from sqlalchemy.orm import joinedload
 
@@ -29,6 +32,8 @@ from datajunction_server.construction.build_v3.builder import build_measures_sql
 from datajunction_server.models.access import ResourceAction
 from tests.authz import VALIDATOR_AUTH_SERVICE, deny
 from tests.conftest import (
+    database_exists,
+    externally_managed_postgres,
     FuncPostgresContainer,
     cleanup_database_for_module,
     clone_database_from_template,
@@ -143,6 +148,25 @@ async def _plan_preagg(
 PREAGGS_TEMPLATE_DB_NAME = "template_preaggs"
 
 
+def _preagg_ids_from(postgres_container, dbname: str) -> list[int]:
+    """Read preagg ids out of an already-built template, in creation order."""
+    url = urlparse(postgres_container.get_connection_url())
+    with connect(
+        host=url.hostname,
+        port=url.port,
+        dbname=dbname,
+        user=url.username,
+        password=url.password,
+        autocommit=True,
+    ) as conn:
+        return [
+            row[0]
+            for row in conn.execute(
+                "SELECT id FROM pre_aggregation ORDER BY id",
+            ).fetchall()
+        ]
+
+
 @pytest.fixture(scope="session")
 def preaggs_template_database(
     postgres_container: PostgresContainer,
@@ -157,6 +181,21 @@ def preaggs_template_database(
 
     Returns the template name and the preagg ids, in preagg1..preagg10 order.
     """
+    externally_managed = externally_managed_postgres()
+    if externally_managed and database_exists(
+        postgres_container,
+        PREAGGS_TEMPLATE_DB_NAME,
+    ):
+        # Planned once outside pytest; read the ids back off the template.
+        yield (
+            PREAGGS_TEMPLATE_DB_NAME,
+            _preagg_ids_from(
+                postgres_container,
+                PREAGGS_TEMPLATE_DB_NAME,
+            ),
+        )
+        return
+
     clone_database_from_template(
         postgres_container,
         template_name=template_database,
@@ -194,7 +233,10 @@ def preaggs_template_database(
         if line.startswith("PREAGG_IDS ")
     )
     yield PREAGGS_TEMPLATE_DB_NAME, ids
-    cleanup_database_for_module(postgres_container, PREAGGS_TEMPLATE_DB_NAME)
+    if not externally_managed:
+        # A shared template outlives this process; dropping it would pull the
+        # rug from under the other workers.
+        cleanup_database_for_module(postgres_container, PREAGGS_TEMPLATE_DB_NAME)
 
 
 @pytest.fixture

--- a/datajunction-server/tests/api/preaggregations_test.py
+++ b/datajunction-server/tests/api/preaggregations_test.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import subprocess
 import sys
+from collections.abc import Generator
 
 import pytest
 import pytest_asyncio
@@ -146,7 +147,7 @@ PREAGGS_TEMPLATE_DB_NAME = "template_preaggs"
 def preaggs_template_database(
     postgres_container: PostgresContainer,
     template_database: str,
-) -> tuple[str, list[int]]:
+) -> Generator[tuple[str, list[int]], None, None]:
     """
     A template database that already holds the ten planned pre-aggregations.
 
@@ -185,7 +186,7 @@ def preaggs_template_database(
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"Failed to populate preaggs template:\n{result.stdout}\n{result.stderr}"
+            f"Failed to populate preaggs template:\n{result.stdout}\n{result.stderr}",
         )
     ids = next(
         json.loads(line.split(" ", 1)[1])

--- a/datajunction-server/tests/api/preaggregations_test.py
+++ b/datajunction-server/tests/api/preaggregations_test.py
@@ -2,11 +2,18 @@
 
 from unittest.mock import MagicMock
 
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from testcontainers.postgres import PostgresContainer
 from sqlalchemy.orm import joinedload
 
 from datajunction_server.database.node import Node, NodeRevision
@@ -20,6 +27,11 @@ from datajunction_server.utils import get_query_service_client
 from datajunction_server.construction.build_v3.builder import build_measures_sql
 from datajunction_server.models.access import ResourceAction
 from tests.authz import VALIDATOR_AUTH_SERVICE, deny
+from tests.conftest import (
+    FuncPostgresContainer,
+    cleanup_database_for_module,
+    clone_database_from_template,
+)
 
 
 @pytest.fixture
@@ -127,132 +139,119 @@ async def _plan_preagg(
     return response.json()["preaggs"][0]
 
 
+PREAGGS_TEMPLATE_DB_NAME = "template_preaggs"
+
+
+@pytest.fixture(scope="session")
+def preaggs_template_database(
+    postgres_container: PostgresContainer,
+    template_database: str,
+) -> tuple[str, list[int]]:
+    """
+    A template database that already holds the ten planned pre-aggregations.
+
+    Planning them costs ten ``/preaggs/plan`` round trips (~1.2s). Doing that
+    once and letting every test clone the result (~90ms) keeps each test fully
+    isolated -- which the 67 mutating tests here need -- without re-planning.
+
+    Returns the template name and the preagg ids, in preagg1..preagg10 order.
+    """
+    clone_database_from_template(
+        postgres_container,
+        template_name=template_database,
+        target_name=PREAGGS_TEMPLATE_DB_NAME,
+    )
+    url = (
+        postgres_container.get_connection_url().rsplit("/", 1)[0]
+        + f"/{PREAGGS_TEMPLATE_DB_NAME}"
+    )
+
+    script = (
+        pathlib.Path(__file__).parent.parent
+        / "helpers"
+        / "populate_preaggs_template.py"
+    )
+    project_root = pathlib.Path(__file__).parent.parent.parent
+    env = {
+        **os.environ,
+        "PYTHONPATH": f"{project_root}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
+    }
+    result = subprocess.run(
+        [sys.executable, str(script), url],
+        capture_output=True,
+        text=True,
+        cwd=str(project_root),
+        env=env,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to populate preaggs template:\n{result.stdout}\n{result.stderr}"
+        )
+    ids = next(
+        json.loads(line.split(" ", 1)[1])
+        for line in result.stdout.splitlines()
+        if line.startswith("PREAGG_IDS ")
+    )
+    yield PREAGGS_TEMPLATE_DB_NAME, ids
+    cleanup_database_for_module(postgres_container, PREAGGS_TEMPLATE_DB_NAME)
+
+
+@pytest.fixture
+def func__postgres_container(
+    request,
+    postgres_container: PostgresContainer,
+    template_database: str,
+    preaggs_template_database: tuple[str, list[int]],
+):
+    """
+    Clone from the preaggs template, but only for tests that ask for preaggs.
+
+    Overrides the conftest fixture for this module. Tests here that drive
+    ``client_with_build_v3`` directly plan their own preaggs and assert on the
+    result, so they must start from the base template -- handing them the
+    pre-seeded one makes those assertions see rows they did not create.
+    """
+    wants_preaggs = "client_with_preaggs" in request.fixturenames
+    template_name = preaggs_template_database[0] if wants_preaggs else template_database
+    dbname = f"test_preagg_{abs(hash(request.node.name)) % 10000000}_{id(request)}"
+    db_url = clone_database_from_template(
+        postgres_container,
+        template_name=template_name,
+        target_name=dbname,
+    )
+    yield FuncPostgresContainer(postgres_container, db_url, dbname)
+    cleanup_database_for_module(postgres_container, dbname)
+
+
 @pytest_asyncio.fixture
 async def client_with_preaggs(
     client_with_build_v3: AsyncClient,
+    preaggs_template_database: tuple[str, list[int]],
 ):
     """
-    Creates pre-aggregations for testing using BUILD_V3 examples.
+    Client whose database already contains the ten pre-aggregations.
 
-    Uses /preaggs/plan API to create preaggs, which is more realistic
-    and ensures consistency with the actual API behavior.
-
-    NOTE: Gets session from client's dependency override to ensure we use
-    the SAME session that the client uses, avoiding event loop binding issues
-    with pytest-xdist in Python 3.11.
+    The preaggs come from the template clone, so nothing is planned here -- we
+    only load the ORM objects the tests reference. Each test still gets its own
+    database, so the ones that mutate stay isolated.
     """
     client = client_with_build_v3
 
-    # Get session from the client's dependency override - this ensures we use
-    # the same session that the API handlers use, avoiding event loop issues
     from datajunction_server.utils import get_session
 
     session = client.app.dependency_overrides[get_session]()
 
-    # preagg1: Basic preagg with FULL strategy, single grain
-    # total_revenue + total_quantity by status
-    preagg1_data = await _plan_preagg(
-        client,
-        metrics=["v3.total_revenue", "v3.total_quantity"],
-        dimensions=["v3.order_details.status"],
-        strategy="full",
-        schedule="0 0 * * *",
-    )
-
-    # preagg2: Multi-grain preagg (status + category)
-    # total_revenue + avg_unit_price by status and category
-    preagg2_data = await _plan_preagg(
-        client,
-        metrics=["v3.total_revenue", "v3.avg_unit_price"],
-        dimensions=["v3.order_details.status", "v3.product.category"],
-        strategy="full",
-        schedule="0 * * * *",
-    )
-
-    # preagg3: Same grain as preagg1 but different metrics (for grain group hash testing)
-    # max_unit_price by status
-    preagg3_data = await _plan_preagg(
-        client,
-        metrics=["v3.max_unit_price"],
-        dimensions=["v3.order_details.status"],
-        strategy="full",
-    )
-
-    # preagg4: No strategy set (for testing "requires strategy" validation)
-    # total_revenue by category
-    preagg4_data = await _plan_preagg(
-        client,
-        metrics=["v3.total_revenue"],
-        dimensions=["v3.product.category"],
-    )
-
-    # preagg5-10: Additional preaggs for tests that modify state
-    # These use different dimension combinations to avoid grain_group_hash conflicts
-    preagg5_data = await _plan_preagg(
-        client,
-        metrics=["v3.order_count"],
-        dimensions=["v3.order_details.status"],
-        strategy="full",
-        schedule="0 0 * * *",
-    )
-    preagg6_data = await _plan_preagg(
-        client,
-        metrics=["v3.min_unit_price"],
-        dimensions=["v3.order_details.status"],
-        strategy="full",
-        schedule="0 0 * * *",
-    )
-    preagg7_data = await _plan_preagg(
-        client,
-        metrics=["v3.total_revenue"],
-        dimensions=["v3.customer.customer_id"],
-    )
-    preagg8_data = await _plan_preagg(
-        client,
-        metrics=["v3.page_view_count"],
-        dimensions=["v3.product.category"],
-        strategy="full",
-        schedule="0 0 * * *",
-    )
-    preagg9_data = await _plan_preagg(
-        client,
-        metrics=["v3.session_count"],
-        dimensions=["v3.product.category"],
-        strategy="full",
-        schedule="0 0 * * *",
-    )
-    preagg10_data = await _plan_preagg(
-        client,
-        metrics=["v3.visitor_count"],
-        dimensions=["v3.product.category"],
-    )
-
-    # Fetch actual PreAggregation objects from DB for tests that need them
+    _, preagg_ids = preaggs_template_database
     _opts = [joinedload(PreAggregation.node_revision)]
-    preagg1 = await session.get(PreAggregation, preagg1_data["id"], options=_opts)
-    preagg2 = await session.get(PreAggregation, preagg2_data["id"], options=_opts)
-    preagg3 = await session.get(PreAggregation, preagg3_data["id"], options=_opts)
-    preagg4 = await session.get(PreAggregation, preagg4_data["id"], options=_opts)
-    preagg5 = await session.get(PreAggregation, preagg5_data["id"], options=_opts)
-    preagg6 = await session.get(PreAggregation, preagg6_data["id"], options=_opts)
-    preagg7 = await session.get(PreAggregation, preagg7_data["id"], options=_opts)
-    preagg8 = await session.get(PreAggregation, preagg8_data["id"], options=_opts)
-    preagg9 = await session.get(PreAggregation, preagg9_data["id"], options=_opts)
-    preagg10 = await session.get(PreAggregation, preagg10_data["id"], options=_opts)
+    preaggs = [
+        await session.get(PreAggregation, preagg_id, options=_opts)
+        for preagg_id in preagg_ids
+    ]
 
     yield {
         "client": client,
         "session": session,
-        "preagg1": preagg1,
-        "preagg2": preagg2,
-        "preagg3": preagg3,
-        "preagg4": preagg4,
-        "preagg5": preagg5,
-        "preagg6": preagg6,
-        "preagg7": preagg7,
-        "preagg8": preagg8,
-        "preagg9": preagg9,
-        "preagg10": preagg10,
+        **{f"preagg{index}": preagg for index, preagg in enumerate(preaggs, start=1)},
     }
 
 

--- a/datajunction-server/tests/api/preaggregations_test.py
+++ b/datajunction-server/tests/api/preaggregations_test.py
@@ -32,11 +32,11 @@ from datajunction_server.construction.build_v3.builder import build_measures_sql
 from datajunction_server.models.access import ResourceAction
 from tests.authz import VALIDATOR_AUTH_SERVICE, deny
 from tests.conftest import (
-    database_exists,
-    externally_managed_postgres,
     FuncPostgresContainer,
     cleanup_database_for_module,
     clone_database_from_template,
+    externally_managed_postgres,
+    require_shared_template,
 )
 
 
@@ -182,11 +182,16 @@ def preaggs_template_database(
     Returns the template name and the preagg ids, in preagg1..preagg10 order.
     """
     externally_managed = externally_managed_postgres()
-    if externally_managed and database_exists(
-        postgres_container,
-        PREAGGS_TEMPLATE_DB_NAME,
-    ):
+    if externally_managed:
         # Planned once outside pytest; read the ids back off the template.
+        require_shared_template(
+            postgres_container,
+            PREAGGS_TEMPLATE_DB_NAME,
+            f"psql -c 'CREATE DATABASE {PREAGGS_TEMPLATE_DB_NAME} "
+            f"TEMPLATE template_all_examples;' && python "
+            f"tests/helpers/populate_preaggs_template.py "
+            f"<url-ending-in>/{PREAGGS_TEMPLATE_DB_NAME}",
+        )
         yield (
             PREAGGS_TEMPLATE_DB_NAME,
             _preagg_ids_from(

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -411,6 +411,53 @@ def database_exists(postgres, dbname: str) -> bool:
     return row is not None
 
 
+def template_is_populated(postgres, dbname: str) -> bool:
+    """
+    Whether ``dbname`` exists *and* actually holds a schema.
+
+    Existence alone is not enough. A build that dies after CREATE DATABASE but
+    before loading anything leaves a database that looks usable and is not, and
+    on a shared server nothing cleans it up -- every later run then fails
+    somewhere downstream with an opaque UndefinedTable.
+    """
+    if not database_exists(postgres, dbname):
+        return False
+    url = urlparse(postgres.get_connection_url())
+    with connect(
+        host=url.hostname,
+        port=url.port,
+        dbname=dbname,
+        user=url.username,
+        password=url.password,
+        autocommit=True,
+    ) as conn:
+        row = conn.execute(
+            "SELECT count(*) FROM pg_tables WHERE schemaname = 'public'",
+        ).fetchone()
+    return bool(row and row[0] > 0)
+
+
+def require_shared_template(postgres, dbname: str, how_to_build: str) -> None:
+    """
+    Insist that a shared template is present and populated.
+
+    On a server this process does not own, templates are built once before
+    pytest runs. Building them here instead would race between workers and, on
+    failure, leave a half-made database behind, so refuse loudly and say what
+    is missing.
+    """
+    if template_is_populated(postgres, dbname):
+        return
+    state = "exists but is empty" if database_exists(postgres, dbname) else "is missing"
+    raise RuntimeError(
+        f"Shared template database `{dbname}` {state}.\n"
+        f"DJ_TEST_POSTGRES_URL is set, so templates must be built before pytest "
+        f"starts. Build it with:\n\n    {how_to_build}\n\n"
+        f"If it exists but is empty, drop it first: "
+        f'psql -c "DROP DATABASE {dbname};"',
+    )
+
+
 def worker_suffix() -> str:
     """
     Identifier unique to this xdist worker.
@@ -2270,11 +2317,14 @@ def template_database(postgres_container: PostgresContainer) -> str:
     Session-scoped fixture that creates a template database with ALL examples.
     This runs ONCE per test session and then each module clones from it.
     """
-    if externally_managed_postgres() and database_exists(
-        postgres_container,
-        TEMPLATE_DB_NAME,
-    ):
+    if externally_managed_postgres():
         # Built once outside pytest; every worker just clones it.
+        require_shared_template(
+            postgres_container,
+            TEMPLATE_DB_NAME,
+            f"python tests/helpers/populate_template.py "
+            f"<url-ending-in>/{TEMPLATE_DB_NAME}",
+        )
         return TEMPLATE_DB_NAME
     template_url = create_database_for_module(postgres_container, TEMPLATE_DB_NAME)
     _populate_template_via_subprocess(template_url)

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -458,6 +458,37 @@ def require_shared_template(postgres, dbname: str, how_to_build: str) -> None:
     )
 
 
+def require_shared_readonly_role(postgres) -> None:
+    """
+    Insist the ``readonly_user`` role exists on a shared server.
+
+    For containers it starts itself the suite creates this role, but on a server
+    it does not own it cannot. The reader database URL depends on it, so a
+    missing role surfaces as an authentication error deep inside an unrelated
+    test rather than as a setup problem.
+    """
+    url = urlparse(postgres.get_connection_url())
+    with connect(
+        host=url.hostname,
+        port=url.port,
+        dbname=url.path.lstrip("/"),
+        user=url.username,
+        password=url.password,
+        autocommit=True,
+    ) as conn:
+        row = conn.execute(
+            "SELECT 1 FROM pg_roles WHERE rolname = 'readonly_user'",
+        ).fetchone()
+    if row is None:
+        raise RuntimeError(
+            "Shared Postgres is missing the `readonly_user` role, which the "
+            "reader database URL needs.\nDJ_TEST_POSTGRES_URL is set, so the "
+            "role has to be created before pytest starts:\n\n"
+            '    psql -c "CREATE ROLE readonly_user WITH LOGIN '
+            "PASSWORD 'readonly'\"",
+        )
+
+
 def worker_suffix() -> str:
     """
     Identifier unique to this xdist worker.
@@ -2319,6 +2350,7 @@ def template_database(postgres_container: PostgresContainer) -> str:
     """
     if externally_managed_postgres():
         # Built once outside pytest; every worker just clones it.
+        require_shared_readonly_role(postgres_container)
         require_shared_template(
             postgres_container,
             TEMPLATE_DB_NAME,

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -1860,12 +1860,27 @@ async def module__clean_client(
     cleanup_database_for_module(postgres_container, dbname)
 
 
+@pytest.fixture
+def isolated_client_template() -> str | None:
+    """
+    Template database for ``isolated_client`` to clone, if any.
+
+    Defaults to none, so ``isolated_client`` builds an empty database and the
+    caller loads what it needs. A module whose tests all want the same data can
+    override this with a template name: creating the schema and loading examples
+    costs seconds per test, cloning a template costs ~90ms, and each test still
+    gets its own database.
+    """
+    return None
+
+
 @pytest_asyncio.fixture
 async def isolated_client(
     request,
     postgres_container: PostgresContainer,
     mocker: MockerFixture,
     background_tasks,
+    isolated_client_template: str | None,
 ) -> AsyncGenerator[AsyncClient, None]:
     """
     Function-scoped client with a CLEAN database (no template, no pre-loaded examples).
@@ -1881,7 +1896,15 @@ async def isolated_client(
     # Create a unique database for this test function
     test_name = request.node.name
     dbname = f"test_isolated_{abs(hash(test_name)) % 10000000}_{id(request)}"
-    db_url = create_database_for_module(postgres_container, dbname)
+    db_url = (
+        clone_database_from_template(
+            postgres_container,
+            template_name=isolated_client_template,
+            target_name=dbname,
+        )
+        if isolated_client_template
+        else create_database_for_module(postgres_container, dbname)
+    )
 
     # Create settings for this clean database
     writer_db = DatabaseConfig(uri=db_url)
@@ -1918,10 +1941,11 @@ async def isolated_client(
         poolclass=NullPool,  # Avoids lock binding issues across event loops
     )
 
-    # Create tables in the clean database
-    async with engine.begin() as conn:
-        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm;"))
-        await conn.run_sync(Base.metadata.create_all)
+    # Create tables in the clean database. A clone already has them.
+    if not isolated_client_template:
+        async with engine.begin() as conn:
+            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm;"))
+            await conn.run_sync(Base.metadata.create_all)
 
     async_session_factory = async_sessionmaker(
         bind=engine,
@@ -1932,14 +1956,16 @@ async def isolated_client(
     async with async_session_factory() as session:
         session.remove = AsyncMock(return_value=None)
 
-        # Initialize the empty database with required seed data
-        from datajunction_server.api.attributes import default_attribute_types
-        from datajunction_server.internal.seed import seed_default_catalogs
+        # Initialize the empty database with required seed data. A clone of a
+        # template already carries it.
+        if not isolated_client_template:
+            from datajunction_server.api.attributes import default_attribute_types
+            from datajunction_server.internal.seed import seed_default_catalogs
 
-        await default_attribute_types(session)
-        await seed_default_catalogs(session)
-        await create_default_user(session)
-        await session.commit()
+            await default_attribute_types(session)
+            await seed_default_catalogs(session)
+            await create_default_user(session)
+            await session.commit()
 
         def get_session_override() -> AsyncSession:
             return session

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -259,7 +259,9 @@ def func__postgres_container(
     """
     # Create a unique database name for this test
     test_name = request.node.name
-    dbname = f"test_func_{abs(hash(test_name)) % 10000000}_{id(request)}"
+    dbname = (
+        f"test_func_{worker_suffix()}_{abs(hash(test_name)) % 10000000}_{id(request)}"
+    )
 
     # Clone from template
     db_url = clone_database_from_template(
@@ -286,7 +288,9 @@ def func__clean_postgres_container(
     """
     # Create a unique database name for this test
     test_name = request.node.name
-    dbname = f"test_clean_{abs(hash(test_name)) % 10000000}_{id(request)}"
+    dbname = (
+        f"test_clean_{worker_suffix()}_{abs(hash(test_name)) % 10000000}_{id(request)}"
+    )
 
     # Create a fresh empty database (no template)
     db_url = create_database_for_module(postgres_container, dbname)
@@ -371,6 +375,53 @@ def duckdb_conn() -> duckdb.DuckDBPyConnection:
         yield conn
 
 
+class ExternalPostgres:
+    """
+    Stands in for ``PostgresContainer`` when tests run against a server this
+    process did not start, so nothing tears it down at the end of a session.
+    """
+
+    def __init__(self, url: str):
+        self._url = url
+
+    def get_connection_url(self) -> str:
+        return self._url
+
+
+def externally_managed_postgres() -> bool:
+    """True when the Postgres server (and its templates) outlive this process."""
+    return bool(os.environ.get("DJ_TEST_POSTGRES_URL"))
+
+
+def database_exists(postgres, dbname: str) -> bool:
+    """Whether ``dbname`` is already present on the server."""
+    url = urlparse(postgres.get_connection_url())
+    with connect(
+        host=url.hostname,
+        port=url.port,
+        dbname=url.path.lstrip("/"),
+        user=url.username,
+        password=url.password,
+        autocommit=True,
+    ) as conn:
+        row = conn.execute(
+            "SELECT 1 FROM pg_database WHERE datname = %s",
+            (dbname,),
+        ).fetchone()
+    return row is not None
+
+
+def worker_suffix() -> str:
+    """
+    Identifier unique to this xdist worker.
+
+    Generated database names have to include it once workers share one server:
+    the old names leaned on ``id(request)``, which is only unique within a
+    process.
+    """
+    return os.environ.get("PYTEST_XDIST_WORKER", "gw0")
+
+
 @pytest.fixture(scope="session")
 def postgres_container() -> PostgresContainer:
     """
@@ -380,7 +431,17 @@ def postgres_container() -> PostgresContainer:
     1. The 'dj' database (default)
     2. The template database with all examples pre-loaded
     3. Per-module databases cloned from the template
+    Under pytest-xdist "session" means *per worker process*, so without
+    ``DJ_TEST_POSTGRES_URL`` every worker starts its own container and builds its
+    own template -- N times the same ~50s of work, all at once at startup. Set
+    that variable to a running Postgres and the workers share it, cloning
+    templates somebody else already built.
     """
+    external_url = os.environ.get("DJ_TEST_POSTGRES_URL")
+    if external_url:
+        yield ExternalPostgres(external_url)  # type: ignore[misc]
+        return
+
     postgres = PostgresContainer(
         image="postgres:latest",
         username="dj",
@@ -571,7 +632,9 @@ async def clean_client(
 
     # Create a unique database for this test
     test_name = request.node.name
-    dbname = f"test_clean_{abs(hash(test_name)) % 10000000}_{id(request)}"
+    dbname = (
+        f"test_clean_{worker_suffix()}_{abs(hash(test_name)) % 10000000}_{id(request)}"
+    )
     db_url = create_database_for_module(postgres_container, dbname)
 
     # Create settings for this clean database
@@ -1744,7 +1807,7 @@ async def module__clean_client(
     """
     # Create a unique database for this module
     module_name = request.module.__name__
-    dbname = f"test_mod_clean_{abs(hash(module_name)) % 10000000}"
+    dbname = f"test_mod_clean_{worker_suffix()}_{abs(hash(module_name)) % 10000000}"
     db_url = create_database_for_module(postgres_container, dbname)
 
     # Create settings for this clean database
@@ -1895,7 +1958,7 @@ async def isolated_client(
 
     # Create a unique database for this test function
     test_name = request.node.name
-    dbname = f"test_isolated_{abs(hash(test_name)) % 10000000}_{id(request)}"
+    dbname = f"test_isolated_{worker_suffix()}_{abs(hash(test_name)) % 10000000}_{id(request)}"
     db_url = (
         clone_database_from_template(
             postgres_container,
@@ -2207,6 +2270,12 @@ def template_database(postgres_container: PostgresContainer) -> str:
     Session-scoped fixture that creates a template database with ALL examples.
     This runs ONCE per test session and then each module clones from it.
     """
+    if externally_managed_postgres() and database_exists(
+        postgres_container,
+        TEMPLATE_DB_NAME,
+    ):
+        # Built once outside pytest; every worker just clones it.
+        return TEMPLATE_DB_NAME
     template_url = create_database_for_module(postgres_container, TEMPLATE_DB_NAME)
     _populate_template_via_subprocess(template_url)
     return TEMPLATE_DB_NAME
@@ -2223,7 +2292,7 @@ def module__postgres_container(
     Each module gets its own database cloned from the template with all examples.
     """
     path = pathlib.Path(request.module.__file__).resolve()
-    dbname = f"test_mod_{abs(hash(path)) % 10000000}"
+    dbname = f"test_mod_{worker_suffix()}_{abs(hash(path)) % 10000000}"
 
     module_db_url = clone_database_from_template(
         postgres_container,

--- a/datajunction-server/tests/helpers/populate_preaggs_template.py
+++ b/datajunction-server/tests/helpers/populate_preaggs_template.py
@@ -3,76 +3,30 @@
 Create the pre-aggregations that ``tests/api/preaggregations_test.py`` needs.
 
 The target database is already a clone of the main template, so the BUILD_V3
-examples these preaggs sit on top of are present. This only runs the ten
-``/preaggs/plan`` calls and prints the resulting ids, so the caller can turn
-the database into a template that every test clones instead of re-planning.
+nodes these preaggs sit on top of are present. This only runs the ten
+``/preaggs/plan`` calls and prints the resulting ids, so the caller can turn the
+database into a template that every test clones instead of re-planning.
 
-Run as a subprocess to avoid event loop conflicts with pytest-asyncio.
+Run as a subprocess to avoid event loop conflicts with pytest-asyncio, the same
+way ``populate_template.py`` is.
 
 Usage: python populate_preaggs_template.py <database_url>
 """
-
-# ruff: noqa: E402 - env vars must be set before importing datajunction_server modules
 
 import asyncio
 import json
 import os
 import sys
-from datetime import timedelta
-from unittest.mock import MagicMock
-
-import httpx
-from cachelib.simple import SimpleCache
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.pool import StaticPool
-
-db_url = sys.argv[1]
-reader_db_url = db_url.replace("dj:dj@", "readonly_user:readonly@")
-
-os.environ["DJ_DATABASE__URI"] = db_url
-os.environ["WRITER_DB__URI"] = db_url
-os.environ["READER_DB__URI"] = reader_db_url
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-# Import the database package first: importing datajunction_server.utils directly
-# trips a circular import through datajunction_server.database.catalog.
-import datajunction_server.database  # noqa: F401
-from datajunction_server.config import DatabaseConfig, Settings
-from datajunction_server.utils import get_settings
+from helpers.template_app import configure_database_env, template_app_client
 
-get_settings.cache_clear()
+db_url = sys.argv[1]
+reader_db_url = configure_database_env(db_url)
 
-from datajunction_server.api.main import app
-from datajunction_server.internal import seed as seed_module
-from datajunction_server.internal.access.authentication.tokens import create_token
-from datajunction_server.internal.access.authorization import (
-    PassthroughAuthorizationService,
-    get_authorization_service,
-)
-from datajunction_server.models.dialect import register_dialect_plugin
-from datajunction_server.transpilation import SQLTranspilationPlugin
-from datajunction_server.utils import get_query_service_client, get_session
-
-template_settings = Settings(
-    writer_db=DatabaseConfig(uri=db_url),
-    reader_db=DatabaseConfig(uri=reader_db_url),
-    repository="/path/to/repository",
-    results_backend=SimpleCache(default_timeout=0),
-    celery_broker=None,
-    redis_cache=None,
-    query_service=None,
-    secret="a-fake-secretkey",
-    transpilation_plugins=["default"],
-)
-seed_module.settings = template_settings
-
-register_dialect_plugin("spark", SQLTranspilationPlugin)
-register_dialect_plugin("trino", SQLTranspilationPlugin)
-register_dialect_plugin("druid", SQLTranspilationPlugin)
-
-# Kept in the same order as the fixture's preagg1..preagg10 so the printed ids
-# line up positionally with the names the tests use.
+# Same order as the fixture's preagg1..preagg10, so the printed ids line up
+# positionally with the names the tests use.
 PREAGG_SPECS: list[dict] = [
     {
         "metrics": ["v3.total_revenue", "v3.total_quantity"],
@@ -131,58 +85,17 @@ PREAGG_SPECS: list[dict] = [
 
 
 async def main() -> None:
-    engine = create_async_engine(url=db_url, poolclass=StaticPool)
-    session_factory = async_sessionmaker(bind=engine, expire_on_commit=False)
-
-    async with session_factory() as session:
-
-        def get_session_override() -> AsyncSession:
-            return session
-
-        def get_settings_override() -> Settings:
-            return template_settings
-
-        def get_passthrough_auth_service():
-            return PassthroughAuthorizationService()
-
-        def get_query_service_client_override(request=None):
-            return MagicMock()
-
-        app.dependency_overrides[get_session] = get_session_override
-        app.dependency_overrides[get_settings] = get_settings_override
-        app.dependency_overrides[get_authorization_service] = (
-            get_passthrough_auth_service
-        )
-        app.dependency_overrides[get_query_service_client] = (
-            get_query_service_client_override
-        )
-
-        jwt_token = create_token(
-            {"username": "dj"},
-            secret="a-fake-secretkey",
-            iss="http://localhost:8000/",
-            expires_delta=timedelta(hours=24),
-        )
-
+    async with template_app_client(db_url, reader_db_url) as (session, client):
         preagg_ids: list[int] = []
-        async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            client.headers.update({"Authorization": f"Bearer {jwt_token}"})
-            for index, spec in enumerate(PREAGG_SPECS, start=1):
-                response = await client.post("/preaggs/plan", json=spec)
-                if response.status_code != 201:
-                    raise RuntimeError(
-                        f"preagg {index} failed ({response.status_code}): "
-                        f"{response.text}",
-                    )
-                preagg_ids.append(response.json()["preaggs"][0]["id"])
-
+        for index, spec in enumerate(PREAGG_SPECS, start=1):
+            response = await client.post("/preaggs/plan", json=spec)
+            if response.status_code != 201:
+                raise RuntimeError(
+                    f"preagg {index} failed ({response.status_code}): {response.text}",
+                )
+            preagg_ids.append(response.json()["preaggs"][0]["id"])
         await session.commit()
-        app.dependency_overrides.clear()
 
-    await engine.dispose()
     print("PREAGG_IDS " + json.dumps(preagg_ids))
 
 

--- a/datajunction-server/tests/helpers/populate_preaggs_template.py
+++ b/datajunction-server/tests/helpers/populate_preaggs_template.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+"""
+Create the pre-aggregations that ``tests/api/preaggregations_test.py`` needs.
+
+The target database is already a clone of the main template, so the BUILD_V3
+examples these preaggs sit on top of are present. This only runs the ten
+``/preaggs/plan`` calls and prints the resulting ids, so the caller can turn
+the database into a template that every test clones instead of re-planning.
+
+Run as a subprocess to avoid event loop conflicts with pytest-asyncio.
+
+Usage: python populate_preaggs_template.py <database_url>
+"""
+
+# ruff: noqa: E402 - env vars must be set before importing datajunction_server modules
+
+import asyncio
+import json
+import os
+import sys
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import httpx
+from cachelib.simple import SimpleCache
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+db_url = sys.argv[1]
+reader_db_url = db_url.replace("dj:dj@", "readonly_user:readonly@")
+
+os.environ["DJ_DATABASE__URI"] = db_url
+os.environ["WRITER_DB__URI"] = db_url
+os.environ["READER_DB__URI"] = reader_db_url
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Import the database package first: importing datajunction_server.utils directly
+# trips a circular import through datajunction_server.database.catalog.
+import datajunction_server.database  # noqa: F401
+from datajunction_server.config import DatabaseConfig, Settings
+from datajunction_server.utils import get_settings
+
+get_settings.cache_clear()
+
+from datajunction_server.api.main import app
+from datajunction_server.internal import seed as seed_module
+from datajunction_server.internal.access.authentication.tokens import create_token
+from datajunction_server.internal.access.authorization import (
+    PassthroughAuthorizationService,
+    get_authorization_service,
+)
+from datajunction_server.models.dialect import register_dialect_plugin
+from datajunction_server.transpilation import SQLTranspilationPlugin
+from datajunction_server.utils import get_query_service_client, get_session
+
+template_settings = Settings(
+    writer_db=DatabaseConfig(uri=db_url),
+    reader_db=DatabaseConfig(uri=reader_db_url),
+    repository="/path/to/repository",
+    results_backend=SimpleCache(default_timeout=0),
+    celery_broker=None,
+    redis_cache=None,
+    query_service=None,
+    secret="a-fake-secretkey",
+    transpilation_plugins=["default"],
+)
+seed_module.settings = template_settings
+
+register_dialect_plugin("spark", SQLTranspilationPlugin)
+register_dialect_plugin("trino", SQLTranspilationPlugin)
+register_dialect_plugin("druid", SQLTranspilationPlugin)
+
+# Kept in the same order as the fixture's preagg1..preagg10 so the printed ids
+# line up positionally with the names the tests use.
+PREAGG_SPECS: list[dict] = [
+    {
+        "metrics": ["v3.total_revenue", "v3.total_quantity"],
+        "dimensions": ["v3.order_details.status"],
+        "strategy": "full",
+        "schedule": "0 0 * * *",
+    },
+    {
+        "metrics": ["v3.total_revenue", "v3.avg_unit_price"],
+        "dimensions": ["v3.order_details.status", "v3.product.category"],
+        "strategy": "full",
+        "schedule": "0 * * * *",
+    },
+    {
+        "metrics": ["v3.max_unit_price"],
+        "dimensions": ["v3.order_details.status"],
+        "strategy": "full",
+    },
+    {
+        "metrics": ["v3.total_revenue"],
+        "dimensions": ["v3.product.category"],
+    },
+    {
+        "metrics": ["v3.order_count"],
+        "dimensions": ["v3.order_details.status"],
+        "strategy": "full",
+        "schedule": "0 0 * * *",
+    },
+    {
+        "metrics": ["v3.min_unit_price"],
+        "dimensions": ["v3.order_details.status"],
+        "strategy": "full",
+        "schedule": "0 0 * * *",
+    },
+    {
+        "metrics": ["v3.total_revenue"],
+        "dimensions": ["v3.customer.customer_id"],
+    },
+    {
+        "metrics": ["v3.page_view_count"],
+        "dimensions": ["v3.product.category"],
+        "strategy": "full",
+        "schedule": "0 0 * * *",
+    },
+    {
+        "metrics": ["v3.session_count"],
+        "dimensions": ["v3.product.category"],
+        "strategy": "full",
+        "schedule": "0 0 * * *",
+    },
+    {
+        "metrics": ["v3.visitor_count"],
+        "dimensions": ["v3.product.category"],
+    },
+]
+
+
+async def main() -> None:
+    engine = create_async_engine(url=db_url, poolclass=StaticPool)
+    session_factory = async_sessionmaker(bind=engine, expire_on_commit=False)
+
+    async with session_factory() as session:
+
+        def get_session_override() -> AsyncSession:
+            return session
+
+        def get_settings_override() -> Settings:
+            return template_settings
+
+        def get_passthrough_auth_service():
+            return PassthroughAuthorizationService()
+
+        def get_query_service_client_override(request=None):
+            return MagicMock()
+
+        app.dependency_overrides[get_session] = get_session_override
+        app.dependency_overrides[get_settings] = get_settings_override
+        app.dependency_overrides[get_authorization_service] = (
+            get_passthrough_auth_service
+        )
+        app.dependency_overrides[get_query_service_client] = (
+            get_query_service_client_override
+        )
+
+        jwt_token = create_token(
+            {"username": "dj"},
+            secret="a-fake-secretkey",
+            iss="http://localhost:8000/",
+            expires_delta=timedelta(hours=24),
+        )
+
+        preagg_ids: list[int] = []
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            client.headers.update({"Authorization": f"Bearer {jwt_token}"})
+            for index, spec in enumerate(PREAGG_SPECS, start=1):
+                response = await client.post("/preaggs/plan", json=spec)
+                if response.status_code != 201:
+                    raise RuntimeError(
+                        f"preagg {index} failed ({response.status_code}): "
+                        f"{response.text}",
+                    )
+                preagg_ids.append(response.json()["preaggs"][0]["id"])
+
+        await session.commit()
+        app.dependency_overrides.clear()
+
+    await engine.dispose()
+    print("PREAGG_IDS " + json.dumps(preagg_ids))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/datajunction-server/tests/helpers/populate_template.py
+++ b/datajunction-server/tests/helpers/populate_template.py
@@ -11,93 +11,28 @@ Usage: python populate_template.py <database_url>
 import asyncio
 import os
 import sys
-from datetime import timedelta
 from http.client import HTTPException
 
-import httpx
-from cachelib.simple import SimpleCache
 from httpx import AsyncClient
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.pool import StaticPool
-
-# Get database URL from command line
-template_db_url = sys.argv[1]
-reader_db_url = template_db_url.replace("dj:dj@", "readonly_user:readonly@")
-
-# Set environment variables BEFORE importing any datajunction_server modules
-# This ensures the Settings class picks up these values
-os.environ["DJ_DATABASE__URI"] = template_db_url
-os.environ["WRITER_DB__URI"] = template_db_url
-os.environ["READER_DB__URI"] = reader_db_url
 
 # Add tests directory to path for examples import
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from examples import COLUMN_MAPPINGS, EXAMPLES, SERVICE_SETUP
+from helpers.template_app import configure_database_env, template_app_client
 
-# Import config first and clear cache to ensure our env vars are used
-from datajunction_server.config import DatabaseConfig, Settings
-from datajunction_server.utils import get_settings
+# Get database URL from command line
+template_db_url = sys.argv[1]
+reader_db_url = configure_database_env(template_db_url)
 
-# Clear the lru_cache on get_settings to force it to re-read
-get_settings.cache_clear()
-
-# Now import the rest of the modules - they should use our settings
+# Imported after configure_database_env so they read the settings above.
 from datajunction_server.api.attributes import default_attribute_types
-from datajunction_server.api.main import app
 from datajunction_server.database.base import Base
-from datajunction_server.database.column import Column
-from datajunction_server.database.engine import Engine
 from datajunction_server.database.user import User
-from datajunction_server.internal.access.authentication.tokens import (
-    create_token,
-)
-from datajunction_server.internal.access.authorization import (
-    PassthroughAuthorizationService,
-    get_authorization_service,
-)
 from datajunction_server.internal.seed import seed_default_catalogs
-from datajunction_server.models.dialect import register_dialect_plugin
-from datajunction_server.models.query import QueryCreate, QueryWithResults
 from datajunction_server.models.user import OAuthProvider
-from datajunction_server.service_clients import QueryServiceClient
-from datajunction_server.transpilation import SQLTranspilationPlugin
-from datajunction_server.typing import QueryState
-from datajunction_server.utils import (
-    get_query_service_client,
-    get_session,
-)
-
-# Verify our settings are correct
-actual_settings = get_settings()
-print(f"Using writer_db: {actual_settings.writer_db.uri}")
-print(
-    f"Using reader_db: {actual_settings.reader_db.uri if actual_settings.reader_db else 'None'}",
-)
-
-# Import seed module to patch its cached settings
-from datajunction_server.internal import seed as seed_module
-
-# Create template settings (matching what get_settings() should return)
-template_settings = Settings(
-    writer_db=DatabaseConfig(uri=template_db_url),
-    reader_db=DatabaseConfig(uri=reader_db_url),
-    repository="/path/to/repository",
-    results_backend=SimpleCache(default_timeout=0),
-    celery_broker=None,
-    redis_cache=None,
-    query_service=None,
-    secret="a-fake-secretkey",
-    transpilation_plugins=["default"],
-)
-
-# Patch the cached settings in seed module
-seed_module.settings = template_settings
-
-# Register dialect plugins
-register_dialect_plugin("spark", SQLTranspilationPlugin)
-register_dialect_plugin("trino", SQLTranspilationPlugin)
-register_dialect_plugin("druid", SQLTranspilationPlugin)
 
 
 # Helper functions (copied from conftest.py)
@@ -172,126 +107,27 @@ async def create_default_user(session: AsyncSession) -> User:
 async def main():
     print(f"Populating template database: {template_db_url}")
 
-    engine = create_async_engine(
-        url=template_db_url,
-        poolclass=StaticPool,
-    )
-
-    # Create all tables
+    engine = create_async_engine(url=template_db_url, poolclass=StaticPool)
     async with engine.begin() as conn:
         await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm;"))
         await conn.run_sync(Base.metadata.create_all)
     print("Tables created")
+    await engine.dispose()
 
-    async_session_factory = async_sessionmaker(
-        bind=engine,
-        autocommit=False,
-        expire_on_commit=False,
-    )
-
-    async with async_session_factory() as session:
-        # Seed default data
+    async with template_app_client(
+        template_db_url,
+        reader_db_url,
+        column_mappings=COLUMN_MAPPINGS,
+    ) as (session, test_client):
         await default_attribute_types(session)
         await seed_default_catalogs(session)
         await create_default_user(session)
         print("Default data seeded")
 
-        # Create mock query service client
-        qs_client = QueryServiceClient(uri="query_service:8001")
-
-        def mock_get_columns_for_table(
-            catalog: str,
-            schema: str,
-            table: str,
-            engine: Engine | None = None,
-            request_headers: dict[str, str] | None = None,
-        ) -> list[Column]:
-            return COLUMN_MAPPINGS.get(f"{catalog}.{schema}.{table}", [])
-
-        def mock_submit_query(
-            query_create: QueryCreate,
-            request_headers: dict[str, str] | None = None,
-        ) -> QueryWithResults:
-            return QueryWithResults(
-                id="bd98d6be-e2d2-413e-94c7-96d9411ddee2",
-                submitted_query=query_create.submitted_query,
-                state=QueryState.FINISHED,
-                results=[
-                    {"columns": [], "rows": [], "sql": query_create.submitted_query},
-                ],
-                errors=[],
-            )
-
-        async def mock_get_columns_for_table_async(
-            catalog: str,
-            schema: str,
-            table: str,
-            request_headers: dict[str, str] | None = None,
-            engine: Engine | None = None,
-        ) -> list[Column]:
-            return mock_get_columns_for_table(
-                catalog,
-                schema,
-                table,
-                engine,
-                request_headers,
-            )
-
-        async def mock_submit_query_async(
-            query_create: QueryCreate,
-            request_headers: dict[str, str] | None = None,
-        ) -> QueryWithResults:
-            return mock_submit_query(query_create, request_headers)
-
-        qs_client.get_columns_for_table = mock_get_columns_for_table  # type: ignore
-        qs_client.submit_query = mock_submit_query  # type: ignore
-        qs_client.get_columns_for_table = mock_get_columns_for_table_async  # type: ignore
-        qs_client.submit_query = mock_submit_query_async  # type: ignore
-
-        # Override dependencies
-        def get_session_override() -> AsyncSession:
-            return session
-
-        def get_settings_override() -> Settings:
-            return template_settings
-
-        def get_passthrough_auth_service():
-            """Override to approve all requests in tests."""
-            return PassthroughAuthorizationService()
-
-        def get_query_service_client_override(request=None):
-            return qs_client
-
-        app.dependency_overrides[get_session] = get_session_override
-        app.dependency_overrides[get_settings] = get_settings_override
-        app.dependency_overrides[get_authorization_service] = (
-            get_passthrough_auth_service
-        )
-        app.dependency_overrides[get_query_service_client] = (
-            get_query_service_client_override
-        )
-
-        # Create JWT token
-        jwt_token = create_token(
-            {"username": "dj"},
-            secret="a-fake-secretkey",
-            iss="http://localhost:8000/",
-            expires_delta=timedelta(hours=24),
-        )
-
-        # Load ALL examples
         print("Loading examples via HTTP client...")
-        async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app),
-            base_url="http://test",
-        ) as test_client:
-            test_client.headers.update({"Authorization": f"Bearer {jwt_token}"})
-            await load_examples_in_client(test_client, None)  # None = load ALL examples
+        await load_examples_in_client(test_client, None)  # None = load ALL examples
         print("Examples loaded")
 
-        app.dependency_overrides.clear()
-
-    await engine.dispose()
     print("Template database populated successfully!")
 
 

--- a/datajunction-server/tests/helpers/populate_template.py
+++ b/datajunction-server/tests/helpers/populate_template.py
@@ -18,15 +18,17 @@ import sys
 from http.client import HTTPException
 
 from httpx import AsyncClient
-from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.pool import StaticPool
+from sqlalchemy.ext.asyncio import AsyncSession
 
 # Add tests directory to path for examples import
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import examples as examples_module
 from examples import COLUMN_MAPPINGS, EXAMPLES, SERVICE_SETUP
-from helpers.template_app import configure_database_env, template_app_client
+from helpers.template_app import (
+    configure_database_env,
+    create_schema,
+    template_app_client,
+)
 
 # Get database URL from command line
 template_db_url = sys.argv[1]
@@ -35,7 +37,6 @@ reader_db_url = configure_database_env(template_db_url)
 
 # Imported after configure_database_env so they read the settings above.
 from datajunction_server.api.attributes import default_attribute_types
-from datajunction_server.database.base import Base
 from datajunction_server.database.user import User
 from datajunction_server.internal.seed import seed_default_catalogs
 from datajunction_server.models.user import OAuthProvider
@@ -119,12 +120,8 @@ async def create_default_user(session: AsyncSession) -> User:
 async def main():
     print(f"Populating template database: {template_db_url}")
 
-    engine = create_async_engine(url=template_db_url, poolclass=StaticPool)
-    async with engine.begin() as conn:
-        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm;"))
-        await conn.run_sync(Base.metadata.create_all)
+    await create_schema(template_db_url)
     print("Tables created")
-    await engine.dispose()
 
     async with template_app_client(
         template_db_url,

--- a/datajunction-server/tests/helpers/populate_template.py
+++ b/datajunction-server/tests/helpers/populate_template.py
@@ -3,7 +3,11 @@
 Script to populate the template database with all examples.
 Run as a subprocess to avoid event loop conflicts with pytest-asyncio.
 
-Usage: python populate_template.py <database_url>
+Usage: python populate_template.py <database_url> [EXAMPLE_NAME ...]
+
+With no example names every example is loaded, which is what the shared
+all-examples template wants. Naming a subset builds a smaller template for a
+module that only needs part of the fixture data.
 """
 
 # ruff: noqa: E402 - env vars must be set before importing datajunction_server modules
@@ -20,11 +24,13 @@ from sqlalchemy.pool import StaticPool
 
 # Add tests directory to path for examples import
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import examples as examples_module
 from examples import COLUMN_MAPPINGS, EXAMPLES, SERVICE_SETUP
 from helpers.template_app import configure_database_env, template_app_client
 
 # Get database URL from command line
 template_db_url = sys.argv[1]
+examples_to_load = sys.argv[2:] or None
 reader_db_url = configure_database_env(template_db_url)
 
 # Imported after configure_database_env so they read the settings above.
@@ -64,7 +70,13 @@ async def load_examples_in_client(
     # Load only the selected examples if any are specified
     if examples_to_load is not None:
         for example_name in examples_to_load:
-            for endpoint, json in EXAMPLES[example_name]:
+            # Most names are EXAMPLES keys, but some fixture sets are only
+            # module-level constants in tests/examples.py.
+            example = EXAMPLES.get(example_name) or getattr(
+                examples_module,
+                example_name,
+            )
+            for endpoint, json in example:
                 await post_and_raise_if_error(
                     client=client,
                     endpoint=endpoint,
@@ -124,8 +136,8 @@ async def main():
         await create_default_user(session)
         print("Default data seeded")
 
-        print("Loading examples via HTTP client...")
-        await load_examples_in_client(test_client, None)  # None = load ALL examples
+        print(f"Loading examples via HTTP client: {examples_to_load or 'ALL'}")
+        await load_examples_in_client(test_client, examples_to_load)
         print("Examples loaded")
 
     print("Template database populated successfully!")

--- a/datajunction-server/tests/helpers/template_app.py
+++ b/datajunction-server/tests/helpers/template_app.py
@@ -1,0 +1,198 @@
+"""
+Shared bootstrap for the scripts that populate template databases.
+
+Both ``populate_template.py`` and ``populate_preaggs_template.py`` need the same
+thing: an authenticated HTTP client talking to the DJ app, with the app pointed
+at one specific database. Getting there involves setting environment variables
+before ``datajunction_server`` is imported at all, building a ``Settings``,
+registering dialect plugins, stubbing the query service and installing four
+dependency overrides -- none of which is interesting to either caller.
+
+Nothing here imports ``datajunction_server`` at module scope: the caller must be
+able to ``import`` this module, call :func:`configure_database_env`, and only
+then have any DJ module read its settings.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from typing import Any
+
+import httpx
+
+TEST_SECRET = "a-fake-secretkey"
+TEST_ISSUER = "http://localhost:8000/"
+
+
+def configure_database_env(db_url: str) -> str:
+    """
+    Point the DJ settings at ``db_url``, and return the reader URL.
+
+    Must be called before any ``datajunction_server`` module is imported, since
+    ``Settings`` reads these at import time.
+    """
+    reader_db_url = db_url.replace("dj:dj@", "readonly_user:readonly@")
+    os.environ["DJ_DATABASE__URI"] = db_url
+    os.environ["WRITER_DB__URI"] = db_url
+    os.environ["READER_DB__URI"] = reader_db_url
+    return reader_db_url
+
+
+def build_settings(db_url: str, reader_db_url: str) -> Any:
+    """Build the Settings the app should use, and patch the seed module's copy."""
+    from cachelib.simple import SimpleCache
+
+    from datajunction_server.config import DatabaseConfig, Settings
+    from datajunction_server.internal import seed as seed_module
+    from datajunction_server.models.dialect import register_dialect_plugin
+    from datajunction_server.transpilation import SQLTranspilationPlugin
+    from datajunction_server.utils import get_settings
+
+    get_settings.cache_clear()
+
+    settings = Settings(
+        writer_db=DatabaseConfig(uri=db_url),
+        reader_db=DatabaseConfig(uri=reader_db_url),
+        repository="/path/to/repository",
+        results_backend=SimpleCache(default_timeout=0),
+        celery_broker=None,
+        redis_cache=None,
+        query_service=None,
+        secret=TEST_SECRET,
+        transpilation_plugins=["default"],
+    )
+    # The seed module caches settings at import time.
+    seed_module.settings = settings
+
+    for dialect in ("spark", "trino", "druid"):
+        register_dialect_plugin(dialect, SQLTranspilationPlugin)
+
+    return settings
+
+
+def build_mock_query_service_client(column_mappings: dict | None = None) -> Any:
+    """
+    A query service client that answers from ``column_mappings`` and reports every
+    submitted query as finished, so template population never needs a live one.
+    """
+    from datajunction_server.database.column import Column
+    from datajunction_server.database.engine import Engine
+    from datajunction_server.models.query import QueryCreate, QueryWithResults
+    from datajunction_server.service_clients import QueryServiceClient
+    from datajunction_server.typing import QueryState
+
+    mappings = column_mappings or {}
+    client = QueryServiceClient(uri="query_service:8001")
+
+    def get_columns_for_table(
+        catalog: str,
+        schema: str,
+        table: str,
+        engine: Engine | None = None,
+        request_headers: dict[str, str] | None = None,
+    ) -> list[Column]:
+        return mappings.get(f"{catalog}.{schema}.{table}", [])
+
+    def submit_query(
+        query_create: QueryCreate,
+        request_headers: dict[str, str] | None = None,
+    ) -> QueryWithResults:
+        return QueryWithResults(
+            id="bd98d6be-e2d2-413e-94c7-96d9411ddee2",
+            submitted_query=query_create.submitted_query,
+            state=QueryState.FINISHED,
+            results=[
+                {"columns": [], "rows": [], "sql": query_create.submitted_query},
+            ],
+            errors=[],
+        )
+
+    async def get_columns_for_table_async(
+        catalog: str,
+        schema: str,
+        table: str,
+        request_headers: dict[str, str] | None = None,
+        engine: Engine | None = None,
+    ) -> list[Column]:
+        return get_columns_for_table(catalog, schema, table, engine, request_headers)
+
+    async def submit_query_async(
+        query_create: QueryCreate,
+        request_headers: dict[str, str] | None = None,
+    ) -> QueryWithResults:
+        return submit_query(query_create, request_headers)
+
+    client.get_columns_for_table = get_columns_for_table_async  # type: ignore[method-assign]
+    client.submit_query = submit_query_async  # type: ignore[method-assign]
+    return client
+
+
+@asynccontextmanager
+async def template_app_client(
+    db_url: str,
+    reader_db_url: str,
+    column_mappings: dict | None = None,
+) -> AsyncIterator[tuple[Any, httpx.AsyncClient]]:
+    """
+    Yield ``(session, client)`` for a DJ app bound to ``db_url``.
+
+    The session is the one the app resolves through ``get_session``, so a caller
+    can read back whatever its HTTP calls wrote. Dependency overrides and the
+    engine are torn down on exit; committing is left to the caller.
+    """
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from sqlalchemy.pool import StaticPool
+
+    from datajunction_server.api.main import app
+    from datajunction_server.internal.access.authentication.tokens import create_token
+    from datajunction_server.internal.access.authorization import (
+        PassthroughAuthorizationService,
+        get_authorization_service,
+    )
+    from datajunction_server.utils import (
+        get_query_service_client,
+        get_session,
+        get_settings,
+    )
+
+    settings = build_settings(db_url, reader_db_url)
+    query_service_client = build_mock_query_service_client(column_mappings)
+
+    engine = create_async_engine(url=db_url, poolclass=StaticPool)
+    session_factory = async_sessionmaker(
+        bind=engine,
+        autocommit=False,
+        expire_on_commit=False,
+    )
+
+    try:
+        async with session_factory() as session:
+            app.dependency_overrides[get_session] = lambda: session
+            app.dependency_overrides[get_settings] = lambda: settings
+            app.dependency_overrides[get_authorization_service] = lambda: (
+                PassthroughAuthorizationService()
+            )
+            app.dependency_overrides[get_query_service_client] = lambda request=None: (
+                query_service_client
+            )
+
+            jwt_token = create_token(
+                {"username": "dj"},
+                secret=TEST_SECRET,
+                iss=TEST_ISSUER,
+                expires_delta=timedelta(hours=24),
+            )
+
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                client.headers.update({"Authorization": f"Bearer {jwt_token}"})
+                yield session, client
+
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/datajunction-server/tests/helpers/template_app.py
+++ b/datajunction-server/tests/helpers/template_app.py
@@ -130,6 +130,31 @@ def build_mock_query_service_client(column_mappings: dict | None = None) -> Any:
     return client
 
 
+async def create_schema(db_url: str) -> None:
+    """
+    Create every table on a fresh database.
+
+    Importing the app is what registers the models on ``Base.metadata``. Without
+    it ``create_all`` silently creates only whichever subset happens to have
+    been imported, so tables belonging to newer features go missing and the
+    failure surfaces much later as ``relation "..." does not exist``.
+    """
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from sqlalchemy.pool import StaticPool
+
+    import datajunction_server.api.main  # noqa: F401  registers every model
+    from datajunction_server.database.base import Base
+
+    engine = create_async_engine(url=db_url, poolclass=StaticPool)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm;"))
+            await conn.run_sync(Base.metadata.create_all)
+    finally:
+        await engine.dispose()
+
+
 @asynccontextmanager
 async def template_app_client(
     db_url: str,


### PR DESCRIPTION
### Summary

Test setup was rebuilding the same database state in two different ways.

The first is per-test:
- `preaggregations_test.py` planned ten pre-aggregations over `/preaggs/plan` on every test (so ~1.2 s repeated across 90 tests). That cost can't be removed by making the fixture module-scoped, because many of those tests mutate the preaggs they were given.
- `dimension_links_test.py` had the same shape.

These are fixed the way the suite already handles its shared examples, by building the state once into a template database and letting each test clone the template.

The second per-worker -- under pytest-xdist "session" scope means per worker process, so every worker was starting its own Postgres container and building its own copy of the all-examples template. This is all at startup where the runner is already oversubscribed. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
