### PR TITLE
[DJ Semantic Fingerprint 3] Add semantic fingerprints to deployment impact

### DIFF
--- a/datajunction-clients/python/datajunction/models.py
+++ b/datajunction-clients/python/datajunction/models.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import enum
+import re
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 from datajunction._base import SerializableMixin
 
@@ -362,6 +363,42 @@ class BranchInfo(SerializableMixin):
 
 
 @dataclass
+class SemanticFingerprint:
+    """A semantic node digest returned by the server."""
+
+    digest: str
+    version: Literal[1] = 1
+
+    def __post_init__(self) -> None:
+        if self.version != 1:
+            raise ValueError(
+                f"Unsupported semantic fingerprint version: {self.version}",
+            )
+        if re.fullmatch(r"[0-9a-f]{64}", self.digest) is None:
+            raise ValueError(
+                "Semantic fingerprint digest must be 64 lowercase hexadecimal characters",
+            )
+
+    @classmethod
+    def from_dict(cls, d: dict) -> SemanticFingerprint:
+        return cls(
+            version=d.get("version", 1),
+            digest=d.get("digest", ""),
+        )
+
+
+SemanticFingerprintValue: TypeAlias = SemanticFingerprint | Literal["unknown"]
+
+
+def _parse_semantic_fingerprint(value: Any) -> SemanticFingerprintValue | None:
+    if value is None or value == "unknown":
+        return value
+    if not isinstance(value, dict):
+        raise ValueError("Semantic fingerprint must be an object or 'unknown'")
+    return SemanticFingerprint.from_dict(value)
+
+
+@dataclass
 class DeploymentResult:
     """A single node-level result within a deployment."""
 
@@ -370,15 +407,22 @@ class DeploymentResult:
     status: str
     message: str = ""
     changed_fields: list[str] = field(default_factory=list)
+    deploy_type: str = ""
+    change_tier: Literal["none", "minor", "major"] | None = None
+    semantic_fingerprint: SemanticFingerprintValue | None = None
 
     @classmethod
     def from_dict(cls, d: dict) -> DeploymentResult:
+        fingerprint = d.get("semantic_fingerprint")
         return cls(
             name=d.get("name", ""),
             operation=d.get("operation", ""),
             status=d.get("status", ""),
             message=d.get("message", ""),
             changed_fields=d.get("changed_fields") or [],
+            deploy_type=d.get("deploy_type", ""),
+            change_tier=d.get("change_tier"),
+            semantic_fingerprint=_parse_semantic_fingerprint(fingerprint),
         )
 
 
@@ -392,9 +436,11 @@ class DownstreamImpact:
     caused_by: list[str] = field(default_factory=list)
     depth: int = 0
     impact_type: str = ""
+    semantic_fingerprint: SemanticFingerprintValue | None = None
 
     @classmethod
     def from_dict(cls, d: dict) -> DownstreamImpact:
+        fingerprint = d.get("semantic_fingerprint")
         return cls(
             name=d.get("name", ""),
             node_type=d.get("node_type", ""),
@@ -402,6 +448,7 @@ class DownstreamImpact:
             caused_by=d.get("caused_by") or [],
             depth=d.get("depth", 0),
             impact_type=d.get("impact_type", ""),
+            semantic_fingerprint=_parse_semantic_fingerprint(fingerprint),
         )
 
 

--- a/datajunction-clients/python/datajunction/models.py
+++ b/datajunction-clients/python/datajunction/models.py
@@ -367,13 +367,9 @@ class SemanticFingerprint:
     """A semantic node digest returned by the server."""
 
     digest: str
-    version: Literal[1] = 1
+    version: int = 1
 
     def __post_init__(self) -> None:
-        if self.version != 1:
-            raise ValueError(
-                f"Unsupported semantic fingerprint version: {self.version}",
-            )
         if re.fullmatch(r"[0-9a-f]{64}", self.digest) is None:
             raise ValueError(
                 "Semantic fingerprint digest must be 64 lowercase hexadecimal characters",

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -1504,12 +1504,24 @@ class TestGetImpact:
         with pytest.raises(ValueError, match="64 lowercase hexadecimal"):
             SemanticFingerprint(digest=digest)
 
-    def test_semantic_fingerprint_rejects_unknown_version(self):
-        with pytest.raises(
-            ValueError,
-            match="Unsupported semantic fingerprint version",
-        ):
-            SemanticFingerprint(version=2, digest="a" * 64)
+    def test_semantic_fingerprint_preserves_unknown_version(self):
+        parsed = DeploymentInfo.from_dict(
+            {
+                "results": [
+                    {
+                        "semantic_fingerprint": {
+                            "version": 2,
+                            "digest": "a" * 64,
+                        },
+                    },
+                ],
+            },
+        )
+
+        assert parsed.results[0].semantic_fingerprint == SemanticFingerprint(
+            version=2,
+            digest="a" * 64,
+        )
 
     def test_get_impact_with_namespace_override(self, tmp_path, monkeypatch):
         """get_impact should respect namespace override."""

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -1,22 +1,23 @@
 import importlib.metadata
 import io
 import json
-from pathlib import Path
 import time
 import zipfile
+from pathlib import Path
 from unittest import mock
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
 from datajunction.deployment import DeploymentService
 from datajunction.exceptions import DJClientException, DJDeploymentFailure
-from datajunction.models import DeploymentInfo
+from datajunction.models import DeploymentInfo, SemanticFingerprint
 from datajunction.rendering import (
     _render_error_bullets,
     _strip_summary_lines,
     print_deployment_header,
     print_results,
 )
-import yaml
 from rich.console import Console
 
 
@@ -1401,24 +1402,41 @@ class TestGetImpact:
         monkeypatch.delenv("DJ_DEPLOY_REPO", raising=False)
 
         # Create mock client
-        mock_client = MagicMock()
-        mock_client.get_deployment_impact.return_value = {
+        response = {
             "uuid": "dry_run",
             "namespace": "test.ns",
             "status": "success",
             "results": [
                 {
                     "name": "test.ns.my_node",
+                    "deploy_type": "node",
                     "operation": "noop",
                     "status": "success",
                     "message": "",
+                    "change_tier": "none",
+                    "semantic_fingerprint": {
+                        "version": 1,
+                        "digest": "a" * 64,
+                    },
                 },
             ],
-            "downstream_impacts": [],
+            "downstream_impacts": [
+                {
+                    "name": "external.metric",
+                    "node_type": "metric",
+                    "predicted_status": "valid",
+                    "semantic_fingerprint": {
+                        "version": 1,
+                        "digest": "b" * 64,
+                    },
+                },
+            ],
         }
+        mock_client = MagicMock()
+        mock_client.get_deployment_impact.return_value = response
 
         svc = DeploymentService(mock_client)
-        result = svc.get_impact(tmp_path)
+        result = svc.get_impact(tmp_path, display=False)
 
         # Verify the API was called
         mock_client.get_deployment_impact.assert_called_once()
@@ -1426,9 +1444,72 @@ class TestGetImpact:
         assert call_args["namespace"] == "test.ns"
         assert "nodes" in call_args
 
-        # Verify the result is returned
-        assert result["namespace"] == "test.ns"
-        assert result["uuid"] == "dry_run"
+        assert result is response
+        parsed = DeploymentInfo.from_dict(result)
+        assert parsed.results[0].deploy_type == "node"
+        assert parsed.results[0].change_tier == "none"
+        assert parsed.results[0].semantic_fingerprint == SemanticFingerprint(
+            digest="a" * 64,
+        )
+        assert parsed.downstream_impacts[0].semantic_fingerprint == SemanticFingerprint(
+            digest="b" * 64,
+        )
+
+    def test_deployment_info_parses_unknown_fingerprints(self):
+        parsed = DeploymentInfo.from_dict(
+            {
+                "uuid": "dry_run",
+                "namespace": "test.ns",
+                "status": "success",
+                "results": [{"semantic_fingerprint": "unknown"}],
+                "downstream_impacts": [{"semantic_fingerprint": "unknown"}],
+            },
+        )
+
+        assert parsed.results[0].semantic_fingerprint == "unknown"
+        assert parsed.downstream_impacts[0].semantic_fingerprint == "unknown"
+
+        with pytest.raises(
+            ValueError,
+            match="Semantic fingerprint must be an object or 'unknown'",
+        ):
+            DeploymentInfo.from_dict(
+                {
+                    "results": [{"semantic_fingerprint": "invalid"}],
+                },
+            )
+
+    def test_deployment_info_parses_older_impact_response(self):
+        parsed = DeploymentInfo.from_dict(
+            {
+                "uuid": "dry_run",
+                "namespace": "test.ns",
+                "status": "success",
+                "results": [
+                    {
+                        "name": "test.ns.my_node",
+                        "operation": "noop",
+                        "status": "skipped",
+                    },
+                ],
+            },
+        )
+        assert parsed.results[0].deploy_type == ""
+        assert parsed.results[0].change_tier is None
+        assert parsed.results[0].semantic_fingerprint is None
+        assert parsed.downstream_impacts == []
+
+    @pytest.mark.parametrize("digest", ["a" * 63, "A" * 64, "g" * 64])
+    def test_semantic_fingerprint_rejects_invalid_digest(self, digest):
+        with pytest.raises(ValueError, match="64 lowercase hexadecimal"):
+            SemanticFingerprint(digest=digest)
+
+    def test_semantic_fingerprint_rejects_unknown_version(self):
+        with pytest.raises(
+            ValueError,
+            match="Unsupported semantic fingerprint version",
+        ):
+            SemanticFingerprint(version=2, digest="a" * 64)
 
     def test_get_impact_with_namespace_override(self, tmp_path, monkeypatch):
         """get_impact should respect namespace override."""

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -139,6 +139,7 @@ from datajunction_server.models.unit import (
     structured_to_legacy_unit,
 )
 from datajunction_server.sql.dag import get_metric_parents_map
+from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import (
     SEPARATOR,
@@ -1619,6 +1620,21 @@ class DeploymentOrchestrator:
             external_deps=external_dep_names,
         )
 
+    def _extract_plan_node_graph(
+        self,
+        nodes: list[NodeSpec],
+    ) -> dict[str, list[str]]:
+        if not self.dry_run:
+            return extract_node_graph(nodes)
+
+        node_graph = {}
+        for node in nodes:
+            try:
+                node_graph.update(extract_node_graph([node]))
+            except DJParseException:
+                node_graph[node.rendered_name] = []
+        return node_graph
+
     async def _create_deployment_plan(
         self,
     ) -> tuple[DeploymentPlan, list[DeploymentResult]]:
@@ -1680,9 +1696,8 @@ class DeploymentOrchestrator:
         external_deps: set[str] = set()
         if to_deploy or to_delete:
             with self._timer.phase("  plan: extract node graph") as p:
-                node_graph = extract_node_graph(
+                node_graph = self._extract_plan_node_graph(
                     [node for node in to_deploy if not isinstance(node, CubeSpec)],
-                    tolerate_parse_errors=self.dry_run,
                 )
                 p.append(f"{len(node_graph)} nodes in graph")
             with self._timer.phase("  plan: check external deps") as p:
@@ -1802,9 +1817,8 @@ class DeploymentOrchestrator:
                             existing_node.name,
                         )
 
-                node_graph = extract_node_graph(
+                node_graph = self._extract_plan_node_graph(
                     [node for node in to_deploy if not isinstance(node, CubeSpec)],
-                    tolerate_parse_errors=self.dry_run,
                 )
 
                 # Re-check external deps (should be empty now)

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -540,21 +540,6 @@ class DeploymentOrchestrator:
         # SAVEPOINT, so setup-phase writes roll back too.
         await self._authorize_deployment_plan(deployment_plan)
 
-        with self._timer.phase("build semantic fingerprints"):
-            (
-                self._current_semantic_fingerprints,
-                self._proposed_semantic_fingerprints,
-            ) = await build_deployment_fingerprints(
-                self.session,
-                deployment_plan.existing_specs,
-                self.deployment_spec.nodes,
-                [],
-                additional_target_names={
-                    spec.rendered_name for spec in deployment_plan.to_delete
-                },
-            )
-        self._apply_semantic_fingerprints()
-
         if deployment_plan.is_empty() and not self.deployment_spec.hierarchies:
             # Pre-aggregations still need reconciling on an otherwise-empty
             # deploy: to register specs, or to delete external pre-aggs that were
@@ -577,13 +562,17 @@ class DeploymentOrchestrator:
                 isinstance(spec, CubeSpec) for spec in self.deployment_spec.nodes
             )
             if not needs_preagg_reconcile and not declares_cube:
+                with self._timer.phase("build semantic fingerprints"):
+                    await self._build_and_apply_semantic_fingerprints(
+                        deployment_plan,
+                        [],
+                    )
                 return DeploymentExecuteResult(
                     results=await self._handle_no_changes(),
                     downstream_impacts=[],
                 )
 
         downstream = await self._execute_deployment_plan(deployment_plan)
-        self._apply_semantic_fingerprints()
         return DeploymentExecuteResult(
             results=self.deployed_results,
             downstream_impacts=downstream,
@@ -905,7 +894,7 @@ class DeploymentOrchestrator:
             )
             result.semantic_fingerprint = fingerprints.get(result.name)
 
-    async def _apply_downstream_semantic_fingerprints(
+    async def _build_and_apply_semantic_fingerprints(
         self,
         plan: DeploymentPlan,
         downstream: list,
@@ -922,6 +911,7 @@ class DeploymentOrchestrator:
         )
         self._current_semantic_fingerprints = current
         self._proposed_semantic_fingerprints = proposed
+        self._apply_semantic_fingerprints()
         for impact in downstream:
             proposed_fingerprint = proposed.get(impact.name)
             if current.get(impact.name) != proposed_fingerprint:
@@ -1939,7 +1929,7 @@ class DeploymentOrchestrator:
             )
             p.append(f"{len(downstream)} downstream")
         with timer.phase("build downstream semantic fingerprints"):
-            await self._apply_downstream_semantic_fingerprints(plan, downstream)
+            await self._build_and_apply_semantic_fingerprints(plan, downstream)
 
         # Hard-delete after impact propagation (cascade-deletes
         # NodeRelationship rows that were needed for the BFS above).
@@ -4150,13 +4140,12 @@ class DeploymentOrchestrator:
         references: dict[str, list[str]] = {}
 
         # Query just IDs and names of nodes being deleted (more efficient than loading full objects)
-        # Hold the target rows until commit so no concurrent transaction can add
-        # a new foreign-key reference after this validation snapshot.
-        stmt = (
-            select(Node.id, Node.name)
-            .where(Node.name.in_(list(nodes_to_delete)))
-            .with_for_update()
+        stmt = select(Node.id, Node.name).where(
+            Node.name.in_(list(nodes_to_delete)),
         )
+        if not self.dry_run:
+            # Keep new foreign-key references from racing the delete.
+            stmt = stmt.with_for_update()
         result = await self.session.execute(stmt)
         id_to_name = {node_id: node_name for node_id, node_name in result}
         deleted_node_ids = set(id_to_name.keys())

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -51,6 +51,10 @@ from datajunction_server.internal.custom_metadata import upsert_schema_specs
 from datajunction_server.internal.deployment.dimension_reachability import (
     DimensionReachability,
 )
+from datajunction_server.internal.deployment.fingerprints import (
+    FingerprintMap,
+    build_deployment_fingerprints,
+)
 from datajunction_server.internal.deployment.utils import (
     DeploymentContext,
     classify_parents,
@@ -105,6 +109,7 @@ from datajunction_server.models.deployment import (
     SourceSpec,
     TagSpec,
     bump_version,
+    change_tier_name,
     declared_materialization_blocks,
     eq_or_fallback,
     render_prefixes,
@@ -320,11 +325,20 @@ class DeploymentPlan:
     node_graph: dict[str, list[str]]
     external_deps: set[str]
     to_delete_namespaces: list[str] = field(default_factory=list)
+    delete_references: dict[str, list[str]] = field(default_factory=dict)
 
     def is_empty(self) -> bool:
         return (
             not self.to_deploy and not self.to_delete and not self.to_delete_namespaces
         )
+
+    @property
+    def deletable_specs(self) -> list[NodeSpec]:
+        return [
+            spec
+            for spec in self.to_delete
+            if spec.rendered_name not in self.delete_references
+        ]
 
     @property
     def linked_dimension_nodes(self) -> set[str]:
@@ -371,6 +385,8 @@ class DeploymentOrchestrator:
         self._cubes_bumped_by_upstream: dict[str, list[str]] = {}
         # Node name -> the tier its change earned, for those cubes to inherit.
         self._change_tiers: dict[str, ChangeTier] = {}
+        self._current_semantic_fingerprints: FingerprintMap = {}
+        self._proposed_semantic_fingerprints: FingerprintMap = {}
 
     @property
     def _history_user(self) -> str:
@@ -523,6 +539,21 @@ class DeploymentOrchestrator:
         # SAVEPOINT, so setup-phase writes roll back too.
         await self._authorize_deployment_plan(deployment_plan)
 
+        with self._timer.phase("build semantic fingerprints"):
+            (
+                self._current_semantic_fingerprints,
+                self._proposed_semantic_fingerprints,
+            ) = await build_deployment_fingerprints(
+                self.session,
+                deployment_plan.existing_specs,
+                self.deployment_spec.nodes,
+                [],
+                additional_target_names={
+                    spec.rendered_name for spec in deployment_plan.to_delete
+                },
+            )
+        self._apply_semantic_fingerprints()
+
         if deployment_plan.is_empty() and not self.deployment_spec.hierarchies:
             # Pre-aggregations still need reconciling on an otherwise-empty
             # deploy: to register specs, or to delete external pre-aggs that were
@@ -551,6 +582,7 @@ class DeploymentOrchestrator:
                 )
 
         downstream = await self._execute_deployment_plan(deployment_plan)
+        self._apply_semantic_fingerprints()
         return DeploymentExecuteResult(
             results=self.deployed_results,
             downstream_impacts=downstream,
@@ -860,6 +892,39 @@ class DeploymentOrchestrator:
         logger.info("No changes detected, skipping deployment")
         await self._update_deployment_status()
         return self.deployed_results
+
+    def _apply_semantic_fingerprints(self) -> None:
+        for result in self.deployed_results:
+            if result.deploy_type != DeploymentResult.Type.NODE:
+                continue
+            fingerprints = (
+                self._current_semantic_fingerprints
+                if result.operation == DeploymentResult.Operation.DELETE
+                else self._proposed_semantic_fingerprints
+            )
+            result.semantic_fingerprint = fingerprints.get(result.name)
+
+    async def _apply_downstream_semantic_fingerprints(
+        self,
+        plan: DeploymentPlan,
+        downstream: list,
+    ) -> None:
+        target_names = {impact.name for impact in downstream} | {
+            spec.rendered_name for spec in plan.to_delete
+        }
+        current, proposed = await build_deployment_fingerprints(
+            self.session,
+            plan.existing_specs,
+            self.deployment_spec.nodes,
+            plan.deletable_specs,
+            additional_target_names=target_names,
+        )
+        self._current_semantic_fingerprints = current
+        self._proposed_semantic_fingerprints = proposed
+        for impact in downstream:
+            proposed_fingerprint = proposed.get(impact.name)
+            if current.get(impact.name) != proposed_fingerprint:
+                impact.semantic_fingerprint = proposed_fingerprint
 
     async def _find_namespaces_to_create(self) -> set[str]:
         """
@@ -1606,6 +1671,7 @@ class DeploymentOrchestrator:
                     else DeploymentResult.Status.SKIPPED,
                     operation=DeploymentResult.Operation.NOOP,
                     message="Unchanged, still INVALID" if is_invalid else "Unchanged",
+                    change_tier=change_tier_name(ChangeTier.NONE),
                 ),
             )
 
@@ -1616,6 +1682,7 @@ class DeploymentOrchestrator:
             with self._timer.phase("  plan: extract node graph") as p:
                 node_graph = extract_node_graph(
                     [node for node in to_deploy if not isinstance(node, CubeSpec)],
+                    tolerate_parse_errors=self.dry_run,
                 )
                 p.append(f"{len(node_graph)} nodes in graph")
             with self._timer.phase("  plan: check external deps") as p:
@@ -1737,6 +1804,7 @@ class DeploymentOrchestrator:
 
                 node_graph = extract_node_graph(
                     [node for node in to_deploy if not isinstance(node, CubeSpec)],
+                    tolerate_parse_errors=self.dry_run,
                 )
 
                 # Re-check external deps (should be empty now)
@@ -1844,23 +1912,29 @@ class DeploymentOrchestrator:
             if r.deploy_type == DeploymentResult.Type.LINK
             and r.status != DeploymentResult.Status.SKIPPED
         }
+        plan.delete_references = await self._validate_node_deletion(plan.to_delete)
         with timer.phase("propagate impact") as p:
             downstream = await propagate_impact(
                 session=self.session,
                 namespace=self.deployment_spec.namespace,
                 changed_node_names=changed_names,
                 deleted_node_names=frozenset(
-                    spec.rendered_name for spec in plan.to_delete
+                    spec.rendered_name for spec in plan.deletable_specs
                 ),
                 changed_link_node_names=changed_link_names,
             )
             p.append(f"{len(downstream)} downstream")
+        with timer.phase("build downstream semantic fingerprints"):
+            await self._apply_downstream_semantic_fingerprints(plan, downstream)
 
         # Hard-delete after impact propagation (cascade-deletes
         # NodeRelationship rows that were needed for the BFS above).
         if plan.to_delete:
             with timer.phase("delete nodes") as p:
-                delete_results = await self._delete_nodes(plan.to_delete)
+                delete_results = await self._delete_nodes(
+                    plan.to_delete,
+                    references=plan.delete_references,
+                )
                 p.append(f"{len(delete_results)} deleted")
             self.deployed_results.extend(delete_results)
             await self._update_deployment_status()
@@ -3915,6 +3989,12 @@ class DeploymentOrchestrator:
                 + ("\n".join([""] + changelog))
                 + invalid_note,
                 changed_fields=changed_fields,
+                change_tier=change_tier_name(
+                    change_tier if existing else ChangeTier.MAJOR,
+                ),
+                semantic_fingerprint=self._proposed_semantic_fingerprints.get(
+                    cube_spec.rendered_name,
+                ),
             )
 
             deployment_results.append(deployment_result)
@@ -4056,7 +4136,13 @@ class DeploymentOrchestrator:
         references: dict[str, list[str]] = {}
 
         # Query just IDs and names of nodes being deleted (more efficient than loading full objects)
-        stmt = select(Node.id, Node.name).where(Node.name.in_(list(nodes_to_delete)))
+        # Hold the target rows until commit so no concurrent transaction can add
+        # a new foreign-key reference after this validation snapshot.
+        stmt = (
+            select(Node.id, Node.name)
+            .where(Node.name.in_(list(nodes_to_delete)))
+            .with_for_update()
+        )
         result = await self.session.execute(stmt)
         id_to_name = {node_id: node_name for node_id, node_name in result}
         deleted_node_ids = set(id_to_name.keys())
@@ -4140,11 +4226,16 @@ class DeploymentOrchestrator:
 
         return references
 
-    async def _delete_nodes(self, to_delete: list[NodeSpec]) -> list[DeploymentResult]:
+    async def _delete_nodes(
+        self,
+        to_delete: list[NodeSpec],
+        references: dict[str, list[str]] | None = None,
+    ) -> list[DeploymentResult]:
         logger.info("Starting deletion of %d nodes", len(to_delete))
 
         # Check which nodes have references that would prevent deletion
-        references = await self._validate_node_deletion(to_delete)
+        if references is None:
+            references = await self._validate_node_deletion(to_delete)
 
         # Bulk-delete every deletable node via the shared ``hard_delete_nodes``
         # helper (the same machinery ``hard_delete_namespace`` uses): it
@@ -4192,6 +4283,7 @@ class DeploymentOrchestrator:
         results = []
         for node_spec in to_delete:
             node_name = node_spec.rendered_name
+            semantic_fingerprint = self._current_semantic_fingerprints.get(node_name)
             if node_name in references:
                 # Node has references - skip deletion and return FAILED result
                 referencing_nodes = references[node_name]
@@ -4207,6 +4299,8 @@ class DeploymentOrchestrator:
                         status=DeploymentResult.Status.FAILED,
                         operation=DeploymentResult.Operation.DELETE,
                         message=error_msg,
+                        change_tier=change_tier_name(ChangeTier.MAJOR),
+                        semantic_fingerprint=semantic_fingerprint,
                     ),
                 )
             elif node_name in deleted_names:
@@ -4217,6 +4311,8 @@ class DeploymentOrchestrator:
                         status=DeploymentResult.Status.SUCCESS,
                         operation=DeploymentResult.Operation.DELETE,
                         message=f"Node {node_name} has been removed.",
+                        change_tier=change_tier_name(ChangeTier.MAJOR),
+                        semantic_fingerprint=semantic_fingerprint,
                     ),
                 )
             else:
@@ -4228,6 +4324,8 @@ class DeploymentOrchestrator:
                         status=DeploymentResult.Status.FAILED,
                         operation=DeploymentResult.Operation.DELETE,
                         message=f"Node {node_name} not found.",
+                        change_tier=change_tier_name(ChangeTier.MAJOR),
+                        semantic_fingerprint=semantic_fingerprint,
                     ),
                 )
 
@@ -4328,9 +4426,28 @@ class DeploymentOrchestrator:
             existing_spec = existing_nodes_map.get(node_spec.rendered_name)
             if not existing_spec:
                 to_create.append(node_spec)
-            elif force or node_spec != existing_spec:
-                to_update.append(node_spec)
             else:
+                if force:
+                    to_update.append(node_spec)
+                    continue
+                resolved_columns = None
+                proposed_columns = None
+                if isinstance(existing_spec, SourceSpec) and isinstance(
+                    node_spec,
+                    SourceSpec,
+                ):
+                    if not existing_spec.columns:
+                        resolved_columns = node_spec.columns
+                    if not node_spec.columns:
+                        proposed_columns = existing_spec.columns
+                changed_fields, reordered_fields = existing_spec.semantic_diff(
+                    node_spec,
+                    resolved_columns=resolved_columns,
+                    other_resolved_columns=proposed_columns,
+                )
+                if changed_fields or reordered_fields:
+                    to_update.append(node_spec)
+                    continue
                 # Re-deploy unchanged nodes that are stuck in INVALID state so
                 # they get revalidated (e.g. after an upstream fix).
                 existing_node = self.registry.nodes.get(node_spec.rendered_name)
@@ -4962,6 +5079,12 @@ class DeploymentOrchestrator:
             + ("\n".join([""] + changelog))
             + invalid_note,
             changed_fields=changed_fields,
+            change_tier=change_tier_name(
+                change_tier if existing else ChangeTier.MAJOR,
+            ),
+            semantic_fingerprint=self._proposed_semantic_fingerprints.get(
+                result.spec.rendered_name,
+            ),
         )
         return deployment_result, new_node, new_revision
 
@@ -5006,61 +5129,42 @@ class DeploymentOrchestrator:
                 f"└─ Set properties for {sum(changed_count)} columns",
             )
 
-        # Track changes to other node fields
+        # Classify changes from the same normalized values used by fingerprints.
         existing_node_spec = await existing.to_spec(self.session)
-        # to_spec() never sets namespace; diff() needs it to render ${prefix}.
-        existing_node_spec.namespace = result.spec.namespace
-        changed_fields = existing_node_spec.diff(result.spec) if existing else []
-
-        # Check if query changed (diff() ignores it, but we want to surface it)
-        if hasattr(
-            existing_node_spec,
-            "rendered_query",
-        ) and hasattr(  # pragma: no branch
+        existing_columns: list[ColumnSpec] | None = None
+        proposed_columns: list[ColumnSpec] | None = result.inferred_columns
+        if isinstance(existing_node_spec, SourceSpec) and isinstance(
             result.spec,
-            "rendered_query",
+            SourceSpec,
         ):
-            old_query = existing_node_spec.rendered_query
-            new_query = result.spec.rendered_spec().rendered_query
-            if old_query != new_query:
-                changed_fields = ["query"] + changed_fields
+            if not existing_node_spec.columns:
+                existing_columns = proposed_columns
+            if not proposed_columns:
+                proposed_columns = existing_node_spec.columns
+        changed_fields, reordered_fields = existing_node_spec.semantic_diff(
+            result.spec,
+            resolved_columns=existing_columns,
+            other_resolved_columns=proposed_columns,
+        )
 
-        # Check if column metadata changed (diff() ignores columns)
+        # Keep detailed column notes for the human-readable changelog.
         from datajunction_server.models.deployment import LinkableNodeSpec as LNS
 
-        if isinstance(result.spec, LNS) and isinstance(existing_node_spec, LNS):
+        if (
+            "columns" in changed_fields
+            and isinstance(result.spec, LNS)
+            and isinstance(existing_node_spec, LNS)
+        ):
             col_change_notes = _diff_column_metadata(
                 result.spec.rendered_spec().columns,
                 existing_node_spec.columns,
             )
-            if col_change_notes:
-                changed_fields = changed_fields + ["columns"]
-                for note in col_change_notes:
-                    changelog.append(f"└─ {note}")
-
-        # A cube's columns are derived from its metrics and dimensions; the only
-        # user-authored thing on them is partition config, which is exactly what
-        # CubeSpec.__eq__ compares. So a partition-only edit reaches the update path
-        # and has to be visible here too, or it would earn no version at all.
-        if isinstance(result.spec, CubeSpec) and isinstance(
-            existing_node_spec,
-            CubeSpec,
-        ):
-            from datajunction_server.semantic_fingerprints.normalization import (
-                normalize_cube_columns,
-            )
-
-            if normalize_cube_columns(
-                result.spec.matched_rendered_columns,
-            ) != normalize_cube_columns(existing_node_spec.matched_rendered_columns):
-                changed_fields = changed_fields + ["columns"]
+            for note in col_change_notes:
+                changelog.append(f"└─ {note}")
 
         if changed_fields:
             changelog.append("└─ Updated " + ", ".join(changed_fields))
 
-        # Fields whose contents are unchanged but whose ordering moved. diff()
-        # compares list fields as sets and so cannot see these on its own.
-        reordered_fields = existing_node_spec.order_diff(result.spec)
         if reordered_fields:
             changelog.append("└─ Reordered " + ", ".join(reordered_fields))
 
@@ -5341,13 +5445,18 @@ class DeploymentOrchestrator:
             )
             new_revision.schema_ = schema
             new_revision.table = table
+            source_columns = source_spec.columns
+            if not source_columns and new_node.current:
+                source_columns = [
+                    column.to_spec() for column in new_node.current.columns
+                ]
             new_revision.columns = [
                 self._create_column_from_spec(
                     col,
                     pk_columns,
                     order=col.order if col.order is not None else idx,
                 )
-                for idx, col in enumerate(result.spec.columns)
+                for idx, col in enumerate(source_columns or [])
             ]
 
         if result.spec.node_type == NodeType.METRIC:

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -59,7 +59,7 @@ from datajunction_server.internal.deployment.utils import (
     DeploymentContext,
     classify_parents,
     creates_cycle,
-    extract_dimension_refs_from_filters as _extract_dimension_refs_from_filters,
+    extract_dimension_refs_from_filters,
     extract_node_graph,
     topological_levels,
 )
@@ -3386,7 +3386,7 @@ class DeploymentOrchestrator:
             if cube.rendered_filters:
                 all_dim_node_names |= {
                     node_name
-                    for node_name, _ in _extract_dimension_refs_from_filters(
+                    for node_name, _ in extract_dimension_refs_from_filters(
                         cube.rendered_filters,
                     )
                 }
@@ -3665,7 +3665,7 @@ class DeploymentOrchestrator:
         # reachable only under a role can deploy green and flip on revalidation,
         # the same gap just closed above for cube dimensions.
         if cube_spec.rendered_filters and cube_parent_rev_ids:
-            filter_refs = _extract_dimension_refs_from_filters(
+            filter_refs = extract_dimension_refs_from_filters(
                 cube_spec.rendered_filters,
             )
             filter_dim_nodes = {node_name for node_name, _ in filter_refs}
@@ -4433,6 +4433,7 @@ class DeploymentOrchestrator:
                 if force:
                     to_update.append(node_spec)
                     continue
+                existing_spec.namespace = node_spec.namespace
                 resolved_columns = None
                 proposed_columns = None
                 if isinstance(existing_spec, SourceSpec) and isinstance(
@@ -5134,6 +5135,8 @@ class DeploymentOrchestrator:
 
         # Classify changes from the same normalized values used by fingerprints.
         existing_node_spec = await existing.to_spec(self.session)
+        # to_spec() never sets namespace; semantic_diff() needs it to render ${prefix}.
+        existing_node_spec.namespace = result.spec.namespace
         existing_columns: list[ColumnSpec] | None = None
         proposed_columns: list[ColumnSpec] | None = result.inferred_columns
         if isinstance(existing_node_spec, SourceSpec) and isinstance(

--- a/datajunction-server/datajunction_server/internal/impact.py
+++ b/datajunction-server/datajunction_server/internal/impact.py
@@ -16,10 +16,17 @@ from dataclasses import dataclass, field
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload
+from sqlalchemy.orm import aliased, joinedload, selectinload
 from sqlalchemy.sql.operators import is_
 
-from datajunction_server.database.node import Node, NodeRelationship, NodeRevision
+from datajunction_server.database.column import Column as DBColumn
+from datajunction_server.database.dimensionlink import DimensionLink
+from datajunction_server.database.node import (
+    BoundDimensionsRelationship,
+    Node,
+    NodeRelationship,
+    NodeRevision,
+)
 from datajunction_server.database.user import User
 from datajunction_server.instrumentation.provider import get_metrics_provider
 from datajunction_server.internal.deployment.dimension_reachability import (
@@ -191,11 +198,37 @@ async def _build_propagation_context(
 # ---------------------------------------------------------------------------
 
 
+async def _cube_filter_children_by_parent(
+    session: AsyncSession,
+) -> dict[str, set[int]]:
+    from datajunction_server.internal.deployment.utils import (
+        extract_dimension_refs_from_filters,
+    )
+
+    rows = (
+        await session.execute(
+            select(Node.id, NodeRevision.cube_filters)
+            .join(
+                NodeRevision,
+                (NodeRevision.node_id == Node.id)
+                & (NodeRevision.version == Node.current_version),
+            )
+            .where(Node.type == NodeType.CUBE)
+            .where(is_(Node.deactivated_at, None)),
+        )
+    ).all()
+    children_by_parent: dict[str, set[int]] = defaultdict(set)
+    for node_id, filters in rows:
+        for parent_name, _ in extract_dimension_refs_from_filters(filters or []):
+            children_by_parent[parent_name].add(node_id)
+    return children_by_parent
+
+
 async def _propagate_via_parent_graph(
     session: AsyncSession,
     ctx: PropagationContext,
 ) -> list[DownstreamImpact]:
-    """BFS through NodeRelationship to find all downstream nodes.
+    """BFS through persisted semantic relationships to find downstream nodes.
 
     Returns impacts without mutating DB state — Phase 3 determines the actual
     impact type via revalidation.
@@ -207,19 +240,68 @@ async def _propagate_via_parent_graph(
     visited_node_ids = set(frontier_ids)
     results: list[DownstreamImpact] = []
     depth = 1
+    cube_filter_children = await _cube_filter_children_by_parent(session)
 
     while frontier_ids:
-        rows = (
+        relationship_rows = (
             await session.execute(
                 select(NodeRevision.node_id, NodeRelationship.parent_id)
                 .join(NodeRelationship, NodeRelationship.child_id == NodeRevision.id)
-                .where(NodeRelationship.parent_id.in_(frontier_ids)),
+                .join(Node, Node.id == NodeRevision.node_id)
+                .where(NodeRelationship.parent_id.in_(frontier_ids))
+                .where(Node.current_version == NodeRevision.version),
+            )
+        ).all()
+        dimension_link_rows = (
+            await session.execute(
+                select(NodeRevision.node_id, DimensionLink.dimension_id)
+                .join(
+                    DimensionLink,
+                    DimensionLink.node_revision_id == NodeRevision.id,
+                )
+                .join(Node, Node.id == NodeRevision.node_id)
+                .where(DimensionLink.dimension_id.in_(frontier_ids))
+                .where(Node.current_version == NodeRevision.version),
+            )
+        ).all()
+
+        parent_revision = aliased(NodeRevision)
+        metric_revision = aliased(NodeRevision)
+        required_dimension_rows = (
+            await session.execute(
+                select(metric_revision.node_id, parent_revision.node_id)
+                .select_from(BoundDimensionsRelationship)
+                .join(
+                    DBColumn,
+                    DBColumn.id == BoundDimensionsRelationship.bound_dimension_id,
+                )
+                .join(
+                    parent_revision,
+                    parent_revision.id == DBColumn.node_revision_id,
+                )
+                .join(
+                    metric_revision,
+                    metric_revision.id == BoundDimensionsRelationship.metric_id,
+                )
+                .join(Node, Node.id == metric_revision.node_id)
+                .where(parent_revision.node_id.in_(frontier_ids))
+                .where(Node.current_version == metric_revision.version),
             )
         ).all()
 
         child_to_parents: dict[int, set[int]] = {}
-        for child_node_id, parent_id in rows:
+        for child_node_id, parent_id in [
+            *relationship_rows,
+            *dimension_link_rows,
+            *required_dimension_rows,
+        ]:
             child_to_parents.setdefault(child_node_id, set()).add(parent_id)
+        for parent_id in frontier_ids:
+            parent_node = ctx.visited_nodes_by_id.get(parent_id)
+            if parent_node is None:  # pragma: no cover
+                continue
+            for child_node_id in cube_filter_children.get(parent_node.name, set()):
+                child_to_parents.setdefault(child_node_id, set()).add(parent_id)
 
         unvisited = [nid for nid in child_to_parents if nid not in visited_node_ids]
         if not unvisited:

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -1148,14 +1148,14 @@ class MetricSpec(NodeSpec):
         Required dimensions rewritten so the two ways of naming the same column
         compare equal.
 
-            ns.date_dim.dateint  ->  ns.date_dim.dateint  (already canonical)
-            currency_code        ->  ns.orders_fact.currency_code  (single parent)
-            currency_code        ->  currency_code  (zero or multiple parents: ambiguous, left as-is)
+            ns.orders_fact.currency_code  ->  currency_code  (a query parent)
+            currency_code                 ->  currency_code  (already canonical)
+            ns.date_dim.dateint            ->  ns.date_dim.dateint  (not a query parent)
 
         Parents come from the spec's own query, so this needs no session.
         """
         required_dims = self.rendered_required_dimensions
-        if all(SEPARATOR in required_dim for required_dim in required_dims):
+        if not any(SEPARATOR in required_dim for required_dim in required_dims):
             return required_dims
 
         from datajunction_server.internal.deployment.utils import (
@@ -1167,10 +1167,10 @@ class MetricSpec(NodeSpec):
             if self.query_ast is not None
             else set()
         )
-        sole_parent = next(iter(parents)) if len(parents) == 1 else None
         return [
-            f"{sole_parent}{SEPARATOR}{required_dim}"
-            if SEPARATOR not in required_dim and sole_parent is not None
+            required_dim.rsplit(SEPARATOR, 1)[1]
+            if SEPARATOR in required_dim
+            and required_dim.rsplit(SEPARATOR, 1)[0] in parents
             else required_dim
             for required_dim in required_dims
         ]

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -40,6 +40,7 @@ from datajunction_server.models.node import (
     NodeType,
 )
 from datajunction_server.models.partition import Granularity, PartitionType
+from datajunction_server.models.semantic_fingerprint import SemanticFingerprintValue
 from datajunction_server.models.unit import (
     Unit,
     legacy_unit_to_structured,
@@ -65,6 +66,19 @@ class ChangeTier(IntEnum):
     NONE = 0
     MINOR = 10
     MAJOR = 20
+
+
+ChangeTierName = Literal["none", "minor", "major"]
+
+
+def change_tier_name(tier: ChangeTier) -> ChangeTierName:
+    """Return the stable API representation of a change tier."""
+    names: dict[ChangeTier, ChangeTierName] = {
+        ChangeTier.NONE: "none",
+        ChangeTier.MINOR: "minor",
+        ChangeTier.MAJOR: "major",
+    }
+    return names[tier]
 
 
 def fold_change_tiers(tiers: Iterable[ChangeTier]) -> ChangeTier:
@@ -1767,6 +1781,8 @@ class DeploymentResult(BaseModel):
     operation: Operation
     message: str = ""
     changed_fields: list[str] = Field(default_factory=list)
+    change_tier: ChangeTierName | None = None
+    semantic_fingerprint: SemanticFingerprintValue | None = None
 
 
 class DeploymentInfo(BaseModel):

--- a/datajunction-server/datajunction_server/models/impact.py
+++ b/datajunction-server/datajunction_server/models/impact.py
@@ -7,6 +7,7 @@ from enum import Enum
 from pydantic import BaseModel, Field
 
 from datajunction_server.models.node import NodeStatus, NodeType
+from datajunction_server.models.semantic_fingerprint import SemanticFingerprintValue
 
 
 class ImpactType(str, Enum):
@@ -34,3 +35,4 @@ class DownstreamImpact(BaseModel):
     # Defaulted so that deployment rows persisted before this field existed can
     # still be rehydrated from JSON.
     owners: list[str] = Field(default_factory=list)
+    semantic_fingerprint: SemanticFingerprintValue | None = None

--- a/datajunction-server/datajunction_server/semantic_fingerprints/normalization.py
+++ b/datajunction-server/datajunction_server/semantic_fingerprints/normalization.py
@@ -211,6 +211,28 @@ def normalize_field(
     )
 
 
+def _normalize_comparison_field(
+    spec: NodeSpec,
+    field: str,
+    *,
+    resolved_columns: list[ColumnSpec] | None,
+    preserve_order: bool = False,
+) -> Any:
+    """Normalize change detection without altering versioned fingerprints."""
+    if field == "required_dimensions" and isinstance(spec, MetricSpec):
+        try:
+            value = spec.canonical_required_dimensions
+        except DJParseException:
+            value = spec.rendered_required_dimensions
+        return normalize_sequence(value, preserve_order=preserve_order)
+    return normalize_field(
+        spec,
+        field,
+        resolved_columns=resolved_columns,
+        preserve_order=preserve_order,
+    )
+
+
 def semantic_diff(
     one: NodeSpec,
     two: NodeSpec,
@@ -239,12 +261,12 @@ def semantic_diff(
             continue
 
         try:
-            left = normalize_field(
+            left = _normalize_comparison_field(
                 rendered_one,
                 field,
                 resolved_columns=resolved_columns,
             )
-            right = normalize_field(
+            right = _normalize_comparison_field(
                 rendered_two,
                 field,
                 resolved_columns=other_resolved_columns,
@@ -260,13 +282,13 @@ def semantic_diff(
 
         if type(rendered_two).field_order_change_tier(field) == ChangeTier.NONE:
             continue
-        left_ordered = normalize_field(
+        left_ordered = _normalize_comparison_field(
             rendered_one,
             field,
             resolved_columns=resolved_columns,
             preserve_order=True,
         )
-        right_ordered = normalize_field(
+        right_ordered = _normalize_comparison_field(
             rendered_two,
             field,
             resolved_columns=other_resolved_columns,

--- a/datajunction-server/datajunction_server/semantic_fingerprints/normalization.py
+++ b/datajunction-server/datajunction_server/semantic_fingerprints/normalization.py
@@ -185,6 +185,11 @@ def normalize_field(
             else value,
             compare_types=isinstance(spec, SourceSpec),
         )
+    if field == "required_dimensions" and isinstance(spec, MetricSpec):
+        try:
+            value = spec.canonical_required_dimensions
+        except DJParseException:
+            value = spec.rendered_required_dimensions
     if field == "dimension_links" and isinstance(spec, LinkableNodeSpec):
         return normalize_dimension_links(
             spec.dimension_links,
@@ -208,28 +213,6 @@ def normalize_field(
         normalize_sequence(normalized, preserve_order=preserve_order)
         if isinstance(normalized, list)
         else normalized
-    )
-
-
-def _normalize_comparison_field(
-    spec: NodeSpec,
-    field: str,
-    *,
-    resolved_columns: list[ColumnSpec] | None,
-    preserve_order: bool = False,
-) -> Any:
-    """Normalize change detection without altering versioned fingerprints."""
-    if field == "required_dimensions" and isinstance(spec, MetricSpec):
-        try:
-            value = spec.canonical_required_dimensions
-        except DJParseException:
-            value = spec.rendered_required_dimensions
-        return normalize_sequence(value, preserve_order=preserve_order)
-    return normalize_field(
-        spec,
-        field,
-        resolved_columns=resolved_columns,
-        preserve_order=preserve_order,
     )
 
 
@@ -261,12 +244,12 @@ def semantic_diff(
             continue
 
         try:
-            left = _normalize_comparison_field(
+            left = normalize_field(
                 rendered_one,
                 field,
                 resolved_columns=resolved_columns,
             )
-            right = _normalize_comparison_field(
+            right = normalize_field(
                 rendered_two,
                 field,
                 resolved_columns=other_resolved_columns,
@@ -282,13 +265,13 @@ def semantic_diff(
 
         if type(rendered_two).field_order_change_tier(field) == ChangeTier.NONE:
             continue
-        left_ordered = _normalize_comparison_field(
+        left_ordered = normalize_field(
             rendered_one,
             field,
             resolved_columns=resolved_columns,
             preserve_order=True,
         )
-        right_ordered = _normalize_comparison_field(
+        right_ordered = normalize_field(
             rendered_two,
             field,
             resolved_columns=other_resolved_columns,

--- a/datajunction-server/tests/api/deployment_impact_test.py
+++ b/datajunction-server/tests/api/deployment_impact_test.py
@@ -9,8 +9,12 @@ import pytest
 
 from datajunction_server.models.deployment import (
     ColumnSpec,
+    CubeSpec,
     DeploymentInfo,
     DeploymentSpec,
+    DimensionJoinLinkSpec,
+    DimensionSpec,
+    MetricSpec,
     SourceSpec,
     TransformSpec,
 )
@@ -37,6 +41,79 @@ async def _wait_for_deployment(client, deployment_id: str, timeout: int = 30):
             return resp.json()
         await asyncio.sleep(0.1)
     return (await client.get(f"/deployments/{deployment_id}")).json()
+
+
+def _source(
+    name: str,
+    *,
+    description: str | None = None,
+    dimension_links: list[DimensionJoinLinkSpec] | None = None,
+) -> SourceSpec:
+    return SourceSpec(
+        name=name,
+        catalog="default",
+        schema_="test",
+        table=name,
+        columns=[ColumnSpec(name="id", type="int")],
+        description=description,
+        dimension_links=dimension_links or [],
+    )
+
+
+def _dimension_project(namespace: str) -> DeploymentSpec:
+    return DeploymentSpec(
+        namespace=namespace,
+        nodes=[
+            _source("raw"),
+            DimensionSpec(
+                name="dimension",
+                query="SELECT id FROM ${prefix}raw",
+                primary_key=["id"],
+            ),
+        ],
+    )
+
+
+def _updated_dimension_project(project: DeploymentSpec) -> DeploymentSpec:
+    updated = project.model_copy(deep=True)
+    dimension = updated.nodes[1]
+    assert isinstance(dimension, DimensionSpec)
+    dimension.query = "SELECT id FROM ${prefix}raw WHERE id IS NOT NULL"
+    return updated
+
+
+def _dimension_fingerprint(project: DeploymentSpec):
+    return project.nodes[1].semantic_fingerprint(
+        parent_fingerprints=[project.nodes[0].semantic_fingerprint()],
+    )
+
+
+async def _deploy(client, *specs: DeploymentSpec):
+    for spec in specs:
+        response = await client.post(
+            "/deployments",
+            json=spec.model_dump(by_alias=True),
+        )
+        assert response.status_code == 200
+        await _wait_for_deployment(client, response.json()["uuid"])
+
+
+async def _impact(client, spec: DeploymentSpec):
+    response = await client.post(
+        "/deployments/impact",
+        json=spec.model_dump(by_alias=True),
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+async def _impact_nodes(client, spec):
+    data = await _impact(client, spec)
+    return {
+        result["name"]: result
+        for result in data["results"]
+        if result["deploy_type"] == "node"
+    }
 
 
 class TestDeploymentImpactEndpoint:
@@ -76,10 +153,14 @@ class TestDeploymentImpactEndpoint:
         assert len(node_results) == 1
         assert node_results[0].name == "impact_create_test.orders"
         assert node_results[0].operation == "create"
+        assert node_results[0].change_tier == "major"
+        assert (
+            node_results[0].semantic_fingerprint == spec.nodes[0].semantic_fingerprint()
+        )
 
     @pytest.mark.asyncio
     async def test_impact_detects_updates(self, client_with_roads):
-        """After deploying a node, a dry-run with a changed query shows UPDATE."""
+        """A source change updates its own result and descendant fingerprint."""
         initial_spec = DeploymentSpec(
             namespace="impact_update_test",
             nodes=[
@@ -109,13 +190,13 @@ class TestDeploymentImpactEndpoint:
             nodes=[
                 TransformSpec(
                     name="orders_summary",
-                    query="SELECT 1 AS order_id, 'updated' AS status FROM ${prefix}raw",
+                    query="SELECT 1 AS order_id FROM ${prefix}raw",
                 ),
                 SourceSpec(
                     name="raw",
                     catalog="default",
                     schema_="test",
-                    table="raw",
+                    table="raw_v2",
                     columns=[ColumnSpec(name="order_id", type="int")],
                 ),
             ],
@@ -135,8 +216,34 @@ class TestDeploymentImpactEndpoint:
         ]
         skip_results = [r for r in data["results"] if r["operation"] == "noop"]
         assert len(update_results) == 1
-        assert "orders_summary" in update_results[0]["name"]
+        assert update_results[0]["name"] == "impact_update_test.raw"
         assert len(skip_results) >= 1
+        assert update_results[0]["change_tier"] == "major"
+        assert (
+            update_results[0]["semantic_fingerprint"]
+            == updated_spec.nodes[1].semantic_fingerprint().model_dump()
+        )
+        updated_fingerprint = updated_spec.nodes[0].semantic_fingerprint(
+            parent_fingerprints=[updated_spec.nodes[1].semantic_fingerprint()],
+        )
+        initial_fingerprint = initial_spec.nodes[0].semantic_fingerprint(
+            parent_fingerprints=[initial_spec.nodes[1].semantic_fingerprint()],
+        )
+        unchanged_nodes = [
+            result for result in skip_results if result["deploy_type"] == "node"
+        ]
+        assert all(result["change_tier"] == "none" for result in unchanged_nodes)
+        transform_result = next(
+            result
+            for result in unchanged_nodes
+            if result["name"] == "impact_update_test.orders_summary"
+        )
+        assert (
+            transform_result["semantic_fingerprint"] == updated_fingerprint.model_dump()
+        )
+        assert (
+            transform_result["semantic_fingerprint"] != initial_fingerprint.model_dump()
+        )
 
     @pytest.mark.asyncio
     async def test_impact_detects_deletions(self, client_with_roads):
@@ -192,6 +299,59 @@ class TestDeploymentImpactEndpoint:
         delete_results = [r for r in data["results"] if r["operation"] == "delete"]
         assert len(delete_results) == 1
         assert "to_delete" in delete_results[0]["name"]
+        assert delete_results[0]["change_tier"] == "major"
+        assert (
+            delete_results[0]["semantic_fingerprint"]
+            == initial_spec.nodes[1].semantic_fingerprint().model_dump()
+        )
+
+    @pytest.mark.asyncio
+    async def test_impact_minor_full_noop_and_forced_revalidation(
+        self,
+        client_with_roads,
+    ):
+        initial = DeploymentSpec(
+            namespace="impact_tiers_test",
+            nodes=[
+                _source("one", description="Before"),
+                _source("two"),
+            ],
+        )
+        await _deploy(client_with_roads, initial)
+
+        minor = initial.model_copy(deep=True)
+        minor.nodes[0].description = "After"
+        by_name = await _impact_nodes(client_with_roads, minor)
+        assert by_name["impact_tiers_test.one"]["change_tier"] == "minor"
+        assert (
+            by_name["impact_tiers_test.one"]["semantic_fingerprint"]
+            == initial.nodes[0].semantic_fingerprint().model_dump()
+        )
+        assert by_name["impact_tiers_test.two"]["change_tier"] == "none"
+
+        equivalent = initial.model_copy(deep=True)
+        equivalent.nodes[1].columns = None
+        noop_nodes = await _impact_nodes(client_with_roads, equivalent)
+        assert set(noop_nodes) == {
+            "impact_tiers_test.one",
+            "impact_tiers_test.two",
+        }
+        assert all(result["change_tier"] == "none" for result in noop_nodes.values())
+        assert all(result["semantic_fingerprint"] for result in noop_nodes.values())
+        assert (
+            noop_nodes["impact_tiers_test.two"]["semantic_fingerprint"]
+            == initial.nodes[1].semantic_fingerprint().model_dump()
+        )
+
+        forced = equivalent.model_copy(update={"force": True})
+        forced_nodes = await _impact_nodes(client_with_roads, forced)
+        assert all(result["operation"] == "update" for result in forced_nodes.values())
+        assert all(result["change_tier"] == "none" for result in forced_nodes.values())
+        assert all(result["semantic_fingerprint"] for result in forced_nodes.values())
+        assert (
+            forced_nodes["impact_tiers_test.two"]["semantic_fingerprint"]
+            == initial.nodes[1].semantic_fingerprint().model_dump()
+        )
 
     @pytest.mark.asyncio
     async def test_dry_run_does_not_mutate_db(self, client_with_roads):
@@ -317,5 +477,221 @@ class TestDeploymentImpactEndpoint:
                 "caused_by": ["impact_downstream_test.base"],
                 "is_external": False,
                 "owners": ["dj"],
+                "semantic_fingerprint": modified_spec.nodes[1]
+                .semantic_fingerprint(
+                    parent_fingerprints=[
+                        modified_spec.nodes[0].semantic_fingerprint(),
+                    ],
+                )
+                .model_dump(),
             },
         ]
+
+    @pytest.mark.asyncio
+    async def test_external_downstream_impacts_include_changed_fingerprint(
+        self,
+        client_with_roads,
+    ):
+        parent = DeploymentSpec(
+            namespace="impact_external_parent",
+            nodes=[_source("base")],
+        )
+        consumer = DeploymentSpec(
+            namespace="impact_external_consumer",
+            nodes=[
+                TransformSpec(
+                    name="derived",
+                    query="SELECT id FROM impact_external_parent.base",
+                ),
+            ],
+        )
+        await _deploy(client_with_roads, parent, consumer)
+
+        updated_parent = parent.model_copy(deep=True)
+        assert isinstance(updated_parent.nodes[0], SourceSpec)
+        updated_parent.nodes[0].table = "base_v2"
+        data = await _impact(client_with_roads, updated_parent)
+
+        external = next(
+            impact
+            for impact in data["downstream_impacts"]
+            if impact["name"] == "impact_external_consumer.derived"
+        )
+        expected = consumer.nodes[0].semantic_fingerprint(
+            parent_fingerprints=[
+                updated_parent.nodes[0].semantic_fingerprint(),
+            ],
+        )
+        assert external["is_external"] is True
+        assert external["semantic_fingerprint"] == expected.model_dump()
+
+        metadata_only = parent.model_copy(deep=True)
+        metadata_only.nodes[0].description = "Updated description"
+        data = await _impact(client_with_roads, metadata_only)
+        external = next(
+            impact
+            for impact in data["downstream_impacts"]
+            if impact["name"] == "impact_external_consumer.derived"
+        )
+        assert external["semantic_fingerprint"] is None
+
+    @pytest.mark.asyncio
+    async def test_unparseable_node_and_dependents_return_unknown_fingerprints(
+        self,
+        client_with_roads,
+    ):
+        initial = DeploymentSpec(
+            namespace="impact_unknown",
+            nodes=[
+                _source("base"),
+                TransformSpec(
+                    name="broken",
+                    query="SELECT id FROM ${prefix}base",
+                ),
+                TransformSpec(
+                    name="dependent",
+                    query="SELECT id FROM ${prefix}broken",
+                ),
+            ],
+        )
+        await _deploy(client_with_roads, initial)
+
+        proposed = DeploymentSpec(
+            namespace="impact_unknown",
+            nodes=[
+                _source("base"),
+                TransformSpec(name="broken", query="SELECT ("),
+                TransformSpec(
+                    name="dependent",
+                    query="SELECT id FROM ${prefix}broken",
+                ),
+            ],
+        )
+        data = await _impact(client_with_roads, proposed)
+        results = {
+            result["name"]: result
+            for result in data["results"]
+            if result["deploy_type"] == "node"
+        }
+
+        assert results["impact_unknown.broken"]["semantic_fingerprint"] == "unknown"
+        assert results["impact_unknown.dependent"]["semantic_fingerprint"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_blocked_delete_keeps_current_fingerprint_state(
+        self,
+        client_with_roads,
+    ):
+        parent = DeploymentSpec(
+            namespace="impact_blocked_delete",
+            nodes=[_source("keep"), _source("base")],
+        )
+        consumer = DeploymentSpec(
+            namespace="impact_blocked_consumer",
+            nodes=[
+                TransformSpec(
+                    name="derived",
+                    query="SELECT id FROM impact_blocked_delete.base",
+                ),
+            ],
+        )
+        await _deploy(client_with_roads, parent, consumer)
+
+        without_parent = parent.model_copy(
+            deep=True,
+            update={"nodes": [parent.nodes[0]]},
+        )
+        data = await _impact(client_with_roads, without_parent)
+
+        delete_result = next(
+            result
+            for result in data["results"]
+            if result["name"] == "impact_blocked_delete.base"
+        )
+        assert delete_result["status"] == "failed"
+        assert (
+            delete_result["semantic_fingerprint"]
+            == parent.nodes[1].semantic_fingerprint().model_dump()
+        )
+        assert data["downstream_impacts"] == []
+
+    @pytest.mark.asyncio
+    async def test_dimension_link_descendants_are_discovered(
+        self,
+        client_with_roads,
+    ):
+        parent = _dimension_project("impact_link_parent")
+        consumer = DeploymentSpec(
+            namespace="impact_link_consumer",
+            nodes=[
+                _source(
+                    "fact",
+                    dimension_links=[
+                        DimensionJoinLinkSpec(
+                            dimension_node="impact_link_parent.dimension",
+                            join_on=(
+                                "impact_link_consumer.fact.id = "
+                                "impact_link_parent.dimension.id"
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+        )
+        await _deploy(client_with_roads, parent, consumer)
+
+        updated_parent = _updated_dimension_project(parent)
+        data = await _impact(client_with_roads, updated_parent)
+
+        external = next(
+            impact
+            for impact in data["downstream_impacts"]
+            if impact["name"] == "impact_link_consumer.fact"
+        )
+        expected = consumer.nodes[0].semantic_fingerprint(
+            parent_fingerprints=[_dimension_fingerprint(updated_parent)],
+        )
+        assert external["semantic_fingerprint"] == expected.model_dump()
+
+    @pytest.mark.asyncio
+    async def test_cube_filter_descendants_are_discovered(
+        self,
+        client_with_roads,
+    ):
+        parent = _dimension_project("impact_filter_parent")
+        consumer = DeploymentSpec(
+            namespace="impact_filter_consumer",
+            nodes=[
+                _source("fact"),
+                MetricSpec(
+                    name="metric",
+                    query="SELECT COUNT(*) FROM ${prefix}fact",
+                ),
+                CubeSpec(
+                    name="cube",
+                    metrics=["${prefix}metric"],
+                    filters=["impact_filter_parent.dimension.id > 0"],
+                ),
+            ],
+        )
+        await _deploy(client_with_roads, parent, consumer)
+
+        updated_parent = _updated_dimension_project(parent)
+        data = await _impact(client_with_roads, updated_parent)
+
+        external = next(
+            impact
+            for impact in data["downstream_impacts"]
+            if impact["name"] == "impact_filter_consumer.cube"
+        )
+        fact_fingerprint = consumer.nodes[0].semantic_fingerprint()
+        metric_fingerprint = consumer.nodes[1].semantic_fingerprint(
+            parent_fingerprints=[fact_fingerprint],
+        )
+        expected = consumer.nodes[2].semantic_fingerprint(
+            parent_fingerprints=[
+                _dimension_fingerprint(updated_parent),
+                metric_fingerprint,
+            ],
+        )
+        assert external["semantic_fingerprint"] == expected.model_dump()

--- a/datajunction-server/tests/api/deployment_impact_test.py
+++ b/datajunction-server/tests/api/deployment_impact_test.py
@@ -7,6 +7,9 @@ from unittest import mock
 
 import pytest
 
+from datajunction_server.internal.deployment.fingerprints import (
+    SemanticFingerprintGraph,
+)
 from datajunction_server.models.deployment import (
     ColumnSpec,
     CubeSpec,
@@ -82,9 +85,9 @@ def _updated_dimension_project(project: DeploymentSpec) -> DeploymentSpec:
     return updated
 
 
-def _dimension_fingerprint(project: DeploymentSpec):
-    return project.nodes[1].semantic_fingerprint(
-        parent_fingerprints=[project.nodes[0].semantic_fingerprint()],
+def _fingerprint_graph(*projects: DeploymentSpec) -> SemanticFingerprintGraph:
+    return SemanticFingerprintGraph(
+        {node.rendered_name: node for project in projects for node in project.nodes},
     )
 
 
@@ -154,9 +157,10 @@ class TestDeploymentImpactEndpoint:
         assert node_results[0].name == "impact_create_test.orders"
         assert node_results[0].operation == "create"
         assert node_results[0].change_tier == "major"
-        assert (
-            node_results[0].semantic_fingerprint == spec.nodes[0].semantic_fingerprint()
+        expected = _fingerprint_graph(spec).fingerprint(
+            spec.nodes[0].rendered_name,
         )
+        assert node_results[0].semantic_fingerprint == expected
 
     @pytest.mark.asyncio
     async def test_impact_detects_updates(self, client_with_roads):
@@ -221,13 +225,15 @@ class TestDeploymentImpactEndpoint:
         assert update_results[0]["change_tier"] == "major"
         assert (
             update_results[0]["semantic_fingerprint"]
-            == updated_spec.nodes[1].semantic_fingerprint().model_dump()
+            == _fingerprint_graph(updated_spec)
+            .fingerprint(updated_spec.nodes[1].rendered_name)
+            .model_dump()
         )
-        updated_fingerprint = updated_spec.nodes[0].semantic_fingerprint(
-            parent_fingerprints=[updated_spec.nodes[1].semantic_fingerprint()],
+        updated_fingerprint = _fingerprint_graph(updated_spec).fingerprint(
+            updated_spec.nodes[0].rendered_name,
         )
-        initial_fingerprint = initial_spec.nodes[0].semantic_fingerprint(
-            parent_fingerprints=[initial_spec.nodes[1].semantic_fingerprint()],
+        initial_fingerprint = _fingerprint_graph(initial_spec).fingerprint(
+            initial_spec.nodes[0].rendered_name,
         )
         unchanged_nodes = [
             result for result in skip_results if result["deploy_type"] == "node"
@@ -302,7 +308,9 @@ class TestDeploymentImpactEndpoint:
         assert delete_results[0]["change_tier"] == "major"
         assert (
             delete_results[0]["semantic_fingerprint"]
-            == initial_spec.nodes[1].semantic_fingerprint().model_dump()
+            == _fingerprint_graph(initial_spec)
+            .fingerprint(initial_spec.nodes[1].rendered_name)
+            .model_dump()
         )
 
     @pytest.mark.asyncio
@@ -318,6 +326,7 @@ class TestDeploymentImpactEndpoint:
             ],
         )
         await _deploy(client_with_roads, initial)
+        initial_graph = _fingerprint_graph(initial)
 
         minor = initial.model_copy(deep=True)
         minor.nodes[0].description = "After"
@@ -325,7 +334,7 @@ class TestDeploymentImpactEndpoint:
         assert by_name["impact_tiers_test.one"]["change_tier"] == "minor"
         assert (
             by_name["impact_tiers_test.one"]["semantic_fingerprint"]
-            == initial.nodes[0].semantic_fingerprint().model_dump()
+            == initial_graph.fingerprint(initial.nodes[0].rendered_name).model_dump()
         )
         assert by_name["impact_tiers_test.two"]["change_tier"] == "none"
 
@@ -340,7 +349,7 @@ class TestDeploymentImpactEndpoint:
         assert all(result["semantic_fingerprint"] for result in noop_nodes.values())
         assert (
             noop_nodes["impact_tiers_test.two"]["semantic_fingerprint"]
-            == initial.nodes[1].semantic_fingerprint().model_dump()
+            == initial_graph.fingerprint(initial.nodes[1].rendered_name).model_dump()
         )
 
         forced = equivalent.model_copy(update={"force": True})
@@ -350,7 +359,7 @@ class TestDeploymentImpactEndpoint:
         assert all(result["semantic_fingerprint"] for result in forced_nodes.values())
         assert (
             forced_nodes["impact_tiers_test.two"]["semantic_fingerprint"]
-            == initial.nodes[1].semantic_fingerprint().model_dump()
+            == initial_graph.fingerprint(initial.nodes[1].rendered_name).model_dump()
         )
 
     @pytest.mark.asyncio
@@ -477,11 +486,9 @@ class TestDeploymentImpactEndpoint:
                 "caused_by": ["impact_downstream_test.base"],
                 "is_external": False,
                 "owners": ["dj"],
-                "semantic_fingerprint": modified_spec.nodes[1]
-                .semantic_fingerprint(
-                    parent_fingerprints=[
-                        modified_spec.nodes[0].semantic_fingerprint(),
-                    ],
+                "semantic_fingerprint": _fingerprint_graph(modified_spec)
+                .fingerprint(
+                    modified_spec.nodes[1].rendered_name,
                 )
                 .model_dump(),
             },
@@ -517,10 +524,8 @@ class TestDeploymentImpactEndpoint:
             for impact in data["downstream_impacts"]
             if impact["name"] == "impact_external_consumer.derived"
         )
-        expected = consumer.nodes[0].semantic_fingerprint(
-            parent_fingerprints=[
-                updated_parent.nodes[0].semantic_fingerprint(),
-            ],
+        expected = _fingerprint_graph(updated_parent, consumer).fingerprint(
+            consumer.nodes[0].rendered_name,
         )
         assert external["is_external"] is True
         assert external["semantic_fingerprint"] == expected.model_dump()
@@ -611,7 +616,9 @@ class TestDeploymentImpactEndpoint:
         assert delete_result["status"] == "failed"
         assert (
             delete_result["semantic_fingerprint"]
-            == parent.nodes[1].semantic_fingerprint().model_dump()
+            == _fingerprint_graph(parent)
+            .fingerprint(parent.nodes[1].rendered_name)
+            .model_dump()
         )
         assert data["downstream_impacts"] == []
 
@@ -648,8 +655,8 @@ class TestDeploymentImpactEndpoint:
             for impact in data["downstream_impacts"]
             if impact["name"] == "impact_link_consumer.fact"
         )
-        expected = consumer.nodes[0].semantic_fingerprint(
-            parent_fingerprints=[_dimension_fingerprint(updated_parent)],
+        expected = _fingerprint_graph(updated_parent, consumer).fingerprint(
+            consumer.nodes[0].rendered_name,
         )
         assert external["semantic_fingerprint"] == expected.model_dump()
 
@@ -684,14 +691,7 @@ class TestDeploymentImpactEndpoint:
             for impact in data["downstream_impacts"]
             if impact["name"] == "impact_filter_consumer.cube"
         )
-        fact_fingerprint = consumer.nodes[0].semantic_fingerprint()
-        metric_fingerprint = consumer.nodes[1].semantic_fingerprint(
-            parent_fingerprints=[fact_fingerprint],
-        )
-        expected = consumer.nodes[2].semantic_fingerprint(
-            parent_fingerprints=[
-                _dimension_fingerprint(updated_parent),
-                metric_fingerprint,
-            ],
+        expected = _fingerprint_graph(updated_parent, consumer).fingerprint(
+            consumer.nodes[2].rendered_name,
         )
         assert external["semantic_fingerprint"] == expected.model_dump()

--- a/datajunction-server/tests/api/deployment_impact_test.py
+++ b/datajunction-server/tests/api/deployment_impact_test.py
@@ -9,6 +9,7 @@ import pytest
 
 from datajunction_server.internal.deployment.fingerprints import (
     SemanticFingerprintGraph,
+    build_deployment_fingerprints,
 )
 from datajunction_server.models.deployment import (
     ColumnSpec,
@@ -161,6 +162,22 @@ class TestDeploymentImpactEndpoint:
             spec.nodes[0].rendered_name,
         )
         assert node_results[0].semantic_fingerprint == expected
+
+    @pytest.mark.asyncio
+    async def test_impact_builds_fingerprints_once(self, client_with_roads):
+        spec = DeploymentSpec(
+            namespace="impact_single_fingerprint_build",
+            nodes=[_source("orders")],
+        )
+
+        with mock.patch(
+            "datajunction_server.internal.deployment.orchestrator."
+            "build_deployment_fingerprints",
+            wraps=build_deployment_fingerprints,
+        ) as build_fingerprints:
+            await _impact(client_with_roads, spec)
+
+        assert build_fingerprints.await_count == 1
 
     @pytest.mark.asyncio
     async def test_impact_detects_updates(self, client_with_roads):
@@ -579,6 +596,8 @@ class TestDeploymentImpactEndpoint:
             if result["deploy_type"] == "node"
         }
 
+        assert results["impact_unknown.broken"]["status"] == "invalid"
+        assert "[invalid]" in results["impact_unknown.broken"]["message"]
         assert results["impact_unknown.broken"]["semantic_fingerprint"] == "unknown"
         assert results["impact_unknown.dependent"]["semantic_fingerprint"] == "unknown"
 

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -11553,12 +11553,8 @@ class TestDimensionAttributeAddedInSamePush:
                 "deploy_type": "node",
                 "status": "success",
                 "operation": "update",
-                "message": (
-                    "Updated dimension (v2.0)\n"
-                    "\u2514\u2500 Column removed: state_id, state_name\n"
-                    "\u2514\u2500 Updated query, display_name, columns"
-                ),
-                "changed_fields": ["query", "display_name", "columns"],
+                "message": "Updated dimension (v2.0)\n\u2514\u2500 Updated query",
+                "changed_fields": ["query"],
             },
             {
                 "name": f"{namespace}.default.hard_hat",
@@ -11786,12 +11782,8 @@ class TestDimensionAttributeAddedInSamePush:
                 "deploy_type": "node",
                 "status": "success",
                 "operation": "update",
-                "message": (
-                    "Updated dimension (v2.0)\n"
-                    "\u2514\u2500 Column removed: state_id, state_name\n"
-                    "\u2514\u2500 Updated query, display_name, columns"
-                ),
-                "changed_fields": ["query", "display_name", "columns"],
+                "message": "Updated dimension (v2.0)\n\u2514\u2500 Updated query",
+                "changed_fields": ["query"],
             },
             {
                 "name": f"{namespace}.default.hard_hats_fact",

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1346,6 +1346,8 @@ async def deploy_and_wait(client, deployment_spec: DeploymentSpec):
         response = await client.get(f"/deployments/{deployment_uuid}")
         data = response.json()
     for result in data.get("results", []):
+        assert "change_tier" in result
+        assert "semantic_fingerprint" in result
         result.pop("change_tier", None)
         result.pop("semantic_fingerprint", None)
     return data

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1345,6 +1345,9 @@ async def deploy_and_wait(client, deployment_spec: DeploymentSpec):
         await asyncio.sleep(1)
         response = await client.get(f"/deployments/{deployment_uuid}")
         data = response.json()
+    for result in data.get("results", []):
+        result.pop("change_tier", None)
+        result.pop("semantic_fingerprint", None)
     return data
 
 
@@ -2460,8 +2463,8 @@ class TestDeployments:
             "name": f"{namespace}.default.hard_hat",
             "status": "success",
             "operation": "update",
-            "changed_fields": ["query", "columns"],
-            "message": "Updated dimension (v2.0)\n└─ Column removed: hard_hat_id, state\n└─ Updated query, columns",
+            "changed_fields": ["query"],
+            "message": "Updated dimension (v2.0)\n└─ Updated query",
         }
         update_us_state = next(
             res
@@ -2520,12 +2523,12 @@ class TestDeployments:
         )
         assert metric_result == {
             "deploy_type": "node",
-            "message": "Updated metric (v2.0)\n└─ Updated query, display_name\n"
+            "message": "Updated metric (v2.0)\n└─ Updated query\n"
             "[invalid] Metric metric_update.default.avg_length_of_employment has an invalid "
             "query, should have an aggregate expression",
             "name": "metric_update.default.avg_length_of_employment",
             "operation": "update",
-            "changed_fields": ["query", "display_name"],
+            "changed_fields": ["query"],
             "status": "invalid",
         }
 
@@ -2545,10 +2548,10 @@ class TestDeployments:
         )
         assert metric_result == {
             "deploy_type": "node",
-            "message": "Updated metric (v3.0)\n└─ Updated query, display_name",
+            "message": "Updated metric (v3.0)\n└─ Updated query",
             "name": "metric_update.default.avg_length_of_employment",
             "operation": "update",
-            "changed_fields": ["query", "display_name"],
+            "changed_fields": ["query"],
             "status": "success",
         }
 
@@ -3212,7 +3215,7 @@ class TestDeployments:
         await deploy(description="Hard hats, revised")
         response = await client.get(f"/nodes/{name}/")
         assert response.status_code == 200, response.json()
-        assert response.json()["version"] == "v2.0"
+        assert response.json()["version"] == "v1.1"
         assert response.json()["description"] == "Hard hats, revised"
 
     @pytest.mark.asyncio
@@ -4667,10 +4670,10 @@ class TestDeployments:
         )
         assert data["results"][-1] == {
             "deploy_type": "node",
-            "message": "Updated dimension (v2.0)\n└─ Column removed: state_id, state_name, state_region, state_short\n└─ Updated tags, columns",
+            "message": "Updated dimension (v1.1)\n└─ Updated tags",
             "name": "node_update.default.us_state",
             "operation": "update",
-            "changed_fields": ["tags", "columns"],
+            "changed_fields": ["tags"],
             "status": "success",
         }
         node = await Node.get_by_name(session, f"{namespace}.default.us_state")

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -4402,7 +4402,23 @@ class TestCopyNodesToNamespace:
             assert response.status_code == HTTPStatus.CREATED
             data = response.json()
             assert data["branch"]["namespace"] == "copy_test.feature_copy"
-            assert data["deployment_results"] == [
+            assert all(
+                result["change_tier"] == "major"
+                for result in data["deployment_results"]
+            )
+            assert all(
+                result["semantic_fingerprint"]["version"] == 1
+                for result in data["deployment_results"]
+            )
+            deployment_results = [
+                {
+                    key: value
+                    for key, value in result.items()
+                    if key not in {"change_tier", "semantic_fingerprint"}
+                }
+                for result in data["deployment_results"]
+            ]
+            assert deployment_results == [
                 {
                     "deploy_type": "node",
                     "message": "Created source (v1.0)",

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -24,6 +24,9 @@ from datajunction_server.database.partition import Partition
 from datajunction_server.database.tag import Tag
 from datajunction_server.database.user import OAuthProvider, User
 from datajunction_server.errors import DJError, DJInvalidDeploymentConfig, ErrorCode
+from datajunction_server.internal.deployment.fingerprints import (
+    SemanticFingerprintGraph,
+)
 from datajunction_server.internal.deployment.orchestrator import (
     DeploymentOrchestrator,
     DeploymentPlan,
@@ -57,7 +60,6 @@ from datajunction_server.models.deployment import (
     MetricSpec,
     PartitionSpec,
     PartitionType,
-    SemanticFingerprint,
     SourceSpec,
     TagSpec,
     TransformSpec,
@@ -67,6 +69,7 @@ from datajunction_server.models.history import ActivityType
 from datajunction_server.models.node import MetricUnit, NodeStatus
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.partition import Granularity
+from datajunction_server.models.semantic_fingerprint import SemanticFingerprint
 from datajunction_server.sql.parsing.types import StringType
 
 
@@ -1201,7 +1204,10 @@ class TestCubeDeployment:
         orchestrator._generate_changelog = AsyncMock(
             return_value=([], [], ChangeTier.NONE),
         )
-        cube_fingerprint = invalid_results[0].spec.semantic_fingerprint()
+        cube = invalid_results[0].spec
+        cube_fingerprint = SemanticFingerprintGraph(
+            {cube.rendered_name: cube},
+        ).fingerprint(cube.rendered_name)
         orchestrator._proposed_semantic_fingerprints = {
             invalid_results[0].spec.rendered_name: cube_fingerprint,
         }

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -57,6 +57,7 @@ from datajunction_server.models.deployment import (
     MetricSpec,
     PartitionSpec,
     PartitionType,
+    SemanticFingerprint,
     SourceSpec,
     TagSpec,
     TransformSpec,
@@ -837,6 +838,47 @@ class TestDeploymentPlanning:
         assert len(to_skip) == len(sample_deployment_spec.nodes)
         assert to_delete == []
 
+    def test_filter_nodes_uses_normalized_query_and_source_columns(self):
+        incoming = [
+            TransformSpec(name="transform", query=" SELECT id\nFROM source "),
+            SourceSpec(
+                name="source",
+                catalog="catalog",
+                schema_="schema",
+                table="table",
+                columns=None,
+            ),
+        ]
+        orchestrator = DeploymentOrchestrator(
+            deployment_spec=DeploymentSpec(namespace="test", nodes=incoming),
+            deployment_id="normalized-filter",
+            session=MagicMock(),
+            context=MagicMock(),
+        )
+        existing = {
+            "test.transform": TransformSpec(
+                name="transform",
+                namespace="test",
+                query="SELECT id FROM source",
+            ),
+            "test.source": SourceSpec(
+                name="source",
+                namespace="test",
+                catalog="catalog",
+                schema_="schema",
+                table="table",
+                columns=[ColumnSpec(name="id", type="bigint")],
+            ),
+        }
+
+        to_deploy, to_skip, _ = orchestrator.filter_nodes_to_deploy(existing)
+        assert to_deploy == []
+        assert to_skip == incoming
+
+        incoming[1].columns = [ColumnSpec(name="id", type="string")]
+        to_deploy, _, _ = orchestrator.filter_nodes_to_deploy(existing)
+        assert to_deploy == [incoming[1]]
+
     def test_filter_nodes_to_deploy_with_force(
         self,
         session,
@@ -897,6 +939,7 @@ class TestOrchestrationFlow:
             mock_plan.to_deploy = []
             mock_plan.to_delete = []
             mock_plan.to_delete_namespaces = []
+            mock_plan.existing_specs = {}
             mock_create_plan.return_value = (mock_plan, [])
 
             # Execute
@@ -924,6 +967,7 @@ class TestOrchestrationFlow:
             mock_plan.to_deploy = []
             mock_plan.to_delete = []
             mock_plan.to_delete_namespaces = []
+            mock_plan.existing_specs = {}
             mock_create_plan.return_value = (mock_plan, [])
 
             mock_handle_no_changes.return_value = []
@@ -1157,6 +1201,10 @@ class TestCubeDeployment:
         orchestrator._generate_changelog = AsyncMock(
             return_value=([], [], ChangeTier.NONE),
         )
+        cube_fingerprint = invalid_results[0].spec.semantic_fingerprint()
+        orchestrator._proposed_semantic_fingerprints = {
+            invalid_results[0].spec.rendered_name: cube_fingerprint,
+        }
 
         with patch(
             "datajunction_server.internal.deployment.orchestrator.get_node_namespace",
@@ -1174,6 +1222,8 @@ class TestCubeDeployment:
         assert len(revisions) == 1
         assert len(results) == 1
         assert results[0].status == "invalid"
+        assert results[0].change_tier == "major"
+        assert results[0].semantic_fingerprint == cube_fingerprint
 
     @pytest.mark.asyncio
     async def test_cube_column_partition_applied_from_spec(
@@ -2714,9 +2764,13 @@ async def test_delete_nodes_bulk_deletes_existing_node(
         context=mock_deployment_context,
         dry_run=False,
     )
-    # "default.hard_hat" is present in the pre-loaded roads example DB.
-    spec = Mock()
-    spec.rendered_name = "default.hard_hat"
+    # "default.hard_hat" is present in the pre-loaded roads example DB. Its
+    # unparseable legacy query must not prevent deletion.
+    spec = TransformSpec(
+        name="hard_hat",
+        namespace="default",
+        query="SELECT (",
+    )
     # No external references block the delete.
     with patch.object(orch, "_validate_node_deletion", AsyncMock(return_value={})):
         results = await orch._delete_nodes([spec])
@@ -2725,6 +2779,8 @@ async def test_delete_nodes_bulk_deletes_existing_node(
     assert results[0].status == DeploymentResult.Status.SUCCESS
     assert results[0].operation == DeploymentResult.Operation.DELETE
     assert results[0].name == "default.hard_hat"
+    assert results[0].change_tier == "major"
+    assert results[0].semantic_fingerprint is None
 
     # The node row is gone.
     gone = (
@@ -2753,6 +2809,10 @@ async def test_delete_nodes_reports_referenced_and_missing(
     referenced.rendered_name = "default.referenced"
     absent = Mock()
     absent.rendered_name = "default.does_not_exist"
+    orch._current_semantic_fingerprints = {
+        "default.referenced": SemanticFingerprint(digest="b" * 64),
+        "default.does_not_exist": SemanticFingerprint(digest="c" * 64),
+    }
 
     with patch.object(
         orch,
@@ -2766,6 +2826,8 @@ async def test_delete_nodes_reports_referenced_and_missing(
     assert "referenced by" in by_name["default.referenced"].message
     assert by_name["default.does_not_exist"].status == DeploymentResult.Status.FAILED
     assert "not found" in by_name["default.does_not_exist"].message
+    assert all(result.change_tier == "major" for result in results)
+    assert by_name["default.referenced"].semantic_fingerprint.digest == "b" * 64
 
 
 class TestGenerateChangelog:
@@ -2787,7 +2849,7 @@ class TestGenerateChangelog:
         transform_spec = TransformSpec(
             name="test_node",
             namespace="default",
-            query="SELECT id FROM default.source_table",
+            query=" SELECT  id\nFROM default.source_table ",
             dimension_links=[dim_link],
         )
         # existing_spec is identical — diff() will return []
@@ -2829,6 +2891,44 @@ class TestGenerateChangelog:
         assert changed_fields == []
         assert changelog == ["└─ Updated dimension_links"]
         assert change_tier == ChangeTier.NONE
+
+    @pytest.mark.asyncio
+    async def test_source_column_type_change_is_major(self):
+        existing_spec = SourceSpec(
+            name="source",
+            namespace="test",
+            catalog="catalog",
+            schema_="schema",
+            table="table",
+            columns=[ColumnSpec(name="id", type="bigint")],
+        )
+        proposed = existing_spec.model_copy(deep=True)
+        proposed.columns[0].type = "string"
+        existing = MagicMock()
+        existing.current.columns = []
+        existing.to_spec = AsyncMock(return_value=existing_spec)
+        orchestrator = DeploymentOrchestrator(
+            deployment_spec=DeploymentSpec(namespace="test", nodes=[]),
+            deployment_id="source-changelog",
+            session=MagicMock(),
+            context=MagicMock(),
+        )
+        orchestrator.registry.nodes["test.source"] = existing
+        result = NodeValidationResult(
+            spec=proposed,
+            status=NodeStatus.VALID,
+            inferred_columns=proposed.columns,
+            errors=[],
+            dependencies=[],
+        )
+
+        changelog, changed_fields, tier = await orchestrator._generate_changelog(
+            result,
+        )
+
+        assert changed_fields == ["columns"]
+        assert tier == ChangeTier.MAJOR
+        assert changelog[-1] == "└─ Updated columns"
 
     @pytest.mark.asyncio
     async def test_cube_column_change_uses_role_qualified_identity(

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -971,6 +971,7 @@ class TestOrchestrationFlow:
             mock_plan.to_delete = []
             mock_plan.to_delete_namespaces = []
             mock_plan.existing_specs = {}
+            mock_plan.deletable_specs = []
             mock_create_plan.return_value = (mock_plan, [])
 
             mock_handle_no_changes.return_value = []

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -2937,6 +2937,42 @@ class TestGenerateChangelog:
         assert changelog[-1] == "└─ Updated columns"
 
     @pytest.mark.asyncio
+    async def test_source_without_declared_columns_uses_inferred_columns(self):
+        source_spec = SourceSpec(
+            name="source",
+            namespace="test",
+            catalog="catalog",
+            schema_="schema",
+            table="table",
+            columns=[],
+        )
+        existing = MagicMock()
+        existing.current.columns = []
+        existing.to_spec = AsyncMock(return_value=source_spec)
+        orchestrator = DeploymentOrchestrator(
+            deployment_spec=DeploymentSpec(namespace="test", nodes=[]),
+            deployment_id="source-inferred-columns",
+            session=MagicMock(),
+            context=MagicMock(),
+        )
+        orchestrator.registry.nodes["test.source"] = existing
+        result = NodeValidationResult(
+            spec=source_spec,
+            status=NodeStatus.VALID,
+            inferred_columns=[ColumnSpec(name="id", type="bigint")],
+            errors=[],
+            dependencies=[],
+        )
+
+        changelog, changed_fields, tier = await orchestrator._generate_changelog(
+            result,
+        )
+
+        assert changed_fields == []
+        assert tier == ChangeTier.NONE
+        assert changelog == []
+
+    @pytest.mark.asyncio
     async def test_cube_column_change_uses_role_qualified_identity(
         self,
         session,

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -2798,6 +2798,32 @@ async def test_delete_nodes_bulk_deletes_existing_node(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(("dry_run", "expects_lock"), [(True, False), (False, True)])
+async def test_validate_node_deletion_only_locks_wet_runs(
+    current_user,
+    mock_deployment_context,
+    dry_run,
+    expects_lock,
+):
+    session = AsyncMock()
+    session.execute.return_value = []
+    orch = DeploymentOrchestrator(
+        deployment_spec=DeploymentSpec(namespace="default", nodes=[]),
+        deployment_id="delete-lock-test",
+        session=session,
+        context=mock_deployment_context,
+        dry_run=dry_run,
+    )
+
+    await orch._validate_node_deletion(
+        [TransformSpec(name="target", query="SELECT 1")],
+    )
+
+    stmt = session.execute.await_args.args[0]
+    assert (stmt._for_update_arg is not None) is expects_lock
+
+
+@pytest.mark.asyncio
 async def test_delete_nodes_reports_referenced_and_missing(
     session,
     mock_deployment_context,

--- a/datajunction-server/tests/internal/deployment/test_dimension_reachability.py
+++ b/datajunction-server/tests/internal/deployment/test_dimension_reachability.py
@@ -10,6 +10,9 @@ from datajunction_server.internal.deployment.dimension_reachability import (
     DimensionReachability,
     find_reference_dimensions_batch,
 )
+from datajunction_server.internal.deployment.utils import (
+    extract_dimension_refs_from_filters,
+)
 
 
 class TestDimensionReachabilityInMemory:
@@ -271,65 +274,37 @@ class TestDimensionReachabilityBuild:
 
 
 class TestExtractDimensionRefsFromFilters:
-    """Tests for _extract_dimension_refs_from_filters."""
+    """Tests for extract_dimension_refs_from_filters."""
 
     def test_single_filter(self):
-        from datajunction_server.internal.deployment.orchestrator import (
-            _extract_dimension_refs_from_filters,
-        )
-
-        result = _extract_dimension_refs_from_filters(
+        result = extract_dimension_refs_from_filters(
             ["ns.hard_hat.state = 'CA'"],
         )
         assert result == [("ns.hard_hat", "state")]
 
     def test_multiple_filters(self):
-        from datajunction_server.internal.deployment.orchestrator import (
-            _extract_dimension_refs_from_filters,
-        )
-
-        result = _extract_dimension_refs_from_filters(
+        result = extract_dimension_refs_from_filters(
             ["ns.hard_hat.state = 'CA'", "ns.date_dim.year > 2020"],
         )
         assert sorted(result) == [("ns.date_dim", "year"), ("ns.hard_hat", "state")]
 
     def test_empty_filters(self):
-        from datajunction_server.internal.deployment.orchestrator import (
-            _extract_dimension_refs_from_filters,
-        )
-
-        assert _extract_dimension_refs_from_filters([]) == []
+        assert extract_dimension_refs_from_filters([]) == []
 
     def test_unparseable_filter(self):
-        from datajunction_server.internal.deployment.orchestrator import (
-            _extract_dimension_refs_from_filters,
-        )
-
-        result = _extract_dimension_refs_from_filters(["not valid sql !!!"])
+        result = extract_dimension_refs_from_filters(["not valid sql !!!"])
         assert result == []
 
     def test_filter_with_no_namespace(self):
-        from datajunction_server.internal.deployment.orchestrator import (
-            _extract_dimension_refs_from_filters,
-        )
-
-        result = _extract_dimension_refs_from_filters(["x > 5"])
+        result = extract_dimension_refs_from_filters(["x > 5"])
         assert result == []
 
     def test_filter_with_single_namespace_segment(self):
-        from datajunction_server.internal.deployment.orchestrator import (
-            _extract_dimension_refs_from_filters,
-        )
-
-        result = _extract_dimension_refs_from_filters(["hard_hat.state = 'CA'"])
+        result = extract_dimension_refs_from_filters(["hard_hat.state = 'CA'"])
         assert result == []
 
     def test_filter_with_multiple_refs_in_one_expression(self):
-        from datajunction_server.internal.deployment.orchestrator import (
-            _extract_dimension_refs_from_filters,
-        )
-
-        result = _extract_dimension_refs_from_filters(
+        result = extract_dimension_refs_from_filters(
             ["ns.dim_a.col1 > 5 AND ns.dim_b.col2 = 'x'"],
         )
         assert sorted(result) == [("ns.dim_a", "col1"), ("ns.dim_b", "col2")]

--- a/datajunction-server/tests/internal/deployment_test.py
+++ b/datajunction-server/tests/internal/deployment_test.py
@@ -516,6 +516,7 @@ async def test_delete_nodes_success(
             status=DeploymentResult.Status.SUCCESS,
             operation=DeploymentResult.Operation.DELETE,
             message="Node catalog.dim.categories has been removed.",
+            change_tier="major",
         ),
     ]
     assert await Node.get_by_name(session, categories.name) is None
@@ -542,6 +543,7 @@ async def test_delete_nodes_missing(
             status=DeploymentResult.Status.FAILED,
             operation=DeploymentResult.Operation.DELETE,
             message="Node catalog.dim.categoriesbogus not found.",
+            change_tier="major",
         ),
     ]
 

--- a/datajunction-server/tests/internal/impact_test.py
+++ b/datajunction-server/tests/internal/impact_test.py
@@ -12,9 +12,19 @@ from sqlalchemy import event
 
 from datajunction_server.database.column import Column as DBColumn
 from datajunction_server.database.namespace import NodeNamespace
-from datajunction_server.database.node import Node, NodeRelationship, NodeRevision
+from datajunction_server.database.node import (
+    BoundDimensionsRelationship,
+    Node,
+    NodeRelationship,
+    NodeRevision,
+)
 from datajunction_server.database.user import User
-from datajunction_server.internal.impact import _merge_impacts, propagate_impact
+from datajunction_server.internal.impact import (
+    _build_propagation_context,
+    _merge_impacts,
+    _propagate_via_parent_graph,
+    propagate_impact,
+)
 from datajunction_server.models.impact import DownstreamImpact, ImpactType
 from datajunction_server.models.node import NodeStatus, NodeType
 from datajunction_server.models.user import OAuthProvider
@@ -139,6 +149,63 @@ async def test_propagate_impact_valid_parent_may_affect(session, current_user: U
     assert "ns.source" in impact.caused_by
     # Status must NOT have been mutated
     assert child_rev.status == NodeStatus.VALID
+
+
+@pytest.mark.asyncio
+async def test_required_dimension_on_older_revision_is_discovered(
+    session,
+    current_user: User,
+):
+    session.add(NodeNamespace(namespace="ns"))
+    dimension, current_dimension_rev = _make_node(
+        "ns.dimension",
+        NodeType.DIMENSION,
+        NodeStatus.VALID,
+        current_user.id,
+        version="v2.0",
+        columns=[("id", IntegerType())],
+    )
+    older_dimension_rev = NodeRevision(
+        name=dimension.name,
+        type=NodeType.DIMENSION,
+        node=dimension,
+        version="v1.0",
+        status=NodeStatus.VALID,
+        query="SELECT 1 AS id",
+        created_by_id=current_user.id,
+        columns=[DBColumn(name="id", type=IntegerType())],
+    )
+    metric, metric_rev = _make_node(
+        "ns.metric",
+        NodeType.METRIC,
+        NodeStatus.VALID,
+        current_user.id,
+    )
+    await _persist(
+        session,
+        dimension,
+        older_dimension_rev,
+        current_dimension_rev,
+        metric,
+        metric_rev,
+    )
+    await _persist(
+        session,
+        BoundDimensionsRelationship(
+            metric_id=metric_rev.id,
+            bound_dimension_id=older_dimension_rev.columns[0].id,
+        ),
+    )
+
+    ctx = await _build_propagation_context(
+        session,
+        "ns",
+        {dimension.name},
+        frozenset(),
+    )
+    impacts = await _propagate_via_parent_graph(session, ctx)
+
+    assert [impact.name for impact in impacts] == [metric.name]
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -1985,6 +1985,26 @@ def test_semantic_diff_canonicalizes_required_dimension_identity():
     assert fingerprint(bare) == fingerprint(qualified)
 
 
+def test_semantic_diff_canonicalizes_required_dimension_with_multiple_parents():
+    bare = MetricSpec(
+        namespace="analytics",
+        name="order_count",
+        query=(
+            "SELECT COUNT(*) FROM analytics.orders "
+            "JOIN analytics.customers "
+            "ON analytics.orders.customer_id = analytics.customers.customer_id"
+        ),
+        required_dimensions=["order_id"],
+    )
+    qualified = bare.model_copy(
+        update={"required_dimensions": ["analytics.orders.order_id"]},
+    )
+
+    assert bare.canonical_required_dimensions == qualified.canonical_required_dimensions
+    assert bare.semantic_diff(qualified) == ([], [])
+    assert fingerprint(bare) == fingerprint(qualified)
+
+
 def test_semantic_diff_compares_unparseable_queries_as_raw_sql():
     original = TransformSpec(name="node", query="SELECT (")
     same = TransformSpec(name="node", query="SELECT (")

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -698,13 +698,35 @@ def test_deployment_results_property_getter():
                 "status": "success",
                 "operation": "create",
                 "message": "Created",
+                "change_tier": "major",
+                "semantic_fingerprint": {
+                    "digest": "a" * 64,
+                },
+            },
+            {
+                "name": "legacy_node",
+                "deploy_type": "node",
+                "status": "invalid",
+                "operation": "update",
+                "semantic_fingerprint": "unknown",
+            },
+            {
+                "name": "test_node -> test_dimension",
+                "deploy_type": "link",
+                "status": "success",
+                "operation": "create",
             },
         ],
     )
     results = deployment.deployment_results
-    assert len(results) == 1
+    assert len(results) == 3
     assert results[0].name == "test_node"
     assert results[0].status == DeploymentResult.Status.SUCCESS
+    assert results[0].change_tier == "major"
+    assert results[0].semantic_fingerprint == SemanticFingerprint(digest="a" * 64)
+    assert results[1].semantic_fingerprint == "unknown"
+    assert results[2].change_tier is None
+    assert results[2].semantic_fingerprint is None
 
 
 def test_deployment_spec_preserves_explicit_preagg_namespace():

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -1982,6 +1982,7 @@ def test_semantic_diff_canonicalizes_required_dimension_identity():
     assert bare.diff(bare) == []
     assert bare.diff(qualified) == []
     assert bare.semantic_diff(qualified) == ([], [])
+    assert fingerprint(bare) == fingerprint(qualified)
 
 
 def test_semantic_diff_compares_unparseable_queries_as_raw_sql():

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -50,6 +50,7 @@ from datajunction_server.semantic_fingerprints.engine import (
 )
 from datajunction_server.semantic_fingerprints.normalization import (
     canonical_json,
+    normalize_field,
     normalize_sequence,
     normalize_value,
 )
@@ -2221,6 +2222,19 @@ def test_semantic_fingerprint_normalizes_primary_keys_and_cube_ordering():
     partition_changed = cube.model_copy(deep=True)
     partition_changed.columns[0].partition.type = PartitionType.TEMPORAL
     assert fingerprint(cube) != fingerprint(partition_changed)
+
+
+def test_required_dimensions_normalization_falls_back_for_invalid_query():
+    metric = MetricSpec(
+        namespace="analytics",
+        name="orders",
+        query="SELECT (",
+        required_dimensions=["${prefix}orders.order_id"],
+    )
+
+    assert normalize_field(metric, "required_dimensions") == [
+        "analytics.orders.order_id",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -1979,6 +1979,7 @@ def test_semantic_diff_canonicalizes_required_dimension_identity():
     )
 
     assert bare.canonical_required_dimensions == qualified.canonical_required_dimensions
+    assert bare.diff(bare) == []
     assert bare.diff(qualified) == []
     assert bare.semantic_diff(qualified) == ([], [])
 

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -1979,6 +1979,7 @@ def test_semantic_diff_canonicalizes_required_dimension_identity():
     )
 
     assert bare.canonical_required_dimensions == qualified.canonical_required_dimensions
+    assert bare.diff(qualified) == []
     assert bare.semantic_diff(qualified) == ([], [])
 
 
@@ -1989,6 +1990,16 @@ def test_semantic_diff_compares_unparseable_queries_as_raw_sql():
 
     assert original.semantic_diff(same) == ([], [])
     assert original.semantic_diff(changed) == (["query"], [])
+
+    metric = MetricSpec(
+        name="metric",
+        query="SELECT (",
+        required_dimensions=["id"],
+    )
+    same_metric = metric.model_copy(deep=True)
+    changed_metric = metric.model_copy(update={"required_dimensions": ["other_id"]})
+    assert metric.semantic_diff(same_metric) == ([], [])
+    assert metric.semantic_diff(changed_metric) == (["required_dimensions"], [])
 
 
 @pytest.mark.parametrize(

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -1967,6 +1967,21 @@ def test_semantic_diff_and_fingerprint_share_change_rules():
     assert MetricSpec.change_tier(changed, reordered) == ChangeTier.MINOR
 
 
+def test_semantic_diff_canonicalizes_required_dimension_identity():
+    bare = MetricSpec(
+        namespace="analytics",
+        name="order_count",
+        query="SELECT COUNT(*) FROM analytics.orders",
+        required_dimensions=["order_id"],
+    )
+    qualified = bare.model_copy(
+        update={"required_dimensions": ["analytics.orders.order_id"]},
+    )
+
+    assert bare.canonical_required_dimensions == qualified.canonical_required_dimensions
+    assert bare.semantic_diff(qualified) == ([], [])
+
+
 def test_semantic_diff_compares_unparseable_queries_as_raw_sql():
     original = TransformSpec(name="node", query="SELECT (")
     same = TransformSpec(name="node", query="SELECT (")


### PR DESCRIPTION
`/deployments/impact` reports operations and changed fields without a server-owned semantic identity. Metadata consumers otherwise have to repeat DJ's classification, SQL handling, and graph traversal.

Depends on [#2488](https://github.com/DataJunction/dj/pull/2488).

This PR:
- wires deployment graph fingerprints into create, update, no-op, delete, and downstream impact results
- discovers external downstream nodes across SQL, dimension-link, required-dimension, and cube-filter edges
- preserves current fingerprint state when a requested deletion is blocked
- returns additive nullable `change_tier` and `semantic_fingerprint` fields
- preserves `deploy_type` and parses old and new response shapes in the Python client

### Impact propagation example

```mermaid
flowchart LR
    X{"orders table changes"}
    S["source: orders<br/>object hash: h_orders to h_orders_next<br/>operation: update<br/>direct tier: major"]
    T["transform: clean_orders<br/>object hash: h_clean_orders to h_clean_orders_next<br/>operation: noop<br/>direct tier: none"]
    M["metric: order_count<br/>object hash: h_order_count to h_order_count_next<br/>operation: noop<br/>direct tier: none"]
    C["cube: orders_cube<br/>object hash: h_orders_cube to h_orders_cube_next<br/>operation: noop<br/>direct tier: none"]

    X --> S
    S ==>|h_orders changed| T
    T ==>|h_clean_orders changed| M
    M ==>|h_order_count changed| C

    classDef direct fill:#fff1d6,stroke:#c2410c,color:#431407
    classDef propagated fill:#dbeafe,stroke:#2563eb,color:#172554
    class S direct
    class T,M,C propagated
```

The metadata rows become `source::orders::h_orders_next`, `transform::clean_orders::h_clean_orders_next`, `metric::order_count::h_order_count_next`, and `cube::orders_cube::h_orders_cube_next`. All four CODEOWNERS are therefore included in review.

---
Verification:

Started this branch on development slot 1:

```bash
printf '1\n' > .dev-port
./dev.sh up -d
```

Then deployed a source, transform, and metric before changing only the source table and calling `POST /deployments/impact`:

```python
import copy
import json
import time

import requests

base = "http://127.0.0.1:8100"
namespace = "fingerprint_verification"
session = requests.Session()
session.post(
    f"{base}/basic/login/",
    data={"username": "dj", "password": "dj"},
).raise_for_status()

initial = {
    "namespace": namespace,
    "nodes": [
        {
            "name": "source",
            "node_type": "source",
            "catalog": "default",
            "schema": "test",
            "table": "orders",
            "columns": [{"name": "id", "type": "bigint"}],
        },
        {
            "name": "transform",
            "node_type": "transform",
            "query": "SELECT id FROM ${prefix}source",
        },
        {
            "name": "metric",
            "node_type": "metric",
            "query": "SELECT COUNT(*) FROM ${prefix}transform",
        },
    ],
}

def deploy(spec):
    deployment = session.post(f"{base}/deployments", json=spec).json()
    while True:
        result = session.get(f"{base}/deployments/{deployment['uuid']}").json()
        if result["status"] in {"success", "failed"}:
            return result
        time.sleep(0.1)

before = deploy(initial)
before_hashes = {
    result["name"]: result["semantic_fingerprint"]["digest"]
    for result in before["results"]
    if result["deploy_type"] == "node"
}
proposed = copy.deepcopy(initial)
proposed["nodes"][0]["table"] = "orders_v2"
response = session.post(f"{base}/deployments/impact", json=proposed)
response.raise_for_status()
results = [
    {
        "name": result["name"],
        "operation": result["operation"],
        "change_tier": result["change_tier"],
        "semantic_fingerprint": result["semantic_fingerprint"],
        "hash_changed": (
            result["semantic_fingerprint"]["digest"]
            != before_hashes[result["name"]]
        ),
    }
    for result in response.json()["results"]
    if result["deploy_type"] == "node"
]
print(json.dumps({"status": response.status_code, "results": results}, indent=2))
```

Observed:

```json
{
  "status": 200,
  "results": [
    {
      "name": "fingerprint_verification.transform",
      "operation": "noop",
      "change_tier": "none",
      "semantic_fingerprint": {
        "version": 1,
        "digest": "396e92df092afb466e34ef038b4bd6b2987b6ec09b1f39700f5d1cbf649e3c71"
      },
      "hash_changed": true
    },
    {
      "name": "fingerprint_verification.metric",
      "operation": "noop",
      "change_tier": "none",
      "semantic_fingerprint": {
        "version": 1,
        "digest": "3f6230e34838ea84ca8cd10ce6b4049b45b3ff79cf2e9840a419ade1731d19d2"
      },
      "hash_changed": true
    },
    {
      "name": "fingerprint_verification.source",
      "operation": "update",
      "change_tier": "major",
      "semantic_fingerprint": {
        "version": 1,
        "digest": "dd0e10eeead298cdb31af85f3ccd3dac98760564c4d1f97473eb25bc5d024e98"
      },
      "hash_changed": true
    }
  ]
}
```

---
### Semantic fingerprint stack

This is PR 3 of 4:

1. [#2482: Add semantic node fingerprints](https://github.com/DataJunction/dj/pull/2482)
2. [#2488: Evaluate fingerprints across deployment graphs](https://github.com/DataJunction/dj/pull/2488)
3. [#2483: Add semantic fingerprints to deployment impact](https://github.com/DataJunction/dj/pull/2483) (this PR)
4. [#2490: Bulk endpoint for viewing fingerprints and testing fixtures](https://github.com/DataJunction/dj/pull/2490)