### PR TITLE
[DJ Semantic Fingerprint 2] Evaluate fingerprints across deployment graphs

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/fingerprints.py
+++ b/datajunction-server/datajunction_server/internal/deployment/fingerprints.py
@@ -21,9 +21,14 @@ from datajunction_server.models.deployment import (
 )
 from datajunction_server.models.node import NodeType
 from datajunction_server.models.semantic_fingerprint import (
+    LATEST_SEMANTIC_FINGERPRINT_VERSION,
     UNKNOWN_SEMANTIC_FINGERPRINT,
     SemanticFingerprint,
     SemanticFingerprintValue,
+)
+from datajunction_server.semantic_fingerprints.engine import (
+    compose_node_fingerprint,
+    local_node_fingerprint,
 )
 from datajunction_server.semantic_fingerprints.merkle import (
     cycle_component_fingerprint,
@@ -225,13 +230,11 @@ def _resolved_proposed_specs(
 
 def _compute_merkle_fingerprints(
     specs: dict[str, NodeSpec],
-    target_names: Iterable[str],
     ignored_parse_errors: set[str],
     parent_cache: ParentCandidateCache | None = None,
+    *,
+    version: int = LATEST_SEMANTIC_FINGERPRINT_VERSION,
 ) -> FingerprintMap:
-    target_names = set(target_names)
-    if not target_names:
-        return {}
     parent_cache = parent_cache if parent_cache is not None else {}
     graph: dict[str, list[str]] = {}
     failed_names: set[str] = set()
@@ -334,9 +337,9 @@ def _compute_merkle_fingerprints(
                 try:
                     if not is_cycle:
                         component_results[component_index] = {
-                            members[0]: fingerprint_specs[
-                                members[0]
-                            ].semantic_fingerprint(
+                            members[0]: compose_node_fingerprint(
+                                fingerprint_specs[members[0]],
+                                version,
                                 parent_fingerprints=[
                                     edge[2] for edge in external_edges
                                 ],
@@ -344,7 +347,10 @@ def _compute_merkle_fingerprints(
                         }
                     else:
                         local_fingerprints = {
-                            name: fingerprint_specs[name].semantic_fingerprint()
+                            name: local_node_fingerprint(
+                                fingerprint_specs[name],
+                                version,
+                            )
                             for name in members
                         }
                         internal_edges = [
@@ -360,7 +366,9 @@ def _compute_merkle_fingerprints(
                             external_edges,
                         )
                         component_results[component_index] = {
-                            name: fingerprint_specs[name].semantic_fingerprint(
+                            name: compose_node_fingerprint(
+                                fingerprint_specs[name],
+                                version,
                                 parent_fingerprints=[component_fingerprint],
                             )
                             for name in members
@@ -384,11 +392,52 @@ def _compute_merkle_fingerprints(
     if processed != len(components):  # pragma: no cover
         raise RuntimeError("SCC condensation graph contains a cycle")
 
-    return {
-        name: component_results[component_by_name[name]][name]
-        for name in target_names
-        if name in specs
-    }
+    return {name: component_results[component_by_name[name]][name] for name in specs}
+
+
+class SemanticFingerprintGraph:
+    """Semantic fingerprints evaluated within one graph snapshot."""
+
+    def __init__(
+        self,
+        specs: dict[str, NodeSpec],
+        *,
+        ignored_parse_errors: set[str] | None = None,
+        parent_cache: ParentCandidateCache | None = None,
+        version: int = LATEST_SEMANTIC_FINGERPRINT_VERSION,
+    ):
+        self._specs = dict(specs)
+        self._ignored_parse_errors = set(ignored_parse_errors or ())
+        self._parent_cache = parent_cache if parent_cache is not None else {}
+        self._version = version
+        self._fingerprints: FingerprintMap | None = None
+
+    def fingerprint(self, name: str) -> SemanticFingerprintValue:
+        """Return one node's fingerprint in this graph snapshot."""
+        return self._evaluate()[name]
+
+    def fingerprints(
+        self,
+        names: Iterable[str] | None = None,
+    ) -> FingerprintMap:
+        """Return fingerprints for selected nodes in this graph snapshot."""
+        target_names = list(self._specs if names is None else names)
+        if not target_names:
+            return {}
+        fingerprints = self._evaluate()
+        return {
+            name: fingerprints[name] for name in target_names if name in fingerprints
+        }
+
+    def _evaluate(self) -> FingerprintMap:
+        if self._fingerprints is None:
+            self._fingerprints = _compute_merkle_fingerprints(
+                self._specs,
+                self._ignored_parse_errors,
+                self._parent_cache,
+                version=self._version,
+            )
+        return self._fingerprints
 
 
 async def build_deployment_fingerprints(
@@ -398,6 +447,7 @@ async def build_deployment_fingerprints(
     deleted_specs: Iterable[NodeSpec],
     *,
     additional_target_names: Iterable[str] = (),
+    version: int = LATEST_SEMANTIC_FINGERPRINT_VERSION,
 ) -> tuple[FingerprintMap, FingerprintMap]:
     proposed_specs = list(proposed_specs)
     additional_target_names = set(additional_target_names)
@@ -437,18 +487,21 @@ async def build_deployment_fingerprints(
         parent_cache=parent_cache,
     )
     external.update(target_specs)
-    current_graph = {**external, **existing_specs}
-    proposed_graph = {**external, **proposed}
-    current = _compute_merkle_fingerprints(
-        current_graph,
-        deleted_names | additional_target_names,
+    current_graph = SemanticFingerprintGraph(
+        {**external, **existing_specs},
         ignored_parse_errors=deleted_names,
         parent_cache=parent_cache,
+        version=version,
     )
-    proposed_hashes = _compute_merkle_fingerprints(
-        proposed_graph,
-        submitted_names | additional_target_names,
-        ignored_parse_errors=set(),
+    proposed_graph = SemanticFingerprintGraph(
+        {**external, **proposed},
         parent_cache=parent_cache,
+        version=version,
+    )
+    current = current_graph.fingerprints(
+        deleted_names | additional_target_names,
+    )
+    proposed_hashes = proposed_graph.fingerprints(
+        submitted_names | additional_target_names,
     )
     return current, proposed_hashes

--- a/datajunction-server/datajunction_server/internal/deployment/fingerprints.py
+++ b/datajunction-server/datajunction_server/internal/deployment/fingerprints.py
@@ -1,7 +1,6 @@
 import logging
 from collections.abc import Callable, Iterable
 from heapq import heappop, heappush
-from typing import get_args
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
@@ -16,7 +15,6 @@ from datajunction_server.models.deployment import (
     DimensionSpec,
     LinkableNodeSpec,
     MetricSpec,
-    NodeUnion,
     NodeSpec,
     SourceSpec,
     TransformSpec,
@@ -78,11 +76,6 @@ SEMANTIC_PARENT_RESOLVERS: dict[type[NodeSpec], ParentResolver] = {
     MetricSpec: _metric_parent_candidates,
     CubeSpec: _cube_parent_candidates,
 }
-
-
-def concrete_node_spec_types() -> set[type[NodeSpec]]:
-    node_union = get_args(NodeUnion)[0]
-    return set(get_args(node_union))
 
 
 def _candidate_parts(
@@ -236,6 +229,9 @@ def _compute_merkle_fingerprints(
     ignored_parse_errors: set[str],
     parent_cache: ParentCandidateCache | None = None,
 ) -> FingerprintMap:
+    target_names = set(target_names)
+    if not target_names:
+        return {}
     parent_cache = parent_cache if parent_cache is not None else {}
     graph: dict[str, list[str]] = {}
     failed_names: set[str] = set()
@@ -269,7 +265,6 @@ def _compute_merkle_fingerprints(
                 parent_cache,
             )
         except (DJParseException, TypeError, ValueError) as exc:
-            fingerprint_specs[name] = spec
             failed_names.add(name)
             if name not in ignored_parse_errors:
                 logger.warning("Fingerprint unavailable for %s: %s", name, exc)
@@ -405,7 +400,6 @@ async def build_deployment_fingerprints(
     additional_target_names: Iterable[str] = (),
 ) -> tuple[FingerprintMap, FingerprintMap]:
     proposed_specs = list(proposed_specs)
-    deleted_specs = list(deleted_specs)
     additional_target_names = set(additional_target_names)
     deleted_names = {spec.rendered_name for spec in deleted_specs}
     proposed = _resolved_proposed_specs(

--- a/datajunction-server/datajunction_server/internal/deployment/fingerprints.py
+++ b/datajunction-server/datajunction_server/internal/deployment/fingerprints.py
@@ -22,7 +22,11 @@ from datajunction_server.models.deployment import (
     TransformSpec,
 )
 from datajunction_server.models.node import NodeType
-from datajunction_server.models.semantic_fingerprint import SemanticFingerprint
+from datajunction_server.models.semantic_fingerprint import (
+    UNKNOWN_SEMANTIC_FINGERPRINT,
+    SemanticFingerprint,
+    SemanticFingerprintValue,
+)
 from datajunction_server.semantic_fingerprints.merkle import (
     cycle_component_fingerprint,
     strongly_connected_components,
@@ -30,7 +34,7 @@ from datajunction_server.semantic_fingerprints.merkle import (
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 from datajunction_server.utils import SEPARATOR
 
-FingerprintMap = dict[str, SemanticFingerprint | None]
+FingerprintMap = dict[str, SemanticFingerprintValue]
 ParentCandidates = tuple[frozenset[str], frozenset[str]]
 ParentCandidateCache = dict[int, ParentCandidates]
 ParentResolver = Callable[[NodeSpec], set[str]]
@@ -307,7 +311,9 @@ def _compute_merkle_fingerprints(
         component_index = heappop(ready)
         processed += 1
         members = components[component_index]
-        unavailable: FingerprintMap = {name: None for name in members}
+        unavailable: FingerprintMap = {
+            name: UNKNOWN_SEMANTIC_FINGERPRINT for name in members
+        }
         if any(name in failed_names for name in members):
             component_results[component_index] = unavailable
         else:
@@ -320,7 +326,7 @@ def _compute_merkle_fingerprints(
                     parent_fingerprint = component_results[parent_component][
                         parent_name
                     ]
-                    if parent_fingerprint is None:
+                    if parent_fingerprint == UNKNOWN_SEMANTIC_FINGERPRINT:
                         break
                     external_edges.append(
                         (member, parent_name, parent_fingerprint),

--- a/datajunction-server/datajunction_server/internal/deployment/fingerprints.py
+++ b/datajunction-server/datajunction_server/internal/deployment/fingerprints.py
@@ -1,0 +1,454 @@
+import logging
+from collections.abc import Callable, Iterable
+from heapq import heappop, heappush
+from typing import get_args
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload, selectinload
+
+from datajunction_server.database import Node, NodeRevision
+from datajunction_server.internal.deployment.utils import (
+    extract_dimension_refs_from_filters,
+    extract_node_graph,
+)
+from datajunction_server.models.deployment import (
+    CubeSpec,
+    DimensionSpec,
+    LinkableNodeSpec,
+    MetricSpec,
+    NodeUnion,
+    NodeSpec,
+    SourceSpec,
+    TransformSpec,
+)
+from datajunction_server.models.node import NodeType
+from datajunction_server.models.semantic_fingerprint import SemanticFingerprint
+from datajunction_server.semantic_fingerprints.merkle import (
+    cycle_component_fingerprint,
+    strongly_connected_components,
+)
+from datajunction_server.sql.parsing.backends.exceptions import DJParseException
+from datajunction_server.utils import SEPARATOR
+
+FingerprintMap = dict[str, SemanticFingerprint | None]
+ParentCandidates = tuple[frozenset[str], frozenset[str]]
+ParentCandidateCache = dict[int, ParentCandidates]
+ParentResolver = Callable[[NodeSpec], set[str]]
+logger = logging.getLogger(__name__)
+
+
+def _linkable_parent_candidates(spec: NodeSpec) -> set[str]:
+    linkable = spec
+    if not isinstance(linkable, LinkableNodeSpec):  # pragma: no cover
+        raise TypeError(f"Expected linkable spec, got {type(spec).__name__}")
+    return {link.rendered_dimension_node for link in linkable.dimension_links}
+
+
+def _metric_parent_candidates(spec: NodeSpec) -> set[str]:
+    metric = spec
+    if not isinstance(metric, MetricSpec):  # pragma: no cover
+        raise TypeError(f"Expected metric spec, got {type(spec).__name__}")
+    return {
+        dimension.rsplit(SEPARATOR, 1)[0]
+        for dimension in metric.rendered_required_dimensions
+        if SEPARATOR in dimension
+    }
+
+
+def _cube_parent_candidates(spec: NodeSpec) -> set[str]:
+    cube = spec
+    if not isinstance(cube, CubeSpec):  # pragma: no cover
+        raise TypeError(f"Expected cube spec, got {type(spec).__name__}")
+    return {
+        node_name
+        for node_name, _ in extract_dimension_refs_from_filters(
+            cube.rendered_filters,
+        )
+    }
+
+
+SEMANTIC_PARENT_RESOLVERS: dict[type[NodeSpec], ParentResolver] = {
+    SourceSpec: _linkable_parent_candidates,
+    TransformSpec: _linkable_parent_candidates,
+    DimensionSpec: _linkable_parent_candidates,
+    MetricSpec: _metric_parent_candidates,
+    CubeSpec: _cube_parent_candidates,
+}
+
+
+def concrete_node_spec_types() -> set[type[NodeSpec]]:
+    node_union = get_args(NodeUnion)[0]
+    return set(get_args(node_union))
+
+
+def _candidate_parts(
+    spec: NodeSpec,
+    cache: ParentCandidateCache,
+) -> ParentCandidates:
+    key = id(spec)
+    if key not in cache:
+        resolver = SEMANTIC_PARENT_RESOLVERS.get(type(spec))
+        if resolver is None:
+            raise TypeError(
+                f"No semantic parent resolver for {type(spec).__name__}",
+            )
+        query = extract_node_graph([spec]).get(spec.rendered_name, [])
+        cache[key] = (frozenset(query), frozenset(resolver(spec)))
+    return cache[key]
+
+
+def _parent_candidates(
+    spec: NodeSpec,
+    cache: ParentCandidateCache | None = None,
+) -> set[str]:
+    query, extra = _candidate_parts(spec, cache if cache is not None else {})
+    return set(query | extra)
+
+
+def _resolved_parent_names(
+    spec: NodeSpec,
+    specs: dict[str, NodeSpec],
+    cache: ParentCandidateCache,
+) -> tuple[list[str], list[str]]:
+    query, extra = _candidate_parts(spec, cache)
+    query_candidates = set(query)
+    if (
+        isinstance(spec, MetricSpec)
+        and spec.query_ast is not None
+        and spec.query_ast.select.from_ is None
+    ):
+        query_parents = {
+            name
+            for name in query_candidates
+            if name in specs and specs[name].node_type == NodeType.METRIC
+        }
+        unresolved_query: set[str] = set()
+    else:
+        query_parents = query_candidates & specs.keys()
+        unresolved_query = query_candidates - specs.keys()
+
+    extra_candidates = set(extra)
+    resolved = query_parents | (extra_candidates & specs.keys())
+    unresolved = unresolved_query | (extra_candidates - specs.keys())
+    return sorted(resolved), sorted(unresolved)
+
+
+def _spec_with_normalized_required_dimensions(
+    spec: NodeSpec,
+    specs: dict[str, NodeSpec],
+    cache: ParentCandidateCache,
+) -> NodeSpec:
+    if not isinstance(spec, MetricSpec) or not spec.required_dimensions:
+        return spec
+
+    query_candidates, _ = _candidate_parts(spec, cache)
+    if spec.query_ast is not None and spec.query_ast.select.from_ is None:
+        direct_parents = {
+            name
+            for name in query_candidates
+            if name in specs and specs[name].node_type == NodeType.METRIC
+        }
+    else:
+        direct_parents = set(query_candidates) & specs.keys()
+
+    required_dimensions = []
+    for dimension in spec.rendered_required_dimensions:
+        if SEPARATOR in dimension:
+            node_name, column_name = dimension.rsplit(SEPARATOR, 1)
+            if node_name in direct_parents:
+                dimension = column_name
+        required_dimensions.append(dimension)
+    return spec.model_copy(update={"required_dimensions": required_dimensions})
+
+
+async def _load_external_specs(
+    session: AsyncSession,
+    seed_specs: Iterable[NodeSpec],
+    ignored_parse_errors: set[str],
+    parent_cache: ParentCandidateCache,
+) -> dict[str, NodeSpec]:
+    seeds = list(seed_specs)
+    known_names = {spec.rendered_name for spec in seeds}
+    external_specs: dict[str, NodeSpec] = {}
+    pending = seeds
+    while pending:
+        candidates: set[str] = set()
+        for spec in pending:
+            try:
+                candidates.update(_parent_candidates(spec, parent_cache))
+            except (DJParseException, TypeError, ValueError) as exc:
+                if spec.rendered_name not in ignored_parse_errors:
+                    logger.warning(
+                        "Semantic parent extraction failed for %s: %s",
+                        spec.rendered_name,
+                        exc,
+                    )
+        frontier = sorted(candidates - known_names)
+        if not frontier:
+            break
+        known_names.update(frontier)
+        nodes = await Node.get_by_names(
+            session,
+            frontier,
+            options=[
+                joinedload(Node.current).options(
+                    *NodeRevision.export_load_options(),
+                ),
+                selectinload(Node.tags),
+                selectinload(Node.owners),
+            ],
+        )
+        pending = [await node.to_spec(session) for node in nodes]
+        external_specs.update({spec.rendered_name: spec for spec in pending})
+    return external_specs
+
+
+def _resolved_proposed_specs(
+    existing_specs: dict[str, NodeSpec],
+    proposed_specs: Iterable[NodeSpec],
+    deleted_names: set[str],
+) -> dict[str, NodeSpec]:
+    specs = {
+        name: spec for name, spec in existing_specs.items() if name not in deleted_names
+    }
+    for proposed in proposed_specs:
+        existing = existing_specs.get(proposed.rendered_name)
+        if (
+            isinstance(proposed, SourceSpec)
+            and not proposed.columns
+            and isinstance(existing, SourceSpec)
+        ):
+            proposed = proposed.model_copy(
+                deep=True,
+                update={"columns": existing.columns},
+            )
+        specs[proposed.rendered_name] = proposed
+    return specs
+
+
+def _compute_merkle_fingerprints(
+    specs: dict[str, NodeSpec],
+    target_names: Iterable[str],
+    ignored_parse_errors: set[str],
+    parent_cache: ParentCandidateCache | None = None,
+) -> FingerprintMap:
+    parent_cache = parent_cache if parent_cache is not None else {}
+    graph: dict[str, list[str]] = {}
+    failed_names: set[str] = set()
+    for name in sorted(specs):
+        try:
+            graph[name], unresolved = _resolved_parent_names(
+                specs[name],
+                specs,
+                parent_cache,
+            )
+            if unresolved:
+                failed_names.add(name)
+                if name not in ignored_parse_errors:
+                    logger.warning(
+                        "Fingerprint unavailable for %s; unresolved parents: %s",
+                        name,
+                        ", ".join(unresolved),
+                    )
+        except (DJParseException, TypeError, ValueError) as exc:
+            graph[name] = []
+            failed_names.add(name)
+            if name not in ignored_parse_errors:
+                logger.warning("Fingerprint unavailable for %s: %s", name, exc)
+
+    fingerprint_specs: dict[str, NodeSpec] = {}
+    for name, spec in specs.items():
+        try:
+            fingerprint_specs[name] = _spec_with_normalized_required_dimensions(
+                spec,
+                specs,
+                parent_cache,
+            )
+        except (DJParseException, TypeError, ValueError) as exc:
+            fingerprint_specs[name] = spec
+            failed_names.add(name)
+            if name not in ignored_parse_errors:
+                logger.warning("Fingerprint unavailable for %s: %s", name, exc)
+
+    components = strongly_connected_components(graph)
+    component_by_name = {
+        name: component_index
+        for component_index, members in enumerate(components)
+        for name in members
+    }
+    component_results: dict[int, FingerprintMap] = {}
+    component_parents: dict[int, set[int]] = {
+        component_index: {
+            component_by_name[parent]
+            for member in members
+            for parent in graph[member]
+            if component_by_name[parent] != component_index
+        }
+        for component_index, members in enumerate(components)
+    }
+    component_children: dict[int, set[int]] = {
+        component_index: set() for component_index in range(len(components))
+    }
+    for child, parents in component_parents.items():
+        for parent_component in parents:
+            component_children[parent_component].add(child)
+
+    remaining_parents = {
+        component_index: len(parents)
+        for component_index, parents in component_parents.items()
+    }
+    ready: list[int] = []
+    for component_index, remaining in remaining_parents.items():
+        if remaining == 0:
+            heappush(ready, component_index)
+
+    processed = 0
+    while ready:
+        component_index = heappop(ready)
+        processed += 1
+        members = components[component_index]
+        unavailable: FingerprintMap = {name: None for name in members}
+        if any(name in failed_names for name in members):
+            component_results[component_index] = unavailable
+        else:
+            external_edges: list[tuple[str, str, SemanticFingerprint]] = []
+            for member in members:
+                for parent_name in graph[member]:
+                    parent_component = component_by_name[parent_name]
+                    if parent_component == component_index:
+                        continue
+                    parent_fingerprint = component_results[parent_component][
+                        parent_name
+                    ]
+                    if parent_fingerprint is None:
+                        break
+                    external_edges.append(
+                        (member, parent_name, parent_fingerprint),
+                    )
+                else:
+                    continue
+                break
+            else:
+                is_cycle = len(members) > 1 or members[0] in graph[members[0]]
+                try:
+                    if not is_cycle:
+                        component_results[component_index] = {
+                            members[0]: fingerprint_specs[
+                                members[0]
+                            ].semantic_fingerprint(
+                                parent_fingerprints=[
+                                    edge[2] for edge in external_edges
+                                ],
+                            ),
+                        }
+                    else:
+                        local_fingerprints = {
+                            name: fingerprint_specs[name].semantic_fingerprint()
+                            for name in members
+                        }
+                        internal_edges = [
+                            (member, parent)
+                            for member in members
+                            for parent in graph[member]
+                            if component_by_name[parent] == component_index
+                        ]
+                        component_fingerprint = cycle_component_fingerprint(
+                            members,
+                            local_fingerprints,
+                            internal_edges,
+                            external_edges,
+                        )
+                        component_results[component_index] = {
+                            name: fingerprint_specs[name].semantic_fingerprint(
+                                parent_fingerprints=[component_fingerprint],
+                            )
+                            for name in members
+                        }
+                except (DJParseException, TypeError, ValueError) as exc:
+                    component_results[component_index] = unavailable
+                    if not all(name in ignored_parse_errors for name in members):
+                        logger.warning(
+                            "Fingerprint unavailable for component %s: %s",
+                            members,
+                            exc,
+                        )
+            if component_index not in component_results:
+                component_results[component_index] = unavailable
+
+        for child in component_children[component_index]:
+            remaining_parents[child] -= 1
+            if remaining_parents[child] == 0:
+                heappush(ready, child)
+
+    if processed != len(components):  # pragma: no cover
+        raise RuntimeError("SCC condensation graph contains a cycle")
+
+    return {
+        name: component_results[component_by_name[name]][name]
+        for name in target_names
+        if name in specs
+    }
+
+
+async def build_deployment_fingerprints(
+    session: AsyncSession,
+    existing_specs: dict[str, NodeSpec],
+    proposed_specs: Iterable[NodeSpec],
+    deleted_specs: Iterable[NodeSpec],
+    *,
+    additional_target_names: Iterable[str] = (),
+) -> tuple[FingerprintMap, FingerprintMap]:
+    proposed_specs = list(proposed_specs)
+    deleted_specs = list(deleted_specs)
+    additional_target_names = set(additional_target_names)
+    deleted_names = {spec.rendered_name for spec in deleted_specs}
+    proposed = _resolved_proposed_specs(
+        existing_specs,
+        proposed_specs,
+        deleted_names,
+    )
+    submitted_names = {spec.rendered_name for spec in proposed_specs}
+    target_specs: dict[str, NodeSpec] = {}
+    target_names_to_load = (
+        additional_target_names - existing_specs.keys() - submitted_names
+    )
+    if target_names_to_load:
+        target_nodes = await Node.get_by_names(
+            session,
+            sorted(target_names_to_load),
+            options=[
+                joinedload(Node.current).options(
+                    *NodeRevision.export_load_options(),
+                ),
+                selectinload(Node.tags),
+                selectinload(Node.owners),
+            ],
+        )
+        target_specs = {
+            spec.rendered_name: spec
+            for spec in [await node.to_spec(session) for node in target_nodes]
+        }
+
+    parent_cache: ParentCandidateCache = {}
+    external = await _load_external_specs(
+        session,
+        [*existing_specs.values(), *proposed.values(), *target_specs.values()],
+        ignored_parse_errors=deleted_names,
+        parent_cache=parent_cache,
+    )
+    external.update(target_specs)
+    current_graph = {**external, **existing_specs}
+    proposed_graph = {**external, **proposed}
+    current = _compute_merkle_fingerprints(
+        current_graph,
+        deleted_names | additional_target_names,
+        ignored_parse_errors=deleted_names,
+        parent_cache=parent_cache,
+    )
+    proposed_hashes = _compute_merkle_fingerprints(
+        proposed_graph,
+        submitted_names | additional_target_names,
+        ignored_parse_errors=set(),
+        parent_cache=parent_cache,
+    )
+    return current, proposed_hashes

--- a/datajunction-server/datajunction_server/internal/deployment/fingerprints.py
+++ b/datajunction-server/datajunction_server/internal/deployment/fingerprints.py
@@ -38,40 +38,61 @@ from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 from datajunction_server.utils import SEPARATOR
 
 FingerprintMap = dict[str, SemanticFingerprintValue]
-ParentCandidates = tuple[frozenset[str], frozenset[str]]
+ParentOptions = tuple[str, ...]
+ParentReferences = tuple[ParentOptions, ...]
+ParentCandidates = tuple[frozenset[str], ParentReferences]
 ParentCandidateCache = dict[int, ParentCandidates]
-ParentResolver = Callable[[NodeSpec], set[str]]
+ParentResolver = Callable[[NodeSpec], ParentReferences]
 logger = logging.getLogger(__name__)
 
 
-def _linkable_parent_candidates(spec: NodeSpec) -> set[str]:
+def _exact_parent_references(names: Iterable[str]) -> ParentReferences:
+    return tuple((name,) for name in sorted(set(names)))
+
+
+def _dimension_parent_options(reference: str) -> ParentOptions:
+    parts = reference.split(SEPARATOR)
+    return tuple(SEPARATOR.join(parts[:end]) for end in range(len(parts) - 1, 1, -1))
+
+
+def _dimension_parent_references(references: Iterable[str]) -> ParentReferences:
+    resolved = []
+    for reference in sorted(set(references)):
+        options = _dimension_parent_options(reference)
+        if options:
+            resolved.append(options)
+    return tuple(resolved)
+
+
+def _linkable_parent_candidates(spec: NodeSpec) -> ParentReferences:
     linkable = spec
     if not isinstance(linkable, LinkableNodeSpec):  # pragma: no cover
         raise TypeError(f"Expected linkable spec, got {type(spec).__name__}")
-    return {link.rendered_dimension_node for link in linkable.dimension_links}
+    return _exact_parent_references(
+        link.rendered_dimension_node for link in linkable.dimension_links
+    )
 
 
-def _metric_parent_candidates(spec: NodeSpec) -> set[str]:
+def _metric_parent_candidates(spec: NodeSpec) -> ParentReferences:
     metric = spec
     if not isinstance(metric, MetricSpec):  # pragma: no cover
         raise TypeError(f"Expected metric spec, got {type(spec).__name__}")
-    return {
-        dimension.rsplit(SEPARATOR, 1)[0]
-        for dimension in metric.rendered_required_dimensions
-        if SEPARATOR in dimension
-    }
+    return _dimension_parent_references(metric.rendered_required_dimensions)
 
 
-def _cube_parent_candidates(spec: NodeSpec) -> set[str]:
+def _cube_parent_candidates(spec: NodeSpec) -> ParentReferences:
     cube = spec
     if not isinstance(cube, CubeSpec):  # pragma: no cover
         raise TypeError(f"Expected cube spec, got {type(spec).__name__}")
-    return {
-        node_name
-        for node_name, _ in extract_dimension_refs_from_filters(
+    filter_references = {
+        f"{node_name}{SEPARATOR}{column_name}"
+        for node_name, column_name in extract_dimension_refs_from_filters(
             cube.rendered_filters,
         )
     }
+    return _dimension_parent_references(
+        [*cube.rendered_dimensions, *filter_references],
+    )
 
 
 SEMANTIC_PARENT_RESOLVERS: dict[type[NodeSpec], ParentResolver] = {
@@ -94,8 +115,12 @@ def _candidate_parts(
             raise TypeError(
                 f"No semantic parent resolver for {type(spec).__name__}",
             )
-        query = extract_node_graph([spec]).get(spec.rendered_name, [])
-        cache[key] = (frozenset(query), frozenset(resolver(spec)))
+        query = (
+            spec.rendered_metrics
+            if isinstance(spec, CubeSpec)
+            else extract_node_graph([spec]).get(spec.rendered_name, [])
+        )
+        cache[key] = (frozenset(query), resolver(spec))
     return cache[key]
 
 
@@ -104,7 +129,47 @@ def _parent_candidates(
     cache: ParentCandidateCache | None = None,
 ) -> set[str]:
     query, extra = _candidate_parts(spec, cache if cache is not None else {})
-    return set(query | extra)
+    return set(query) | {
+        candidate for parent_options in extra for candidate in parent_options
+    }
+
+
+def _is_derived_metric(spec: NodeSpec) -> bool:
+    return (
+        isinstance(spec, MetricSpec)
+        and spec.query_ast is not None
+        and spec.query_ast.select.from_ is None
+    )
+
+
+def _direct_query_parents(
+    spec: NodeSpec,
+    specs: dict[str, NodeSpec],
+    candidates: Iterable[str],
+) -> set[str]:
+    candidate_names = set(candidates)
+    if _is_derived_metric(spec):
+        return {
+            name
+            for name in candidate_names
+            if name in specs and specs[name].node_type == NodeType.METRIC
+        }
+    return candidate_names & specs.keys()
+
+
+def _resolve_parent_references(
+    references: ParentReferences,
+    specs: dict[str, NodeSpec],
+) -> tuple[set[str], set[str]]:
+    resolved = set()
+    unresolved = set()
+    for options in references:
+        parent = next((candidate for candidate in options if candidate in specs), None)
+        if parent is not None:
+            resolved.add(parent)
+        else:
+            unresolved.add(options[0])
+    return resolved, unresolved
 
 
 def _resolved_parent_names(
@@ -114,24 +179,16 @@ def _resolved_parent_names(
 ) -> tuple[list[str], list[str]]:
     query, extra = _candidate_parts(spec, cache)
     query_candidates = set(query)
-    if (
-        isinstance(spec, MetricSpec)
-        and spec.query_ast is not None
-        and spec.query_ast.select.from_ is None
-    ):
-        query_parents = {
-            name
-            for name in query_candidates
-            if name in specs and specs[name].node_type == NodeType.METRIC
-        }
-        unresolved_query: set[str] = set()
-    else:
-        query_parents = query_candidates & specs.keys()
-        unresolved_query = query_candidates - specs.keys()
-
-    extra_candidates = set(extra)
-    resolved = query_parents | (extra_candidates & specs.keys())
-    unresolved = unresolved_query | (extra_candidates - specs.keys())
+    query_parents = _direct_query_parents(spec, specs, query_candidates)
+    unresolved_query = (
+        set() if _is_derived_metric(spec) else query_candidates - specs.keys()
+    )
+    extra_parents, unresolved_extra = _resolve_parent_references(
+        extra,
+        specs,
+    )
+    resolved = query_parents | extra_parents
+    unresolved = unresolved_query | unresolved_extra
     return sorted(resolved), sorted(unresolved)
 
 
@@ -144,21 +201,23 @@ def _spec_with_normalized_required_dimensions(
         return spec
 
     query_candidates, _ = _candidate_parts(spec, cache)
-    if spec.query_ast is not None and spec.query_ast.select.from_ is None:
-        direct_parents = {
-            name
-            for name in query_candidates
-            if name in specs and specs[name].node_type == NodeType.METRIC
-        }
-    else:
-        direct_parents = set(query_candidates) & specs.keys()
+    direct_parents = _direct_query_parents(spec, specs, query_candidates)
 
     required_dimensions = []
     for dimension in spec.rendered_required_dimensions:
-        if SEPARATOR in dimension:
-            node_name, column_name = dimension.rsplit(SEPARATOR, 1)
-            if node_name in direct_parents:
-                dimension = column_name
+        direct_parent = next(
+            (
+                parent
+                for parent in sorted(
+                    direct_parents,
+                    key=lambda name: (-len(name), name),
+                )
+                if dimension.startswith(f"{parent}{SEPARATOR}")
+            ),
+            None,
+        )
+        if direct_parent is not None:
+            dimension = dimension[len(direct_parent) + 1 :]
         required_dimensions.append(dimension)
     return spec.model_copy(update={"required_dimensions": required_dimensions})
 
@@ -238,10 +297,12 @@ def _compute_merkle_fingerprints(
     parent_cache = parent_cache if parent_cache is not None else {}
     graph: dict[str, list[str]] = {}
     failed_names: set[str] = set()
+    fingerprint_specs: dict[str, NodeSpec] = {}
     for name in sorted(specs):
+        spec = specs[name]
         try:
             graph[name], unresolved = _resolved_parent_names(
-                specs[name],
+                spec,
                 specs,
                 parent_cache,
             )
@@ -258,9 +319,6 @@ def _compute_merkle_fingerprints(
             failed_names.add(name)
             if name not in ignored_parse_errors:
                 logger.warning("Fingerprint unavailable for %s: %s", name, exc)
-
-    fingerprint_specs: dict[str, NodeSpec] = {}
-    for name, spec in specs.items():
         try:
             fingerprint_specs[name] = _spec_with_normalized_required_dimensions(
                 spec,

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -54,6 +54,7 @@ from datajunction_server.internal.deployment.dimension_reachability import (
 from datajunction_server.internal.deployment.utils import (
     DeploymentContext,
     classify_parents,
+    extract_dimension_refs_from_filters as _extract_dimension_refs_from_filters,
     extract_node_graph,
     topological_levels,
 )
@@ -138,36 +139,6 @@ from datajunction_server.utils import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _extract_dimension_refs_from_filters(
-    filters: list[str],
-) -> list[tuple[str, str]]:
-    """Extract (node_name, column_name) pairs from filter expressions.
-
-    Parses all filters as a single WHERE clause (joined with AND) and
-    collects namespaced column references.  For example,
-    ``ns.hard_hat.state = 'CA'`` yields ``('ns.hard_hat', 'state')``.
-
-    Returns a list of (node_name, column_name) tuples.  Dimension node
-    names are identified by having at least one SEPARATOR in the namespace.
-    """
-    from datajunction_server.sql.parsing.backends.antlr4 import ast, parse
-
-    if not filters:
-        return []
-    combined = " AND ".join(f"({f})" for f in filters)
-    try:
-        tree = parse(f"SELECT 1 WHERE {combined}")
-    except Exception:
-        return []  # Unparseable — skip, will be caught at query time
-    refs: list[tuple[str, str]] = []
-    for col in tree.find_all(ast.Column):
-        if col.namespace and len(col.namespace) >= 1:
-            node_name = SEPARATOR.join(n.name for n in col.namespace)
-            if SEPARATOR in node_name:  # pragma: no branch
-                refs.append((node_name, col.name.name))
-    return refs
 
 
 def _diff_column_metadata(

--- a/datajunction-server/datajunction_server/internal/deployment/utils.py
+++ b/datajunction-server/datajunction_server/internal/deployment/utils.py
@@ -74,7 +74,7 @@ def extract_dimension_refs_from_filters(
         return []
     refs = []
     for column in tree.find_all(ast.Column):
-        if column.namespace and len(column.namespace) >= 1:
+        if column.namespace:
             node_name = SEPARATOR.join(name.name for name in column.namespace)
             if SEPARATOR in node_name:
                 refs.append((node_name, column.name.name))

--- a/datajunction-server/datajunction_server/internal/deployment/utils.py
+++ b/datajunction-server/datajunction_server/internal/deployment/utils.py
@@ -70,7 +70,7 @@ def extract_dimension_refs_from_filters(
     combined = " AND ".join(f"({filter_})" for filter_ in filters)
     try:
         tree = parse(f"SELECT 1 WHERE {combined}")
-    except Exception:
+    except DJParseException:
         return []
     refs = []
     for column in tree.find_all(ast.Column):
@@ -107,11 +107,7 @@ def classify_parents(
     return resolved, missing
 
 
-def extract_node_graph(
-    nodes: list[NodeSpec],
-    *,
-    tolerate_parse_errors: bool = False,
-) -> dict[str, list[str]]:
+def extract_node_graph(nodes: list[NodeSpec]) -> dict[str, list[str]]:
     """
     Extract the node graph from a list of nodes.
 
@@ -123,13 +119,8 @@ def extract_node_graph(
     logger.info("Extracting node graph for %d nodes", len(nodes))
     dependencies_map: dict[str, list[str]] = {}
     for node in nodes:
-        try:
-            with fast_parse_mode():
-                name, deps, parsed = _find_upstreams_for_node(node)
-        except DJParseException:
-            if not tolerate_parse_errors:
-                raise
-            name, deps, parsed = node.rendered_name, [], None
+        with fast_parse_mode():
+            name, deps, parsed = _find_upstreams_for_node(node)
         dependencies_map[name] = deps
         if parsed is not None:
             node._query_ast = parsed

--- a/datajunction-server/datajunction_server/internal/deployment/utils.py
+++ b/datajunction-server/datajunction_server/internal/deployment/utils.py
@@ -60,6 +60,26 @@ def extract_upstream_candidates(
     return tables
 
 
+def extract_dimension_refs_from_filters(
+    filters: list[str],
+) -> list[tuple[str, str]]:
+    """Extract namespaced dimension columns referenced by filter expressions."""
+    if not filters:
+        return []
+    combined = " AND ".join(f"({filter_})" for filter_ in filters)
+    try:
+        tree = parse(f"SELECT 1 WHERE {combined}")
+    except Exception:
+        return []
+    refs = []
+    for column in tree.find_all(ast.Column):
+        if column.namespace and len(column.namespace) >= 1:
+            node_name = SEPARATOR.join(name.name for name in column.namespace)
+            if SEPARATOR in node_name:
+                refs.append((node_name, column.name.name))
+    return refs
+
+
 def classify_parents(
     is_derived_metric: bool,
     dep_names: Iterable[str],

--- a/datajunction-server/datajunction_server/internal/deployment/utils.py
+++ b/datajunction-server/datajunction_server/internal/deployment/utils.py
@@ -21,6 +21,7 @@ from datajunction_server.service_clients import QueryServiceClient
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.ast import fast_parse_mode
 from datajunction_server.sql.parsing.backends.antlr4 import parse
+from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 from datajunction_server.utils import SEPARATOR
 
 logger = logging.getLogger(__name__)
@@ -106,7 +107,11 @@ def classify_parents(
     return resolved, missing
 
 
-def extract_node_graph(nodes: list[NodeSpec]) -> dict[str, list[str]]:
+def extract_node_graph(
+    nodes: list[NodeSpec],
+    *,
+    tolerate_parse_errors: bool = False,
+) -> dict[str, list[str]]:
     """
     Extract the node graph from a list of nodes.
 
@@ -118,8 +123,13 @@ def extract_node_graph(nodes: list[NodeSpec]) -> dict[str, list[str]]:
     logger.info("Extracting node graph for %d nodes", len(nodes))
     dependencies_map: dict[str, list[str]] = {}
     for node in nodes:
-        with fast_parse_mode():
-            name, deps, parsed = _find_upstreams_for_node(node)
+        try:
+            with fast_parse_mode():
+                name, deps, parsed = _find_upstreams_for_node(node)
+        except DJParseException:
+            if not tolerate_parse_errors:
+                raise
+            name, deps, parsed = node.rendered_name, [], None
         dependencies_map[name] = deps
         if parsed is not None:
             node._query_ast = parsed

--- a/datajunction-server/datajunction_server/semantic_fingerprints/merkle.py
+++ b/datajunction-server/datajunction_server/semantic_fingerprints/merkle.py
@@ -1,0 +1,96 @@
+"""Pure graph and component hashing for semantic fingerprints."""
+
+import hashlib
+
+from datajunction_server.models.semantic_fingerprint import SemanticFingerprint
+from datajunction_server.semantic_fingerprints.normalization import canonical_json
+
+
+def strongly_connected_components(
+    graph: dict[str, list[str]],
+) -> list[tuple[str, ...]]:
+    """Find graph components iteratively in deterministic order."""
+    visited: set[str] = set()
+    finish_order: list[str] = []
+    for start in sorted(graph):
+        if start in visited:
+            continue
+        visited.add(start)
+        dfs_stack = [(start, 0)]
+        while dfs_stack:
+            name, parent_index = dfs_stack[-1]
+            parents = graph[name]
+            if parent_index < len(parents):
+                parent = parents[parent_index]
+                dfs_stack[-1] = (name, parent_index + 1)
+                if parent not in visited:
+                    visited.add(parent)
+                    dfs_stack.append((parent, 0))
+                continue
+            dfs_stack.pop()
+            finish_order.append(name)
+
+    reverse_graph: dict[str, list[str]] = {name: [] for name in graph}
+    for child, parents in graph.items():
+        for parent in parents:
+            reverse_graph[parent].append(child)
+    for children in reverse_graph.values():
+        children.sort()
+
+    components: list[tuple[str, ...]] = []
+    visited.clear()
+    for start in reversed(finish_order):
+        if start in visited:
+            continue
+        visited.add(start)
+        members = []
+        component_stack = [start]
+        while component_stack:
+            name = component_stack.pop()
+            members.append(name)
+            for child in reversed(reverse_graph[name]):
+                if child not in visited:
+                    visited.add(child)
+                    component_stack.append(child)
+        components.append(tuple(sorted(members)))
+    return components
+
+
+def cycle_component_fingerprint(
+    members: tuple[str, ...],
+    local_fingerprints: dict[str, SemanticFingerprint],
+    internal_edges: list[tuple[str, str]],
+    external_edges: list[tuple[str, str, SemanticFingerprint]],
+) -> SemanticFingerprint:
+    """Hash the members and edge structure of one cyclic component."""
+    version = local_fingerprints[members[0]].version
+    payload = {
+        "domain": "datajunction/node-semantic-scc",
+        "version": version,
+        "members": [
+            {
+                "name": name,
+                "fingerprint": local_fingerprints[name].model_dump(mode="json"),
+            }
+            for name in members
+        ],
+        "internal_edges": [
+            {"child": child, "parent": parent}
+            for child, parent in sorted(internal_edges)
+        ],
+        "external_edges": [
+            {
+                "child": child,
+                "parent": parent,
+                "fingerprint": fingerprint.model_dump(mode="json"),
+            }
+            for child, parent, fingerprint in sorted(
+                external_edges,
+                key=lambda edge: (edge[0], edge[1]),
+            )
+        ],
+    }
+    return SemanticFingerprint(
+        version=version,
+        digest=hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest(),
+    )

--- a/datajunction-server/tests/internal/deployment/fingerprints_test.py
+++ b/datajunction-server/tests/internal/deployment/fingerprints_test.py
@@ -1,3 +1,4 @@
+from typing import get_args
 from unittest.mock import MagicMock
 
 import pytest
@@ -9,7 +10,6 @@ from datajunction_server.internal.deployment.fingerprints import (
     _parent_candidates,
     _resolved_proposed_specs,
     build_deployment_fingerprints,
-    concrete_node_spec_types,
 )
 from datajunction_server.models.deployment import (
     ColumnSpec,
@@ -18,6 +18,7 @@ from datajunction_server.models.deployment import (
     DimensionSpec,
     MetricSpec,
     NodeSpec,
+    NodeUnion,
     SourceSpec,
     TransformSpec,
 )
@@ -111,7 +112,8 @@ def test_parent_candidates_follow_oss_semantic_relationships():
         "ns.dimension",
         "ns.filter_dimension",
     }
-    assert set(SEMANTIC_PARENT_RESOLVERS) == concrete_node_spec_types()
+    node_union = get_args(NodeUnion)[0]
+    assert set(SEMANTIC_PARENT_RESOLVERS) == set(get_args(node_union))
 
     cache = {}
     first = _candidate_parts(transform, cache)
@@ -274,8 +276,7 @@ def test_cycle_hashing_is_stable_and_propagates_member_changes():
     )
     assert original == reversed_input
     assert all(
-        fingerprint != UNKNOWN_SEMANTIC_FINGERPRINT
-        for fingerprint in original.values()
+        fingerprint != UNKNOWN_SEMANTIC_FINGERPRINT for fingerprint in original.values()
     )
 
     changed_second = second.model_copy(update={"query": "SELECT 2"})
@@ -346,6 +347,7 @@ def test_fingerprint_build_failures_are_unavailable():
     invalid_source.columns[0].type = object()  # type: ignore[assignment]
     specs = spec_map(invalid_metric, invalid_source)
 
+    assert _compute_merkle_fingerprints(specs, [], set()) == {}
     assert _compute_merkle_fingerprints(specs, specs, set()) == {
         invalid_metric.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT,
         invalid_source.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT,

--- a/datajunction-server/tests/internal/deployment/fingerprints_test.py
+++ b/datajunction-server/tests/internal/deployment/fingerprints_test.py
@@ -1,0 +1,353 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from datajunction_server.internal.deployment.fingerprints import (
+    SEMANTIC_PARENT_RESOLVERS,
+    _candidate_parts,
+    _compute_merkle_fingerprints,
+    _parent_candidates,
+    _resolved_proposed_specs,
+    build_deployment_fingerprints,
+    concrete_node_spec_types,
+)
+from datajunction_server.models.deployment import (
+    ColumnSpec,
+    CubeSpec,
+    DimensionJoinLinkSpec,
+    DimensionSpec,
+    MetricSpec,
+    NodeSpec,
+    SourceSpec,
+    TransformSpec,
+)
+
+
+def source_spec(
+    name: str,
+    *,
+    namespace: str = "ns",
+    table: str | None = None,
+    columns: list[ColumnSpec] | None = None,
+    dimension_links: list[DimensionJoinLinkSpec] | None = None,
+) -> SourceSpec:
+    return SourceSpec(
+        namespace=namespace,
+        name=name,
+        catalog="catalog",
+        schema_="schema",
+        table=table or name,
+        columns=columns,
+        dimension_links=dimension_links or [],
+    )
+
+
+def transform_spec(
+    name: str,
+    query: str,
+    *,
+    namespace: str = "ns",
+) -> TransformSpec:
+    return TransformSpec(namespace=namespace, name=name, query=query)
+
+
+def spec_map(*specs: NodeSpec) -> dict[str, NodeSpec]:
+    return {spec.rendered_name: spec for spec in specs}
+
+
+def linked_dimension(
+    name: str,
+    *targets: str,
+    query: str = "SELECT 1",
+) -> DimensionSpec:
+    return DimensionSpec(
+        namespace="cycle",
+        name=name,
+        query=query,
+        dimension_links=[
+            DimensionJoinLinkSpec(
+                dimension_node=f"cycle.{target}",
+                join_type="cross",
+            )
+            for target in targets
+        ],
+    )
+
+
+def test_parent_candidates_follow_oss_semantic_relationships():
+    transform = TransformSpec(
+        namespace="ns",
+        name="transform",
+        query="SELECT * FROM ${prefix}source",
+        dimension_links=[
+            DimensionJoinLinkSpec(
+                dimension_node="${prefix}dimension",
+                join_on="${prefix}transform.id = ${prefix}dimension.id",
+            ),
+        ],
+    )
+    metric = MetricSpec(
+        namespace="ns",
+        name="metric",
+        query="SELECT SUM(value) FROM ${prefix}transform",
+        required_dimensions=["${prefix}dimension.id"],
+    )
+    cube = CubeSpec(
+        namespace="ns",
+        name="cube",
+        metrics=["${prefix}metric"],
+        dimensions=["${prefix}dimension.id"],
+        filters=["${prefix}filter_dimension.id = 1"],
+    )
+
+    assert _parent_candidates(transform) == {"ns.source", "ns.dimension"}
+    assert _parent_candidates(metric) == {"ns.transform", "ns.dimension"}
+    assert _parent_candidates(cube) == {
+        "ns.metric",
+        "ns.dimension",
+        "ns.filter_dimension",
+    }
+    assert set(SEMANTIC_PARENT_RESOLVERS) == concrete_node_spec_types()
+
+    cache = {}
+    first = _candidate_parts(transform, cache)
+    assert _candidate_parts(transform, cache) is first
+    assert len(cache) == 1
+
+
+def test_merkle_fingerprints_propagate_changes_through_all_descendants():
+    source = source_spec(
+        "source",
+        table="table",
+        columns=[ColumnSpec(name="id", type="bigint")],
+    )
+    transform = transform_spec(
+        "transform",
+        "SELECT id FROM ${prefix}source",
+    )
+    metric = MetricSpec(
+        namespace="ns",
+        name="metric",
+        query="SELECT COUNT(*) FROM ${prefix}transform",
+    )
+    specs = spec_map(source, transform, metric)
+    original = _compute_merkle_fingerprints(
+        specs,
+        specs,
+        ignored_parse_errors=set(),
+    )
+
+    changed_source = source.model_copy(update={"table": "changed"})
+    changed_specs = {**specs, changed_source.rendered_name: changed_source}
+    changed = _compute_merkle_fingerprints(
+        changed_specs,
+        changed_specs,
+        ignored_parse_errors=set(),
+    )
+
+    assert all(original[name] != changed[name] for name in specs)
+
+
+def test_merkle_fingerprints_support_deep_dependency_chains():
+    specs = {}
+    for index in range(1_100):
+        links = (
+            [
+                DimensionJoinLinkSpec(
+                    dimension_node=f"deep.node_{index - 1}",
+                    join_type="cross",
+                ),
+            ]
+            if index
+            else []
+        )
+        spec = source_spec(
+            f"node_{index}",
+            namespace="deep",
+            table=f"table_{index}",
+            dimension_links=links,
+        )
+        specs[spec.rendered_name] = spec
+
+    target = "deep.node_1099"
+    assert _compute_merkle_fingerprints(specs, [target], set())[target] is not None
+
+
+@pytest.mark.parametrize(
+    ("name", "query"),
+    [
+        ("unresolved", "SELECT * FROM missing.parent"),
+        ("invalid", "SELECT ("),
+    ],
+)
+def test_unavailable_fingerprint_propagates_to_dependents(name: str, query: str):
+    unavailable = transform_spec(name, query)
+    dependent = transform_spec(
+        "dependent",
+        f"SELECT * FROM ${{prefix}}{name}",
+    )
+    specs = spec_map(unavailable, dependent)
+
+    assert _compute_merkle_fingerprints(specs, specs, set()) == {
+        unavailable.rendered_name: None,
+        dependent.rendered_name: None,
+    }
+
+
+def test_direct_required_dimension_paths_use_persisted_identity():
+    parent = source_spec("parent")
+    authored = MetricSpec(
+        namespace="ns",
+        name="metric",
+        query="SELECT COUNT(*) FROM ${prefix}parent",
+        required_dimensions=["${prefix}parent.id"],
+    )
+    persisted = authored.model_copy(update={"required_dimensions": ["id"]})
+    authored_specs = spec_map(parent, authored)
+    persisted_specs = spec_map(parent, persisted)
+
+    assert _compute_merkle_fingerprints(
+        authored_specs,
+        [authored.rendered_name],
+        set(),
+    ) == _compute_merkle_fingerprints(
+        persisted_specs,
+        [persisted.rendered_name],
+        set(),
+    )
+
+
+def test_cycle_hashing_is_stable_and_propagates_member_changes():
+    first = linked_dimension("first", "second")
+    second = linked_dimension("second", "third")
+    third = linked_dimension("third", "first")
+    downstream = transform_spec(
+        "downstream",
+        "SELECT * FROM ${prefix}first",
+        namespace="cycle",
+    )
+    specs = spec_map(first, second, third, downstream)
+    original = _compute_merkle_fingerprints(specs, specs, set())
+    reversed_input = _compute_merkle_fingerprints(
+        dict(reversed(list(specs.items()))),
+        reversed(list(specs)),
+        set(),
+    )
+    assert original == reversed_input
+    assert all(fingerprint is not None for fingerprint in original.values())
+
+    changed_second = second.model_copy(update={"query": "SELECT 2"})
+    changed_specs = {
+        **specs,
+        changed_second.rendered_name: changed_second,
+    }
+    changed = _compute_merkle_fingerprints(changed_specs, changed_specs, set())
+    assert all(original[name] != changed[name] for name in specs)
+
+    broken_third = linked_dimension("third")
+    broken_specs = {**specs, broken_third.rendered_name: broken_third}
+    broken = _compute_merkle_fingerprints(broken_specs, broken_specs, set())
+    assert all(original[name] != broken[name] for name in specs)
+
+
+def test_self_link_and_external_parent_cycles_have_stable_hashes():
+    self_link = linked_dimension("self", "self")
+    assert (
+        _compute_merkle_fingerprints(
+            {self_link.rendered_name: self_link},
+            [self_link.rendered_name],
+            set(),
+        )[self_link.rendered_name]
+        is not None
+    )
+
+    parent = source_spec(
+        "parent",
+        namespace="cycle",
+        table="table",
+    )
+    first = linked_dimension(
+        "first",
+        "second",
+        query="SELECT * FROM ${prefix}parent",
+    )
+    second = linked_dimension("second", "first")
+    specs = spec_map(parent, first, second)
+    original = _compute_merkle_fingerprints(specs, specs, set())
+    changed_parent = parent.model_copy(update={"table": "changed"})
+    changed_specs = {**specs, changed_parent.rendered_name: changed_parent}
+    changed = _compute_merkle_fingerprints(changed_specs, changed_specs, set())
+    assert all(original[name] != changed[name] for name in specs)
+
+
+def test_deleted_legacy_node_can_omit_unparseable_fingerprint():
+    legacy = transform_spec("legacy", "SELECT (")
+    assert _compute_merkle_fingerprints(
+        {legacy.rendered_name: legacy},
+        [legacy.rendered_name],
+        ignored_parse_errors={legacy.rendered_name},
+    ) == {legacy.rendered_name: None}
+
+
+def test_proposed_sources_reuse_resolved_columns_and_remove_deletes():
+    source = source_spec(
+        "source",
+        table="table",
+        columns=[ColumnSpec(name="id", type="bigint")],
+    )
+    deleted = source_spec(
+        "deleted",
+        table="deleted",
+    )
+    proposed = source.model_copy(update={"columns": None})
+    resolved = _resolved_proposed_specs(
+        {
+            source.rendered_name: source,
+            deleted.rendered_name: deleted,
+        },
+        [proposed],
+        {deleted.rendered_name},
+    )
+
+    assert resolved[source.rendered_name].semantic_fingerprint() == (
+        source.semantic_fingerprint()
+    )
+    assert deleted.rendered_name not in resolved
+
+
+@pytest.mark.asyncio
+async def test_build_deployment_fingerprints_without_external_parents():
+    source = source_spec("source", table="table")
+    transform = transform_spec(
+        "transform",
+        "SELECT * FROM ${prefix}source",
+    )
+    current, proposed = await build_deployment_fingerprints(
+        MagicMock(),
+        {},
+        [source, transform],
+        [],
+    )
+
+    assert current == {}
+    assert proposed[source.rendered_name] == source.semantic_fingerprint()
+    assert proposed[transform.rendered_name] == transform.semantic_fingerprint(
+        parent_fingerprints=[proposed[source.rendered_name]],
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_deployment_fingerprints_loads_external_ancestors(session):
+    transform = transform_spec(
+        "external_child",
+        "SELECT * FROM default.hard_hat",
+    )
+    _, proposed = await build_deployment_fingerprints(
+        session,
+        {},
+        [transform],
+        [],
+    )
+
+    assert proposed[transform.rendered_name] is not None
+    assert proposed[transform.rendered_name] != transform.semantic_fingerprint()

--- a/datajunction-server/tests/internal/deployment/fingerprints_test.py
+++ b/datajunction-server/tests/internal/deployment/fingerprints_test.py
@@ -124,6 +124,18 @@ def test_parent_candidates_follow_oss_semantic_relationships():
         _candidate_parts(NodeSpec(name="unknown", node_type="source"), {})
 
 
+def test_unparseable_cube_filter_remains_in_local_fingerprint():
+    broken = CubeSpec(
+        namespace="ns",
+        name="cube",
+        filters=["not valid sql !!!"],
+    )
+    without_filter = broken.model_copy(update={"filters": []})
+
+    assert _parent_candidates(broken) == set()
+    assert local_node_fingerprint(broken) != local_node_fingerprint(without_filter)
+
+
 def test_merkle_fingerprints_propagate_changes_through_all_descendants():
     source = source_spec(
         "source",
@@ -262,6 +274,69 @@ def test_direct_required_dimension_paths_use_persisted_identity():
         authored_derived.rendered_name,
     ) == SemanticFingerprintGraph(persisted_specs).fingerprint(
         persisted_derived.rendered_name,
+    )
+
+
+def test_nested_required_dimensions_use_existing_node_boundary():
+    parent = source_spec("parent")
+    authored = MetricSpec(
+        namespace="ns",
+        name="metric",
+        query="SELECT COUNT(*) FROM ${prefix}parent",
+        required_dimensions=["${prefix}parent.address.city"],
+    )
+    persisted = authored.model_copy(
+        update={"required_dimensions": ["address.city"]},
+    )
+
+    authored_fingerprint = SemanticFingerprintGraph(
+        spec_map(parent, authored),
+    ).fingerprint(authored.rendered_name)
+    persisted_fingerprint = SemanticFingerprintGraph(
+        spec_map(parent, persisted),
+    ).fingerprint(persisted.rendered_name)
+
+    assert authored_fingerprint != UNKNOWN_SEMANTIC_FINGERPRINT
+    assert authored_fingerprint == persisted_fingerprint
+
+
+def test_nested_cube_dimension_paths_use_existing_node_boundary():
+    dimension = DimensionSpec(namespace="ns", name="dimension", query="SELECT 1")
+    metric = MetricSpec(namespace="ns", name="metric", query="SELECT COUNT(*)")
+    cube = CubeSpec(
+        namespace="ns",
+        name="cube",
+        metrics=["${prefix}metric"],
+        dimensions=["${prefix}dimension.address.city"],
+        filters=["${prefix}dimension.address.city = 'LA'"],
+    )
+    original_specs = spec_map(dimension, metric, cube)
+    original = SemanticFingerprintGraph(original_specs).fingerprint(
+        cube.rendered_name,
+    )
+    changed_dimension = dimension.model_copy(update={"query": "SELECT 2"})
+    changed_specs = {
+        **original_specs,
+        changed_dimension.rendered_name: changed_dimension,
+    }
+
+    assert original != UNKNOWN_SEMANTIC_FINGERPRINT
+    assert original != SemanticFingerprintGraph(changed_specs).fingerprint(
+        cube.rendered_name,
+    )
+
+    missing = cube.model_copy(
+        update={
+            "name": "missing_cube",
+            "dimensions": [],
+            "filters": ["missing.dimension.address.city = 'LA'"],
+        },
+    )
+    assert (
+        SemanticFingerprintGraph(spec_map(metric, missing)).fingerprint(
+            missing.rendered_name,
+        )
+        == UNKNOWN_SEMANTIC_FINGERPRINT
     )
 
 
@@ -444,6 +519,25 @@ async def test_build_deployment_fingerprints_loads_external_ancestors(session):
     assert proposed == {
         spec.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT for spec in unavailable
     }
+
+    metric = MetricSpec(
+        namespace="ns",
+        name="external_metric",
+        query="SELECT COUNT(*)",
+    )
+    cube = CubeSpec(
+        namespace="ns",
+        name="external_cube",
+        metrics=["${prefix}external_metric"],
+        filters=["default.hard_hat.address.city = 'LA'"],
+    )
+    _, proposed = await build_deployment_fingerprints(
+        session,
+        {},
+        [metric, cube],
+        [],
+    )
+    assert proposed[cube.rendered_name] != UNKNOWN_SEMANTIC_FINGERPRINT
 
     legacy = transform_spec("legacy", "SELECT (")
     current, _ = await build_deployment_fingerprints(

--- a/datajunction-server/tests/internal/deployment/fingerprints_test.py
+++ b/datajunction-server/tests/internal/deployment/fingerprints_test.py
@@ -5,8 +5,8 @@ import pytest
 
 from datajunction_server.internal.deployment.fingerprints import (
     SEMANTIC_PARENT_RESOLVERS,
+    SemanticFingerprintGraph,
     _candidate_parts,
-    _compute_merkle_fingerprints,
     _parent_candidates,
     _resolved_proposed_specs,
     build_deployment_fingerprints,
@@ -26,6 +26,7 @@ from datajunction_server.models.semantic_fingerprint import (
     UNKNOWN_SEMANTIC_FINGERPRINT,
     SemanticFingerprint,
 )
+from datajunction_server.semantic_fingerprints.engine import local_node_fingerprint
 
 
 def source_spec(
@@ -139,21 +140,35 @@ def test_merkle_fingerprints_propagate_changes_through_all_descendants():
         query="SELECT COUNT(*) FROM ${prefix}transform",
     )
     specs = spec_map(source, transform, metric)
-    original = _compute_merkle_fingerprints(
-        specs,
-        specs,
-        ignored_parse_errors=set(),
-    )
+    original = SemanticFingerprintGraph(specs).fingerprints()
 
     changed_source = source.model_copy(update={"table": "changed"})
     changed_specs = {**specs, changed_source.rendered_name: changed_source}
-    changed = _compute_merkle_fingerprints(
-        changed_specs,
-        changed_specs,
-        ignored_parse_errors=set(),
-    )
+    changed = SemanticFingerprintGraph(changed_specs).fingerprints()
 
     assert all(original[name] != changed[name] for name in specs)
+
+
+def test_graph_fingerprint_uses_its_parent_snapshot():
+    orders_v1 = source_spec("orders", table="orders_v1")
+    orders_v2 = orders_v1.model_copy(update={"table": "orders_v2"})
+    revenue = transform_spec(
+        "revenue",
+        "SELECT * FROM ${prefix}orders",
+    )
+
+    current = SemanticFingerprintGraph(spec_map(orders_v1, revenue))
+    proposed = SemanticFingerprintGraph(spec_map(orders_v2, revenue))
+
+    current_fingerprint = current.fingerprint(revenue.rendered_name)
+    assert current.fingerprint(revenue.rendered_name) is current_fingerprint
+    assert current_fingerprint != proposed.fingerprint(
+        revenue.rendered_name,
+    )
+    assert (
+        SemanticFingerprintGraph(spec_map(revenue)).fingerprint(revenue.rendered_name)
+        == UNKNOWN_SEMANTIC_FINGERPRINT
+    )
 
 
 def test_merkle_fingerprints_support_deep_dependency_chains():
@@ -179,7 +194,7 @@ def test_merkle_fingerprints_support_deep_dependency_chains():
 
     target = "deep.node_1099"
     assert (
-        _compute_merkle_fingerprints(specs, [target], set())[target]
+        SemanticFingerprintGraph(specs).fingerprint(target)
         != UNKNOWN_SEMANTIC_FINGERPRINT
     )
 
@@ -199,7 +214,7 @@ def test_unavailable_fingerprint_propagates_to_dependents(name: str, query: str)
     )
     specs = spec_map(unavailable, dependent)
 
-    assert _compute_merkle_fingerprints(specs, specs, set()) == {
+    assert SemanticFingerprintGraph(specs).fingerprints() == {
         unavailable.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT,
         dependent.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT,
     }
@@ -217,14 +232,10 @@ def test_direct_required_dimension_paths_use_persisted_identity():
     authored_specs = spec_map(parent, authored)
     persisted_specs = spec_map(parent, persisted)
 
-    assert _compute_merkle_fingerprints(
-        authored_specs,
-        [authored.rendered_name],
-        set(),
-    ) == _compute_merkle_fingerprints(
-        persisted_specs,
-        [persisted.rendered_name],
-        set(),
+    assert SemanticFingerprintGraph(authored_specs).fingerprint(
+        authored.rendered_name,
+    ) == SemanticFingerprintGraph(persisted_specs).fingerprint(
+        persisted.rendered_name,
     )
 
     dimension = DimensionSpec(namespace="ns", name="dimension", query="SELECT 1")
@@ -247,14 +258,10 @@ def test_direct_required_dimension_paths_use_persisted_identity():
     )
     authored_specs = spec_map(parent, dimension, base_metric, authored_derived)
     persisted_specs = spec_map(parent, dimension, base_metric, persisted_derived)
-    assert _compute_merkle_fingerprints(
-        authored_specs,
-        [authored_derived.rendered_name],
-        set(),
-    ) == _compute_merkle_fingerprints(
-        persisted_specs,
-        [persisted_derived.rendered_name],
-        set(),
+    assert SemanticFingerprintGraph(authored_specs).fingerprint(
+        authored_derived.rendered_name,
+    ) == SemanticFingerprintGraph(persisted_specs).fingerprint(
+        persisted_derived.rendered_name,
     )
 
 
@@ -268,12 +275,10 @@ def test_cycle_hashing_is_stable_and_propagates_member_changes():
         namespace="cycle",
     )
     specs = spec_map(first, second, third, downstream)
-    original = _compute_merkle_fingerprints(specs, specs, set())
-    reversed_input = _compute_merkle_fingerprints(
+    original = SemanticFingerprintGraph(specs).fingerprints()
+    reversed_input = SemanticFingerprintGraph(
         dict(reversed(list(specs.items()))),
-        reversed(list(specs)),
-        set(),
-    )
+    ).fingerprints()
     assert original == reversed_input
     assert all(
         fingerprint != UNKNOWN_SEMANTIC_FINGERPRINT for fingerprint in original.values()
@@ -284,23 +289,21 @@ def test_cycle_hashing_is_stable_and_propagates_member_changes():
         **specs,
         changed_second.rendered_name: changed_second,
     }
-    changed = _compute_merkle_fingerprints(changed_specs, changed_specs, set())
+    changed = SemanticFingerprintGraph(changed_specs).fingerprints()
     assert all(original[name] != changed[name] for name in specs)
 
     broken_third = linked_dimension("third")
     broken_specs = {**specs, broken_third.rendered_name: broken_third}
-    broken = _compute_merkle_fingerprints(broken_specs, broken_specs, set())
+    broken = SemanticFingerprintGraph(broken_specs).fingerprints()
     assert all(original[name] != broken[name] for name in specs)
 
 
 def test_self_link_and_external_parent_cycles_have_stable_hashes():
     self_link = linked_dimension("self", "self")
     assert (
-        _compute_merkle_fingerprints(
+        SemanticFingerprintGraph(
             {self_link.rendered_name: self_link},
-            [self_link.rendered_name],
-            set(),
-        )[self_link.rendered_name]
+        ).fingerprint(self_link.rendered_name)
         != UNKNOWN_SEMANTIC_FINGERPRINT
     )
 
@@ -316,21 +319,21 @@ def test_self_link_and_external_parent_cycles_have_stable_hashes():
     )
     second = linked_dimension("second", "first")
     specs = spec_map(parent, first, second)
-    original = _compute_merkle_fingerprints(specs, specs, set())
+    original = SemanticFingerprintGraph(specs).fingerprints()
     changed_parent = parent.model_copy(update={"table": "changed"})
     changed_specs = {**specs, changed_parent.rendered_name: changed_parent}
-    changed = _compute_merkle_fingerprints(changed_specs, changed_specs, set())
+    changed = SemanticFingerprintGraph(changed_specs).fingerprints()
     assert all(original[name] != changed[name] for name in specs)
 
 
 @pytest.mark.parametrize("query", ["SELECT (", "SELECT * FROM missing.parent"])
-def test_deleted_legacy_node_can_omit_unavailable_fingerprint(query: str):
+def test_deleted_legacy_node_returns_unknown_without_failure(query: str):
     legacy = transform_spec("legacy", query)
-    assert _compute_merkle_fingerprints(
+    graph = SemanticFingerprintGraph(
         {legacy.rendered_name: legacy},
-        [legacy.rendered_name],
         ignored_parse_errors={legacy.rendered_name},
-    ) == {legacy.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT}
+    )
+    assert graph.fingerprint(legacy.rendered_name) == UNKNOWN_SEMANTIC_FINGERPRINT
 
 
 def test_fingerprint_build_failures_are_unavailable():
@@ -347,12 +350,16 @@ def test_fingerprint_build_failures_are_unavailable():
     invalid_source.columns[0].type = object()  # type: ignore[assignment]
     specs = spec_map(invalid_metric, invalid_source)
 
-    assert _compute_merkle_fingerprints(specs, [], set()) == {}
-    assert _compute_merkle_fingerprints(specs, specs, set()) == {
+    graph = SemanticFingerprintGraph(specs)
+    assert graph.fingerprints([]) == {}
+    assert graph.fingerprints() == {
         invalid_metric.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT,
         invalid_source.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT,
     }
-    assert _compute_merkle_fingerprints(specs, specs, set(specs)) == {
+    assert SemanticFingerprintGraph(
+        specs,
+        ignored_parse_errors=set(specs),
+    ).fingerprints() == {
         invalid_metric.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT,
         invalid_source.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT,
     }
@@ -378,9 +385,9 @@ def test_proposed_sources_reuse_resolved_columns_and_remove_deletes():
         {deleted.rendered_name},
     )
 
-    assert resolved[source.rendered_name].semantic_fingerprint() == (
-        source.semantic_fingerprint()
-    )
+    assert local_node_fingerprint(
+        resolved[source.rendered_name],
+    ) == local_node_fingerprint(source)
     assert deleted.rendered_name not in resolved
 
 
@@ -399,11 +406,12 @@ async def test_build_deployment_fingerprints_without_external_parents():
     )
 
     assert current == {}
+    graph = SemanticFingerprintGraph(spec_map(source, transform))
     source_fingerprint = proposed[source.rendered_name]
     assert isinstance(source_fingerprint, SemanticFingerprint)
-    assert source_fingerprint == source.semantic_fingerprint()
-    assert proposed[transform.rendered_name] == transform.semantic_fingerprint(
-        parent_fingerprints=[source_fingerprint],
+    assert source_fingerprint == graph.fingerprint(source.rendered_name)
+    assert proposed[transform.rendered_name] == graph.fingerprint(
+        transform.rendered_name,
     )
 
 
@@ -421,7 +429,7 @@ async def test_build_deployment_fingerprints_loads_external_ancestors(session):
     )
 
     assert proposed[transform.rendered_name] != UNKNOWN_SEMANTIC_FINGERPRINT
-    assert proposed[transform.rendered_name] != transform.semantic_fingerprint()
+    assert proposed[transform.rendered_name] != local_node_fingerprint(transform)
 
     unavailable = [
         transform_spec("missing_child", "SELECT * FROM missing.parent"),

--- a/datajunction-server/tests/internal/deployment/fingerprints_test.py
+++ b/datajunction-server/tests/internal/deployment/fingerprints_test.py
@@ -113,6 +113,8 @@ def test_parent_candidates_follow_oss_semantic_relationships():
     first = _candidate_parts(transform, cache)
     assert _candidate_parts(transform, cache) is first
     assert len(cache) == 1
+    with pytest.raises(TypeError, match="No semantic parent resolver for NodeSpec"):
+        _candidate_parts(NodeSpec(name="unknown", node_type="source"), {})
 
 
 def test_merkle_fingerprints_propagate_changes_through_all_descendants():
@@ -216,6 +218,36 @@ def test_direct_required_dimension_paths_use_persisted_identity():
         set(),
     )
 
+    dimension = DimensionSpec(namespace="ns", name="dimension", query="SELECT 1")
+    base_metric = MetricSpec(
+        namespace="ns",
+        name="base_metric",
+        query="SELECT COUNT(*) FROM ${prefix}parent",
+    )
+    authored_derived = MetricSpec(
+        namespace="ns",
+        name="derived_metric",
+        query="SELECT ${prefix}base_metric * 2",
+        required_dimensions=[
+            "${prefix}base_metric.id",
+            "${prefix}dimension.id",
+        ],
+    )
+    persisted_derived = authored_derived.model_copy(
+        update={"required_dimensions": ["id", "ns.dimension.id"]},
+    )
+    authored_specs = spec_map(parent, dimension, base_metric, authored_derived)
+    persisted_specs = spec_map(parent, dimension, base_metric, persisted_derived)
+    assert _compute_merkle_fingerprints(
+        authored_specs,
+        [authored_derived.rendered_name],
+        set(),
+    ) == _compute_merkle_fingerprints(
+        persisted_specs,
+        [persisted_derived.rendered_name],
+        set(),
+    )
+
 
 def test_cycle_hashing_is_stable_and_propagates_member_changes():
     first = linked_dimension("first", "second")
@@ -280,13 +312,38 @@ def test_self_link_and_external_parent_cycles_have_stable_hashes():
     assert all(original[name] != changed[name] for name in specs)
 
 
-def test_deleted_legacy_node_can_omit_unparseable_fingerprint():
-    legacy = transform_spec("legacy", "SELECT (")
+@pytest.mark.parametrize("query", ["SELECT (", "SELECT * FROM missing.parent"])
+def test_deleted_legacy_node_can_omit_unavailable_fingerprint(query: str):
+    legacy = transform_spec("legacy", query)
     assert _compute_merkle_fingerprints(
         {legacy.rendered_name: legacy},
         [legacy.rendered_name],
         ignored_parse_errors={legacy.rendered_name},
     ) == {legacy.rendered_name: None}
+
+
+def test_fingerprint_build_failures_are_unavailable():
+    invalid_metric = MetricSpec(
+        namespace="ns",
+        name="invalid_metric",
+        query="SELECT (",
+        required_dimensions=["ns.dimension.id"],
+    )
+    invalid_source = source_spec(
+        "invalid_source",
+        columns=[ColumnSpec(name="id", type="bigint")],
+    )
+    invalid_source.columns[0].type = object()  # type: ignore[assignment]
+    specs = spec_map(invalid_metric, invalid_source)
+
+    assert _compute_merkle_fingerprints(specs, specs, set()) == {
+        invalid_metric.rendered_name: None,
+        invalid_source.rendered_name: None,
+    }
+    assert _compute_merkle_fingerprints(specs, specs, set(specs)) == {
+        invalid_metric.rendered_name: None,
+        invalid_source.rendered_name: None,
+    }
 
 
 def test_proposed_sources_reuse_resolved_columns_and_remove_deletes():
@@ -351,3 +408,34 @@ async def test_build_deployment_fingerprints_loads_external_ancestors(session):
 
     assert proposed[transform.rendered_name] is not None
     assert proposed[transform.rendered_name] != transform.semantic_fingerprint()
+
+    unavailable = [
+        transform_spec("missing_child", "SELECT * FROM missing.parent"),
+        transform_spec("invalid_child", "SELECT ("),
+    ]
+    _, proposed = await build_deployment_fingerprints(
+        session,
+        {},
+        unavailable,
+        [],
+    )
+    assert proposed == {spec.rendered_name: None for spec in unavailable}
+
+    legacy = transform_spec("legacy", "SELECT (")
+    current, _ = await build_deployment_fingerprints(
+        session,
+        {legacy.rendered_name: legacy},
+        [],
+        [legacy],
+    )
+    assert current == {legacy.rendered_name: None}
+
+    current, proposed = await build_deployment_fingerprints(
+        session,
+        {},
+        [],
+        [],
+        additional_target_names=["default.hard_hat"],
+    )
+    assert current["default.hard_hat"] is not None
+    assert proposed["default.hard_hat"] is not None

--- a/datajunction-server/tests/internal/deployment/fingerprints_test.py
+++ b/datajunction-server/tests/internal/deployment/fingerprints_test.py
@@ -21,6 +21,10 @@ from datajunction_server.models.deployment import (
     SourceSpec,
     TransformSpec,
 )
+from datajunction_server.models.semantic_fingerprint import (
+    UNKNOWN_SEMANTIC_FINGERPRINT,
+    SemanticFingerprint,
+)
 
 
 def source_spec(
@@ -172,7 +176,10 @@ def test_merkle_fingerprints_support_deep_dependency_chains():
         specs[spec.rendered_name] = spec
 
     target = "deep.node_1099"
-    assert _compute_merkle_fingerprints(specs, [target], set())[target] is not None
+    assert (
+        _compute_merkle_fingerprints(specs, [target], set())[target]
+        != UNKNOWN_SEMANTIC_FINGERPRINT
+    )
 
 
 @pytest.mark.parametrize(
@@ -191,8 +198,8 @@ def test_unavailable_fingerprint_propagates_to_dependents(name: str, query: str)
     specs = spec_map(unavailable, dependent)
 
     assert _compute_merkle_fingerprints(specs, specs, set()) == {
-        unavailable.rendered_name: None,
-        dependent.rendered_name: None,
+        unavailable.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT,
+        dependent.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT,
     }
 
 
@@ -266,7 +273,10 @@ def test_cycle_hashing_is_stable_and_propagates_member_changes():
         set(),
     )
     assert original == reversed_input
-    assert all(fingerprint is not None for fingerprint in original.values())
+    assert all(
+        fingerprint != UNKNOWN_SEMANTIC_FINGERPRINT
+        for fingerprint in original.values()
+    )
 
     changed_second = second.model_copy(update={"query": "SELECT 2"})
     changed_specs = {
@@ -290,7 +300,7 @@ def test_self_link_and_external_parent_cycles_have_stable_hashes():
             [self_link.rendered_name],
             set(),
         )[self_link.rendered_name]
-        is not None
+        != UNKNOWN_SEMANTIC_FINGERPRINT
     )
 
     parent = source_spec(
@@ -319,7 +329,7 @@ def test_deleted_legacy_node_can_omit_unavailable_fingerprint(query: str):
         {legacy.rendered_name: legacy},
         [legacy.rendered_name],
         ignored_parse_errors={legacy.rendered_name},
-    ) == {legacy.rendered_name: None}
+    ) == {legacy.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT}
 
 
 def test_fingerprint_build_failures_are_unavailable():
@@ -337,12 +347,12 @@ def test_fingerprint_build_failures_are_unavailable():
     specs = spec_map(invalid_metric, invalid_source)
 
     assert _compute_merkle_fingerprints(specs, specs, set()) == {
-        invalid_metric.rendered_name: None,
-        invalid_source.rendered_name: None,
+        invalid_metric.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT,
+        invalid_source.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT,
     }
     assert _compute_merkle_fingerprints(specs, specs, set(specs)) == {
-        invalid_metric.rendered_name: None,
-        invalid_source.rendered_name: None,
+        invalid_metric.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT,
+        invalid_source.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT,
     }
 
 
@@ -387,9 +397,11 @@ async def test_build_deployment_fingerprints_without_external_parents():
     )
 
     assert current == {}
-    assert proposed[source.rendered_name] == source.semantic_fingerprint()
+    source_fingerprint = proposed[source.rendered_name]
+    assert isinstance(source_fingerprint, SemanticFingerprint)
+    assert source_fingerprint == source.semantic_fingerprint()
     assert proposed[transform.rendered_name] == transform.semantic_fingerprint(
-        parent_fingerprints=[proposed[source.rendered_name]],
+        parent_fingerprints=[source_fingerprint],
     )
 
 
@@ -406,7 +418,7 @@ async def test_build_deployment_fingerprints_loads_external_ancestors(session):
         [],
     )
 
-    assert proposed[transform.rendered_name] is not None
+    assert proposed[transform.rendered_name] != UNKNOWN_SEMANTIC_FINGERPRINT
     assert proposed[transform.rendered_name] != transform.semantic_fingerprint()
 
     unavailable = [
@@ -419,7 +431,9 @@ async def test_build_deployment_fingerprints_loads_external_ancestors(session):
         unavailable,
         [],
     )
-    assert proposed == {spec.rendered_name: None for spec in unavailable}
+    assert proposed == {
+        spec.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT for spec in unavailable
+    }
 
     legacy = transform_spec("legacy", "SELECT (")
     current, _ = await build_deployment_fingerprints(
@@ -428,7 +442,7 @@ async def test_build_deployment_fingerprints_loads_external_ancestors(session):
         [],
         [legacy],
     )
-    assert current == {legacy.rendered_name: None}
+    assert current == {legacy.rendered_name: UNKNOWN_SEMANTIC_FINGERPRINT}
 
     current, proposed = await build_deployment_fingerprints(
         session,
@@ -437,5 +451,5 @@ async def test_build_deployment_fingerprints_loads_external_ancestors(session):
         [],
         additional_target_names=["default.hard_hat"],
     )
-    assert current["default.hard_hat"] is not None
-    assert proposed["default.hard_hat"] is not None
+    assert current["default.hard_hat"] != UNKNOWN_SEMANTIC_FINGERPRINT
+    assert proposed["default.hard_hat"] != UNKNOWN_SEMANTIC_FINGERPRINT

--- a/datajunction-server/tests/internal/deployment/test_dimension_reachability.py
+++ b/datajunction-server/tests/internal/deployment/test_dimension_reachability.py
@@ -316,6 +316,14 @@ class TestExtractDimensionRefsFromFilters:
         result = _extract_dimension_refs_from_filters(["x > 5"])
         assert result == []
 
+    def test_filter_with_single_namespace_segment(self):
+        from datajunction_server.internal.deployment.orchestrator import (
+            _extract_dimension_refs_from_filters,
+        )
+
+        result = _extract_dimension_refs_from_filters(["hard_hat.state = 'CA'"])
+        assert result == []
+
     def test_filter_with_multiple_refs_in_one_expression(self):
         from datajunction_server.internal.deployment.orchestrator import (
             _extract_dimension_refs_from_filters,

--- a/datajunction-server/tests/internal/deployment_test.py
+++ b/datajunction-server/tests/internal/deployment_test.py
@@ -97,15 +97,11 @@ def test_extract_node_graph(basic_nodes):
     }
 
 
-def test_extract_node_graph_can_tolerate_unparseable_queries():
+def test_extract_node_graph_rejects_unparseable_queries():
     invalid = TransformSpec(name="lunch.mystery_meat", query="SELECT (")
 
     with pytest.raises(DJParseException):
         extract_node_graph([invalid])
-
-    assert extract_node_graph([invalid], tolerate_parse_errors=True) == {
-        "lunch.mystery_meat": [],
-    }
 
 
 def test_graph_complex():

--- a/datajunction-server/tests/internal/deployment_test.py
+++ b/datajunction-server/tests/internal/deployment_test.py
@@ -40,6 +40,7 @@ from datajunction_server.models.node import (
     NodeType,
 )
 from datajunction_server.models.node_type import NodeType
+from datajunction_server.sql.parsing.backends.exceptions import DJParseException
 from datajunction_server.sql.parsing.types import IntegerType, StringType
 
 
@@ -93,6 +94,17 @@ def test_extract_node_graph(basic_nodes):
         ],
         "example.transform_node": ["catalog.facts.clicks"],
         "example.metric_node": ["example.transform_node"],
+    }
+
+
+def test_extract_node_graph_can_tolerate_unparseable_queries():
+    invalid = TransformSpec(name="lunch.mystery_meat", query="SELECT (")
+
+    with pytest.raises(DJParseException):
+        extract_node_graph([invalid])
+
+    assert extract_node_graph([invalid], tolerate_parse_errors=True) == {
+        "lunch.mystery_meat": [],
     }
 
 


### PR DESCRIPTION
Fingerprint construction primitives can compose parent hashes, but deployment code has no server-owned evaluator for the full semantic parent graph. Cyclic dimension links also have no topological starting node, and recursive graph traversal can exceed Python's recursion limit on deep chains.

Depends on [#2482](https://github.com/DataJunction/dj/pull/2482).

This PR:
- adds `SemanticFingerprintGraph` for lazy, memoized evaluation within one graph snapshot
- resolves semantic parents from SQL, dimension links, required dimensions, cube members, and cube filters
- loads external ancestors and computes current and proposed Merkle fingerprints
- requires every concrete node spec type to register its parent resolver
- normalizes source columns and required-dimension identity across authored and persisted specs
- propagates unavailable fingerprints to dependent nodes without blocking deployment
- evaluates cycles with deterministic strongly connected component hashes

Callers construct one graph for each current or proposed snapshot, then use `fingerprint(name)` or `fingerprints(names)`. Missing parents return `unknown`, so an incomplete snapshot cannot produce a plausible graph-bound hash.

### Why cyclic graphs need SCC hashing

Direct Merkle evaluation cannot compute `A`, `B`, or `C` here because every object hash requires another unfinished object hash:

```mermaid
flowchart LR
    A["dimension A<br/>h_A = H(f_A, h_B)"]
    B["dimension B<br/>h_B = H(f_B, h_C)"]
    C["dimension C<br/>h_C = H(f_C, h_A)"]

    A -->|requires h_B| B
    B -->|requires h_C| C
    C -->|requires h_A| A

    classDef cycle fill:#fee2e2,stroke:#dc2626,color:#450a0a
    class A,B,C cycle
```

The evaluator uses an iterative two-pass SCC traversal. Its graph walk is `O(V + E)`, where `V` is the node count and `E` is the semantic parent edge count. Deterministic ordering adds sorting overhead. Explicit stacks avoid Python recursion limits on deep dependency chains. Parent discovery, SQL parsing, and database loading occur outside this graph-walk bound.

Each cycle becomes one atomic component in a condensation graph, which is always a DAG:

```text
h_scc = H(
  sorted(member name + intrinsic fingerprint),
  sorted(internal child + parent edges),
  sorted(external child + parent + parent hash)
)

h_A = H(f_A, h_scc)
h_B = H(f_B, h_scc)
h_C = H(f_C, h_scc)
```

```mermaid
flowchart LR
    P["external parent P<br/>object hash: h_P"]
    SCC["SCC {A, B, C}<br/>component hash: h_scc"]
    A["dimension A<br/>h_A = H(f_A, h_scc)"]
    B["dimension B<br/>h_B = H(f_B, h_scc)"]
    C["dimension C<br/>h_C = H(f_C, h_scc)"]
    D["downstream node D<br/>object hash changes"]

    P -->|external parent hash| SCC
    SCC --> A
    SCC --> B
    SCC --> C
    A --> D
    B --> D
    C --> D

    classDef parent fill:#fff1d6,stroke:#c2410c,color:#431407
    classDef component fill:#ede9fe,stroke:#7c3aed,color:#2e1065
    classDef member fill:#ecfdf5,stroke:#059669,color:#064e3b
    classDef downstream fill:#dbeafe,stroke:#2563eb,color:#172554
    class P parent
    class SCC component
    class A,B,C member
    class D downstream
```

Changing a member definition, internal edge, or external parent hash changes `h_scc`, every member hash, and downstream hashes. Acyclic singleton components keep the ordinary Merkle path. An unavailable member or external parent makes the component and its dependents unavailable.

---
Verification:

1. Checked out the exact PR head and built it in a fresh Docker slot:

```bash
git rev-parse HEAD
printf '2\n' > .dev-port
./dev.sh up -d
curl http://localhost:8200/health/
```

Observed:

```text
de5ed41cd22d6d3ea3cfc18ba94e30157b0a8c85
[{"name":"database","status":"ok"}]
```

2. Logged in as `dj` and deployed `graph_verification.external_source` so the graph evaluator could load a parent from committed database state:

```text
POST /basic/login/                              -> 200
POST /deployments                              -> 200
GET /deployments/{uuid}                        -> status=success
```

3. Ran `SemanticFingerprintGraph` inside the backend container with:

```bash
docker exec -i dj-s2 /code/.venv/bin/python -
```

The script exercised these inputs directly against the code at `/code/datajunction_server`:
- `source -> transform -> metric`, then changed only the source table
- repeated lookup from one graph snapshot to check memoization
- `first -> second -> third -> first` plus a downstream node, with reversed input order and a changed cycle member
- a 1,100-node dimension-link chain
- invalid SQL and unresolved-parent nodes with dependents
- authored and persisted forms of the same required dimension
- a proposed transform whose source parent existed only in Postgres

Observed:

```json
{
  "acyclic_propagation": {
    "all_descendants_changed": true,
    "changed": [
      "verify.metric",
      "verify.source",
      "verify.transform"
    ],
    "memoized": true
  },
  "cycle_evaluation": {
    "input_order_stable": true,
    "member_change_propagates": true,
    "members": [
      "cycle_verify.downstream",
      "cycle_verify.first",
      "cycle_verify.second",
      "cycle_verify.third"
    ]
  },
  "deep_chain": {
    "nodes": 1100,
    "target": "deep_verify.node_1099",
    "target_known": true
  },
  "external_ancestor": {
    "loaded_from_database": true,
    "matches_expected_merkle_hash": true,
    "fingerprint": {
      "version": 1,
      "digest": "ecce67b36517bb7ad6ce126902d0116909759c96838b08d5ce1b372cd96a4aac"
    }
  },
  "failure_propagation": {
    "verify.invalid": "unknown",
    "verify.invalid_dependent": "unknown",
    "verify.unresolved": "unknown",
    "verify.unresolved_dependent": "unknown"
  },
  "required_dimension_identity_stable": true
}
```

---
### Semantic fingerprint stack

This is PR 2 of 4:

1. [#2482: Add semantic node fingerprints](https://github.com/DataJunction/dj/pull/2482)
2. [#2488: Evaluate fingerprints across deployment graphs](https://github.com/DataJunction/dj/pull/2488) (this PR)
3. [#2483: Add semantic fingerprints to deployment impact](https://github.com/DataJunction/dj/pull/2483)
4. [#2490: Bulk endpoint for viewing fingerprints and testing fixtures](https://github.com/DataJunction/dj/pull/2490)