### PR TITLE
fix: standard types in `_generate_sql`

### DIFF
--- a/datajunction-server/datajunction_server/api/semantic_layer.py
+++ b/datajunction-server/datajunction_server/api/semantic_layer.py
@@ -107,6 +107,18 @@ def _cube_metadata_map(cube: NodeRevision) -> dict[str, dict[str, str | None]]:
     }
 
 
+def _generated_column_arrow_type_name(column: Any) -> str:
+    """Return the semantic-layer Arrow type name for a generated SQL column."""
+    arrow_type = _arrow_type_name(getattr(column, "type", None))
+    if arrow_type:
+        return arrow_type
+
+    semantic_type = str(getattr(column, "semantic_type", "") or "").lower()
+    if semantic_type == "dimension":
+        return DIMENSION_FALLBACK_ARROW_TYPE_NAME
+    return METRIC_FALLBACK_ARROW_TYPE_NAME
+
+
 def _metrics_payload(cube: NodeRevision) -> list["MetricInfo"]:
     """Spec ``metrics`` list. ``definition`` is display-only."""
     type_by_name = _cube_column_type_map(cube)
@@ -410,7 +422,10 @@ async def _generate_sql(
     return GeneratedSQLResponse(
         sql=generated_sql.sql,
         dialect=generated_sql.dialect.value,
-        columns=[ColumnInfo(name=col.name, type=str(col.type)) for col in columns],
+        columns=[
+            ColumnInfo(name=col.name, type=_generated_column_arrow_type_name(col))
+            for col in columns
+        ],
         cube_name=generated_sql.cube_name,
     )
 

--- a/datajunction-server/tests/api/semantic_layer_test.py
+++ b/datajunction-server/tests/api/semantic_layer_test.py
@@ -18,6 +18,7 @@ from datajunction_server.api.semantic_layer import (
     _arrow_type_name,
     _dimensions_payload,
     _filter_to_sql,
+    _generated_column_arrow_type_name,
     _metrics_payload,
     _quote_value,
 )
@@ -181,6 +182,21 @@ class TestSemanticViewPayloadTypes:
 
         assert metrics[0].type == "floating"
         assert dimensions[0].type == "utf8"
+
+    def test_generated_sql_column_types_use_standard_names(self):
+        column = SimpleNamespace(type="varchar(255)", semantic_type="dimension")
+
+        assert _generated_column_arrow_type_name(column) == "utf8"
+
+    def test_generated_sql_dimension_column_type_fallback(self):
+        column = SimpleNamespace(type="unknown_type", semantic_type="dimension")
+
+        assert _generated_column_arrow_type_name(column) == "utf8"
+
+    def test_generated_sql_metric_column_type_fallback(self):
+        column = SimpleNamespace(type=None, semantic_type="metric")
+
+        assert _generated_column_arrow_type_name(column) == "floating"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

<!-- What's this change about? -->

Follow up to https://github.com/DataJunction/dj/pull/2404, standardizing the types in the `_generate_sql` method.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
