### PR TITLE
feat: annotate sqlglot ast

### DIFF
--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -18,6 +18,7 @@ from enum import Enum
 from functools import reduce
 from itertools import chain, zip_longest
 import re
+from sqlglot import exp as sqlglot_exp
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -63,24 +64,34 @@ from datajunction_server.sql.functions import function_registry, table_function_
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 from datajunction_server.sql.parsing.types import (
     BigIntType,
+    BinaryType,
     BooleanType,
     ColumnType,
     DateTimeBase,
+    DateType,
     DayTimeIntervalType,
     DecimalType,
     DoubleType,
+    FixedType,
     FloatType,
     IntegerBase,
     IntegerType,
     ListType,
+    LongType,
     MapType,
     NestedField,
     NullType,
+    SmallIntType,
     StringBase,
     StringType,
     StructType,
+    TimeType,
+    TinyIntType,
     TimestampType,
     TimestamptzType,
+    UUIDType,
+    UnknownType,
+    VarcharType,
     WildcardType,
     YearMonthIntervalType,
 )
@@ -107,15 +118,94 @@ def get_render_dialect() -> Dialect | None:
     return _render_dialect.get()
 
 
+def _sqlglot_type(column_type: ColumnType) -> sqlglot_exp.DataType:
+    """Convert a DJ column type to a sqlglot type."""
+    type_ = sqlglot_exp.DataType.Type
+
+    if isinstance(column_type, NullType):
+        return sqlglot_exp.DataType.build(type_.NULL)
+    if isinstance(column_type, FixedType):
+        return sqlglot_exp.DataType.build(f"BINARY({column_type.length})")
+    if isinstance(column_type, DecimalType):
+        return sqlglot_exp.DataType.build(
+            f"DECIMAL({column_type.precision}, {column_type.scale})",
+        )
+    if isinstance(column_type, StructType):
+        fields = []
+        for nested_field in column_type.fields:
+            constraints = (
+                [
+                    sqlglot_exp.ColumnConstraint(
+                        kind=sqlglot_exp.NotNullColumnConstraint(),
+                    ),
+                ]
+                if nested_field.is_required
+                else None
+            )
+            fields.append(
+                sqlglot_exp.ColumnDef(
+                    this=sqlglot_exp.to_identifier(nested_field.name.name),
+                    kind=_sqlglot_type(nested_field.type),
+                    constraints=constraints,
+                ),
+            )
+        return sqlglot_exp.DataType(this=type_.STRUCT, expressions=fields, nested=True)
+    if isinstance(column_type, ListType):
+        return sqlglot_exp.DataType(
+            this=type_.ARRAY,
+            expressions=[_sqlglot_type(column_type.element.type)],
+            nested=True,
+        )
+    if isinstance(column_type, MapType):
+        return sqlglot_exp.DataType(
+            this=type_.MAP,
+            expressions=[
+                _sqlglot_type(column_type.key.type),
+                _sqlglot_type(column_type.value.type),
+            ],
+            nested=True,
+        )
+
+    primitive_types = (
+        (BooleanType, type_.BOOLEAN),
+        (TinyIntType, type_.TINYINT),
+        (SmallIntType, type_.SMALLINT),
+        (IntegerType, type_.INT),
+        (LongType, type_.BIGINT),
+        (BigIntType, type_.BIGINT),
+        (FloatType, type_.FLOAT),
+        (DoubleType, type_.DOUBLE),
+        (DateType, type_.DATE),
+        (TimeType, type_.TIME),
+        (TimestampType, type_.TIMESTAMP),
+        (TimestamptzType, type_.TIMESTAMPTZ),
+        (StringType, type_.TEXT),
+        (UUIDType, type_.UUID),
+        (BinaryType, type_.BINARY),
+    )
+    for dj_type, sqlglot_type in primitive_types:
+        if isinstance(column_type, dj_type):
+            return sqlglot_exp.DataType.build(sqlglot_type)
+
+    if isinstance(column_type, VarcharType):
+        return sqlglot_exp.DataType.build(str(column_type))
+    if isinstance(column_type, (DayTimeIntervalType, YearMonthIntervalType)):
+        return sqlglot_exp.DataType.build(str(column_type))
+    if isinstance(column_type, (UnknownType, WildcardType)):
+        return sqlglot_exp.DataType.build(type_.UNKNOWN)
+
+    return sqlglot_exp.DataType.build(type_.UNKNOWN)
+
+
 def _sqlglot_schema(query: Query) -> dict[str, Any]:
-    """Build a SQLGlot schema from the DJ metadata attached to compiled tables."""
+    """Build sqlglot schema from DJ metadata attached to compiled tables."""
     schema: dict[str, Any] = {}
     for table in query.find_all(Table):
         if not table.dj_node:
             continue
 
-        table_schema: dict[str, str] = {
-            column.name: str(column.type)
+        table_schema: dict[str, sqlglot_exp.DataType] = {
+            column.name: _sqlglot_type(column.type)
             for column in table.dj_node.columns
             if column.type is not None
         }

--- a/datajunction-server/datajunction_server/sql/parsing/ast.py
+++ b/datajunction-server/datajunction_server/sql/parsing/ast.py
@@ -107,6 +107,29 @@ def get_render_dialect() -> Dialect | None:
     return _render_dialect.get()
 
 
+def _sqlglot_schema(query: Query) -> dict[str, Any]:
+    """Build a SQLGlot schema from the DJ metadata attached to compiled tables."""
+    schema: dict[str, Any] = {}
+    for table in query.find_all(Table):
+        if not table.dj_node:
+            continue
+
+        table_schema: dict[str, str] = {
+            column.name: str(column.type)
+            for column in table.dj_node.columns
+            if column.type is not None
+        }
+        if not table_schema:
+            continue
+
+        current = schema
+        table_parts = table.identifier(quotes=False).split(".")
+        for part in table_parts[:-1]:
+            current = current.setdefault(part, {})
+        current[table_parts[-1]] = table_schema
+    return schema
+
+
 @contextmanager
 def render_for_dialect(dialect: Dialect):
     """
@@ -146,7 +169,7 @@ def to_sql(query: Query, dialect: Dialect | None = None) -> str:
     with render_for_dialect(dialect):
         rendered = str(query)
     try:
-        return transpile_sql(rendered, dialect)
+        return transpile_sql(rendered, dialect, schema=_sqlglot_schema(query))
     except Exception:  # pragma: no cover - fall back to native render
         logger.warning(
             "Transpilation to %s failed; falling back to native render",

--- a/datajunction-server/datajunction_server/transpilation.py
+++ b/datajunction-server/datajunction_server/transpilation.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import sqlglot
 from sqlglot.optimizer.annotate_types import annotate_types
+from sqlglot.optimizer.qualify import qualify
 
 from datajunction_server.models.dialect import DialectRegistry, dialect_plugin
 from datajunction_server.models.engine import Dialect
@@ -76,6 +77,8 @@ class SQLGlotTranspilationPlugin(SQLTranspilationPlugin):
         ):
             input_name = str(input_dialect.name.lower())
             expression = sqlglot.parse_one(query, read=input_name)
+            if schema:
+                expression = qualify(expression, schema=schema, dialect=input_name)
             annotate_types(expression, schema=schema, dialect=input_name)
             return expression.sql(
                 dialect=str(output_dialect.name.lower()),

--- a/datajunction-server/datajunction_server/transpilation.py
+++ b/datajunction-server/datajunction_server/transpilation.py
@@ -1,8 +1,10 @@
 """SQL transpilation plugins manager."""
 
 import logging
+from typing import Any
 
 import sqlglot
+from sqlglot.optimizer.annotate_types import annotate_types
 
 from datajunction_server.models.dialect import DialectRegistry, dialect_plugin
 from datajunction_server.models.engine import Dialect
@@ -32,6 +34,7 @@ class SQLTranspilationPlugin:
         *,
         input_dialect: Dialect | None = None,
         output_dialect: Dialect | None = None,
+        schema: dict[str, Any] | None = None,
     ) -> str:
         """Transpile a given SQL query using the specific library."""
         return query
@@ -60,6 +63,7 @@ class SQLGlotTranspilationPlugin(SQLTranspilationPlugin):
         *,
         input_dialect: Dialect | None = None,
         output_dialect: Dialect | None = None,
+        schema: dict[str, Any] | None = None,
     ) -> str:
         """
         Transpile a given SQL query using the specific library.
@@ -70,19 +74,20 @@ class SQLGlotTranspilationPlugin(SQLTranspilationPlugin):
             and output_dialect
             and output_dialect.name in dir(sqlglot.dialects.Dialects)
         ):
-            value = sqlglot.transpile(
-                query,
-                read=str(input_dialect.name.lower()),  # type: ignore
-                write=str(output_dialect.name.lower()),  # type: ignore
+            input_name = str(input_dialect.name.lower())
+            expression = sqlglot.parse_one(query, read=input_name)
+            annotate_types(expression, schema=schema, dialect=input_name)
+            return expression.sql(
+                dialect=str(output_dialect.name.lower()),
                 pretty=True,
-            )[0]
-            return value
+            )
         return query
 
 
 def transpile_sql(
     sql: str,
     dialect: Dialect | None = None,
+    schema: dict[str, Any] | None = None,
 ) -> str:
     """
     Transpile SQL to a target dialect.
@@ -94,6 +99,7 @@ def transpile_sql(
     Args:
         sql: The SQL string to transpile
         dialect: The target SQL dialect (if None, returns SQL unchanged)
+        schema: Optional SQLGlot schema mapping used to annotate AST types
 
     Returns:
         The transpiled SQL string
@@ -104,9 +110,16 @@ def transpile_sql(
             dialect.name.lower(),
         ):
             plugin = plugin_class()
+            kwargs: dict[str, Any] = {
+                "input_dialect": Dialect.SPARK,
+                "output_dialect": dialect,
+            }
+            # Schema annotation is a SQLGlot capability. Keeping it out of calls
+            # to other plugins preserves compatibility with their existing API.
+            if schema is not None and isinstance(plugin, SQLGlotTranspilationPlugin):
+                kwargs["schema"] = schema
             return plugin.transpile_sql(
                 sql,
-                input_dialect=Dialect.SPARK,
-                output_dialect=dialect,
+                **kwargs,
             )
     return sql

--- a/datajunction-server/datajunction_server/transpilation.py
+++ b/datajunction-server/datajunction_server/transpilation.py
@@ -35,7 +35,6 @@ class SQLTranspilationPlugin:
         *,
         input_dialect: Dialect | None = None,
         output_dialect: Dialect | None = None,
-        schema: dict[str, Any] | None = None,
     ) -> str:
         """Transpile a given SQL query using the specific library."""
         return query

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -5,6 +5,7 @@ testing ast Nodes and their methods
 from typing import cast
 
 import pytest
+from sqlglot import exp as sqlglot_exp
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -1548,9 +1549,66 @@ def test_to_sql_passes_dj_table_schema_to_sqlglot(monkeypatch):
     table.set_dj_node(
         SimpleNamespace(
             columns=[
-                SimpleNamespace(name="payload", type="struct<name string>"),
+                SimpleNamespace(
+                    name="payload",
+                    type=types.StructType(
+                        types.NestedField("name", types.StringType()),
+                    ),
+                ),
             ],
         ),
     )
 
     assert "`events`.`payload`.name" in ast.to_sql(query, Dialect.BIGQUERY)
+
+
+@pytest.mark.parametrize(
+    ("dj_type", "expected"),
+    [
+        (types.NullType(), "NULL"),
+        (types.FixedType(8), "BINARY(8)"),
+        (types.DecimalType(12, 3), "DECIMAL(12, 3)"),
+        (types.BooleanType(), "BOOLEAN"),
+        (types.TinyIntType(), "TINYINT"),
+        (types.SmallIntType(), "SMALLINT"),
+        (types.IntegerType(), "INT"),
+        (types.LongType(), "BIGINT"),
+        (types.BigIntType(), "BIGINT"),
+        (types.FloatType(), "FLOAT"),
+        (types.DoubleType(), "DOUBLE"),
+        (types.DateType(), "DATE"),
+        (types.TimeType(), "TIME"),
+        (types.TimestampType(), "TIMESTAMP"),
+        (types.TimestamptzType(), "TIMESTAMPTZ"),
+        (types.StringType(), "TEXT"),
+        (types.VarcharType(20), "VARCHAR(20)"),
+        (types.UUIDType(), "UUID"),
+        (types.BinaryType(), "BINARY"),
+        (types.DayTimeIntervalType(), "INTERVAL DAY TO SECOND"),
+        (types.YearMonthIntervalType(), "INTERVAL YEAR TO MONTH"),
+        (types.UnknownType(), "UNKNOWN"),
+        (types.WildcardType(), "UNKNOWN"),
+    ],
+)
+def test_sqlglot_type_maps_dj_types(dj_type, expected):
+    assert ast._sqlglot_type(dj_type).sql() == expected
+
+
+def test_sqlglot_type_maps_nested_types():
+    dj_type = types.StructType(
+        types.NestedField("id", types.IntegerType(), is_optional=False),
+        types.NestedField(
+            "attributes",
+            types.MapType(
+                types.StringType(),
+                types.ListType(types.TimestampType()),
+            ),
+        ),
+    )
+
+    result = ast._sqlglot_type(dj_type)
+
+    assert result.this == sqlglot_exp.DataType.Type.STRUCT
+    assert result.sql() == (
+        "STRUCT<id INT NOT NULL, attributes MAP<TEXT, ARRAY<TIMESTAMP>>>"
+    )

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -1553,4 +1553,4 @@ def test_to_sql_passes_dj_table_schema_to_sqlglot(monkeypatch):
         ),
     )
 
-    assert "events.payload.name" in ast.to_sql(query, Dialect.BIGQUERY)
+    assert "`events`.`payload`.name" in ast.to_sql(query, Dialect.BIGQUERY)

--- a/datajunction-server/tests/sql/parsing/test_ast.py
+++ b/datajunction-server/tests/sql/parsing/test_ast.py
@@ -1527,3 +1527,30 @@ def test_to_sql_transpiles_functions_for_dialect(monkeypatch):
 
     # No dialect => no transpilation, canonical names returned verbatim.
     assert "COLLECT_LIST" in ast.to_sql(query, None).upper()
+
+
+def test_to_sql_passes_dj_table_schema_to_sqlglot(monkeypatch):
+    """Compiled DJ table metadata is retained for SQLGlot type annotation."""
+    from types import SimpleNamespace
+
+    from datajunction_server.models.dialect import DialectRegistry
+    from datajunction_server.transpilation import SQLGlotTranspilationPlugin
+
+    monkeypatch.setitem(
+        DialectRegistry._registry,
+        "bigquery",
+        SQLGlotTranspilationPlugin,
+    )
+    query = parse(
+        "SELECT events.payload['name'] FROM catalog.schema.events AS events",
+    )
+    table = query.select.from_.relations[0].primary
+    table.set_dj_node(
+        SimpleNamespace(
+            columns=[
+                SimpleNamespace(name="payload", type="struct<name string>"),
+            ],
+        ),
+    )
+
+    assert "events.payload.name" in ast.to_sql(query, Dialect.BIGQUERY)

--- a/datajunction-server/tests/transpilation_test.py
+++ b/datajunction-server/tests/transpilation_test.py
@@ -96,6 +96,25 @@ def test_sqlglot_transpile_success():
         assert result == "SELECT * FROM bar"
 
 
+def test_sqlglot_transpile_uses_schema_to_annotate_types():
+    """Schema types are attached before dialect-specific SQL generation."""
+    plugin = SQLGlotTranspilationPlugin()
+    result = plugin.transpile_sql(
+        "SELECT t.payload['name'] FROM catalog.schema.events AS t",
+        input_dialect=Dialect.SPARK,
+        output_dialect=Dialect.BIGQUERY,
+        schema={
+            "catalog": {
+                "schema": {
+                    "events": {"payload": "struct<name string>"},
+                },
+            },
+        },
+    )
+
+    assert result == "SELECT\n  t.payload.name\nFROM catalog.schema.events AS t"
+
+
 def test_default_transpile_success():
     with mock.patch(
         "datajunction_server.transpilation.settings.transpilation_plugins",

--- a/datajunction-server/tests/transpilation_test.py
+++ b/datajunction-server/tests/transpilation_test.py
@@ -129,24 +129,20 @@ def test_sqlglot_transpile_map_explode_with_schema():
     result = plugin.transpile_sql(
         """SELECT
   CAST(test_id AS BIGINT) AS test_id,
-  cell_id,
-  cell_name
+  key,
+  value
 FROM (
   SELECT
     test_id,
-    explode(cells) AS (cell_id, cell_name)
-  FROM source.prodhive.dse.ab_test_detail_d_v2 T
+    explode(map_column) AS (key, value)
+  FROM some_table T
 )""",
         input_dialect=Dialect.SPARK,
         output_dialect=Dialect.TRINO,
         schema={
-            "prodhive": {
-                "dse": {
-                    "ab_test_detail_d_v2": {
-                        "test_id": "INT",
-                        "cells": "MAP<INT, VARCHAR>",
-                    },
-                },
+            "some_table": {
+                "test_id": "INT",
+                "map_column": "MAP<INT, VARCHAR>",
             },
         },
     )
@@ -155,15 +151,15 @@ FROM (
         result
         == '''SELECT
   TRY_CAST("_0"."test_id" AS BIGINT) AS "test_id",
-  "_0"."cell_id" AS "cell_id",
-  "_0"."cell_name" AS "cell_name"
+  "_0"."key" AS "key",
+  "_0"."value" AS "value"
 FROM (
   SELECT
     "t"."test_id" AS "test_id",
-    _u_2."cell_id" AS "cell_id",
-    _u_2."cell_name" AS "cell_name"
-  FROM "source"."prodhive"."dse"."ab_test_detail_d_v2" AS "t"
-  CROSS JOIN UNNEST("t"."cells") AS _u_2("cell_id", "cell_name")
+    _u_2."key" AS "key",
+    _u_2."value" AS "value"
+  FROM "some_table" AS "t"
+  CROSS JOIN UNNEST("t"."map_column") AS _u_2("key", "value")
 ) AS "_0"'''
     )
 

--- a/datajunction-server/tests/transpilation_test.py
+++ b/datajunction-server/tests/transpilation_test.py
@@ -2,6 +2,8 @@
 
 from unittest import mock
 
+import pytest
+
 from datajunction_server.models.dialect import Dialect, DialectRegistry
 from datajunction_server.models.engine import Dialect
 from datajunction_server.models.metric import TranslatedSQL
@@ -112,7 +114,58 @@ def test_sqlglot_transpile_uses_schema_to_annotate_types():
         },
     )
 
-    assert result == "SELECT\n  t.payload.name\nFROM catalog.schema.events AS t"
+    assert result == (
+        "SELECT\n  `t`.`payload`.name AS `name`\n"
+        "FROM `catalog`.`schema`.`events` AS `t`"
+    )
+
+
+# TODO: Remove this skip after upgrading to a SQLGlot release containing the
+# map EXPLODE type-annotation fix.
+@pytest.mark.skip(reason="Requires the unreleased SQLGlot map EXPLODE fix")
+def test_sqlglot_transpile_map_explode_with_schema():
+    """A typed Spark map EXPLODE becomes a two-column Trino UNNEST."""
+    plugin = SQLGlotTranspilationPlugin()
+    result = plugin.transpile_sql(
+        """SELECT
+  CAST(test_id AS BIGINT) AS test_id,
+  cell_id,
+  cell_name
+FROM (
+  SELECT
+    test_id,
+    explode(cells) AS (cell_id, cell_name)
+  FROM source.prodhive.dse.ab_test_detail_d_v2 T
+)""",
+        input_dialect=Dialect.SPARK,
+        output_dialect=Dialect.TRINO,
+        schema={
+            "prodhive": {
+                "dse": {
+                    "ab_test_detail_d_v2": {
+                        "test_id": "INT",
+                        "cells": "MAP<INT, VARCHAR>",
+                    },
+                },
+            },
+        },
+    )
+
+    assert (
+        result
+        == '''SELECT
+  TRY_CAST("_0"."test_id" AS BIGINT) AS "test_id",
+  "_0"."cell_id" AS "cell_id",
+  "_0"."cell_name" AS "cell_name"
+FROM (
+  SELECT
+    "t"."test_id" AS "test_id",
+    _u_2."cell_id" AS "cell_id",
+    _u_2."cell_name" AS "cell_name"
+  FROM "source"."prodhive"."dse"."ab_test_detail_d_v2" AS "t"
+  CROSS JOIN UNNEST("t"."cells") AS _u_2("cell_id", "cell_name")
+) AS "_0"'''
+    )
 
 
 def test_default_transpile_success():


### PR DESCRIPTION
### Summary

<!-- What's this change about? -->

When transpiling between sqlglot dialects it's helpful to annotate the sqlglot AST so that the generators have more context. The example that made me work on this PR is this Spark query:

```sql
SELECT
  CAST(id AS BIGINT) AS id,
  key,
  value
FROM (
  SELECT
    id,
    explode(map_column) AS (key, value)
  FROM some_table T
)
```

Here, `map_column` is a map — in Spark `EXPLODE()` can be used both on arrays and maps. But when transpiled to Trino, the Trino generator treats it like an array, resulting in this invalid SQL:

```sql
SELECT
  TRY_CAST(id AS BIGINT) AS id,
  key,
  value
FROM (
  SELECT
    id,
    IF(_u.pos = _u_2.key, _u_2.value) AS value
  FROM some_table AS T
  CROSS JOIN UNNEST(SEQUENCE(1, GREATEST(CARDINALITY(map_column)))) AS _u(pos)
  CROSS JOIN UNNEST(map_column) WITH ORDINALITY AS _u_2(value, key)
  WHERE
    _u.pos = _u_2.key
    OR (
      _u.pos > CARDINALITY(map_column) AND _u_2.key = CARDINALITY(map_column)
    )
)
```

The query above is invalid here:

```sql
CROSS JOIN UNNEST(map_column) WITH ORDINALITY AS _u_2(value, key)
```

Since in Trino `UNNEST(map_column) with ORDINALITY` applied to a map returns 3 columns `(key, value, index)`, not the expected 2.

https://github.com/tobymao/sqlglot/pull/8235 fixed this, so that when the argument to `EXPLODE()` is annotated as a map the SQL gets generated correctly:

```sql
SELECT
  TRY_CAST("_0"."id" AS BIGINT) AS "id",
  "_0"."key" AS "key",
  "_0"."value" AS "value"
FROM (
  SELECT
    "t"."id" AS "id",
    _u_2."key" AS "key",
    _u_2."value" AS "value"
  FROM "some_table" AS "t"
  CROSS JOIN UNNEST("t"."map_column") AS _u_2("key", "value")
) AS "_0"
```

The problem is that, for the transpilation to work we need to make sure the sqlglot is annotated with types. I added logic that builds a sqlglot schema from the DJ schema, and qualifies and annotates the SQL before transpilation. This way we get the expected valid SQL.

### Test Plan

I added a unit test capturing the problem, but until we have a new release of `sqlglot` it has to be skipped. But I tested locally with the `main` branch, and the tests passed.

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->

