### PR TITLE
Allow role-qualified dimension attributes in DJ SQL projections

### DIFF
--- a/datajunction-server/datajunction_server/api/djsql.py
+++ b/datajunction-server/datajunction_server/api/djsql.py
@@ -101,12 +101,21 @@ def parse_dj_sql(
     # Validation that these are actual metric nodes is delegated to build_metrics_sql
     metrics = []
     for col in select.projection:
-        if not isinstance(col, ast.Column):
+        # Remove the alias first, if one was set
+        if isinstance(col, ast.Alias):
+            col = col.child
+
+        if isinstance(col, ast.Column):
+            col_ident = col.identifier(False)
+        # A role-qualified attribute like ``dim.attr[role]`` parses as a Subscript
+        # wrapping a Column, and stringifies exactly like its GROUP BY counterpart.
+        elif isinstance(col, ast.Subscript) and isinstance(col.expr, ast.Column):
+            col_ident = str(col)
+        else:
             raise DJInvalidInputException(
                 f"Only direct columns are allowed in DJ SQL queries, found: {col}",
             )
 
-        col_ident = col.identifier(False)
         if col_ident not in dimensions:
             metrics.append(col_ident)
 

--- a/datajunction-server/tests/api/djql_test.py
+++ b/datajunction-server/tests/api/djql_test.py
@@ -510,6 +510,103 @@ async def test_get_djsql_with_orderby_and_limit(
 
 
 @pytest.mark.asyncio
+async def test_get_djsql_role_qualified_dimension(
+    module__client_with_examples: AsyncClient,
+) -> None:
+    """
+    A role-qualified dimension attribute is allowed in the projection and is
+    classified as a dimension (not a metric) when it's also in the GROUP BY.
+    """
+    query = """
+        SELECT
+            default.special_country_dim.name[birth_country],
+            default.avg_user_age
+        FROM metrics
+        GROUP BY default.special_country_dim.name[birth_country]
+    """
+
+    response = await module__client_with_examples.get(
+        "/djsql/",
+        params={"query": query},
+    )
+    assert response.status_code == 200, response.json()
+
+    semantics = {
+        (col["semantic_name"], col["semantic_type"])
+        for col in response.json()["columns"]
+    }
+    assert semantics == {
+        ("default.special_country_dim.name[birth_country]", "dimension"),
+        ("default.avg_user_age", "metric"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_djsql_role_path_dimension(
+    module__client_with_examples: AsyncClient,
+) -> None:
+    """
+    A multi-hop role path dimension attribute is allowed in the projection and
+    is classified as a dimension (not a metric) when it's also in the GROUP BY.
+    """
+    query = """
+        SELECT
+            default.date_dim.dateint[birth_country->formation_date],
+            default.avg_user_age
+        FROM metrics
+        GROUP BY default.date_dim.dateint[birth_country->formation_date]
+    """
+
+    response = await module__client_with_examples.get(
+        "/djsql/",
+        params={"query": query},
+    )
+    assert response.status_code == 200, response.json()
+
+    semantics = {
+        (col["semantic_name"], col["semantic_type"])
+        for col in response.json()["columns"]
+    }
+    assert semantics == {
+        ("default.date_dim.dateint[birth_country->formation_date]", "dimension"),
+        ("default.avg_user_age", "metric"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_djsql_role_qualified_dimension_with_alias(
+    module__client_with_examples: AsyncClient,
+) -> None:
+    """
+    A role-qualified attribute may carry an alias. Unlike a plain column, which
+    absorbs its own alias, it is wrapped in an Alias node, so the alias has to be
+    unwrapped before the reference is classified.
+    """
+    query = """
+        SELECT
+            default.special_country_dim.name[birth_country] AS birth_country_name,
+            default.avg_user_age
+        FROM metrics
+        GROUP BY default.special_country_dim.name[birth_country]
+    """
+
+    response = await module__client_with_examples.get(
+        "/djsql/",
+        params={"query": query},
+    )
+    assert response.status_code == 200, response.json()
+
+    semantics = {
+        (col["semantic_name"], col["semantic_type"])
+        for col in response.json()["columns"]
+    }
+    assert semantics == {
+        ("default.special_country_dim.name[birth_country]", "dimension"),
+        ("default.avg_user_age", "metric"),
+    }
+
+
+@pytest.mark.asyncio
 async def test_get_djsql_no_nodes(
     module__client_with_roads: AsyncClient,
 ) -> None:


### PR DESCRIPTION
### Summary

This PR handles support for role-qualified dimension attributes such as
`default.special_country_dim.name[birth_country]` that are pulled in via the `SELECT` projection. It handles any aliasing first (e.g., `default.special_country_dim.name[birth_country] AS bc_alias`), then checks to see if it's a regular dimension attribute or a role-qualified one, before converting it to a string. 

It converts to strings first because this is consistent with the logic behind the `/sql` endpoint, which just takes a series of strings for dimension attributes.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #2480
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
