### PR TITLE
Add swr cache control option

### DIFF
--- a/datajunction-query/djqs/api/queries.py
+++ b/datajunction-query/djqs/api/queries.py
@@ -5,7 +5,7 @@ Query related APIs.
 import json
 import logging
 import uuid
-from dataclasses import asdict
+from dataclasses import asdict, replace
 from http import HTTPStatus
 from typing import Any
 
@@ -35,10 +35,86 @@ from djqs.models.query import (
     decode_results,
     encode_results,
 )
+from djqs.result_cache import (
+    CachedQueryResult,
+    build_result_cache_key,
+    get_cached_result,
+    has_stale_while_revalidate,
+    parse_cache_control,
+)
 from djqs.utils import get_settings
 
 _logger = logging.getLogger(__name__)
 router = APIRouter(tags=["SQL Queries"])
+_pending_refresh_keys: set[str] = set()
+
+
+async def _process_refresh(
+    settings: Settings,
+    postgres_pool: AsyncConnectionPool,
+    query: Query,
+    headers: dict[str, str] | None,
+    result_cache_key: str | None,
+    result_cache_timeout: int | None,
+    refresh_key: str,
+) -> QueryResults:
+    """Run a result refresh and always release its in-process lease."""
+    try:
+        return await process_query(
+            settings=settings,
+            postgres_pool=postgres_pool,
+            query=query,
+            headers=headers,
+            result_cache_key=result_cache_key,
+            result_cache_timeout=result_cache_timeout,
+        )
+    finally:
+        _pending_refresh_keys.discard(refresh_key)
+
+
+async def get_cached_or_schedule_refresh(
+    create_query: QueryCreate,
+    settings: Settings,
+    response: Response,
+    background_tasks: BackgroundTasks,
+    postgres_pool: AsyncConnectionPool,
+    request: Request,
+) -> QueryResults | None:
+    """Return an SWR result or schedule its refresh when the caller opted in."""
+    cache_control = request.headers.get("cache-control")
+    if not has_stale_while_revalidate(cache_control):
+        return None
+
+    no_cache, no_store, retention = parse_cache_control(cache_control)
+    if no_cache:
+        return None
+
+    cache_key = build_result_cache_key(create_query, dict(request.headers))
+    cached_result, is_fresh = get_cached_result(settings.results_backend, cache_key)
+    if (
+        cached_result is not None
+        and not is_fresh
+        and not no_store
+        and cache_key not in _pending_refresh_keys
+    ):
+        _pending_refresh_keys.add(cache_key)
+        try:
+            await save_query_and_run(
+                create_query=replace(create_query, async_=True),
+                settings=settings,
+                response=response,
+                background_tasks=background_tasks,
+                postgres_pool=postgres_pool,
+                headers=request.headers,
+                result_cache_key=cache_key,
+                result_cache_timeout=retention,
+                refresh_key=cache_key,
+            )
+        except Exception:
+            _pending_refresh_keys.discard(cache_key)
+            raise
+        response.status_code = HTTPStatus.OK
+    return cached_result
 
 
 @router.post(
@@ -75,6 +151,15 @@ async def submit_query(  # pylint: disable=too-many-arguments
 
     This endpoint is different from others in that it accepts both JSON and msgpack, and
     can also return JSON or msgpack, depending on HTTP headers.
+
+    Request cache policy:
+      - ``Cache-Control: stale-while-revalidate`` opts into reusable completed-result
+        caching. Fresh results are returned immediately; retained stale results are
+        returned while an asynchronous refresh runs.
+      - ``max-age=N`` overrides result retention in seconds (up to one week) without
+        changing the 12-hour freshness window.
+      - ``no-cache`` bypasses reusable results and ``no-store`` prevents writing or
+        refreshing them.
     """
     content_type = request.headers.get("content-type")
     if content_type == "application/json":
@@ -102,15 +187,36 @@ async def submit_query(  # pylint: disable=too-many-arguments
     data["catalog_name"] = data.get("catalog_name") or settings.default_catalog
 
     create_query = QueryCreate(**data)
-
-    query_with_results = await save_query_and_run(
-        create_query=create_query,
-        settings=settings,
-        response=response,
-        background_tasks=background_tasks,
-        postgres_pool=postgres_pool,
-        headers=request.headers,
+    query_with_results = await get_cached_or_schedule_refresh(
+        create_query,
+        settings,
+        response,
+        background_tasks,
+        postgres_pool,
+        request,
     )
+    if query_with_results is None:
+        use_result_cache = has_stale_while_revalidate(
+            request.headers.get("cache-control"),
+        )
+        no_store = False
+        retention = None
+        cache_key = None
+        if use_result_cache:
+            _, no_store, retention = parse_cache_control(
+                request.headers.get("cache-control"),
+            )
+            cache_key = build_result_cache_key(create_query, dict(request.headers))
+        query_with_results = await save_query_and_run(
+            create_query=create_query,
+            settings=settings,
+            response=response,
+            background_tasks=background_tasks,
+            postgres_pool=postgres_pool,
+            headers=request.headers,
+            result_cache_key=None if no_store else cache_key,
+            result_cache_timeout=retention,
+        )
 
     return_type = get_best_match(accept, ["application/json", "application/msgpack"])
     if not return_type:
@@ -141,6 +247,9 @@ async def save_query_and_run(  # pylint: disable=R0913
     background_tasks: BackgroundTasks,
     postgres_pool: AsyncConnectionPool,
     headers: dict[str, str] | None = None,
+    result_cache_key: str | None = None,
+    result_cache_timeout: int | None = None,
+    refresh_key: str | None = None,
 ) -> QueryResults:
     """
     Store a new query to the DB and run it.
@@ -176,13 +285,27 @@ async def save_query_and_run(  # pylint: disable=R0913
             )
 
         if query.async_:
-            background_tasks.add_task(
-                process_query,
-                settings,
-                postgres_pool,
-                query,
-                headers,
-            )
+            if refresh_key:
+                background_tasks.add_task(
+                    _process_refresh,
+                    settings,
+                    postgres_pool,
+                    query,
+                    headers,
+                    result_cache_key,
+                    result_cache_timeout,
+                    refresh_key,
+                )
+            else:
+                background_tasks.add_task(
+                    process_query,
+                    settings,
+                    postgres_pool,
+                    query,
+                    headers,
+                    result_cache_key,
+                    result_cache_timeout,
+                )
 
             response.status_code = HTTPStatus.CREATED
             return QueryResults(
@@ -202,6 +325,9 @@ async def save_query_and_run(  # pylint: disable=R0913
         postgres_pool=postgres_pool,
         query=query,
         headers=headers,
+        result_cache_key=result_cache_key,
+        result_cache_timeout=result_cache_timeout,
+        refresh_key=refresh_key,
     )
     return query_results
 

--- a/datajunction-query/djqs/api/queries.py
+++ b/datajunction-query/djqs/api/queries.py
@@ -36,7 +36,6 @@ from djqs.models.query import (
     encode_results,
 )
 from djqs.result_cache import (
-    CachedQueryResult,
     build_result_cache_key,
     get_cached_result,
     has_stale_while_revalidate,
@@ -327,7 +326,6 @@ async def save_query_and_run(  # pylint: disable=R0913
         headers=headers,
         result_cache_key=result_cache_key,
         result_cache_timeout=result_cache_timeout,
-        refresh_key=refresh_key,
     )
     return query_results
 

--- a/datajunction-query/djqs/engine.py
+++ b/datajunction-query/djqs/engine.py
@@ -25,6 +25,7 @@ from djqs.models.query import (
     QueryState,
     StatementResults,
 )
+from djqs.result_cache import CachedQueryResult
 from djqs.typing import ColumnType, Description, SQLADialect, Stream, TypeEnum
 from djqs.utils import get_settings
 
@@ -224,6 +225,8 @@ async def process_query(
     postgres_pool: AsyncConnectionPool,
     query: Query,
     headers: dict[str, str] | None = None,
+    result_cache_key: str | None = None,
+    result_cache_timeout: int | None = None,
 ) -> QueryResults:
     """
     Process a query.
@@ -265,7 +268,7 @@ async def process_query(
             .save_query(
                 query_id=query.id,
                 submitted_query=query.submitted_query,
-                state=QueryState.FINISHED.value,
+                state=query.state.value,
                 async_=query.async_,
             )
             .execute(conn=conn)
@@ -283,7 +286,7 @@ async def process_query(
         ),
     )
 
-    return QueryResults(
+    query_results = QueryResults(
         id=query.id,
         catalog_name=query.catalog_name,
         engine_name=query.engine_name,
@@ -298,3 +301,13 @@ async def process_query(
         results=results,
         errors=errors,
     )
+    if query.state == QueryState.FINISHED and result_cache_key:
+        settings.results_backend.set(
+            result_cache_key,
+            CachedQueryResult(
+                result=query_results,
+                created_at=datetime.now(timezone.utc).timestamp(),
+            ),
+            timeout=result_cache_timeout,
+        )
+    return query_results

--- a/datajunction-query/djqs/result_cache.py
+++ b/datajunction-query/djqs/result_cache.py
@@ -34,7 +34,9 @@ def parse_cache_control(cache_control: str | None) -> tuple[bool, bool, int]:
     shared freshness window, which prevents one caller from making a shared
     result appear fresh indefinitely.
     """
-    directives = [directive.strip().lower() for directive in (cache_control or "").split(",")]
+    directives = [
+        directive.strip().lower() for directive in (cache_control or "").split(",")
+    ]
     no_cache = "no-cache" in directives
     no_store = "no-store" in directives
     retention = DEFAULT_RETENTION_SECONDS

--- a/datajunction-query/djqs/result_cache.py
+++ b/datajunction-query/djqs/result_cache.py
@@ -1,0 +1,98 @@
+"""
+Stale-while-revalidate caching for completed query results.
+"""
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from cachelib.base import BaseCache
+
+from djqs.constants import SQLALCHEMY_URI
+from djqs.models.query import QueryCreate, QueryResults
+
+DEFAULT_FRESHNESS_SECONDS = 12 * 60 * 60
+DEFAULT_RETENTION_SECONDS = 24 * 60 * 60
+MAX_RETENTION_SECONDS = 7 * 24 * 60 * 60
+
+
+@dataclass
+class CachedQueryResult:
+    """A successful query result together with its freshness timestamp."""
+
+    result: QueryResults
+    created_at: float
+
+
+def parse_cache_control(cache_control: str | None) -> tuple[bool, bool, int]:
+    """
+    Return ``(no_cache, no_store, retention_seconds)`` for Cache-Control.
+
+    ``max-age`` extends or shortens result retention only. It never changes the
+    shared freshness window, which prevents one caller from making a shared
+    result appear fresh indefinitely.
+    """
+    directives = [directive.strip().lower() for directive in (cache_control or "").split(",")]
+    no_cache = "no-cache" in directives
+    no_store = "no-store" in directives
+    retention = DEFAULT_RETENTION_SECONDS
+    for directive in directives:
+        name, separator, value = directive.partition("=")
+        if name != "max-age" or not separator:
+            continue
+        try:
+            candidate = int(value.strip().strip('"'))
+        except ValueError:
+            continue
+        if candidate > 0:
+            retention = min(candidate, MAX_RETENTION_SECONDS)
+            break
+    return no_cache, no_store, retention
+
+
+def has_stale_while_revalidate(cache_control: str | None) -> bool:
+    """Return whether the caller explicitly opts into result SWR."""
+    return any(
+        directive.strip().lower().partition("=")[0] == "stale-while-revalidate"
+        for directive in (cache_control or "").split(",")
+    )
+
+
+def build_result_cache_key(
+    query: QueryCreate,
+    headers: dict[str, str] | None = None,
+) -> str:
+    """Build a stable key for a query's execution-affecting inputs."""
+    sqlalchemy_uri = next(
+        (
+            value
+            for name, value in (headers or {}).items()
+            if name.lower() == SQLALCHEMY_URI.lower()
+        ),
+        None,
+    )
+    payload = json.dumps(
+        {
+            "catalog_name": query.catalog_name,
+            "engine_name": query.engine_name,
+            "engine_version": query.engine_version,
+            "submitted_query": query.submitted_query,
+            "sqlalchemy_uri": sqlalchemy_uri,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"query-results:{hashlib.sha256(payload.encode()).hexdigest()}"
+
+
+def get_cached_result(
+    cache: BaseCache,
+    key: str,
+) -> tuple[QueryResults | None, bool]:
+    """Return a cached result and whether it is still within freshness."""
+    cached: Any = cache.get(key)
+    if not isinstance(cached, CachedQueryResult):
+        return None, False
+    return cached.result, (time.time() - cached.created_at) < DEFAULT_FRESHNESS_SECONDS

--- a/datajunction-query/tests/api/queries_test.py
+++ b/datajunction-query/tests/api/queries_test.py
@@ -10,15 +10,18 @@ from http import HTTPStatus
 from unittest import mock
 
 import msgpack
+import pytest
 from fastapi.testclient import TestClient
 from freezegun import freeze_time
 from pytest_mock import MockerFixture
 
+from djqs.api import queries as queries_api
 from djqs.config import Settings
 from djqs.engine import process_query
 from djqs.models.query import (
     Query,
     QueryCreate,
+    QueryResults,
     QueryState,
     StatementResults,
     decode_results,
@@ -457,6 +460,76 @@ def test_submit_query_async(
     assert arguments[0] == process_query  # pylint: disable=comparison-with-callable
     assert isinstance(arguments[1], Settings)
     assert isinstance(arguments[3], Query)
+
+
+def test_stale_swr_forces_async_refresh(
+    mocker: MockerFixture,
+    client: TestClient,
+) -> None:
+    """A stale SWR hit returns immediately and refreshes asynchronously."""
+    stale_result = QueryResults(
+        submitted_query="SELECT 1 AS col",
+        state=QueryState.FINISHED,
+    )
+    add_task = mocker.patch("fastapi.BackgroundTasks.add_task")
+    mocker.patch(
+        "djqs.api.queries.get_cached_result",
+        return_value=(stale_result, False),
+    )
+    mocker.patch(
+        "djqs.api.queries.build_result_cache_key",
+        return_value="cache-key",
+    )
+    query_create = QueryCreate(
+        catalog_name="warehouse_inmemory",
+        engine_name="duckdb_inmemory",
+        engine_version="0.7.1",
+        submitted_query="SELECT 1 AS col",
+    )
+
+    try:
+        response = client.post(
+            "/queries/",
+            data=json.dumps(asdict(query_create)),
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "Cache-Control": "stale-while-revalidate",
+            },
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["id"] == str(stale_result.id)
+        arguments = add_task.call_args.args
+        assert arguments[0] is queries_api._process_refresh
+        assert arguments[3].async_ is True
+        assert arguments[5] == "cache-key"
+        assert arguments[7] == "cache-key"
+    finally:
+        queries_api._pending_refresh_keys.discard("cache-key")
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_releases_its_lease(mocker: MockerFixture) -> None:
+    """A failed refresh does not prevent a later refresh attempt."""
+    queries_api._pending_refresh_keys.add("cache-key")
+    mocker.patch(
+        "djqs.api.queries.process_query",
+        side_effect=RuntimeError("refresh failed"),
+    )
+    try:
+        with pytest.raises(RuntimeError, match="refresh failed"):
+            await queries_api._process_refresh(
+                settings=mocker.MagicMock(),
+                postgres_pool=mocker.MagicMock(),
+                query=Query(),
+                headers=None,
+                result_cache_key="cache-key",
+                result_cache_timeout=60,
+                refresh_key="cache-key",
+            )
+        assert "cache-key" not in queries_api._pending_refresh_keys
+    finally:
+        queries_api._pending_refresh_keys.discard("cache-key")
 
 
 def test_submit_query_error(client: TestClient) -> None:

--- a/datajunction-query/tests/api/queries_test.py
+++ b/datajunction-query/tests/api/queries_test.py
@@ -11,6 +11,7 @@ from unittest import mock
 
 import msgpack
 import pytest
+from fastapi import BackgroundTasks, Request, Response
 from fastapi.testclient import TestClient
 from freezegun import freeze_time
 from pytest_mock import MockerFixture
@@ -508,6 +509,39 @@ def test_stale_swr_forces_async_refresh(
         queries_api._pending_refresh_keys.discard("cache-key")
 
 
+def test_swr_cache_miss_stores_result(client: TestClient) -> None:
+    """An SWR cache miss writes the completed result for a later request."""
+    query_create = QueryCreate(
+        catalog_name="warehouse_inmemory",
+        engine_name="duckdb_inmemory",
+        engine_version="0.7.1",
+        submitted_query="SELECT 2 AS col",
+    )
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Cache-Control": "stale-while-revalidate",
+    }
+    cache_key = queries_api.build_result_cache_key(query_create, headers)
+    settings = get_settings()
+    settings.results_backend.delete(cache_key)
+
+    response = client.post(
+        "/queries/",
+        data=json.dumps(asdict(query_create)),
+        headers=headers,
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    cached_result, is_fresh = queries_api.get_cached_result(
+        settings.results_backend,
+        cache_key,
+    )
+    assert cached_result is not None
+    assert str(cached_result.id) == response.json()["id"]
+    assert is_fresh is True
+
+
 @pytest.mark.asyncio
 async def test_failed_refresh_releases_its_lease(mocker: MockerFixture) -> None:
     """A failed refresh does not prevent a later refresh attempt."""
@@ -530,6 +564,168 @@ async def test_failed_refresh_releases_its_lease(mocker: MockerFixture) -> None:
         assert "cache-key" not in queries_api._pending_refresh_keys
     finally:
         queries_api._pending_refresh_keys.discard("cache-key")
+
+
+@pytest.mark.asyncio
+async def test_no_cache_skips_swr_lookup(mocker: MockerFixture) -> None:
+    """A no-cache request bypasses reading and refreshing result-cache entries."""
+    request = Request(
+        {
+            "type": "http",
+            "headers": [
+                (b"cache-control", b"stale-while-revalidate, no-cache"),
+            ],
+        },
+    )
+    get_cached_result = mocker.patch("djqs.api.queries.get_cached_result")
+
+    result = await queries_api.get_cached_or_schedule_refresh(
+        create_query=QueryCreate(
+            catalog_name="warehouse_inmemory",
+            engine_name="duckdb_inmemory",
+            engine_version="0.7.1",
+            submitted_query="SELECT 1",
+        ),
+        settings=mocker.MagicMock(),
+        response=Response(),
+        background_tasks=BackgroundTasks(),
+        postgres_pool=mocker.MagicMock(),
+        request=request,
+    )
+
+    assert result is None
+    get_cached_result.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_does_not_schedule_refresh(mocker: MockerFixture) -> None:
+    """A cache miss leaves execution to the normal query submission path."""
+    request = Request(
+        {
+            "type": "http",
+            "headers": [
+                (b"cache-control", b"stale-while-revalidate"),
+            ],
+        },
+    )
+    mocker.patch(
+        "djqs.api.queries.build_result_cache_key",
+        return_value="cache-key",
+    )
+    mocker.patch(
+        "djqs.api.queries.get_cached_result",
+        return_value=(None, False),
+    )
+    save_query_and_run = mocker.patch("djqs.api.queries.save_query_and_run")
+
+    result = await queries_api.get_cached_or_schedule_refresh(
+        create_query=QueryCreate(
+            catalog_name="warehouse_inmemory",
+            engine_name="duckdb_inmemory",
+            engine_version="0.7.1",
+            submitted_query="SELECT 1",
+        ),
+        settings=mocker.MagicMock(),
+        response=Response(),
+        background_tasks=BackgroundTasks(),
+        postgres_pool=mocker.MagicMock(),
+        request=request,
+    )
+
+    assert result is None
+    save_query_and_run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_refresh_scheduling_failure_releases_its_lease(
+    mocker: MockerFixture,
+) -> None:
+    """A scheduling failure releases the lease before propagating the error."""
+    request = Request(
+        {
+            "type": "http",
+            "headers": [
+                (b"cache-control", b"stale-while-revalidate"),
+            ],
+        },
+    )
+    query = QueryCreate(
+        catalog_name="warehouse_inmemory",
+        engine_name="duckdb_inmemory",
+        engine_version="0.7.1",
+        submitted_query="SELECT 1",
+    )
+    mocker.patch(
+        "djqs.api.queries.get_cached_result",
+        return_value=(QueryResults(submitted_query="SELECT 1"), False),
+    )
+    mocker.patch(
+        "djqs.api.queries.build_result_cache_key",
+        return_value="cache-key",
+    )
+    mocker.patch(
+        "djqs.api.queries.save_query_and_run",
+        side_effect=RuntimeError("could not schedule refresh"),
+    )
+
+    with pytest.raises(RuntimeError, match="could not schedule refresh"):
+        await queries_api.get_cached_or_schedule_refresh(
+            create_query=query,
+            settings=mocker.MagicMock(),
+            response=Response(),
+            background_tasks=BackgroundTasks(),
+            postgres_pool=mocker.MagicMock(),
+            request=request,
+        )
+
+    assert "cache-key" not in queries_api._pending_refresh_keys
+
+
+@pytest.mark.asyncio
+async def test_submit_query_cache_miss_uses_result_cache(mocker: MockerFixture) -> None:
+    """An SWR cache miss executes and caches the query using its retention policy."""
+    request = Request(
+        {
+            "type": "http",
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"cache-control", b"stale-while-revalidate, max-age=60"),
+            ],
+        },
+    )
+    result = QueryResults(submitted_query="SELECT 1", state=QueryState.FINISHED)
+    mocker.patch(
+        "djqs.api.queries.get_cached_or_schedule_refresh",
+        return_value=None,
+    )
+    mocker.patch(
+        "djqs.api.queries.build_result_cache_key",
+        return_value="cache-key",
+    )
+    save_query_and_run = mocker.patch(
+        "djqs.api.queries.save_query_and_run",
+        return_value=result,
+    )
+
+    response = await queries_api.submit_query(
+        accept="application/json",
+        settings=mocker.MagicMock(),
+        request=request,
+        response=Response(),
+        postgres_pool=mocker.MagicMock(),
+        background_tasks=BackgroundTasks(),
+        body={
+            "catalog_name": "warehouse_inmemory",
+            "engine_name": "duckdb_inmemory",
+            "engine_version": "0.7.1",
+            "submitted_query": "SELECT 1",
+        },
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert json.loads(response.body) == json.loads(json.dumps(asdict(result), default=str))
+    assert save_query_and_run.await_args.kwargs["result_cache_key"] == "cache-key"
+    assert save_query_and_run.await_args.kwargs["result_cache_timeout"] == 60
 
 
 def test_submit_query_error(client: TestClient) -> None:

--- a/datajunction-query/tests/api/queries_test.py
+++ b/datajunction-query/tests/api/queries_test.py
@@ -723,7 +723,9 @@ async def test_submit_query_cache_miss_uses_result_cache(mocker: MockerFixture) 
     )
 
     assert response.status_code == HTTPStatus.OK
-    assert json.loads(response.body) == json.loads(json.dumps(asdict(result), default=str))
+    assert json.loads(response.body) == json.loads(
+        json.dumps(asdict(result), default=str),
+    )
     assert save_query_and_run.await_args.kwargs["result_cache_key"] == "cache-key"
     assert save_query_and_run.await_args.kwargs["result_cache_timeout"] == 60
 

--- a/datajunction-query/tests/result_cache_test.py
+++ b/datajunction-query/tests/result_cache_test.py
@@ -1,0 +1,73 @@
+from unittest.mock import patch
+
+from cachelib.simple import SimpleCache
+
+from djqs.models.query import QueryCreate, QueryResults
+from djqs.result_cache import (
+    CachedQueryResult,
+    DEFAULT_FRESHNESS_SECONDS,
+    MAX_RETENTION_SECONDS,
+    build_result_cache_key,
+    get_cached_result,
+    has_stale_while_revalidate,
+    parse_cache_control,
+)
+
+
+def test_cache_control_uses_positive_max_age_for_retention():
+    assert parse_cache_control("max-age=172800") == (False, False, 172800)
+    assert parse_cache_control("max-age=999999999") == (
+        False,
+        False,
+        MAX_RETENTION_SECONDS,
+    )
+    assert parse_cache_control("no-cache, no-store, max-age=0") == (
+        True,
+        True,
+        24 * 60 * 60,
+    )
+    assert parse_cache_control("max-age=invalid") == (False, False, 24 * 60 * 60)
+    assert has_stale_while_revalidate("max-age=60, stale-while-revalidate") is True
+    assert has_stale_while_revalidate("stale-while-revalidate=60") is True
+    assert has_stale_while_revalidate("max-age=60") is False
+
+
+def test_result_cache_key_ignores_async_execution_mode():
+    first = QueryCreate(
+        catalog_name="warehouse",
+        engine_name="trino",
+        engine_version="1",
+        submitted_query="SELECT 1",
+        async_=True,
+    )
+    second = QueryCreate(
+        catalog_name="warehouse",
+        engine_name="trino",
+        engine_version="1",
+        submitted_query="SELECT 1",
+        async_=False,
+    )
+    assert build_result_cache_key(first) == build_result_cache_key(second)
+    assert build_result_cache_key(first, {"SQLALCHEMY_URI": "postgres://one"}) != (
+        build_result_cache_key(first, {"SQLALCHEMY_URI": "postgres://two"})
+    )
+
+
+def test_get_cached_result_distinguishes_fresh_and_stale_entries():
+    cache = SimpleCache()
+    key = "result"
+    result = QueryResults(submitted_query="SELECT 1")
+
+    with patch("djqs.result_cache.time.time", return_value=100):
+        cache.set(key, CachedQueryResult(result=result, created_at=100))
+        cached, is_fresh = get_cached_result(cache, key)
+    assert cached == result
+    assert is_fresh is True
+
+    with patch(
+        "djqs.result_cache.time.time",
+        return_value=100 + DEFAULT_FRESHNESS_SECONDS,
+    ):
+        cached, is_fresh = get_cached_result(cache, key)
+    assert cached == result
+    assert is_fresh is False

--- a/datajunction-query/tests/result_cache_test.py
+++ b/datajunction-query/tests/result_cache_test.py
@@ -71,3 +71,8 @@ def test_get_cached_result_distinguishes_fresh_and_stale_entries():
         cached, is_fresh = get_cached_result(cache, key)
     assert cached == result
     assert is_fresh is False
+
+
+def test_get_cached_result_returns_miss_for_absent_entry():
+    """Non-cache values cannot be treated as reusable query results."""
+    assert get_cached_result(SimpleCache(), "missing") == (None, False)

--- a/datajunction-server/datajunction_server/service_clients.py
+++ b/datajunction-server/datajunction_server/service_clients.py
@@ -405,12 +405,23 @@ class QueryServiceClient:
         request_headers: dict[str, str] | None = None,
     ) -> QueryWithResults:
         """Submit a query to the query service."""
-        # ``request_headers`` intentionally not forwarded — see
-        # ``get_columns_for_table`` for the reason.
+        # Request credentials must not be forwarded. Cache-Control is deliberately
+        # preserved because DJQS uses it to choose result-cache retention.
+        headers = {"accept": "application/json"}
+        cache_control = next(
+            (
+                value
+                for name, value in (request_headers or {}).items()
+                if name.lower() == "cache-control"
+            ),
+            None,
+        )
+        if cache_control:
+            headers["cache-control"] = cache_control
         response = await self._arequest(
             "POST",
             "/queries/",
-            headers={"accept": "application/json"},
+            headers=headers,
             json=query_create.model_dump(),
         )
         if response.status_code not in (200, 201):

--- a/datajunction-server/tests/service_clients_test.py
+++ b/datajunction-server/tests/service_clients_test.py
@@ -371,15 +371,11 @@ class TestQueryServiceClient:
         )
 
     @pytest.mark.asyncio
-    async def test_submit_query_ignores_request_headers(
+    async def test_submit_query_forwards_full_cache_policy(
         self,
         mocker: MockerFixture,
     ) -> None:
-        """``request_headers`` is intentionally not forwarded to DJQS — it stays
-        on the API for caller compatibility, but only the static ``accept`` header
-        actually goes on the wire. This guards against accidentally forwarding
-        the FastAPI request's ``Accept-Encoding`` (e.g. ``zstd``) and getting
-        back a body httpx can't auto-decompress."""
+        """Only Cache-Control is propagated; request credentials stay local."""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
@@ -417,12 +413,16 @@ class TestQueryServiceClient:
             request_headers={
                 "X-DJ-User": "alice",
                 "Accept-Encoding": "zstd",
+                "Cache-Control": "max-age=86400, stale-while-revalidate",
             },
         )
         mock_request.assert_called_with(
             "POST",
             "/queries/",
-            headers={"accept": "application/json"},
+            headers={
+                "accept": "application/json",
+                "cache-control": "max-age=86400, stale-while-revalidate",
+            },
             json=ANY,
         )
 

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -1565,7 +1565,12 @@ export const DataJunctionAPI = {
     return results;
   },
 
-  nodeData: async function (nodeName, selection = null) {
+  nodeData: async function (
+    nodeName,
+    selection = null,
+    maxAge = 86400,
+    staleWhileRevalidate = false,
+  ) {
     if (selection === null) {
       selection = {
         dimensions: [],
@@ -1581,11 +1586,16 @@ export const DataJunctionAPI = {
     }
     params.append('limit', '1000');
     params.append('async_', 'true');
+    const cacheControl = staleWhileRevalidate
+      ? `max-age=${maxAge}, stale-while-revalidate`
+      : `max-age=${maxAge}`;
 
     return await (
       await fetch(`${DJ_URL}/data/${nodeName}?${params}`, {
         credentials: 'include',
-        headers: { 'Cache-Control': 'max-age=86400' },
+        headers: {
+          'Cache-Control': cacheControl,
+        },
       })
     ).json();
   },

--- a/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
+++ b/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
@@ -733,6 +733,38 @@ describe('DataJunctionAPI', () => {
     );
   });
 
+  it('uses a caller-provided nodeData max age', () => {
+    fetch.mockResponseOnce(JSON.stringify({}));
+
+    DataJunctionAPI.nodeData('transform1', null, 604800);
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${DJ_URL}/data/transform1?limit=1000&async_=true`,
+      {
+        credentials: 'include',
+        headers: {
+          'Cache-Control': 'max-age=604800',
+        },
+      },
+    );
+  });
+
+  it('uses caller-provided nodeData stale-while-revalidate', () => {
+    fetch.mockResponseOnce(JSON.stringify({}));
+
+    DataJunctionAPI.nodeData('transform1', null, 604800, true);
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${DJ_URL}/data/transform1?limit=1000&async_=true`,
+      {
+        credentials: 'include',
+        headers: {
+          'Cache-Control': 'max-age=604800, stale-while-revalidate',
+        },
+      },
+    );
+  });
+
   it('calls dag correctly and processes response', async () => {
     const mockResponse = [
       {


### PR DESCRIPTION
### Summary

This PR adds the ability to pass in the new cache-control option, stale-while-revalidate. Stale-while-revalidate (SWR) is a caching strategy that immediately serves stale (expired) content from a cache while fetching a fresh update in the background. The changes in this PR include:

- Added opt-in result SWR caching in DJQS via Cache-Control: stale-while-revalidate.
- Uses a 12-hour freshness window and configurable retention via max-age (capped at one week).
- Returns retained stale results immediately while scheduling one async refresh; failed refreshes preserve stale data and release the retry lease.
- no-cache continues to force a fresh query; no-store avoids cache writes/refreshes.
- Forwarded Cache-Control from DataJunction server to DJQS without forwarding credentials.
- Added UI support for optional maxAge and staleWhileRevalidate arguments, defaulting SWR off.
- Added cache, refresh, forwarding, and UI request tests.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
