### PR TITLE
Drop the unused `owner` field from the metadata schema registry

### DIFF
--- a/datajunction-server/datajunction_server/alembic/versions/2026_08_30_0000-cm0003dropowner_drop_owner_from_custommetadataschema.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_08_30_0000-cm0003dropowner_drop_owner_from_custommetadataschema.py
@@ -1,0 +1,26 @@
+"""drop owner from custommetadataschema
+
+Revision ID: cm0003dropowner
+Revises: wf0001names
+Create Date: 2026-08-30 00:00:00.000000+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "cm0003dropowner"
+down_revision = "wf0001names"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("custommetadataschema", "owner")
+
+
+def downgrade():
+    op.add_column(
+        "custommetadataschema",
+        sa.Column("owner", sa.String(), nullable=True),
+    )

--- a/datajunction-server/datajunction_server/api/custom_metadata.py
+++ b/datajunction-server/datajunction_server/api/custom_metadata.py
@@ -82,7 +82,6 @@ async def register_schema(
         json_schema=data.json_schema,
         filterable=data.filterable,
         description=data.description,
-        owner=data.owner,
         reserved=data.reserved,
         current_user_id=current_user.id,
     )

--- a/datajunction-server/datajunction_server/database/custom_metadata_schema.py
+++ b/datajunction-server/datajunction_server/database/custom_metadata_schema.py
@@ -41,7 +41,6 @@ class CustomMetadataSchema(Base):
         ForeignKey("users.id"),
         default=None,
     )
-    owner: Mapped[str | None] = mapped_column(String, default=None)
     updated_by_id: Mapped[int | None] = mapped_column(
         BigInteger,
         ForeignKey("users.id"),

--- a/datajunction-server/datajunction_server/internal/custom_metadata.py
+++ b/datajunction-server/datajunction_server/internal/custom_metadata.py
@@ -257,7 +257,6 @@ async def upsert_schema_row(
     json_schema: dict,
     filterable: bool,
     description: str | None,
-    owner: str | None,
     reserved: bool,
     current_user_id: int,
 ) -> CustomMetadataSchema:
@@ -290,7 +289,6 @@ async def upsert_schema_row(
     row.value_kind = value_kind(json_schema)
     row.filterable = filterable
     row.description = description
-    row.owner = owner
     row.reserved = reserved
     row.updated_by_id = current_user_id
     row.deactivated_at = None
@@ -344,7 +342,6 @@ async def upsert_schema_specs(
             json_schema=spec.json_schema,
             filterable=spec.filterable,
             description=spec.description,
-            owner=spec.owner,
             reserved=False,
             current_user_id=current_user_id,
         )

--- a/datajunction-server/datajunction_server/models/custom_metadata.py
+++ b/datajunction-server/datajunction_server/models/custom_metadata.py
@@ -33,7 +33,6 @@ class CustomMetadataSchemaCreate(BaseModel):
     json_schema: dict
     filterable: bool = True
     description: str | None = None
-    owner: str | None = None
     reserved: bool = False
 
 
@@ -46,7 +45,6 @@ class CustomMetadataSchemaOutput(BaseModel):
     value_kind: str | None = None
     filterable: bool
     description: str | None = None
-    owner: str | None = None
     reserved: bool = False
     created_by_id: int | None = None
     updated_by_id: int | None = None

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -1391,9 +1391,6 @@ class CustomMetadataSchemaSpec(BaseModel):
     json_schema: dict
     filterable: bool = True
     description: str | None = None
-    # Advisory team ownership, not authorization: registering through a
-    # deployment is already gated on WRITE for the namespace.
-    owner: str | None = None
 
 
 class GitDeploymentSource(BaseModel):

--- a/datajunction-server/tests/api/test_custom_metadata_api.py
+++ b/datajunction-server/tests/api/test_custom_metadata_api.py
@@ -596,52 +596,6 @@ async def test_created_by_id_and_updated_by_id_populated(
     assert body["updated_by_id"] == admin_id
 
 
-@pytest.mark.asyncio
-async def test_owner_round_trips(
-    client: AsyncClient,
-    session: AsyncSession,
-) -> None:
-    """owner field is persisted and returned in output."""
-    from datajunction_server.database.user import User
-    from datajunction_server.models.user import OAuthProvider
-    from datajunction_server.internal.access.authentication.tokens import create_token
-    from datetime import timedelta
-    import httpx
-    from datajunction_server.api.main import app
-
-    admin_user = User(
-        username="admin_owner",
-        email=None,
-        name=None,
-        oauth_provider=OAuthProvider.BASIC,
-        is_admin=True,
-    )
-    session.add(admin_user)
-    await session.commit()
-    admin_token = create_token(
-        {"username": "admin_owner"},
-        secret="a-fake-secretkey",
-        iss="http://localhost:8000/",
-        expires_delta=timedelta(hours=24),
-    )
-    async with AsyncClient(
-        transport=httpx.ASGITransport(app=app),
-        base_url="http://test",
-        headers={"Authorization": f"Bearer {admin_token}"},
-    ) as admin_client:
-        resp = await admin_client.post(
-            "/metadata-schemas/",
-            json={
-                "key": "owner_key",
-                "json_schema": {"type": "string"},
-                "owner": "team-data-eng",
-            },
-        )
-    assert resp.status_code in (200, 201)
-    body = resp.json()
-    assert body["owner"] == "team-data-eng"
-
-
 # ---------------------------------------------------------------------------
 # Repo-managed namespaces — the API is not a second writer
 # ---------------------------------------------------------------------------

--- a/datajunction-server/tests/database/test_custom_metadata_schema_model.py
+++ b/datajunction-server/tests/database/test_custom_metadata_schema_model.py
@@ -31,20 +31,18 @@ async def test_insert_and_read_schema(session):
 
 @pytest.mark.asyncio
 async def test_new_columns_round_trip(session):
-    """owner, updated_by_id, reserved round-trip through the ORM."""
+    """updated_by_id and reserved round-trip through the ORM."""
     row = CustomMetadataSchema(
         key="contact",
         node_type=None,
         namespace=None,
         json_schema={"type": "string"},
-        owner="team-platform",
         updated_by_id=None,
         reserved=True,
     )
     session.add(row)
     await session.commit()
     fetched = await session.get(CustomMetadataSchema, row.id)
-    assert fetched.owner == "team-platform"
     assert fetched.updated_by_id is None
     assert fetched.reserved is True
 

--- a/datajunction-server/tests/internal/test_custom_metadata_deploy.py
+++ b/datajunction-server/tests/internal/test_custom_metadata_deploy.py
@@ -377,7 +377,7 @@ async def test_a_deploy_cannot_shadow_a_reserved_global_key(session, current_use
 
 @pytest.mark.asyncio
 async def test_a_deploy_records_who_registered_the_schema(session, current_user):
-    """Ownership and provenance, which the deploy path was not setting at all."""
+    """Provenance, which the deploy path was not setting at all."""
     await upsert_schema_specs(
         session,
         namespace="prov_ns",
@@ -385,7 +385,6 @@ async def test_a_deploy_records_who_registered_the_schema(session, current_user)
             CustomMetadataSchemaSpec(
                 key="grain",
                 json_schema={"type": "string"},
-                owner="@corp/some-team",
             ),
         ],
         current_user_id=current_user.id,
@@ -399,7 +398,6 @@ async def test_a_deploy_records_who_registered_the_schema(session, current_user)
     ).scalar_one()
     assert row.created_by_id == current_user.id
     assert row.updated_by_id == current_user.id
-    assert row.owner == "@corp/some-team"
     assert row.reserved is False
 
 


### PR DESCRIPTION
### Summary

`CustomMetadataSchema.owner` was a free-text string that was written but never actually used. Authorization for a schema is resolved by namespace -- the API gates on write for the namespace plus an admin tier for global and reserved keys -- so the `owner` field wasn't being used. This removes it to prevent confusion.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
