### PR TITLE
feat(ui): restore the delete button on the node details page

### DIFF
--- a/datajunction-ui/src/app/pages/NodePage/__tests__/NodePage.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/NodePage.test.jsx
@@ -7,7 +7,7 @@ import DJClientContext from '../../../providers/djclient';
 // React.lazy + Suspense boundary which adds an async resolution step that
 // can race testing-library's waitFor on slower CI runners.
 import { NodePage } from '../index';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useParams } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 
 // Mock cronstrue for NodePreAggregationsTab
@@ -97,6 +97,11 @@ describe('<NodePage />', () => {
         upstreamsGQL: vi.fn().mockResolvedValue([]),
         downstreamsGQL: vi.fn().mockResolvedValue([]),
         findCubesWithMetrics: vi.fn().mockResolvedValue([]),
+        // The server answers DELETE /nodes/{name}/ with 200 + a message body.
+        deactivate: vi.fn().mockResolvedValue({
+          status: 200,
+          json: { message: 'Node `default.num_repair_orders` deleted.' },
+        }),
       },
     };
   };
@@ -445,6 +450,127 @@ describe('<NodePage />', () => {
     expect(
       screen.queryByRole('button', { name: 'Edit' }),
     ).not.toBeInTheDocument();
+    // ...nor is Delete.
+    expect(screen.queryByRole('button', { name: /Delete/ })).toBeNull();
+  }, 60000);
+
+  // Renders the node page under a router that also serves the namespace
+  // route, so a successful delete can be asserted by the redirect landing.
+  const renderNodePageWithNamespaceRoute = djClient => {
+    const element = (
+      <DJClientContext.Provider value={djClient}>
+        <NodePage {...defaultProps} />
+      </DJClientContext.Provider>
+    );
+    const NamespaceLanding = () => {
+      const { namespace } = useParams();
+      return <div data-testid="namespace-landing">{namespace}</div>;
+    };
+    return render(
+      <MemoryRouter initialEntries={['/nodes/default.num_repair_orders/info']}>
+        <Routes>
+          <Route path="nodes/:name/:tab" element={element} />
+          <Route path="namespaces/:namespace" element={<NamespaceLanding />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  };
+
+  it('deletes the node and redirects to its namespace after confirmation', async () => {
+    const djClient = mockDJClient();
+    djClient.DataJunctionAPI.node.mockReturnValue(mocks.mockMetricNode);
+    djClient.DataJunctionAPI.getMetric.mockResolvedValue(
+      mocks.mockMetricNodeJson,
+    );
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    renderNodePageWithNamespaceRoute(djClient);
+
+    const deleteButton = await screen.findByRole('button', {
+      name: /Delete/,
+    });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(djClient.DataJunctionAPI.deactivate).toHaveBeenCalledWith(
+        'default.num_repair_orders',
+      );
+    });
+    // The redirect landed on the parent namespace, not the node page.
+    expect(await screen.findByTestId('namespace-landing')).toHaveTextContent(
+      'default',
+    );
+    confirm.mockRestore();
+  }, 60000);
+
+  it('does not delete the node when the confirmation is dismissed', async () => {
+    const djClient = mockDJClient();
+    djClient.DataJunctionAPI.node.mockReturnValue(mocks.mockMetricNode);
+    djClient.DataJunctionAPI.getMetric.mockResolvedValue(
+      mocks.mockMetricNodeJson,
+    );
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    renderNodePageWithNamespaceRoute(djClient);
+
+    fireEvent.click(await screen.findByRole('button', { name: /Delete/ }));
+
+    expect(djClient.DataJunctionAPI.deactivate).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('namespace-landing')).toBeNull();
+    confirm.mockRestore();
+  }, 60000);
+
+  it('alerts and stays on the page when the delete is rejected', async () => {
+    const djClient = mockDJClient();
+    djClient.DataJunctionAPI.node.mockReturnValue(mocks.mockMetricNode);
+    djClient.DataJunctionAPI.getMetric.mockResolvedValue(
+      mocks.mockMetricNodeJson,
+    );
+    djClient.DataJunctionAPI.deactivate.mockResolvedValue({
+      status: 409,
+      json: { message: 'Node has downstream dependencies' },
+    });
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const alert = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    renderNodePageWithNamespaceRoute(djClient);
+
+    fireEvent.click(await screen.findByRole('button', { name: /Delete/ }));
+
+    await waitFor(() => {
+      expect(alert).toHaveBeenCalledWith(
+        'Unable to delete node default.num_repair_orders: Node has downstream dependencies',
+      );
+    });
+    expect(screen.queryByTestId('namespace-landing')).toBeNull();
+    confirm.mockRestore();
+    alert.mockRestore();
+  }, 60000);
+
+  it('alerts and re-enables the button when the delete request throws', async () => {
+    const djClient = mockDJClient();
+    djClient.DataJunctionAPI.node.mockReturnValue(mocks.mockMetricNode);
+    djClient.DataJunctionAPI.getMetric.mockResolvedValue(
+      mocks.mockMetricNodeJson,
+    );
+    djClient.DataJunctionAPI.deactivate.mockRejectedValue(
+      new Error('Failed to fetch'),
+    );
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const alert = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    renderNodePageWithNamespaceRoute(djClient);
+
+    const deleteButton = await screen.findByRole('button', { name: /Delete/ });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(alert).toHaveBeenCalledWith(
+        'Unable to delete node default.num_repair_orders: Failed to fetch',
+      );
+    });
+    // The in-flight guard is released, so a retry is possible.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Delete/ })).not.toBeDisabled();
+    });
+    confirm.mockRestore();
+    alert.mockRestore();
   }, 60000);
 
   it('renders the NodeInfo tab correctly for cube nodes', async () => {

--- a/datajunction-ui/src/app/pages/NodePage/index.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/index.jsx
@@ -17,6 +17,7 @@ import WatchButton from './WatchNodeButton';
 import NodesWithDimension from './NodesWithDimension';
 import NodeColumnLineage from './NodeLineageTab';
 import EditIcon from '../../icons/EditIcon';
+import DeleteIcon from '../../icons/DeleteIcon';
 import ChartIcon from '../../icons/ChartIcon';
 import AlertIcon from '../../icons/AlertIcon';
 import LoadingIcon from '../../icons/LoadingIcon';
@@ -37,6 +38,7 @@ export function NodePage() {
   // undefined = not yet known; NamespaceHeader reports the read-only verdict
   // (git_only, flat/root shape, or git-deployed) once its config + sources load.
   const [isReadOnly, setIsReadOnly] = useState(undefined);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const onClickTab = id => () => {
     // Preview tab redirects to Query Planner instead of showing content
@@ -193,6 +195,36 @@ export function NodePage() {
     whiteSpace: 'nowrap',
   };
 
+  const deleteButtonStyle = {
+    ...buttonStyle,
+    color: '#b91c1c',
+    borderColor: '#fecaca',
+    cursor: isDeleting ? 'not-allowed' : 'pointer',
+    opacity: isDeleting ? 0.6 : 1,
+  };
+
+  const onDelete = async () => {
+    if (!window.confirm(`Deleting node ${node?.name}. Are you sure?`)) {
+      return;
+    }
+    setIsDeleting(true);
+    try {
+      const { status, json } = await djClient.deactivate(node?.name);
+      if (status === 200 || status === 201 || status === 204) {
+        // Nodes always live under a namespace, but fall back to the root
+        // listing rather than routing to a nameless /namespaces/ URL.
+        const parentNamespace = node?.name?.split('.').slice(0, -1).join('.');
+        navigate(parentNamespace ? `/namespaces/${parentNamespace}` : '/');
+      } else {
+        window.alert(`Unable to delete node ${node?.name}: ${json?.message}`);
+      }
+    } catch (error) {
+      window.alert(`Unable to delete node ${node?.name}: ${error.message}`);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
   const NodeButtons = () => {
     return (
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
@@ -210,6 +242,17 @@ export function NodePage() {
         <ClientCodePopover nodeName={name} buttonStyle={buttonStyle} />
         {node?.type === 'cube' && (
           <NotebookDownload node={node} buttonStyle={buttonStyle} />
+        )}
+
+        {isReadOnly === false && (
+          <button
+            style={deleteButtonStyle}
+            aria-label={`Delete ${node?.name}`}
+            onClick={onDelete}
+            disabled={isDeleting}
+          >
+            <DeleteIcon /> {isDeleting ? 'Deleting…' : 'Delete'}
+          </button>
         )}
       </div>
     );

--- a/datajunction-ui/src/app/services/DJService.js
+++ b/datajunction-ui/src/app/services/DJService.js
@@ -1943,7 +1943,9 @@ export const DataJunctionAPI = {
       },
       credentials: 'include',
     });
-    return { status: response.status, json: await response.json() };
+    // A 204 carries no body, and a gateway error page carries no JSON.
+    const json = await response.json().catch(() => ({}));
+    return { status: response.status, json };
   },
   addNamespace: async function (namespace) {
     const response = await fetch(`${DJ_URL}/namespaces/${namespace}`, {

--- a/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
+++ b/datajunction-ui/src/app/services/__tests__/DJService.test.jsx
@@ -897,6 +897,14 @@ describe('DataJunctionAPI', () => {
     });
   });
 
+  // A gateway can answer with an HTML error page. Parsing that as JSON throws,
+  // so without the guard the call rejects and the caller sees a silent no-op.
+  it('tolerates a non-JSON error body', async () => {
+    fetch.mockResponseOnce('<html>502 Bad Gateway</html>', { status: 502 });
+    const result = await DataJunctionAPI.deactivate('default.transform1');
+    expect(result).toEqual({ status: 502, json: {} });
+  });
+
   it('calls attributes correctly', async () => {
     fetch.mockResponseOnce(JSON.stringify(mocks.attributes));
     await DataJunctionAPI.attributes();


### PR DESCRIPTION
### Summary
The node details page used to have a delete button. At some point it was removed. This diff puts it back.

### Test Plan
new tests & manual testing

