### PR TITLE
Forward the deployment fields the client was dropping

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,11 +104,23 @@ jobs:
           # Run tests
           export MODULE=${{ matrix.library == 'server' && 'datajunction_server' || matrix.library == 'client' && 'datajunction' || matrix.library == 'djqs' && 'djqs' || matrix.library == 'djrs' && 'datajunction_reflection'}}
 
-          # No coverage here -- it roughly doubles the run, and the merge gate is
-          # whichever leg is slowest. The `coverage` job below measures it
-          # across shards in parallel instead, so enforcement survives without
-          # every leg paying for it.
-          uv run pytest ${{ (matrix.library == 'server' || matrix.library == 'client') && '-n auto --dist=loadscope' || '' }} -vv tests/ --doctest-modules $MODULE --without-integration --without-slow-integration --ignore=datajunction_server/alembic/env.py
+          # Only the server skips coverage here. It is the expensive one --
+          # 28.8min instrumented against ~15min not -- so the `coverage-shard`
+          # matrix below measures it in parallel pieces and the `coverage` job
+          # enforces its threshold.
+          #
+          # The other three are instrumented in place. Their suites are small
+          # enough that it costs the gate nothing, and they have nowhere else
+          # to be measured, because the shards are server-only. An earlier
+          # version of this workflow moved coverage off every leg at once,
+          # which silently took client, djqs and djrs from a 100% gate to no
+          # gate at all.
+          COV_ARGS=""
+          if [ "${{ matrix.library }}" != "server" ]; then
+            COV_ARGS="--cov-fail-under=100 --cov-report=term-missing --cov=$MODULE"
+          fi
+
+          uv run pytest ${{ (matrix.library == 'server' || matrix.library == 'client') && '-n auto --dist=loadscope' || '' }} $COV_ARGS -vv tests/ --doctest-modules $MODULE --without-integration --without-slow-integration --ignore=datajunction_server/alembic/env.py
 
   # Coverage roughly doubles the suite, so measure it across shards in parallel
   # rather than serially inside a build leg. Each shard only produces data; the

--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -562,6 +562,10 @@ class DeploymentService:
             or project_metadata.get("prefix", ""),
             "nodes": nodes,
             "tags": project_metadata.get("tags", []),
+            # Upsert-only on the server: an empty list is a no-op, never a
+            # retirement, so defaulting to [] is safe here in a way it is not
+            # for custom_metadata_schemas below.
+            "hierarchies": project_metadata.get("hierarchies", []),
             "preaggregations": preaggregations,
         }
 

--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -565,6 +565,17 @@ class DeploymentService:
             "preaggregations": preaggregations,
         }
 
+        # Forwarded only when dj.yaml declares it, because absent and empty mean
+        # different things to the server: absent leaves registered schemas alone,
+        # while an empty list says this manifest manages them and declares none,
+        # which retires them. Defaulting to [] here would silently retire every
+        # schema in the namespace on the next push from a manifest that never
+        # mentioned them.
+        if "custom_metadata_schemas" in project_metadata:
+            deployment_spec["custom_metadata_schemas"] = project_metadata[
+                "custom_metadata_schemas"
+            ]
+
         # Add deployment source if available from env vars
         source = self._build_deployment_source(cwd=base_dir)
         if source:  # pragma: no branch

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -75,6 +75,81 @@ def test_reconstruct_deployment_spec_separates_preaggregations(tmp_path):
     assert "kind" not in preagg
 
 
+def test_reconstruct_deployment_spec_forwards_custom_metadata_schemas(tmp_path):
+    """A `custom_metadata_schemas:` block in dj.yaml reaches the deployment payload.
+
+    The payload is assembled key by key, so a manifest section the client does not
+    name is read and dropped -- the deploy then succeeds having registered nothing,
+    which is indistinguishable from success.
+    """
+    (tmp_path / "dj.yaml").write_text(
+        "namespace: ns\n"
+        "custom_metadata_schemas:\n"
+        "  - key: system\n"
+        "    description: Governance metadata.\n"
+        "    json_schema:\n"
+        "      type: object\n"
+        "      properties:\n"
+        "        lifecycle:\n"
+        "          type: string\n"
+        "          enum: [experimental, active, retired]\n",
+    )
+    (tmp_path / "revenue.yaml").write_text(
+        "name: ns.revenue\nnode_type: metric\nquery: SELECT SUM(amount) FROM ns.fct\n",
+    )
+
+    svc = DeploymentService(MagicMock())
+    spec, _ = svc._reconstruct_deployment_spec(tmp_path)
+
+    assert spec["custom_metadata_schemas"] == [
+        {
+            "key": "system",
+            "description": "Governance metadata.",
+            "json_schema": {
+                "type": "object",
+                "properties": {
+                    "lifecycle": {
+                        "type": "string",
+                        "enum": ["experimental", "active", "retired"],
+                    },
+                },
+            },
+        },
+    ]
+
+
+def test_reconstruct_deployment_spec_omits_absent_custom_metadata_schemas(tmp_path):
+    """A manifest that never mentions schemas must not send the key at all.
+
+    The server reads absent as "this manifest does not manage schemas" and an empty
+    list as "it manages them and declares none", which retires every schema in the
+    namespace. Sending [] for a manifest that simply has no opinion would delete
+    registrations that something else owns.
+    """
+    (tmp_path / "dj.yaml").write_text("namespace: ns\n")
+    (tmp_path / "revenue.yaml").write_text(
+        "name: ns.revenue\nnode_type: metric\nquery: SELECT SUM(amount) FROM ns.fct\n",
+    )
+
+    svc = DeploymentService(MagicMock())
+    spec, _ = svc._reconstruct_deployment_spec(tmp_path)
+
+    assert "custom_metadata_schemas" not in spec
+
+
+def test_reconstruct_deployment_spec_forwards_empty_custom_metadata_schemas(tmp_path):
+    """An explicitly empty list is forwarded, because it means "retire them"."""
+    (tmp_path / "dj.yaml").write_text("namespace: ns\ncustom_metadata_schemas: []\n")
+    (tmp_path / "revenue.yaml").write_text(
+        "name: ns.revenue\nnode_type: metric\nquery: SELECT SUM(amount) FROM ns.fct\n",
+    )
+
+    svc = DeploymentService(MagicMock())
+    spec, _ = svc._reconstruct_deployment_spec(tmp_path)
+
+    assert spec["custom_metadata_schemas"] == []
+
+
 def test_reconstruct_deployment_spec_rejects_unknown_kind(tmp_path):
     """An unrecognized ``kind`` fails loudly instead of silently becoming a node."""
     (tmp_path / "dj.yaml").write_text("namespace: ns\n")

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -75,6 +75,56 @@ def test_reconstruct_deployment_spec_separates_preaggregations(tmp_path):
     assert "kind" not in preagg
 
 
+def test_reconstruct_deployment_spec_forwards_hierarchies(tmp_path):
+    """A `hierarchies:` block in dj.yaml reaches the deployment payload.
+
+    Same defect as custom_metadata_schemas: the payload names its keys one by one,
+    so an unnamed manifest section is read and dropped. Hierarchies are upsert-only
+    on the server, so an absent block is a no-op and [] is a safe default.
+    """
+    (tmp_path / "dj.yaml").write_text(
+        "namespace: ns\n"
+        "hierarchies:\n"
+        "  - name: geography\n"
+        "    display_name: Geography\n"
+        "    levels:\n"
+        "      - name: country\n"
+        "        dimension_node: ns.country\n"
+        "      - name: city\n"
+        "        dimension_node: ns.city\n",
+    )
+    (tmp_path / "revenue.yaml").write_text(
+        "name: ns.revenue\nnode_type: metric\nquery: SELECT SUM(amount) FROM ns.fct\n",
+    )
+
+    svc = DeploymentService(MagicMock())
+    spec, _ = svc._reconstruct_deployment_spec(tmp_path)
+
+    assert spec["hierarchies"] == [
+        {
+            "name": "geography",
+            "display_name": "Geography",
+            "levels": [
+                {"name": "country", "dimension_node": "ns.country"},
+                {"name": "city", "dimension_node": "ns.city"},
+            ],
+        },
+    ]
+
+
+def test_reconstruct_deployment_spec_defaults_hierarchies_to_empty(tmp_path):
+    """A manifest with no hierarchies sends [], which the server treats as a no-op."""
+    (tmp_path / "dj.yaml").write_text("namespace: ns\n")
+    (tmp_path / "revenue.yaml").write_text(
+        "name: ns.revenue\nnode_type: metric\nquery: SELECT SUM(amount) FROM ns.fct\n",
+    )
+
+    svc = DeploymentService(MagicMock())
+    spec, _ = svc._reconstruct_deployment_spec(tmp_path)
+
+    assert spec["hierarchies"] == []
+
+
 def test_reconstruct_deployment_spec_forwards_custom_metadata_schemas(tmp_path):
     """A `custom_metadata_schemas:` block in dj.yaml reaches the deployment payload.
 


### PR DESCRIPTION
### Summary

The client wasn't sending two sections of the deployment payload to the server: `custom_metadata_schemas` and `hierarchies`. A repo declaring either one deploys successfully, but nothing in those two fields actually gets registered.

This PR changes it to send the two fields.

The last commit fixes a regression with #2474 which removed coverage from the client tests. This puts coverage back on every build (except the server's, which is sharded).

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
