### PR TITLE
Single-Pass Column Pruning

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -938,14 +938,29 @@ def _set_op_arms(select: ast.SelectExpression) -> list[ast.SelectExpression]:
     return arms
 
 
-def _dedups_rows(select: ast.SelectExpression) -> bool:
+def _compares_whole_rows(select: ast.SelectExpression) -> bool:
     """
-    Whether the whole projected row is the select's match key.
+    Whether this select picks its rows by comparing them against each other.
 
-    DISTINCT compares complete rows, and so does every set operation but
-    UNION ALL — the one kind that passes its arms' rows through untouched.
-    Dropping a column then folds together rows that were distinct and
-    silently changes the row count.
+    DISTINCT does — it keeps a row only if no earlier row equals it. So does
+    every set operation but UNION ALL: UNION, INTERSECT, EXCEPT, EXCEPT ALL
+    and MINUS all decide a row's fate by looking at the other arm's rows.
+    UNION ALL alone just concatenates, and is the one safe kind. Read per
+    arm, so an arm that is itself DISTINCT under a UNION ALL counts too.
+
+    This matters because pruning rests on an unread column being free to
+    drop, and a row-to-row comparison uses every column projected, read or
+    not. Drop ``drop_me`` from
+
+        SELECT grp, keep, drop_me FROM t WHERE id <= 2
+        UNION
+        SELECT grp, keep, drop_me FROM t WHERE id >= 3
+
+    and two rows fold into one, so SUM(keep) answers 30 where it owes 40.
+    Nothing raises; the number just gets quieter.
+
+    Callers put such a scope in ``unprunable``, which keeps its projection
+    whole and stops a narrowed demand reaching a source it stars.
     """
     return any(
         (arm.quantifier or "").upper() == "DISTINCT"
@@ -1037,14 +1052,14 @@ def _scopes_readers_first(
     cte_names: set[str],
 ) -> list[str]:
     """
-    Topologically sort the scopes on reads, readers ahead of what they read.
+    Topologically sort the scopes based on read order.
 
     A CTE is only reached once every scope reading it has been, so the demand
     on it is complete by then. Pruning a reader only narrows what it asks of
     its own sources, so one pass in this order settles every projection.
 
-    Returns the CTE names plus ``""`` for the outer select, which nothing
-    reads and which therefore always comes first.
+    Returns the CTE names plus ``""`` for the outer select. No scope reads
+    the outer select, so it always comes first.
     """
     reads: dict[str, set[str]] = {}
     for key, scope in scopes.items():
@@ -1078,14 +1093,24 @@ def _scopes_readers_first(
 
 def prune_cte_projections(query: ast.Query) -> None:
     """
-    Trim every CTE in an assembled query to the columns its readers use.
+    Prune unused columns from the query, once it's fully assembled.
 
-    Runs once the query is whole, so each CTE can be asked of the consumers that
-    actually exist rather than of an enumeration of the ways a column might be
-    demanded. Consumers are pruned first, so by the time a CTE is reached the
-    demand on it has already narrowed. Needs no database and no compilation:
-    every table reference is already a CTE name or a physical table, and a
-    CTE's output names read straight off its own projection.
+    1. Topologically sort the scopes based on read order (the CTEs plus the
+       outer select, keyed ``""``, which is the answer and so never pruned),
+       readers before what they read — :func:`_scopes_readers_first`.
+    2. Walk that order once, keeping two records: ``live[cte]``, columns used
+       by a downstream scope, and ``unprunable``, for CTEs that cannot be
+       pruned.
+    3. At each scope: mark it unprunable if it compares whole rows
+       (:func:`_compares_whole_rows`), prune to what it actually needs, then
+       add the columns it reads to each of its sources' ``live``.
+
+    Pruning a scope before recording its reads is what makes one pass enough:
+    trimming a reader narrows what it goes on to ask of the CTEs beneath it.
+    Using ``*`` makes its source unprunable, unless the star's own scope has
+    demand to pass down. A reference whose qualifier names no CTE in scope is
+    added to every CTE in scope — which one supplies it needs compilation to
+    know, and asking a CTE for a name it has not got is a no-op.
     """
     ctes = {cte.alias_or_name.name: cte for cte in query.ctes}
     if not ctes:
@@ -1099,7 +1124,7 @@ def prune_cte_projections(query: ast.Query) -> None:
 
     for key in _scopes_readers_first(scopes, cte_names):
         scope = scopes[key]
-        if key and _dedups_rows(scope.select):
+        if key and _compares_whole_rows(scope.select):
             # Its row is its match key, so it also can't narrow what it stars.
             unprunable.add(key)
         if key and live[key] and key not in unprunable:

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -800,65 +800,257 @@ def filter_cte_projection(
     if not query_ast.select.projection:  # pragma: no cover
         return query_ast
 
-    projection = query_ast.select.projection
+    _apply_keep_positions(
+        query_ast.select,
+        _keep_positions(query_ast.select, columns_to_select),
+    )
+    return query_ast
 
-    def _col_name(expr: object) -> str | None:
-        if isinstance(expr, ast.Alias):
-            return str(expr.alias.name) if expr.alias else None
-        if isinstance(expr, ast.Column):
-            return str(expr.alias.name) if expr.alias else str(expr.name.name)
+
+def _is_star(expr: object) -> bool:
+    """Whether a projection entry is ``*`` or ``<alias>.*``."""
+    if isinstance(expr, ast.Wildcard):
+        return True
+    return isinstance(expr, ast.Column) and str(expr.name.name) == "*"
+
+
+def _projection_name(expr: object) -> str | None:
+    """The output name of one projection entry, or ``None`` if it has none."""
+    if isinstance(expr, ast.Alias):
+        return str(expr.alias.name) if expr.alias else None
+    if _is_star(expr):
+        # A star stands for whatever its source has; it names nothing itself.
         return None
+    if isinstance(expr, ast.Column):
+        return str(expr.alias.name) if expr.alias else str(expr.name.name)
+    return None
 
-    # Protect columns that GROUP BY depends on so we never prune them.
-    # Positional references (integers) protect the column at that SELECT position;
-    # named references protect by column name.
+
+def _keep_positions(
+    select: ast.SelectExpression,
+    columns_to_select: set[str],
+) -> set[int]:
+    """
+    The 1-indexed projection positions a select must keep.
+
+    A position survives when its output name is wanted downstream, when GROUP BY
+    names or points at it, or when it has no readable output name.
+    """
+    projection = select.projection
     effective_cols = set(columns_to_select)
-    positional_refs: set[int] = set()  # 1-indexed positions from GROUP BY
-    for item in query_ast.select.group_by:
+    for item in select.group_by:
         if isinstance(item, ast.Number) and isinstance(item.value, int):
             pos = int(item.value)
             if 1 <= pos <= len(projection):
-                positional_refs.add(pos)
-                if name := _col_name(projection[pos - 1]):
+                if name := _projection_name(projection[pos - 1]):
                     effective_cols.add(name)
         elif isinstance(item, ast.Column):
-            name = str(item.alias.name) if item.alias else str(item.name.name)
-            effective_cols.add(name)
+            effective_cols.add(
+                str(item.alias.name) if item.alias else str(item.name.name),
+            )
 
-    # Build the filtered projection, tracking old to new position for renumbering.
+    keep: set[int] = set()
+    for i, expr in enumerate(projection):
+        col_name = _projection_name(expr)
+        if col_name is None or col_name in effective_cols:
+            keep.add(i + 1)
+    return keep
+
+
+def _apply_keep_positions(select: ast.SelectExpression, keep: set[int]) -> None:
+    """
+    Drop projection entries outside ``keep`` and renumber positional GROUP BY.
+
+    Positional GROUP BY references are renumbered rather than rewritten to alias
+    names, which is invalid in dialects like Trino. An empty result leaves the
+    projection alone: an empty SELECT is never an improvement.
+    """
     new_projection = []
     old_to_new: dict[int, int] = {}  # 1-indexed old pos to 1-indexed new pos
-    for i, expr in enumerate(projection):
-        old_pos = i + 1
-        col_name = _col_name(expr)
-        if col_name is None:  # pragma: no cover
-            # Keep expressions we can't analyze (defensive)
+    for i, expr in enumerate(select.projection):
+        if i + 1 in keep:
             new_projection.append(expr)
-            old_to_new[old_pos] = len(new_projection)
-        elif col_name in effective_cols:
-            new_projection.append(expr)
-            old_to_new[old_pos] = len(new_projection)
-        # else: pruned — no mapping entry
+            old_to_new[i + 1] = len(new_projection)
 
-    # If we filtered everything, keep original (shouldn't happen)
     if new_projection:
-        query_ast.select.projection = new_projection
+        select.projection = new_projection
 
-    # Renumber positional GROUP BY references if any columns were removed before them.
-    if positional_refs:
-        new_group_by: list[ast.Expression] = []
-        for item in query_ast.select.group_by:
-            if isinstance(item, ast.Number) and isinstance(item.value, int):
-                old_pos = int(item.value)
-                new_pos = old_to_new.get(old_pos, old_pos)
-                new_group_by.append(
-                    ast.Number(value=new_pos) if new_pos != old_pos else item,
-                )
+    new_group_by: list[ast.Expression] = []
+    for item in select.group_by:
+        if isinstance(item, ast.Number) and isinstance(item.value, int):
+            old_pos = int(item.value)
+            new_pos = old_to_new.get(old_pos, old_pos)
+            new_group_by.append(
+                ast.Number(value=new_pos) if new_pos != old_pos else item,
+            )
+        else:
+            new_group_by.append(item)
+    select.group_by = new_group_by
+
+
+def _set_op_arms(select: ast.SelectExpression) -> list[ast.SelectExpression]:
+    """Each arm of a set operation, or the select itself when there is none."""
+    arms = []
+    arm: ast.SelectExpression | None = select
+    while arm is not None:
+        arms.append(arm)
+        arm = arm.set_op.right if arm.set_op else None
+    return arms
+
+
+def _arm_parts(arm: ast.SelectExpression) -> list[ast.Node]:
+    """The clauses of one arm, excluding the arms unioned after it."""
+    return [
+        *arm.projection,
+        *arm.group_by,
+        *arm.lateral_views,
+        *([arm.from_] if arm.from_ else []),
+        *([arm.where] if arm.where else []),
+        *([arm.having] if arm.having else []),
+        *([arm.organization] if arm.organization else []),
+    ]
+
+
+def _table_alias(table: ast.Table) -> ast.Name | None:
+    """The alias a table carries, whether on the table itself or wrapping it."""
+    if table.alias:
+        return table.alias
+    if isinstance(table.parent, ast.Alias):
+        return table.parent.alias
+    return None
+
+
+def _arm_sources(arm: ast.SelectExpression, cte_names: set[str]) -> dict[str, str]:
+    """
+    Map every qualifier an arm can use for a CTE to that CTE's name.
+
+    A table can be addressed by its alias or by the CTE name itself, so both
+    land in the map.
+    """
+    sources: dict[str, str] = {}
+    for part in _arm_parts(arm):
+        for table in part.find_all(ast.Table):
+            name = table.name.identifier(quotes=False)
+            if name in cte_names:
+                sources[name] = name
+                if alias := _table_alias(table):
+                    sources[alias.identifier(quotes=False)] = name
+    return sources
+
+
+def _record_arm_demands(
+    arm: ast.SelectExpression,
+    sources: dict[str, str],
+    live: dict[str, set[str]],
+) -> None:
+    """
+    Charge each column an arm reads to the CTE that has to project it.
+
+    A qualified reference goes to the CTE its qualifier names, and the column
+    wanted there is the segment right after the qualifier — for a struct path
+    like ``p.line_item.target_sets`` the producer projects ``line_item``, not
+    the leaf. A reference with no qualifier we recognize goes to every CTE in
+    scope: which one supplies it is only knowable after compilation, and
+    keeping a name a CTE does not have is a no-op.
+    """
+    bare_targets = set(sources.values())
+    for part in _arm_parts(arm):
+        for column in part.find_all(ast.Column):
+            segments = column.identifier(quotes=False).split(SEPARATOR)
+            if len(segments) > 1 and segments[0] in sources:
+                live[sources[segments[0]]].add(segments[1])
             else:
-                new_group_by.append(item)
-        query_ast.select.group_by = new_group_by
+                for target in bare_targets:
+                    live[target].add(segments[0])
 
-    return query_ast
+
+def _consumers_first(scopes: dict[str, ast.Query], cte_names: set[str]) -> list[str]:
+    """
+    Order the scopes so every reader comes before the CTE it reads.
+
+    Pruning a reader only narrows what it asks of its own sources, so one pass
+    in this order is enough to settle every projection.
+    """
+    reads: dict[str, set[str]] = {}
+    for key, scope in scopes.items():
+        producers: set[str] = set()
+        for arm in _set_op_arms(scope.select):
+            producers.update(_arm_sources(arm, cte_names).values())
+        producers.discard(key)
+        reads[key] = producers
+
+    remaining = dict.fromkeys(scopes, 0)
+    for producers in reads.values():
+        for producer in producers:
+            remaining[producer] += 1
+
+    ready = [key for key, count in remaining.items() if not count]
+    order: list[str] = []
+    while ready:
+        key = ready.pop()
+        order.append(key)
+        for producer in reads[key]:
+            remaining[producer] -= 1
+            if not remaining[producer]:
+                ready.append(producer)
+
+    if len(order) < len(scopes):  # pragma: no cover
+        # A reference cycle among CTEs; fall back to declaration order reversed.
+        settled = set(order)
+        order.extend(key for key in reversed(list(scopes)) if key not in settled)
+    return order
+
+
+def prune_cte_projections(query: ast.Query) -> None:
+    """
+    Trim every CTE in an assembled query to the columns its readers use.
+
+    Runs once the query is whole, so each CTE can be asked of the consumers that
+    actually exist rather than of an enumeration of the ways a column might be
+    demanded. Consumers are pruned first, so by the time a CTE is reached the
+    demand on it has already narrowed. Needs no database and no compilation:
+    every table reference is already a CTE name or a physical table, and a
+    CTE's output names read straight off its own projection.
+    """
+    ctes = {cte.alias_or_name.name: cte for cte in query.ctes}
+    if not ctes:
+        return
+    cte_names = set(ctes)
+    # The outer select is a scope too, and the only one nothing else reads.
+    scopes: dict[str, ast.Query] = {"": query, **ctes}
+
+    live: dict[str, set[str]] = {name: set() for name in cte_names}
+    unprunable: set[str] = set()
+
+    for key in _consumers_first(scopes, cte_names):
+        scope = scopes[key]
+        if key and live[key] and key not in unprunable:
+            arms = _set_op_arms(scope.select)
+            if len(arms) == 1:
+                filter_cte_projection(scope, live[key])
+            else:
+                # Arms are unioned by position, so they all keep the same ones.
+                keep: set[int] = set()
+                for arm in arms:
+                    keep.update(_keep_positions(arm, live[key]))
+                for arm in arms:
+                    _apply_keep_positions(arm, keep)
+
+        for arm in _set_op_arms(scope.select):
+            sources = _arm_sources(arm, cte_names)
+            _record_arm_demands(arm, sources, live)
+            if not any(_is_star(item) for item in arm.projection):
+                continue
+            # A star names no columns of its own: it re-exposes whatever its
+            # source has. So a CTE that stars a source passes its own demand
+            # straight through. Where that demand is unknown — the outer
+            # select, or a CTE nobody reads — the source keeps everything.
+            starred = set(sources.values())
+            if key and key not in unprunable and live[key]:
+                for target in starred:
+                    live[target].update(live[key])
+            else:
+                unprunable.update(starred)
 
 
 def flatten_inner_ctes(
@@ -2072,7 +2264,6 @@ def _build_select_projection_map(
 def collect_node_ctes(
     ctx: BuildContext,
     nodes_to_include: list[Node],
-    needed_columns_by_node: dict[str, set[str]] | None = None,
     injected_filters: dict[str, ast.Expression] | None = None,
     pushdown: PushdownFilters | None = None,
 ) -> tuple[list[tuple[str, ast.Query]], list[str], dict[str, set[str]]]:
@@ -2091,8 +2282,6 @@ def collect_node_ctes(
     Args:
         ctx: Build context
         nodes_to_include: List of nodes to create CTEs for
-        needed_columns_by_node: Optional dict of node_name -> set of column names
-            If provided, CTEs will only select the needed columns.
         injected_filters: Optional dict of node_name -> filter expression to inject
             as a WHERE clause into that node's CTE. Used to push temporal partition
             filters down into upstream CTEs (e.g. a date-spine) rather than applying
@@ -2207,14 +2396,6 @@ def collect_node_ctes(
             cte_names,
             inner_cte_renames,
         )
-
-        # Apply column filtering if specified
-        needed_cols = None
-        if needed_columns_by_node:  # pragma: no branch
-            needed_cols = needed_columns_by_node.get(node.name)
-
-        if needed_cols and not _cte_has_set_operation(query_ast):  # pragma: no branch
-            query_ast = filter_cte_projection(query_ast, needed_cols)
 
         # Inject filters into this CTE's WHERE clause from two sources:
         # (1) Temporal/explicit filters targeted at this node by name

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -829,6 +829,24 @@ def _projection_name(expr: object) -> str | None:
     return None
 
 
+def _output_alias_clauses(select: ast.SelectExpression) -> list[ast.Node]:
+    """
+    The clauses that may name the select's own output, one expression each.
+
+    GROUP BY, HAVING and ORDER BY can all address a projection entry by the
+    alias it is given or by its position. WHERE deliberately does not appear:
+    a column it uses resolves against the FROM, not against the projection, so
+    a column only the WHERE reads is still free to go.
+    """
+    parts: list[ast.Node] = list(select.group_by)
+    if select.having is not None:
+        parts.append(select.having)
+    if select.organization is not None:
+        parts.extend(item.expr for item in select.organization.order)
+        parts.extend(item.expr for item in select.organization.sort)
+    return parts
+
+
 def _keep_positions(
     select: ast.SelectExpression,
     columns_to_select: set[str],
@@ -836,20 +854,29 @@ def _keep_positions(
     """
     The 1-indexed projection positions a select must keep.
 
-    A position survives when its output name is wanted downstream, when GROUP BY
-    names or points at it, or when it has no readable output name.
+    A position survives when its output name is wanted downstream, when a
+    clause that can address the projection names or points at it, or when it
+    has no readable output name.
+
+    Under DISTINCT every position survives: the projection is the dedup key, so
+    narrowing it folds together rows that were distinct and silently changes
+    the row count.
     """
     projection = select.projection
+    if (select.quantifier or "").upper() == "DISTINCT":
+        return set(range(1, len(projection) + 1))
+
     effective_cols = set(columns_to_select)
-    for item in select.group_by:
+    for item in _output_alias_clauses(select):
         if isinstance(item, ast.Number) and isinstance(item.value, int):
             pos = int(item.value)
             if 1 <= pos <= len(projection):
                 if name := _projection_name(projection[pos - 1]):
                     effective_cols.add(name)
-        elif isinstance(item, ast.Column):
+            continue
+        for column in item.find_all(ast.Column):
             effective_cols.add(
-                str(item.alias.name) if item.alias else str(item.name.name),
+                str(column.alias.name) if column.alias else str(column.name.name),
             )
 
     keep: set[int] = set()
@@ -862,11 +889,12 @@ def _keep_positions(
 
 def _apply_keep_positions(select: ast.SelectExpression, keep: set[int]) -> None:
     """
-    Drop projection entries outside ``keep`` and renumber positional GROUP BY.
+    Drop projection entries outside ``keep`` and renumber positional references.
 
-    Positional GROUP BY references are renumbered rather than rewritten to alias
-    names, which is invalid in dialects like Trino. An empty result leaves the
-    projection alone: an empty SELECT is never an improvement.
+    GROUP BY and ORDER BY positions are renumbered rather than rewritten to
+    alias names, which is invalid in dialects like Trino. Left alone they would
+    quietly point at whichever column slid into that slot. An empty result
+    leaves the projection alone: an empty SELECT is never an improvement.
     """
     new_projection = []
     old_to_new: dict[int, int] = {}  # 1-indexed old pos to 1-indexed new pos
@@ -889,6 +917,15 @@ def _apply_keep_positions(select: ast.SelectExpression, keep: set[int]) -> None:
         else:
             new_group_by.append(item)
     select.group_by = new_group_by
+
+    if select.organization is not None:
+        for sort_item in (*select.organization.order, *select.organization.sort):
+            position = sort_item.expr
+            if isinstance(position, ast.Number) and isinstance(position.value, int):
+                position.value = old_to_new.get(
+                    int(position.value),
+                    int(position.value),
+                )
 
 
 def _set_op_arms(select: ast.SelectExpression) -> list[ast.SelectExpression]:

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -938,6 +938,21 @@ def _set_op_arms(select: ast.SelectExpression) -> list[ast.SelectExpression]:
     return arms
 
 
+def _dedups_rows(select: ast.SelectExpression) -> bool:
+    """
+    Whether a set operation makes the whole projected row the match key.
+
+    Only UNION ALL passes its arms' rows through untouched. Every other kind
+    compares complete rows to dedup or to match, so dropping a column folds
+    together rows that were distinct and silently changes the row count.
+    """
+    return any(
+        " ".join((arm.set_op.kind or "").upper().split()) != "UNION ALL"
+        for arm in _set_op_arms(select)
+        if arm.set_op is not None
+    )
+
+
 def _arm_parts(arm: ast.SelectExpression) -> list[ast.Node]:
     """The clauses of one arm, excluding the arms unioned after it."""
     return [
@@ -1073,6 +1088,9 @@ def prune_cte_projections(query: ast.Query) -> None:
 
     for key in _consumers_first(scopes, cte_names):
         scope = scopes[key]
+        if key and _dedups_rows(scope.select):
+            # Its row is its match key, so it also can't narrow what it stars.
+            unprunable.add(key)
         if key and live[key] and key not in unprunable:
             arms = _set_op_arms(scope.select)
             if len(arms) == 1:

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -20,7 +20,10 @@ from datajunction_server.construction.build_v3.types import (
     GrainGroupSQL,
     PushdownFilters,
 )
-from datajunction_server.construction.build_v3.utils import get_cte_name
+from datajunction_server.construction.build_v3.utils import (
+    column_table_name,
+    get_cte_name,
+)
 from datajunction_server.database.node import Node
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.sql.decompose import wrap_divisions_in_nullif
@@ -952,16 +955,25 @@ def _record_arm_demands(
     the leaf. A reference with no qualifier we recognize goes to every CTE in
     scope: which one supplies it is only knowable after compilation, and
     keeping a name a CTE does not have is a no-op.
+
+    A qualifier reaches us two ways. Dotted into the name is the parsed form,
+    and it can carry further struct segments. Hung off the column as a table is
+    what the builder produces for its own projections and GROUP BY, and there
+    the column name stands alone.
     """
     bare_targets = set(sources.values())
     for part in _arm_parts(arm):
         for column in part.find_all(ast.Column):
             segments = column.identifier(quotes=False).split(SEPARATOR)
-            if len(segments) > 1 and segments[0] in sources:
-                live[sources[segments[0]]].add(segments[1])
+            qualifier = segments[0] if len(segments) > 1 else None
+            wanted = segments[1] if len(segments) > 1 else segments[0]
+            if qualifier is None:
+                qualifier = column_table_name(column)
+            if qualifier in sources:
+                live[sources[qualifier]].add(wanted)
             else:
                 for target in bare_targets:
-                    live[target].add(segments[0])
+                    live[target].add(wanted)
 
 
 def _consumers_first(scopes: dict[str, ast.Query], cte_names: set[str]) -> list[str]:

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -856,7 +856,8 @@ def _keep_positions(
 
     A position survives when its output name is wanted downstream, when a
     clause that can address the projection names or points at it, or when it
-    has no readable output name.
+    has no readable output name. Names are matched without regard to case,
+    the way every dialect DJ targets resolves them.
 
     Under DISTINCT every position survives: the projection is the dedup key, so
     narrowing it folds together rows that were distinct and silently changes
@@ -866,23 +867,22 @@ def _keep_positions(
     if (select.quantifier or "").upper() == "DISTINCT":
         return set(range(1, len(projection) + 1))
 
-    effective_cols = set(columns_to_select)
+    effective_cols = {name.casefold() for name in columns_to_select}
     for item in _output_alias_clauses(select):
         if isinstance(item, ast.Number) and isinstance(item.value, int):
             pos = int(item.value)
             if 1 <= pos <= len(projection):
                 if name := _projection_name(projection[pos - 1]):
-                    effective_cols.add(name)
+                    effective_cols.add(name.casefold())
             continue
         for column in item.find_all(ast.Column):
-            effective_cols.add(
-                str(column.alias.name) if column.alias else str(column.name.name),
-            )
+            named = column.alias.name if column.alias else column.name.name
+            effective_cols.add(str(named).casefold())
 
     keep: set[int] = set()
     for i, expr in enumerate(projection):
         col_name = _projection_name(expr)
-        if col_name is None or col_name in effective_cols:
+        if col_name is None or col_name.casefold() in effective_cols:
             keep.add(i + 1)
     return keep
 

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -1032,12 +1032,19 @@ def _record_arm_demands(
                     live[target].add(wanted)
 
 
-def _consumers_first(scopes: dict[str, ast.Query], cte_names: set[str]) -> list[str]:
+def _scopes_readers_first(
+    scopes: dict[str, ast.Query],
+    cte_names: set[str],
+) -> list[str]:
     """
-    Order the scopes so every reader comes before the CTE it reads.
+    Topologically sort the scopes on reads, readers ahead of what they read.
 
-    Pruning a reader only narrows what it asks of its own sources, so one pass
-    in this order is enough to settle every projection.
+    A CTE is only reached once every scope reading it has been, so the demand
+    on it is complete by then. Pruning a reader only narrows what it asks of
+    its own sources, so one pass in this order settles every projection.
+
+    Returns the CTE names plus ``""`` for the outer select, which nothing
+    reads and which therefore always comes first.
     """
     reads: dict[str, set[str]] = {}
     for key, scope in scopes.items():
@@ -1090,7 +1097,7 @@ def prune_cte_projections(query: ast.Query) -> None:
     live: dict[str, set[str]] = {name: set() for name in cte_names}
     unprunable: set[str] = set()
 
-    for key in _consumers_first(scopes, cte_names):
+    for key in _scopes_readers_first(scopes, cte_names):
         scope = scopes[key]
         if key and _dedups_rows(scope.select):
             # Its row is its match key, so it also can't narrow what it stars.

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -940,16 +940,20 @@ def _set_op_arms(select: ast.SelectExpression) -> list[ast.SelectExpression]:
 
 def _dedups_rows(select: ast.SelectExpression) -> bool:
     """
-    Whether a set operation makes the whole projected row the match key.
+    Whether the whole projected row is the select's match key.
 
-    Only UNION ALL passes its arms' rows through untouched. Every other kind
-    compares complete rows to dedup or to match, so dropping a column folds
-    together rows that were distinct and silently changes the row count.
+    DISTINCT compares complete rows, and so does every set operation but
+    UNION ALL — the one kind that passes its arms' rows through untouched.
+    Dropping a column then folds together rows that were distinct and
+    silently changes the row count.
     """
     return any(
-        " ".join((arm.set_op.kind or "").upper().split()) != "UNION ALL"
+        (arm.quantifier or "").upper() == "DISTINCT"
+        or (
+            arm.set_op is not None
+            and " ".join((arm.set_op.kind or "").upper().split()) != "UNION ALL"
+        )
         for arm in _set_op_arms(select)
-        if arm.set_op is not None
     )
 
 

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -20,8 +20,8 @@ from datajunction_server.construction.build_v3.cte import (
     _fk_key_column_names,
     collect_node_ctes,
     extract_dimension_node,
-    get_table_references_from_ast,
     inject_filter_into_select,
+    prune_cte_projections,
     references_filter_only_dimension,
     strip_role_suffix,
 )
@@ -64,8 +64,6 @@ from datajunction_server.construction.build_v3.types import (
     ResolvedDimension,
 )
 from datajunction_server.construction.build_v3.utils import (
-    extract_columns_from_expression,
-    extract_columns_referenced_from_node,
     get_column_type,
     get_cte_name,
     get_short_name,
@@ -101,31 +99,23 @@ def _rewrite_col_refs(expr: Any, table_alias: str) -> None:
 def _resolve_dim_namespace_refs(
     expressions: list[ast.Expression],
     dim_node_to_alias: dict[str, str],
-) -> dict[str, set[str]]:
+) -> None:
     """Resolve dim-namespaced column refs in metric/grain expressions.
 
     A metric or grain expression may contain a fully-qualified column like
     ``v3.customer.tier`` referring to a column on a dimension node that the
-    parent fact joins to. In one walk per expression, this function:
-
-    1. Rewrites the namespace from the dim node name to the dim's joined
-       table alias (so the renderer emits ``t2.tier`` instead of the literal
-       node name, which is not a valid table reference).
-    2. Returns ``{dim_node_name: {col, ...}}`` so the caller can keep those
-       columns in the dim's CTE projection (otherwise filter_cte_projection
-       drops them as unused).
+    parent fact joins to. Rewrites the namespace from the dim node name to the
+    dim's joined table alias, so the renderer emits ``t2.tier`` instead of the
+    literal node name, which is not a valid table reference.
     """
-    dim_cols: dict[str, set[str]] = {}
     for expr in expressions:
         for nc in iter_namespaced_columns(expr):
             if nc.node not in dim_node_to_alias:
                 continue
-            dim_cols.setdefault(nc.node, set()).add(nc.name)
             nc.column.name = ast.Name(
                 nc.name,
                 namespace=ast.Name(dim_node_to_alias[nc.node]),
             )
-    return dim_cols
 
 
 # Mapping from type string to ColumnType instance
@@ -328,37 +318,6 @@ def _add_table_prefixes_to_filter(
     add_prefixes(filter_ast)
 
 
-def extract_join_columns_for_node(join_sql: str, node_name: str) -> set[str]:
-    """
-    Extract column names from join SQL that belong to a specific node.
-
-    Parses the join_sql (e.g., "v3.order_details.customer_id = v3.customer.customer_id")
-    and returns the short column names for columns belonging to the given node.
-
-    Args:
-        join_sql: The join condition SQL string
-        node_name: The fully qualified node name to filter by
-
-    Returns:
-        Set of short column names (e.g., {"customer_id"})
-
-    Examples:
-        extract_join_columns_for_node(
-            "v3.order_details.customer_id = v3.customer.customer_id",
-            "v3.order_details"
-        ) -> {"customer_id"}
-    """
-    result: set[str] = set()
-    join_expr = parse(f"SELECT 1 WHERE {join_sql}").select.where
-    if join_expr:  # pragma: no branch
-        prefix = node_name + SEPARATOR
-        for col in join_expr.find_all(ast.Column):
-            col_id = col.identifier()
-            if col_id.startswith(prefix):
-                result.add(get_short_name(col_id))
-    return result
-
-
 def get_dimension_table_alias(
     resolved_dim: ResolvedDimension,
     main_alias: str,
@@ -393,81 +352,26 @@ def get_dimension_table_alias(
     return main_alias  # pragma: no cover
 
 
-def collect_cte_nodes_and_needed_columns(
+def collect_cte_nodes(
     ctx: BuildContext,
     parent_node: Node,
     resolved_dimensions: list[ResolvedDimension],
-    grain_col_specs: list[tuple[ast.Expression, str]],
-    metric_expressions: list[tuple[str, ast.Expression]],
-) -> tuple[list[Node], dict[str, set[str]]]:
+) -> list[Node]:
     """
-    Determine which nodes need CTEs and the minimal set of columns each must project.
+    Determine which nodes need CTEs.
 
-    Returns a tuple of:
-    - nodes_for_ctes: ordered list of non-source nodes that require CTEs
-    - needed_columns_by_node: mapping of node name -> set of column names that
-      must remain in that node's CTE projection after filter_cte_projection runs
+    Returns the ordered list of non-source nodes that require CTEs: the parent
+    node, plus every dimension node sitting on a resolved dimension's join path
+    (including intermediate hops, which a multi-hop chain routes through).
 
-    The needed columns for each node are gathered from:
-    - For parent_node: local dimension columns, grain columns, metric expression
-      columns, join key columns, and temporal partition columns
-    - For each dimension node: the requested dimension attribute, join key columns,
-      and any columns referenced from that node in parent_node's or other dimension
-      nodes' SQL (including aliased references like CROSS JOIN node AS alias)
+    What each CTE has to project is settled later, by
+    :func:`prune_cte_projections` on the assembled query.
     """
     nodes_for_ctes: list[Node] = []
-    needed_columns_by_node: dict[str, set[str]] = {}
-
-    # Collect columns needed from parent node
-    parent_needed_cols: set[str] = set()
-
-    # Add local dimension columns
-    for resolved_dim in resolved_dimensions:
-        if resolved_dim.is_local:
-            parent_needed_cols.add(resolved_dim.column_name)
-
-    # Add grain columns for LIMITED aggregability.
-    # For complex expressions, extract the actual leaf columns they reference.
-    for gc_expr, _ in grain_col_specs:
-        if isinstance(gc_expr, ast.Column):
-            parent_needed_cols.add(gc_expr.name.name)
-        else:
-            parent_needed_cols.update(extract_columns_from_expression(gc_expr))
-
-    # Add columns from metric expressions
-    for _, expr in metric_expressions:
-        parent_needed_cols.update(extract_columns_from_expression(expr))
-
-    # Add join key columns (from the left side of joins)
-    for resolved_dim in resolved_dimensions:
-        if resolved_dim.join_path:
-            for link in resolved_dim.join_path.links:
-                if link.join_sql:  # pragma: no branch
-                    parent_needed_cols.update(
-                        extract_join_columns_for_node(link.join_sql, parent_node.name),
-                    )
-
-    # Add temporal partition columns from cube if linked to this parent
-    # This ensures the columns are available in the CTE for the WHERE clause
-    if ctx.temporal_partition_columns and parent_node.current:
-        for partition_col_ref in ctx.temporal_partition_columns:
-            dimension_ref = parse_dimension_ref(partition_col_ref)
-
-            # Match the exact dimension link. The same parent can reach one
-            # dimension node through multiple roles.
-            if parent_node.current.dimension_links:  # pragma: no branch
-                for link in parent_node.current.dimension_links:  # pragma: no branch
-                    if (
-                        link.dimension.name == dimension_ref.node_name
-                        and (link.role or None) == dimension_ref.role
-                    ):
-                        parent_needed_cols.add(dimension_ref.column_name)
-                        break
 
     # Parent node needs CTE if it's not a source
     if parent_node.type != NodeType.SOURCE:  # pragma: no branch
         nodes_for_ctes.append(parent_node)
-        needed_columns_by_node[parent_node.name] = parent_needed_cols
 
     # Dimension nodes from joins need CTEs
     for resolved_dim in resolved_dimensions:
@@ -479,155 +383,7 @@ def collect_cte_nodes_and_needed_columns(
                     if dim_node not in nodes_for_ctes:
                         nodes_for_ctes.append(dim_node)
 
-                    # Collect needed columns for this dimension
-                    dim_cols: set[str] = set()
-
-                    # Add the dimension column being selected
-                    if resolved_dim.join_path.target_node_name == dim_node.name:
-                        dim_cols.add(resolved_dim.column_name)
-
-                    # Add join key columns from this dimension (right side of this link)
-                    if link.join_sql:  # pragma: no branch
-                        dim_cols.update(
-                            extract_join_columns_for_node(link.join_sql, dim_node.name),
-                        )
-
-                    # Case 1: parent_node's query directly selects from dim_node
-                    nodes_to_scan: list[Node] = []
-                    if parent_node.current and parent_node.current.query:
-                        nodes_to_scan.append(parent_node)
-                    # Case 2: another dimension node's query references dim_node
-                    for other_rdim in resolved_dimensions:
-                        if other_rdim.join_path:
-                            for other_link in other_rdim.join_path.links:
-                                other_dim = ctx.nodes.get(
-                                    other_link.dimension.name,
-                                    other_link.dimension,
-                                )
-                                if (
-                                    other_dim
-                                    and other_dim.name != dim_node.name
-                                    and other_dim.type != NodeType.SOURCE
-                                    and other_dim.current
-                                    and other_dim.current.query
-                                    and other_dim not in nodes_to_scan
-                                ):
-                                    nodes_to_scan.append(other_dim)
-                    for referencing_node in nodes_to_scan:
-                        rq = ctx.get_parsed_query(referencing_node)
-                        found = extract_columns_referenced_from_node(rq, dim_node.name)
-                        if found:
-                            _logger.info(
-                                "filter_cte_projection: %s references cols %s from %s",
-                                referencing_node.name,
-                                sorted(found),
-                                dim_node.name,
-                            )
-                        dim_cols.update(found)
-
-                    # Merge with existing if any
-                    if dim_node.name in needed_columns_by_node:
-                        needed_columns_by_node[dim_node.name].update(dim_cols)
-                    else:
-                        needed_columns_by_node[dim_node.name] = dim_cols
-                    _logger.info(
-                        "filter_cte_projection: keeping cols %s for %s",
-                        sorted(dim_cols),
-                        dim_node.name,
-                    )
-
-                # For multi-hop joins: the left side of this link is an intermediate
-                # dimension node that also needs the left-side join key columns.
-                # (For the first link, the left side is parent_node, already handled
-                # above in parent_needed_cols.)
-                left_node_name = link.node_revision.name
-                if left_node_name != parent_node.name and link.join_sql:
-                    left_node = ctx.nodes.get(left_node_name)
-                    if (
-                        left_node and left_node.type != NodeType.SOURCE
-                    ):  # pragma: no branch
-                        left_join_cols = extract_join_columns_for_node(
-                            link.join_sql,
-                            left_node_name,
-                        )
-                        if left_node_name in needed_columns_by_node:
-                            needed_columns_by_node[left_node_name].update(
-                                left_join_cols,
-                            )
-                        else:  # pragma: no cover
-                            needed_columns_by_node[left_node_name] = left_join_cols
-
-    _add_transitive_consumer_columns(ctx, nodes_for_ctes, needed_columns_by_node)
-
-    return nodes_for_ctes, needed_columns_by_node
-
-
-def _add_transitive_consumer_columns(
-    ctx: BuildContext,
-    nodes_for_ctes: list[Node],
-    needed_columns_by_node: dict[str, set[str]],
-) -> None:
-    """
-    Widen each node's needed columns to cover every CTE that reads from it.
-
-    The loops above only look at the parent node and the dimension nodes sitting
-    on a resolved join path. ``collect_node_ctes`` builds its CTE set from the
-    full transitive closure of the dependency graph, so a node can end up as a
-    CTE without ever being a resolved dimension — an intermediate transform, or a
-    dimension pulled in only as somebody else's parent. Those nodes are never
-    scanned, so the columns they read stay out of ``needed_columns_by_node`` and
-    ``filter_cte_projection`` prunes them away, leaving the consuming CTE
-    referencing a column its source no longer projects.
-
-    Walking the same closure here and unioning in what each CTE actually reads
-    keeps the two sets consistent. Only nodes already in
-    ``needed_columns_by_node`` are widened: a node with no entry is left alone so
-    it stays unpruned, which is what callers expect.
-    """
-    closure: dict[str, Node] = {}
-
-    def collect(node: Node) -> None:
-        if node.name in closure or node.type == NodeType.SOURCE:
-            return
-        closure[node.name] = node
-        if not (node.current and node.current.query):  # pragma: no cover
-            return
-        try:
-            refs = get_table_references_from_ast(ctx.get_parsed_query(node))
-        except Exception:  # pragma: no cover
-            return
-        for ref in refs:
-            if ref_node := ctx.nodes.get(ref):
-                collect(ref_node)
-
-    for node in nodes_for_ctes:
-        collect(node)
-
-    # Only nodes that are already pruned can be under-projected.
-    targets = [
-        name for name in needed_columns_by_node if name in closure or name in ctx.nodes
-    ]
-
-    for consumer in closure.values():
-        if not (consumer.current and consumer.current.query):  # pragma: no cover
-            continue
-        try:
-            consumer_ast = ctx.get_parsed_query(consumer)
-        except Exception:  # pragma: no cover
-            continue
-        for target in targets:
-            if target == consumer.name:
-                continue
-            referenced = extract_columns_referenced_from_node(consumer_ast, target)
-            if referenced - needed_columns_by_node[target]:
-                _logger.info(
-                    "filter_cte_projection: %s references cols %s from %s "
-                    "(transitive consumer)",
-                    consumer.name,
-                    sorted(referenced),
-                    target,
-                )
-            needed_columns_by_node[target].update(referenced)
+    return nodes_for_ctes
 
 
 def _build_temporal_pushdown(
@@ -1435,9 +1191,8 @@ def build_select_ast(
             grain_col_refs.append(ast.Column(name=ast.Name(gc_alias)))
 
     # Resolve dim-namespaced refs in metric expressions (e.g. ``v3.customer.tier``)
-    # to the dim's joined table alias, and remember which columns each dim
-    # CTE must keep. Done up-front so the rewrite is visible to both the
-    # projection loop below and CTE pruning.
+    # to the dim's joined table alias. Done up-front so the rewrite is visible
+    # to both the projection loop below and CTE pruning.
     dim_node_to_alias: dict[str, str] = {}
     for (dim_node_name, role), alias in dim_aliases.items():
         if dim_node_name not in dim_node_to_alias or not role:
@@ -1446,7 +1201,7 @@ def build_select_ast(
     # (COUNT DISTINCT level) expressions. The grain specs hold the same AST
     # objects already placed in the projection above, so rewriting them here is
     # reflected in the emitted SQL.
-    metric_dim_cols = _resolve_dim_namespace_refs(
+    _resolve_dim_namespace_refs(
         [expr for _, expr in metric_expressions]
         + [expr for expr, _ in grain_col_specs],
         dim_node_to_alias,
@@ -1467,16 +1222,8 @@ def build_select_ast(
         parent_node_name=parent_node.name,
     )
 
-    # Collect all nodes that need CTEs and the minimal columns each must project.
-    nodes_for_ctes, needed_columns_by_node = collect_cte_nodes_and_needed_columns(
-        ctx,
-        parent_node,
-        resolved_dimensions,
-        grain_col_specs,
-        metric_expressions,
-    )
-    for dim_name, cols in metric_dim_cols.items():
-        needed_columns_by_node.setdefault(dim_name, set()).update(cols)
+    # Collect all nodes that need CTEs.
+    nodes_for_ctes = collect_cte_nodes(ctx, parent_node, resolved_dimensions)
 
     temporal_filter_ast, injected_cte_filters = _build_temporal_pushdown(
         ctx,
@@ -1566,7 +1313,6 @@ def build_select_ast(
     ctes, scanned_sources, consumed_by_node = collect_node_ctes(
         ctx,
         nodes_for_ctes,
-        needed_columns_by_node,
         injected_filters=injected_cte_filters or None,
         pushdown=PushdownFilters(
             filters=all_filters,
@@ -1665,6 +1411,9 @@ def build_select_ast(
             cte_query.to_cte(ast.Name(cte_name), query)
             cte_list.append(cte_query)
         query.ctes = cte_list
+
+    # Now that every reader exists, each CTE can be trimmed to what they read.
+    prune_cte_projections(query)
 
     return query, scanned_sources
 
@@ -1894,18 +1643,11 @@ def _preagg_dimension_ctes(
     the join straight at its table instead.
     """
     dim_nodes: list[Node] = []
-    needed_columns: dict[str, set[str]] = {}
     for coverage in join_back:
-        rdim = coverage.dimension
-        link = coverage.link
-        dim_node = ctx.nodes.get(link.dimension.name, link.dimension)
+        dim_node = ctx.nodes.get(coverage.link.dimension.name, coverage.link.dimension)
         if dim_node not in dim_nodes:
             dim_nodes.append(dim_node)
-        cols = needed_columns.setdefault(dim_node.name, set())
-        cols.add(rdim.column_name)
-        if link.join_sql:  # pragma: no branch
-            cols.update(extract_join_columns_for_node(link.join_sql, dim_node.name))
-    ctes, scanned_sources, _ = collect_node_ctes(ctx, dim_nodes, needed_columns)
+    ctes, scanned_sources, _ = collect_node_ctes(ctx, dim_nodes)
     return ctes, scanned_sources
 
 
@@ -2209,6 +1951,9 @@ def build_grain_group_from_preagg(
             cte_query.to_cte(ast.Name(cte_name), query)
             cte_list.append(cte_query)
         query.ctes = cte_list
+
+    # Now that every reader exists, each CTE can be trimmed to what they read.
+    prune_cte_projections(query)
 
     # Pre-aggregation path: the only raw sources scanned are those behind the
     # dimensions joined back onto the pre-agg.

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -64,6 +64,7 @@ from datajunction_server.construction.build_v3.types import (
     ResolvedDimension,
 )
 from datajunction_server.construction.build_v3.utils import (
+    column_table_name,
     get_column_type,
     get_cte_name,
     get_short_name,
@@ -586,26 +587,6 @@ def _apply_outer_where_atoms(
             select.where = atom
 
 
-def _col_table_name(col: ast.Column) -> str | None:
-    """Return the table-qualifier short name for a column, or None.
-
-    Handles both qualification styles:
-    - ``_table`` (set by :func:`make_column_ref`) — projection / GROUP BY.
-    - ``name.namespace`` (set by ``_add_table_prefixes_to_filter``) —
-      filter atoms.
-    """
-    tbl = col._table
-    if tbl is not None:
-        tname = getattr(tbl, "name", None)
-        if tname is None:  # pragma: no cover
-            return None
-        return tname.name if hasattr(tname, "name") else str(tname)
-    if col.name and col.name.namespace:
-        ns = col.name.namespace
-        return ns.name if hasattr(ns, "name") else str(ns)
-    return None  # pragma: no cover
-
-
 def _set_col_table_alias(col: ast.Column, new_alias: str) -> None:
     """Rewrite the table-qualifier on a column to ``new_alias``,
     matching the qualification style already on the column.
@@ -740,7 +721,7 @@ def _absorb_filtered_joins_for_outer_safety(
 
     def _process(node: ast.Node) -> None:
         for col in node.find_all(ast.Column):
-            tname_str = _col_table_name(col)
+            tname_str = column_table_name(col)
             if tname_str is not None and tname_str in absorbed_aliases:
                 absorbed_cols[tname_str].add(col.name.name)
                 _set_col_table_alias(col, main_alias)

--- a/datajunction-server/datajunction_server/construction/build_v3/node_query.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/node_query.py
@@ -43,7 +43,7 @@ from datajunction_server.construction.build_v3.measures import (
     build_dimension_joins,
     build_filter_column_aliases,
     build_outer_where,
-    collect_cte_nodes_and_needed_columns,
+    collect_cte_nodes,
     outer_only_filter_refs,
 )
 from datajunction_server.construction.build_v3.types import (
@@ -404,19 +404,12 @@ def _build_with_dimensions(
     those CTEs via ``PushdownFilters`` (handled inside ``collect_node_ctes``);
     everything else is applied at the outer ``WHERE``.
     """
-    # ``collect_cte_nodes_and_needed_columns`` walks every link in every
-    # resolved dim's ``join_path`` and adds each intermediate hop's
-    # dimension to the CTE list — exactly what we need for multi-hop
-    # chains where a dim link routes through an intermediate transform/dim.
-    # Reused from measures.py so we don't drift.  We pass empty grain /
-    # metric args because non-metric nodes don't decompose into components.
-    nodes_for_ctes, _needed_columns = collect_cte_nodes_and_needed_columns(
-        ctx,
-        starting,
-        resolved_dims,
-        grain_col_specs=[],
-        metric_expressions=[],
-    )
+    # ``collect_cte_nodes`` walks every link in every resolved dim's
+    # ``join_path`` and adds each intermediate hop's dimension to the CTE
+    # list — exactly what we need for multi-hop chains where a dim link
+    # routes through an intermediate transform/dim.  Reused from measures.py
+    # so we don't drift.
+    nodes_for_ctes = collect_cte_nodes(ctx, starting, resolved_dims)
 
     # Build the filter-column-alias map up front so ``PushdownFilters``
     # can resolve user filter refs to the right CTE columns.
@@ -430,10 +423,10 @@ def _build_with_dimensions(
     )
 
     # ``collect_node_ctes`` skips sources (they get inlined as physical refs)
-    # and produces bodies in dep order. We deliberately don't pass
-    # ``needed_columns_by_node`` — the v3 metric path uses it for column
-    # trimming, but for ``/sql/{node}`` we want each node's full projection
-    # in the CTE so the user gets every column the node defines.
+    # and produces bodies in dep order. We deliberately don't prune the
+    # projections afterwards — the v3 metric path trims columns, but for
+    # ``/sql/{node}`` we want each node's full projection in the CTE so the
+    # user gets every column the node defines.
     cte_pairs, _, _ = collect_node_ctes(
         ctx,
         nodes_for_ctes,

--- a/datajunction-server/datajunction_server/construction/build_v3/utils.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/utils.py
@@ -155,6 +155,13 @@ def extract_columns_referenced_from_node(
     columns appear as ``alias.col``) and unaliased references (where columns
     appear as ``node_short_name.col`` or ``full.node.name.col``).
 
+    A column written with no qualifier at all counts too, as long as the node
+    appears somewhere in the query as a table. Which table such a column belongs
+    to is only knowable after compilation, and callers use this set to decide
+    what a CTE must keep projecting: claiming a column the node does not have is
+    a no-op, while missing one the node does have emits SQL that cannot run. So
+    an unqualified column is charged to every node the query reads from.
+
     Args:
         query_ast: The parsed query to scan.
         node_name: Full node name (e.g. ``common.dimensions.xp.max_observation_end``).
@@ -185,6 +192,9 @@ def extract_columns_referenced_from_node(
         # (e.g. "alias.column_name") without requiring col.table to be set,
         # since that is only populated after compilation.
         col_id = col.identifier()
+        if SEPARATOR not in col_id:
+            result.add(col_id)
+            continue
         for prefix in prefixes:
             if col_id.startswith(prefix + SEPARATOR):
                 result.add(get_short_name(col_id))

--- a/datajunction-server/datajunction_server/construction/build_v3/utils.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/utils.py
@@ -104,6 +104,26 @@ def get_column_type(node: Node, column_name: str) -> str:
     return "string"  # pragma: no cover
 
 
+def column_table_name(col: ast.Column) -> str | None:
+    """Return the table-qualifier short name for a column, or None.
+
+    Handles both qualification styles:
+    - ``_table`` (set by :func:`make_column_ref`) — projection / GROUP BY.
+    - ``name.namespace`` (set by ``_add_table_prefixes_to_filter``) —
+      filter atoms.
+    """
+    tbl = col._table
+    if tbl is not None:
+        tname = getattr(tbl, "name", None)
+        if tname is None:  # pragma: no cover
+            return None
+        return tname.name if hasattr(tname, "name") else str(tname)
+    if col.name and col.name.namespace:
+        ns = col.name.namespace
+        return ns.name if hasattr(ns, "name") else str(ns)
+    return None  # pragma: no cover
+
+
 def extract_columns_from_expression(expr: ast.Expression) -> set[str]:
     """
     Extract all column names referenced in an expression.

--- a/datajunction-server/datajunction_server/construction/build_v3/utils.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/utils.py
@@ -144,64 +144,6 @@ def iter_namespaced_columns(expr: ast.Expression) -> Iterator[NamespacedColumn]:
             )
 
 
-def extract_columns_referenced_from_node(
-    query_ast: ast.Query,
-    node_name: str,
-) -> set[str]:
-    """
-    Extract column names that a query uses from a specific node.
-
-    Handles both aliased references (e.g. ``CROSS JOIN node AS alias`` where
-    columns appear as ``alias.col``) and unaliased references (where columns
-    appear as ``node_short_name.col`` or ``full.node.name.col``).
-
-    A column written with no qualifier at all counts too, as long as the node
-    appears somewhere in the query as a table. Which table such a column belongs
-    to is only knowable after compilation, and callers use this set to decide
-    what a CTE must keep projecting: claiming a column the node does not have is
-    a no-op, while missing one the node does have emits SQL that cannot run. So
-    an unqualified column is charged to every node the query reads from.
-
-    Args:
-        query_ast: The parsed query to scan.
-        node_name: Full node name (e.g. ``common.dimensions.xp.max_observation_end``).
-
-    Returns:
-        Set of short column names used from that node.
-    """
-    # Build the set of table-reference prefixes that map to this node.
-    # A table may be aliased (AS tbl_alias) or bare — we collect all identifiers
-    # by which columns may be qualified.
-    prefixes: set[str] = set()
-    for table in query_ast.find_all(ast.Table):
-        if str(table.name) == node_name:
-            if table.alias:
-                prefixes.add(str(table.alias))
-            else:
-                # No alias: SQL can qualify columns by the full name or the
-                # last segment only (most common in practice).
-                prefixes.add(node_name)
-                prefixes.add(node_name.split(SEPARATOR)[-1])
-
-    if not prefixes:
-        return set()
-
-    result: set[str] = set()
-    for col in query_ast.find_all(ast.Column):
-        # col.identifier() returns the full namespace-prefixed name
-        # (e.g. "alias.column_name") without requiring col.table to be set,
-        # since that is only populated after compilation.
-        col_id = col.identifier()
-        if SEPARATOR not in col_id:
-            result.add(col_id)
-            continue
-        for prefix in prefixes:
-            if col_id.startswith(prefix + SEPARATOR):
-                result.add(get_short_name(col_id))
-                break
-    return result
-
-
 def collect_required_dimensions(
     nodes: dict[str, Node],
     metrics: list[str],

--- a/datajunction-server/tests/api/sql_test.py
+++ b/datajunction-server/tests/api/sql_test.py
@@ -1583,8 +1583,7 @@ async def test_metric_with_node_level_and_nth_order_filters(
         ),
         default_repair_orders_fact AS (
         SELECT  repair_orders.repair_order_id,
-        	repair_orders.hard_hat_id,
-        	repair_orders.dispatcher_id
+        	repair_orders.hard_hat_id
          FROM default.roads.repair_orders repair_orders JOIN default.roads.repair_order_details repair_order_details ON repair_orders.repair_order_id = repair_order_details.repair_order_id
          WHERE  repair_orders.dispatcher_id = 1 OR repair_orders.dispatcher_id IS NOT NULL
         ),
@@ -1676,8 +1675,7 @@ async def test_metric_with_nth_order_dimensions_filters(
         SELECT  repair_orders.repair_order_id,
         	repair_orders.municipality_id,
         	repair_orders.hard_hat_id,
-        	repair_orders.dispatcher_id,
-        	repair_orders.order_date
+        	repair_orders.dispatcher_id
          FROM default.roads.repair_orders repair_orders JOIN default.roads.repair_order_details repair_order_details ON repair_orders.repair_order_id = repair_order_details.repair_order_id
          WHERE  repair_orders.dispatcher_id = 1 AND repair_orders.order_date >= '2020-01-01'
         ),

--- a/datajunction-server/tests/construction/build_v3/cte_transitive_consumer_test.py
+++ b/datajunction-server/tests/construction/build_v3/cte_transitive_consumer_test.py
@@ -5,6 +5,8 @@ what its upstream CTEs may prune.
 
 import pytest
 
+from tests.construction.build_v3.projection_invariant import unprojected_references
+
 
 class TestTransitiveConsumerProjection:
     """
@@ -136,9 +138,11 @@ class TestTransitiveConsumerProjection:
         assert resp.status_code == 200, resp.text
         sql = resp.json()["grain_groups"][0]["sql"]
 
+        # ``bundles`` is itself pruned to what ``fact`` reads from it, which
+        # narrows its own demand on ``item`` — so ``item`` need not keep
+        # ``bundle_id``. What has to hold either way is that nothing reads a
+        # column its producer stopped projecting.
+        assert unprojected_references(sql) == set(), sql
+
         item_cte = sql.split(f"{ns}_bundles")[0]
         assert "channel" in item_cte, sql
-        assert "bundle_id" in item_cte, (
-            f"{ns}.item CTE pruned bundle_id, but {ns}.bundles "
-            f"selects it from that CTE:\n\n{sql}"
-        )

--- a/datajunction-server/tests/construction/build_v3/cte_transitive_consumer_test.py
+++ b/datajunction-server/tests/construction/build_v3/cte_transitive_consumer_test.py
@@ -5,6 +5,7 @@ what its upstream CTEs may prune.
 
 import pytest
 
+from tests.construction.build_v3 import assert_sql_equal
 from tests.construction.build_v3.projection_invariant import unprojected_references
 
 
@@ -140,9 +141,29 @@ class TestTransitiveConsumerProjection:
 
         # ``bundles`` is itself pruned to what ``fact`` reads from it, which
         # narrows its own demand on ``item`` — so ``item`` need not keep
-        # ``bundle_id``. What has to hold either way is that nothing reads a
-        # column its producer stopped projecting.
+        # ``bundle_id``. It does keep ``channel``, which the outer select asks
+        # for through a separate join.
+        assert_sql_equal(
+            sql,
+            """
+            WITH ctetrans_item AS (
+              SELECT item_id,
+                CASE WHEN kind_code = 'AUTO' THEN 'auto' ELSE 'manual' END AS channel
+              FROM default.ctetrans.src_item
+            ),
+            ctetrans_bundles AS (
+              SELECT i.item_id FROM ctetrans_item AS i
+            ),
+            ctetrans_fact AS (
+              SELECT e.item_id, e.amount
+              FROM default.ctetrans.src_event AS e
+              LEFT JOIN ctetrans_bundles AS b ON e.item_id = b.item_id
+            )
+            SELECT t2.channel, SUM(t1.amount) AS amount_sum_3ade80bc
+            FROM ctetrans_fact t1
+            LEFT OUTER JOIN ctetrans_item t2 ON t1.item_id = t2.item_id
+            GROUP BY t2.channel
+            """,
+            normalize_aliases=True,
+        )
         assert unprojected_references(sql) == set(), sql
-
-        item_cte = sql.split(f"{ns}_bundles")[0]
-        assert "channel" in item_cte, sql

--- a/datajunction-server/tests/construction/build_v3/cte_unqualified_columns_test.py
+++ b/datajunction-server/tests/construction/build_v3/cte_unqualified_columns_test.py
@@ -9,6 +9,7 @@ other CTE projects.
 
 import pytest
 
+from tests.construction.build_v3 import assert_sql_equal
 from tests.construction.build_v3.projection_invariant import unprojected_references
 
 
@@ -169,6 +170,43 @@ class TestUnqualifiedColumnsSurvivePruning:
         assert resp.status_code == 200, resp.text
         sql = resp.json()["grain_groups"][0]["sql"]
 
+        # ``parent_dim`` keeps code_a, code_b and code_c: ``child_dim`` names
+        # them bare, and the outer select never asks for them.
+        assert_sql_equal(
+            sql,
+            """
+            WITH cteunqual_fact AS (
+              SELECT item_id, amount FROM default.cteunqual.src_event
+            ),
+            cteunqual_parent_dim AS (
+              SELECT item_id, code_a, code_b, code_c, region
+              FROM default.cteunqual.src_item
+            ),
+            cteunqual_partner_dim AS (
+              SELECT external_item_id, is_special
+              FROM default.cteunqual.src_partner_item
+            ),
+            cteunqual_child_dim AS (
+              SELECT item_id,
+                CASE
+                  WHEN code_a = 'PROMO' THEN 'promo'
+                  WHEN code_b = 'DIRECT' AND code_c = 'OPEN' THEN 'direct'
+                  ELSE 'other'
+                END AS channel
+              FROM cteunqual_parent_dim
+              UNION ALL
+              SELECT external_item_id AS item_id,
+                CASE WHEN is_special THEN 'special' ELSE 'other' END AS channel
+              FROM cteunqual_partner_dim
+            )
+            SELECT t2.region, t3.channel, SUM(t1.amount) AS amount_sum_f9cdc501
+            FROM cteunqual_fact t1
+            LEFT OUTER JOIN cteunqual_parent_dim t2 ON t1.item_id = t2.item_id
+            LEFT OUTER JOIN cteunqual_child_dim t3 ON t1.item_id = t3.item_id
+            GROUP BY t2.region, t3.channel
+            """,
+            normalize_aliases=True,
+        )
         assert unprojected_references(sql) == set(), sql
 
 
@@ -329,4 +367,38 @@ class TestPassThroughColumnSurvivesPruning:
         assert resp.status_code == 200, resp.text
         sql = resp.json()["grain_groups"][0]["sql"]
 
+        # ``parent_dim`` derives ``channel`` and ``child_dim`` passes it
+        # through by bare name, so pruning the parent for ``region`` alone
+        # must not take ``channel`` with it.
+        assert_sql_equal(
+            sql,
+            """
+            WITH ctepassthru_fact AS (
+              SELECT item_id, amount FROM default.ctepassthru.src_event
+            ),
+            ctepassthru_parent_dim AS (
+              SELECT item_id,
+                CASE WHEN code_a = 'PROMO' THEN 'promo' ELSE 'other' END AS channel,
+                region
+              FROM default.ctepassthru.src_item
+            ),
+            ctepassthru_partner_dim AS (
+              SELECT external_item_id, is_special
+              FROM default.ctepassthru.src_partner_item
+            ),
+            ctepassthru_child_dim AS (
+              SELECT item_id, channel FROM ctepassthru_parent_dim
+              UNION ALL
+              SELECT external_item_id AS item_id,
+                CASE WHEN is_special THEN 'special' ELSE 'other' END AS channel
+              FROM ctepassthru_partner_dim
+            )
+            SELECT t2.region, t3.channel, SUM(t1.amount) AS amount_sum_d1ea4ab8
+            FROM ctepassthru_fact t1
+            LEFT OUTER JOIN ctepassthru_parent_dim t2 ON t1.item_id = t2.item_id
+            LEFT OUTER JOIN ctepassthru_child_dim t3 ON t1.item_id = t3.item_id
+            GROUP BY t2.region, t3.channel
+            """,
+            normalize_aliases=True,
+        )
         assert unprojected_references(sql) == set(), sql

--- a/datajunction-server/tests/construction/build_v3/cte_unqualified_columns_test.py
+++ b/datajunction-server/tests/construction/build_v3/cte_unqualified_columns_test.py
@@ -7,78 +7,9 @@ tests state the invariant directly: whatever a CTE reads from another CTE, that
 other CTE projects.
 """
 
-from typing import cast
-from collections.abc import Iterator
-
 import pytest
 
-from datajunction_server.sql.parsing import ast
-from datajunction_server.sql.parsing.backends.antlr4 import parse
-
-
-def _projected_names(cte: ast.Query) -> set[str]:
-    """Names a CTE exposes, taking the first branch of any set operation."""
-    names = set()
-    for expression in cte.select.projection:
-        names.add(cast(ast.Aliasable, expression).alias_or_name.name)
-    return names
-
-
-def _branches(select: ast.SelectExpression) -> list[ast.SelectExpression]:
-    """Each arm of a set operation, or the select itself when there is none."""
-    branches = []
-    branch: ast.SelectExpression | None = select
-    while branch is not None:
-        branches.append(branch)
-        branch = branch.set_op.right if branch.set_op else None
-    return branches
-
-
-def _branch_columns(branch: ast.SelectExpression) -> Iterator[ast.Column]:
-    """Columns of one arm, not those of the arms unioned after it."""
-    parts = [
-        *branch.projection,
-        *branch.group_by,
-        *([branch.from_] if branch.from_ else []),
-        *([branch.where] if branch.where else []),
-        *([branch.having] if branch.having else []),
-    ]
-    for part in parts:
-        yield from part.find_all(ast.Column)
-
-
-def unprojected_references(sql: str) -> set[str]:
-    """
-    Find every column a CTE reads from another CTE that is not projected there.
-
-    Each arm of a set operation is read on its own, so a bare column in an arm
-    drawing on a single CTE is charged to that CTE. Returns
-    ``<producing cte>.<column>`` for each reference the producer does not
-    project, so an empty set means the query is internally consistent.
-    """
-    query = parse(sql)
-    ctes = {cte.alias_or_name.name: cte for cte in query.ctes}
-
-    missing = set()
-    for scope in [*query.ctes, query]:
-        for branch in _branches(scope.select):
-            tables = list(branch.from_.find_all(ast.Table)) if branch.from_ else []
-            sources = {
-                (table.alias.name if table.alias else table.name.name): ctes[
-                    table.name.name
-                ]
-                for table in tables
-                if table.name.name in ctes
-            }
-            lone_source = (
-                next(iter(sources.values())) if len(tables) == 1 and sources else None
-            )
-            for column in _branch_columns(branch):
-                qualifier, _, name = column.identifier().rpartition(".")
-                producer = sources.get(qualifier) if qualifier else lone_source
-                if producer is not None and name not in _projected_names(producer):
-                    missing.add(f"{producer.alias_or_name.name}.{name}")
-    return missing
+from tests.construction.build_v3.projection_invariant import unprojected_references
 
 
 class TestUnqualifiedColumnsSurvivePruning:

--- a/datajunction-server/tests/construction/build_v3/cte_unqualified_columns_test.py
+++ b/datajunction-server/tests/construction/build_v3/cte_unqualified_columns_test.py
@@ -1,0 +1,401 @@
+"""
+Columns a CTE reads without a table qualifier still hold its source open.
+
+The projection pruner attributes a column to a node by its qualifier, so a bare
+``code_a`` used to belong to nobody and the CTE producing it dropped it. These
+tests state the invariant directly: whatever a CTE reads from another CTE, that
+other CTE projects.
+"""
+
+from typing import cast
+from collections.abc import Iterator
+
+import pytest
+
+from datajunction_server.sql.parsing import ast
+from datajunction_server.sql.parsing.backends.antlr4 import parse
+
+
+def _projected_names(cte: ast.Query) -> set[str]:
+    """Names a CTE exposes, taking the first branch of any set operation."""
+    names = set()
+    for expression in cte.select.projection:
+        names.add(cast(ast.Aliasable, expression).alias_or_name.name)
+    return names
+
+
+def _branches(select: ast.SelectExpression) -> list[ast.SelectExpression]:
+    """Each arm of a set operation, or the select itself when there is none."""
+    branches = []
+    branch: ast.SelectExpression | None = select
+    while branch is not None:
+        branches.append(branch)
+        branch = branch.set_op.right if branch.set_op else None
+    return branches
+
+
+def _branch_columns(branch: ast.SelectExpression) -> Iterator[ast.Column]:
+    """Columns of one arm, not those of the arms unioned after it."""
+    parts = [
+        *branch.projection,
+        *branch.group_by,
+        *([branch.from_] if branch.from_ else []),
+        *([branch.where] if branch.where else []),
+        *([branch.having] if branch.having else []),
+    ]
+    for part in parts:
+        yield from part.find_all(ast.Column)
+
+
+def unprojected_references(sql: str) -> set[str]:
+    """
+    Find every column a CTE reads from another CTE that is not projected there.
+
+    Each arm of a set operation is read on its own, so a bare column in an arm
+    drawing on a single CTE is charged to that CTE. Returns
+    ``<producing cte>.<column>`` for each reference the producer does not
+    project, so an empty set means the query is internally consistent.
+    """
+    query = parse(sql)
+    ctes = {cte.alias_or_name.name: cte for cte in query.ctes}
+
+    missing = set()
+    for scope in [*query.ctes, query]:
+        for branch in _branches(scope.select):
+            tables = list(branch.from_.find_all(ast.Table)) if branch.from_ else []
+            sources = {
+                (table.alias.name if table.alias else table.name.name): ctes[
+                    table.name.name
+                ]
+                for table in tables
+                if table.name.name in ctes
+            }
+            lone_source = (
+                next(iter(sources.values())) if len(tables) == 1 and sources else None
+            )
+            for column in _branch_columns(branch):
+                qualifier, _, name = column.identifier().rpartition(".")
+                producer = sources.get(qualifier) if qualifier else lone_source
+                if producer is not None and name not in _projected_names(producer):
+                    missing.add(f"{producer.alias_or_name.name}.{name}")
+    return missing
+
+
+class TestUnqualifiedColumnsSurvivePruning:
+    """
+    ``child_dim`` unions two parents and reads ``parent_dim``'s columns bare, so
+    the pruner has to keep them even though nothing says where they come from.
+    """
+
+    async def _setup(self, client, ns: str):
+        resp = await client.post(f"/namespaces/{ns}/")
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": f"{ns}.src_item",
+                "catalog": "default",
+                "schema_": ns,
+                "table": "src_item",
+                "columns": [
+                    {"name": "item_id", "type": "int"},
+                    {"name": "code_a", "type": "string"},
+                    {"name": "code_b", "type": "string"},
+                    {"name": "code_c", "type": "string"},
+                    {"name": "region", "type": "string"},
+                ],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": f"{ns}.src_partner_item",
+                "catalog": "default",
+                "schema_": ns,
+                "table": "src_partner_item",
+                "columns": [
+                    {"name": "external_item_id", "type": "int"},
+                    {"name": "is_special", "type": "bool"},
+                ],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": f"{ns}.src_event",
+                "catalog": "default",
+                "schema_": ns,
+                "table": "src_event",
+                "columns": [
+                    {"name": "event_id", "type": "int"},
+                    {"name": "item_id", "type": "int"},
+                    {"name": "amount", "type": "double"},
+                ],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": f"{ns}.parent_dim",
+                "mode": "published",
+                "primary_key": ["item_id"],
+                "query": (
+                    f"SELECT item_id, code_a, code_b, code_c, region FROM {ns}.src_item"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": f"{ns}.partner_dim",
+                "mode": "published",
+                "primary_key": ["external_item_id"],
+                "query": (
+                    f"SELECT external_item_id, is_special FROM {ns}.src_partner_item"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        # Every code_* here is bare: no alias, no node qualifier.
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": f"{ns}.child_dim",
+                "mode": "published",
+                "primary_key": ["item_id"],
+                "query": (
+                    f"SELECT item_id, "
+                    f"CASE WHEN code_a = 'PROMO' THEN 'promo' "
+                    f"WHEN code_b = 'DIRECT' AND code_c = 'OPEN' THEN 'direct' "
+                    f"ELSE 'other' END AS channel "
+                    f"FROM {ns}.parent_dim "
+                    f"UNION ALL "
+                    f"SELECT external_item_id AS item_id, "
+                    f"CASE WHEN is_special THEN 'special' ELSE 'other' END AS channel "
+                    f"FROM {ns}.partner_dim"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": f"{ns}.fact",
+                "mode": "published",
+                "query": f"SELECT event_id, item_id, amount FROM {ns}.src_event",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        for dimension in ("parent_dim", "child_dim"):
+            resp = await client.post(
+                f"/nodes/{ns}.fact/link",
+                json={
+                    "dimension_node": f"{ns}.{dimension}",
+                    "join_type": "left",
+                    "join_on": f"{ns}.fact.item_id = {ns}.{dimension}.item_id",
+                },
+            )
+            assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": f"{ns}.total_amount",
+                "mode": "published",
+                "query": f"SELECT SUM(amount) FROM {ns}.fact",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+    @pytest.mark.asyncio
+    async def test_every_cte_projects_what_its_readers_ask_for(
+        self,
+        client_with_service_setup,
+    ):
+        client = client_with_service_setup
+        ns = "cteunqual"
+        await self._setup(client, ns)
+
+        resp = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": [f"{ns}.total_amount"],
+                "dimensions": [f"{ns}.parent_dim.region", f"{ns}.child_dim.channel"],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        sql = resp.json()["grain_groups"][0]["sql"]
+
+        assert unprojected_references(sql) == set(), sql
+
+
+class TestPassThroughColumnSurvivesPruning:
+    """
+    ``parent_dim`` derives ``channel`` itself and ``child_dim`` passes it
+    through, naming it bare. The reference carries no qualifier, so pruning the
+    parent for an unrelated dimension used to drop the column out from under it.
+    """
+
+    async def _setup(self, client, ns: str):
+        resp = await client.post(f"/namespaces/{ns}/")
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": f"{ns}.src_item",
+                "catalog": "default",
+                "schema_": ns,
+                "table": "src_item",
+                "columns": [
+                    {"name": "item_id", "type": "int"},
+                    {"name": "code_a", "type": "string"},
+                    {"name": "region", "type": "string"},
+                ],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": f"{ns}.src_partner_item",
+                "catalog": "default",
+                "schema_": ns,
+                "table": "src_partner_item",
+                "columns": [
+                    {"name": "external_item_id", "type": "int"},
+                    {"name": "is_special", "type": "bool"},
+                ],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/source/",
+            json={
+                "name": f"{ns}.src_event",
+                "catalog": "default",
+                "schema_": ns,
+                "table": "src_event",
+                "columns": [
+                    {"name": "event_id", "type": "int"},
+                    {"name": "item_id", "type": "int"},
+                    {"name": "amount", "type": "double"},
+                ],
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        # The parent derives `channel`, so the child has a column to pass through.
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": f"{ns}.parent_dim",
+                "mode": "published",
+                "primary_key": ["item_id"],
+                "query": (
+                    f"SELECT item_id, "
+                    f"CASE WHEN code_a = 'PROMO' THEN 'promo' ELSE 'other' END AS channel, "
+                    f"region FROM {ns}.src_item"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": f"{ns}.partner_dim",
+                "mode": "published",
+                "primary_key": ["external_item_id"],
+                "query": (
+                    f"SELECT external_item_id, is_special FROM {ns}.src_partner_item"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        # `channel` is named bare: no alias, no node qualifier.
+        resp = await client.post(
+            "/nodes/dimension/",
+            json={
+                "name": f"{ns}.child_dim",
+                "mode": "published",
+                "primary_key": ["item_id"],
+                "query": (
+                    f"SELECT item_id, channel FROM {ns}.parent_dim "
+                    f"UNION ALL "
+                    f"SELECT external_item_id AS item_id, "
+                    f"CASE WHEN is_special THEN 'special' ELSE 'other' END AS channel "
+                    f"FROM {ns}.partner_dim"
+                ),
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/transform/",
+            json={
+                "name": f"{ns}.fact",
+                "mode": "published",
+                "query": f"SELECT event_id, item_id, amount FROM {ns}.src_event",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+        for dimension in ("parent_dim", "child_dim"):
+            resp = await client.post(
+                f"/nodes/{ns}.fact/link",
+                json={
+                    "dimension_node": f"{ns}.{dimension}",
+                    "join_type": "left",
+                    "join_on": f"{ns}.fact.item_id = {ns}.{dimension}.item_id",
+                },
+            )
+            assert resp.status_code in (200, 201), resp.text
+
+        resp = await client.post(
+            "/nodes/metric/",
+            json={
+                "name": f"{ns}.total_amount",
+                "mode": "published",
+                "query": f"SELECT SUM(amount) FROM {ns}.fact",
+            },
+        )
+        assert resp.status_code in (200, 201), resp.text
+
+    @pytest.mark.asyncio
+    async def test_parent_keeps_the_column_its_child_passes_through(
+        self,
+        client_with_service_setup,
+    ):
+        client = client_with_service_setup
+        ns = "ctepassthru"
+        await self._setup(client, ns)
+
+        # Asking for a dimension from the parent as well is what turns pruning
+        # on for it; `child_dim.channel` alone leaves the parent unpruned.
+        resp = await client.get(
+            "/sql/measures/v3/",
+            params={
+                "metrics": [f"{ns}.total_amount"],
+                "dimensions": [f"{ns}.parent_dim.region", f"{ns}.child_dim.channel"],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        sql = resp.json()["grain_groups"][0]["sql"]
+
+        assert unprojected_references(sql) == set(), sql

--- a/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
+++ b/datajunction-server/tests/construction/build_v3/filter_pushdown_test.py
@@ -36,8 +36,7 @@ class TestFilterPushdownToParentCTE:
             """
             WITH
             v3_order_details AS (
-              SELECT o.order_date,
-                oi.product_id,
+              SELECT oi.product_id,
                 oi.quantity * oi.unit_price AS line_total
               FROM default.v3.orders o
               JOIN default.v3.order_items oi ON o.order_id = oi.order_id
@@ -129,8 +128,7 @@ class TestFilterPushdownMultiple:
             """
             WITH
             v3_order_details AS (
-              SELECT o.order_date,
-                oi.product_id,
+              SELECT oi.product_id,
                 oi.quantity * oi.unit_price AS line_total
               FROM default.v3.orders o
               JOIN default.v3.order_items oi ON o.order_id = oi.order_id
@@ -176,9 +174,7 @@ class TestFilterPushdownMultiple:
             """
             WITH
             v3_order_details AS (
-              SELECT o.order_date,
-                o.status,
-                oi.product_id,
+              SELECT oi.product_id,
                 oi.quantity * oi.unit_price AS line_total
               FROM default.v3.orders o
               JOIN default.v3.order_items oi ON o.order_id = oi.order_id
@@ -227,9 +223,7 @@ class TestFilterPushdownMultiRef:
             """
             WITH
             v3_order_details AS (
-              SELECT o.order_date,
-                o.status,
-                oi.product_id,
+              SELECT oi.product_id,
                 oi.quantity * oi.unit_price AS line_total
               FROM default.v3.orders o
               JOIN default.v3.order_items oi ON o.order_id = oi.order_id
@@ -389,8 +383,7 @@ class TestFilterPushdownOperators:
             """
             WITH
             v3_order_details AS (
-              SELECT o.order_date,
-                oi.product_id,
+              SELECT oi.product_id,
                 oi.quantity * oi.unit_price AS line_total
               FROM default.v3.orders o
               JOIN default.v3.order_items oi ON o.order_id = oi.order_id
@@ -549,8 +542,7 @@ class TestFilterPushdownOperators:
             """
             WITH
             v3_order_details AS (
-              SELECT o.order_date,
-                oi.product_id,
+              SELECT oi.product_id,
                 oi.quantity * oi.unit_price AS line_total
               FROM default.v3.orders o
               JOIN default.v3.order_items oi ON o.order_id = oi.order_id
@@ -754,9 +746,7 @@ class TestFilterPushdownMultiRole:
             """
             WITH
             v3_order_details AS (
-              SELECT o.order_date,
-                o.from_location_id,
-                oi.product_id,
+              SELECT oi.product_id,
                 oi.quantity * oi.unit_price AS line_total
               FROM default.v3.orders o
               JOIN default.v3.order_items oi ON o.order_id = oi.order_id
@@ -1091,8 +1081,7 @@ class TestFilterPushdownCrossJoinAggregatesColumnAway:
               WHERE window_id IN ('7day')
             ),
             v3_entity_window_config AS (
-              SELECT e.entity_id,
-                MAX(e.base_value + w.window_size) AS max_bound
+              SELECT e.entity_id
               FROM default.v3.entity_facts AS e
               CROSS JOIN (
                 SELECT window_id, window_size
@@ -1102,7 +1091,7 @@ class TestFilterPushdownCrossJoinAggregatesColumnAway:
               GROUP BY e.entity_id
             ),
             v3_entity_report AS (
-              SELECT c.entity_id, w.window_id
+              SELECT c.entity_id
               FROM v3_entity_window_config AS c
               CROSS JOIN v3_time_window_dim AS w
               WHERE w.window_id IN ('7day')
@@ -1659,7 +1648,7 @@ class TestFilterNotPushedToTransitiveUpstreamByColumnNameCollision:
             sql,
             """
             WITH v3_xform_alloc AS (
-              SELECT a.entity_id, SUM(a.value) AS total_value, a.snap_date
+              SELECT a.entity_id, a.snap_date
               FROM default.v3.snap_src AS a
               WHERE a.snap_date = 20240101
               GROUP BY a.entity_id, a.snap_date
@@ -1910,7 +1899,7 @@ class TestDimLabelFilterNameCollision:
             sql,
             """
             WITH v3_ml_alloc AS (
-              SELECT account_id, is_bot, amount
+              SELECT is_bot, amount
               FROM default.v3.ml_alloc_src
             ),
             v3_ml_is_bot_dim AS (
@@ -2084,7 +2073,7 @@ class TestFilterPushdownRoleQualifiedSharedDim:
               FROM default.v3.shows
             ),
             v3_show_activity AS (
-              SELECT show_id, region_date, view_secs
+              SELECT show_id, view_secs
               FROM default.v3.show_events
               WHERE region_date BETWEEN 20240101 AND 20240201
             )

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -66,6 +66,9 @@ from datajunction_server.models.node import NodeType
 from datajunction_server.naming import amenable_col_names
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import ast, parse
+from tests.construction.build_v3.projection_invariant import (
+    unprojected_references,
+)
 
 
 class TestDimensionRefParsing:
@@ -2531,3 +2534,67 @@ class TestPruneCteProjections:
 
     def test_query_without_ctes_is_untouched(self):
         assert self._pruned("SELECT a FROM t") == str(parse("SELECT a FROM t"))
+
+
+class TestProjectionInvariantOracle:
+    """
+    Tests for the oracle the pruning tests are gated on.
+
+    It is only worth trusting if it still fails on the shapes that motivated
+    this work, so those are pinned here directly.
+    """
+
+    def test_consistent_query_reports_nothing(self):
+        assert (
+            unprojected_references(
+                "WITH a AS (SELECT id, keep FROM t) SELECT x.keep FROM a AS x",
+            )
+            == set()
+        )
+
+    def test_reports_a_bare_reference_the_producer_dropped(self):
+        """The original bug: a CTE reads a column its source stopped projecting."""
+        assert unprojected_references(
+            "WITH a AS (SELECT id FROM t), "
+            "b AS (SELECT CASE WHEN code_a = 'x' THEN 1 END AS flag FROM a) "
+            "SELECT y.flag FROM b AS y",
+        ) == {"a.code_a"}
+
+    def test_reports_a_qualified_reference_the_producer_dropped(self):
+        assert unprojected_references(
+            "WITH a AS (SELECT id FROM t) SELECT x.gone FROM a AS x",
+        ) == {"a.gone"}
+
+    def test_reports_per_union_arm(self):
+        """An arm is read on its own, so its own source is the one charged."""
+        assert unprojected_references(
+            "WITH a AS (SELECT id FROM t1), b AS (SELECT id FROM t2), "
+            "c AS (SELECT id FROM a UNION ALL SELECT missing FROM b) "
+            "SELECT z.id FROM c AS z",
+        ) == {"b.missing"}
+
+    def test_excuses_a_filter_on_the_arm_s_own_output_alias(self):
+        """
+        A filter pushed into a CTE can land on a name the arm introduces with
+        ``AS``. The source never had a column by that name, so charging it there
+        would be a false alarm.
+        """
+        assert (
+            unprojected_references(
+                "WITH a AS (SELECT order_date FROM t), "
+                "b AS (SELECT order_date AS date_id FROM a WHERE date_id = 1) "
+                "SELECT y.date_id FROM b AS y",
+            )
+            == set()
+        )
+
+    def test_still_charges_an_alias_name_used_in_the_projection(self):
+        """
+        The excuse is only for filter clauses. A bare name in the projection is
+        read from the source, whatever else the arm happens to alias.
+        """
+        assert unprojected_references(
+            "WITH a AS (SELECT id FROM t), "
+            "b AS (SELECT channel, id AS channel_id FROM a) "
+            "SELECT y.channel FROM b AS y",
+        ) == {"a.channel"}

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -3,6 +3,8 @@
 from typing import cast
 from unittest.mock import MagicMock
 
+import duckdb
+
 import pytest
 
 from datajunction_server.construction.build_v3.cte import (
@@ -2598,3 +2600,111 @@ class TestProjectionInvariantOracle:
             "b AS (SELECT channel, id AS channel_id FROM a) "
             "SELECT y.channel FROM b AS y",
         ) == {"a.channel"}
+
+
+class TestPruneCteProjectionsExecuted:
+    """
+    Pruning faults that neither a parse check nor a string comparison notices.
+
+    Cutting too deep here does not raise. The query still runs and gives back a
+    different number, or the same numbers in a different order, which is how it
+    reaches a Spark job before anyone looks. So these run the SQL both ways and
+    compare what comes back.
+    """
+
+    SETUP = (
+        "CREATE TABLE t (id INTEGER, grp VARCHAR, keep INTEGER, drop_me INTEGER)",
+        "INSERT INTO t VALUES "
+        "(1,'a',10,100),(2,'a',10,101),(3,'b',20,200),(4,'b',20,200)",
+    )
+
+    def _execute(self, sql: str):
+        connection = duckdb.connect(":memory:")
+        try:
+            for statement in self.SETUP:
+                connection.execute(statement)
+            return connection.execute(sql).fetchall()
+        finally:
+            connection.close()
+
+    def _prune(self, sql: str) -> tuple[str, ast.Query]:
+        query = parse(sql)
+        prune_cte_projections(query)
+        return str(query), query
+
+    def _same_results(self, sql: str) -> str:
+        """Assert pruning did not change the answer; return the pruned SQL."""
+        pruned, _ = self._prune(sql)
+        assert self._execute(pruned) == self._execute(sql), pruned
+        return pruned
+
+    def test_distinct_producer_keeps_every_column(self):
+        """
+        Under DISTINCT the projection is the dedup key. Narrowing it folds
+        together rows that were distinct, and the total silently drops.
+        """
+        sql = (
+            "WITH a AS (SELECT DISTINCT grp, keep, drop_me FROM t) "
+            "SELECT SUM(x.keep) AS s FROM a AS x"
+        )
+        assert self._execute(sql) == [(40,)]
+        pruned, query = self._prune(sql)
+        assert self._execute(pruned) == [(40,)], pruned
+        assert [str(entry) for entry in query.ctes[0].select.projection] == [
+            "grp",
+            "keep",
+            "drop_me",
+        ]
+
+    def test_having_on_the_arm_s_own_alias_survives(self):
+        """HAVING can name an output alias, so that alias has to stay."""
+        sql = (
+            "WITH a AS ("
+            "SELECT grp, SUM(keep) AS s FROM t GROUP BY grp HAVING s > 25"
+            ") SELECT x.grp FROM a AS x"
+        )
+        pruned = self._same_results(sql)
+        assert self._execute(pruned) == [("b",)]
+        assert "s" in pruned
+
+    def test_order_by_on_the_arm_s_own_alias_survives(self):
+        """
+        ORDER BY can name an output alias too. With LIMIT above it the ordering
+        decides which row survives, so losing the alias is not cosmetic.
+        """
+        sql = (
+            "WITH a AS ("
+            "SELECT id, id * 10 AS ranked FROM t ORDER BY ranked DESC LIMIT 1"
+            ") SELECT x.id FROM a AS x"
+        )
+        pruned = self._same_results(sql)
+        assert self._execute(pruned) == [(4,)]
+
+    def test_order_by_position_is_renumbered(self):
+        """
+        A position left alone after the projection shrinks points at whatever
+        slid into that slot, or off the end of it.
+        """
+        sql = (
+            "WITH a AS (SELECT drop_me, id FROM t ORDER BY 2 DESC LIMIT 1) "
+            "SELECT x.id FROM a AS x"
+        )
+        pruned, query = self._prune(sql)
+        assert self._execute(pruned) == self._execute(sql) == [(4,)], pruned
+        arm = query.ctes[0].select
+        assert [str(entry) for entry in arm.projection] == ["id"]
+        assert [str(item.expr) for item in arm.organization.order] == ["1"]
+
+    def test_a_column_only_the_producer_s_where_reads_is_still_dropped(self):
+        """
+        WHERE resolves against the FROM, not against the projection, so a column
+        only the filter uses is free to go. Pinned because protecting it would
+        undo the pruning this pass exists for.
+        """
+        sql = (
+            "WITH a AS (SELECT id, keep FROM t WHERE drop_me > 100) "
+            "SELECT SUM(x.keep) AS s FROM a AS x"
+        )
+        pruned, query = self._prune(sql)
+        assert self._execute(pruned) == self._execute(sql)
+        assert [str(entry) for entry in query.ctes[0].select.projection] == ["keep"]

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -2502,6 +2502,18 @@ class TestPruneCteProjections:
         assert pruned.count("keep") == 3
         assert "drop_me" not in pruned
 
+    @pytest.mark.parametrize("kind", ["UNION", "INTERSECT", "EXCEPT"])
+    def test_dedup_set_operation_arms_are_left_whole(self, kind: str):
+        """
+        For every set op but UNION ALL the projected row is the dedup key, so
+        dropping a column changes which rows survive.
+        """
+        sql = (
+            f"WITH a AS (SELECT id, keep, drop_me FROM t1 {kind} "
+            f"SELECT id, keep, drop_me FROM t2) SELECT x.keep FROM a AS x"
+        )
+        assert self._pruned(sql) == str(parse(sql))
+
     def test_star_passes_its_own_demand_through(self):
         """
         A star re-exposes whatever its source has, so a CTE that stars a source

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -2514,6 +2514,34 @@ class TestPruneCteProjections:
         )
         assert self._pruned(sql) == str(parse(sql))
 
+    def test_projection_name_matches_case_insensitively(self):
+        """
+        Every target dialect reads ``x.region`` off a ``Region`` projection.
+        """
+        assert self._pruned(
+            "WITH a AS (SELECT Region, drop_me, keep FROM t) "
+            "SELECT x.region, x.keep FROM a AS x",
+        ) == str(
+            parse(
+                "WITH a AS (SELECT Region, keep FROM t) "
+                "SELECT x.region, x.keep FROM a AS x",
+            ),
+        )
+
+    def test_group_by_alias_matches_case_insensitively(self):
+        """
+        A GROUP BY naming ``Total`` holds the ``total`` projection open.
+        """
+        assert self._pruned(
+            "WITH a AS (SELECT keep, drop_me, SUM(n) AS total FROM t GROUP BY Total) "
+            "SELECT x.keep FROM a AS x",
+        ) == str(
+            parse(
+                "WITH a AS (SELECT keep, SUM(n) AS total FROM t GROUP BY Total) "
+                "SELECT x.keep FROM a AS x",
+            ),
+        )
+
     def test_star_passes_its_own_demand_through(self):
         """
         A star re-exposes whatever its source has, so a CTE that stars a source

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -2373,8 +2373,10 @@ class TestCollectCteNodesAndNeededColumns:
 
         Expected needed columns:
           test.dim_a: {x, id}          -- x requested, id from join key
-          test.dim_b: {p, q, id}       -- p requested, id from join key,
-                                          q pulled in because dim_a selects b_alias.q
+          test.dim_b: {p, q, id, x}    -- p requested, id from join key,
+                                          q pulled in because dim_a selects b_alias.q,
+                                          x because dim_a selects it bare and either
+                                          table in scope could be supplying it
         """
         # --- nodes ---
         fact_node = MagicMock()
@@ -2454,8 +2456,9 @@ class TestCollectCteNodesAndNeededColumns:
 
         assert needed_columns_by_node["test.dim_a"] == {"x", "id"}
         # q must be present even though it was never explicitly requested —
-        # it's referenced in dim_a's SQL as b_alias.q
-        assert needed_columns_by_node["test.dim_b"] == {"p", "q", "id"}
+        # it's referenced in dim_a's SQL as b_alias.q. x rides along because
+        # dim_a writes it bare; keeping a column dim_b lacks costs nothing.
+        assert needed_columns_by_node["test.dim_b"] == {"p", "q", "id", "x"}
 
     def test_parent_directly_references_dim_no_alias(self):
         """
@@ -2512,8 +2515,9 @@ class TestCollectCteNodesAndNeededColumns:
             metric_expressions=[],
         )
 
-        # x requested, id from join key, extra_col from parent's SQL body
-        assert needed_columns_by_node["test.dim_a"] == {"x", "id", "extra_col"}
+        # x requested, id from join key, extra_col from parent's SQL body, and
+        # val because the parent writes it bare with dim_a in scope
+        assert needed_columns_by_node["test.dim_a"] == {"x", "id", "extra_col", "val"}
 
     def test_source_node_excluded_from_nodes_for_ctes(self):
         """

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -68,6 +68,7 @@ from datajunction_server.models.node import NodeType
 from datajunction_server.naming import amenable_col_names
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import ast, parse
+from tests.construction.build_v3 import assert_sql_equal
 from tests.construction.build_v3.projection_invariant import (
     unprojected_references,
 )
@@ -1663,6 +1664,19 @@ class TestFilterCteProjection:
         projection = result.select.projection
         assert len(projection) == 2
 
+    def test_distinct_keeps_every_column(self):
+        """
+        The projection is the dedup key, so a direct caller gets it whole.
+
+        ``prune_cte_projections`` settles this earlier for a CTE, so this is
+        the only guard a caller reaching straight for the helper has.
+        """
+        sql = "SELECT DISTINCT col_a, col_b, col_c FROM t"
+
+        result = filter_cte_projection(parse(sql), {"col_a"})
+
+        assert str(result) == str(parse(sql))
+
 
 class TestFilterCteProjectionPositionalGroupBy:
     """Tests for filter_cte_projection with positional GROUP BY handling."""
@@ -2754,6 +2768,55 @@ class TestPruneCteProjectionsExecuted:
         arm = query.ctes[0].select
         assert [str(entry) for entry in arm.projection] == ["id"]
         assert [str(item.expr) for item in arm.organization.order] == ["1"]
+
+    def test_union_producer_keeps_every_column(self):
+        """
+        UNION dedups on the whole row, so a column the reader never names is
+        still part of what makes two rows different. Pruning it merges them.
+        """
+        sql = (
+            "WITH a AS ("
+            "SELECT grp, keep, drop_me FROM t WHERE id <= 2 "
+            "UNION "
+            "SELECT grp, keep, drop_me FROM t WHERE id >= 3"
+            ") SELECT SUM(x.keep) AS s FROM a AS x"
+        )
+        assert self._execute(sql) == [(40,)]
+        pruned, _ = self._prune(sql)
+        assert self._execute(pruned) == [(40,)], pruned
+        assert_sql_equal(pruned, sql)
+
+    def test_except_producer_keeps_every_column(self):
+        """
+        EXCEPT matches on the whole row too, so a narrowed projection removes
+        rows the full comparison would have kept.
+        """
+        sql = (
+            "WITH a AS ("
+            "SELECT grp, keep, drop_me FROM t "
+            "EXCEPT "
+            "SELECT grp, keep, drop_me FROM t WHERE id = 2"
+            ") SELECT SUM(x.keep) AS s FROM a AS x"
+        )
+        assert self._execute(sql) == [(30,)]
+        pruned, _ = self._prune(sql)
+        assert self._execute(pruned) == [(30,)], pruned
+        assert_sql_equal(pruned, sql)
+
+    def test_source_starred_under_distinct_keeps_every_column(self):
+        """
+        The star is what the DISTINCT dedups on, so narrowing the source it
+        draws from narrows the dedup key just as surely.
+        """
+        sql = (
+            "WITH base AS (SELECT grp, keep, drop_me FROM t), "
+            "d AS (SELECT DISTINCT * FROM base) "
+            "SELECT SUM(x.keep) AS s FROM d AS x"
+        )
+        assert self._execute(sql) == [(40,)]
+        pruned, _ = self._prune(sql)
+        assert self._execute(pruned) == [(40,)], pruned
+        assert_sql_equal(pruned, sql)
 
     def test_a_column_only_the_producer_s_where_reads_is_still_dropped(self):
         """

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -2514,6 +2514,26 @@ class TestPruneCteProjections:
         )
         assert self._pruned(sql) == str(parse(sql))
 
+    def test_distinct_projection_is_left_whole(self):
+        """
+        The projection is the dedup key, so no column is free to go.
+        """
+        sql = (
+            "WITH a AS (SELECT DISTINCT id, keep, drop_me FROM t) "
+            "SELECT x.keep FROM a AS x"
+        )
+        assert self._pruned(sql) == str(parse(sql))
+
+    def test_source_starred_under_distinct_is_left_whole(self):
+        """
+        Narrowing what the star exposes would narrow the dedup key with it.
+        """
+        sql = (
+            "WITH s AS (SELECT id, keep, other FROM t), "
+            "d AS (SELECT DISTINCT * FROM s) SELECT d.keep FROM d"
+        )
+        assert self._pruned(sql) == str(parse(sql))
+
     def test_projection_name_matches_case_insensitively(self):
         """
         Every target dialect reads ``x.region`` off a ``Region`` projection.

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -10,6 +10,7 @@ from datajunction_server.construction.build_v3.cte import (
     flatten_inner_ctes,
     get_column_full_name,
     get_table_references_from_ast,
+    prune_cte_projections,
     rewrite_table_references,
     topological_sort_nodes,
 )
@@ -36,7 +37,7 @@ from datajunction_server.construction.build_v3.materialization import (
 from datajunction_server.construction.build_v3.measures import (
     _add_table_prefixes_to_filter,
     _resolve_dim_namespace_refs,
-    collect_cte_nodes_and_needed_columns,
+    collect_cte_nodes,
 )
 from datajunction_server.construction.build_v3.types import (
     BuildContext,
@@ -915,45 +916,31 @@ class TestAddTablePrefixesToFilter:
 
 class TestResolveDimNamespaceRefs:
     """Tests for ``_resolve_dim_namespace_refs`` — rewrites dim-namespaced
-    column refs to use the dim's joined table alias and returns the columns
-    that must be preserved in each dim's CTE projection."""
+    column refs to use the dim's joined table alias."""
 
     @staticmethod
     def _expr(sql: str) -> ast.Expression:
         return cast(ast.Expression, parse(f"SELECT {sql}").select.projection[0])
 
-    def test_rewrites_known_dim_and_collects_col(self):
+    def test_rewrites_known_dim(self):
         expr = self._expr("v3.customer.tier")
-        cols = _resolve_dim_namespace_refs(
-            [expr],
-            {"v3.customer": "t2"},
-        )
+        _resolve_dim_namespace_refs([expr], {"v3.customer": "t2"})
         assert str(expr) == "t2.tier"
-        assert cols == {"v3.customer": {"tier"}}
 
     def test_skips_unknown_namespace(self):
-        """Namespaces that don't match a joined dim are left unchanged and
-        not recorded."""
+        """Namespaces that don't match a joined dim are left unchanged."""
         expr = self._expr("v3.fact.amount + v3.customer.threshold")
-        cols = _resolve_dim_namespace_refs(
-            [expr],
-            {"v3.customer": "t2"},
-        )
+        _resolve_dim_namespace_refs([expr], {"v3.customer": "t2"})
         rendered = str(expr)
         assert "v3.fact.amount" in rendered
         assert "t2.threshold" in rendered
-        assert cols == {"v3.customer": {"threshold"}}
 
     def test_skips_bare_columns(self):
         """Bare columns have no namespace, so they're not touched here —
         the main-alias rewrite runs separately."""
         expr = self._expr("SUM(amount)")
-        cols = _resolve_dim_namespace_refs(
-            [expr],
-            {"v3.customer": "t2"},
-        )
+        _resolve_dim_namespace_refs([expr], {"v3.customer": "t2"})
         assert str(expr) == "SUM(amount)"
-        assert cols == {}
 
     def test_walks_nested_expression(self):
         """The walk reaches into function args / CASE branches."""
@@ -961,15 +948,11 @@ class TestResolveDimNamespaceRefs:
             "SUM(CASE WHEN amount >= v3.customer.threshold "
             "THEN v3.customer.tier ELSE 'x' END)",
         )
-        cols = _resolve_dim_namespace_refs(
-            [expr],
-            {"v3.customer": "t2"},
-        )
+        _resolve_dim_namespace_refs([expr], {"v3.customer": "t2"})
         rendered = str(expr)
         assert "v3.customer." not in rendered
         assert "t2.threshold" in rendered
         assert "t2.tier" in rendered
-        assert cols == {"v3.customer": {"threshold", "tier"}}
 
 
 class TestBuildComponentExpression:
@@ -2348,247 +2331,67 @@ class TestAnalyzeGrainGroups:
         assert result[0].parent_node.name == "v3.my_parent"
 
 
-class TestCollectCteNodesAndNeededColumns:
+class TestCollectCteNodes:
     """
-    Tests for collect_cte_nodes_and_needed_columns.
+    Tests for ``collect_cte_nodes``, which decides which nodes get a CTE.
 
-    Focuses on the case where a dimension node's SQL references another
-    dimension node via a table alias, and columns used through that alias
-    must be included in the referenced node's CTE projection.
+    What each of those CTEs projects is settled later, on the assembled query,
+    by ``prune_cte_projections``.
     """
 
-    def test_dim_referencing_dim_via_alias(self):
+    def test_parent_and_every_join_hop_get_ctes(self):
         """
-        Columns used by one dimension's SQL from another dimension (via a table
-        alias) must appear in the referenced dimension's needed_columns set.
-
-        Setup:
-          test.fact  --(id)-->  test.dim_a   (requested: x)
-          test.fact  --(id)-->  test.dim_b   (requested: p)
-
-          test.dim_a's SQL:
-            SELECT id, x, b_alias.p, b_alias.q
-            FROM test.source_a
-            CROSS JOIN test.dim_b AS b_alias
-
-        Expected needed columns:
-          test.dim_a: {x, id}          -- x requested, id from join key
-          test.dim_b: {p, q, id, x}    -- p requested, id from join key,
-                                          q pulled in because dim_a selects b_alias.q,
-                                          x because dim_a selects it bare and either
-                                          table in scope could be supplying it
+        The parent node and each dimension on a resolved join path need a CTE,
+        including a hop that is only an intermediate on the way to the target.
         """
-        # --- nodes ---
         fact_node = MagicMock()
         fact_node.name = "test.fact"
         fact_node.type = NodeType.TRANSFORM
-        fact_node.current.query = "SELECT id, val FROM test.source"
-        fact_node.current.dimension_links = []
 
         dim_a_node = MagicMock()
         dim_a_node.name = "test.dim_a"
         dim_a_node.type = NodeType.DIMENSION
-        dim_a_node.current.query = (
-            "SELECT id, x, b_alias.p, b_alias.q "
-            "FROM test.source_a "
-            "CROSS JOIN test.dim_b AS b_alias"
-        )
 
         dim_b_node = MagicMock()
         dim_b_node.name = "test.dim_b"
         dim_b_node.type = NodeType.DIMENSION
-        dim_b_node.current.query = "SELECT id, p, q, r FROM test.source_b"
 
-        # --- dimension links ---
-        link_fact_to_dim_a = MagicMock()
-        link_fact_to_dim_a.dimension = dim_a_node
-        link_fact_to_dim_a.join_sql = "test.fact.id = test.dim_a.id"
-        link_fact_to_dim_a.node_revision.name = "test.fact"
+        first_hop = MagicMock()
+        first_hop.dimension = dim_a_node
+        second_hop = MagicMock()
+        second_hop.dimension = dim_b_node
 
-        link_fact_to_dim_b = MagicMock()
-        link_fact_to_dim_b.dimension = dim_b_node
-        link_fact_to_dim_b.join_sql = "test.fact.id = test.dim_b.id"
-        link_fact_to_dim_b.node_revision.name = "test.fact"
-
-        # --- context ---
         ctx = MagicMock()
-        ctx.temporal_partition_columns = {}
         ctx.nodes = {"test.dim_a": dim_a_node, "test.dim_b": dim_b_node}
-        ctx.get_parsed_query.side_effect = lambda node: parse(node.current.query)
 
-        # --- resolved dimensions ---
         resolved_dimensions = [
-            ResolvedDimension(
-                original_ref="test.dim_a.x",
-                node_name="test.dim_a",
-                column_name="x",
-                role=None,
-                join_path=JoinPath(
-                    links=[link_fact_to_dim_a],
-                    target_dimension=dim_a_node,
-                ),
-                is_local=False,
-            ),
             ResolvedDimension(
                 original_ref="test.dim_b.p",
                 node_name="test.dim_b",
                 column_name="p",
                 role=None,
                 join_path=JoinPath(
-                    links=[link_fact_to_dim_b],
+                    links=[first_hop, second_hop],
                     target_dimension=dim_b_node,
                 ),
                 is_local=False,
             ),
         ]
 
-        nodes_for_ctes, needed_columns_by_node = collect_cte_nodes_and_needed_columns(
+        assert collect_cte_nodes(
             ctx=ctx,
             parent_node=fact_node,
             resolved_dimensions=resolved_dimensions,
-            grain_col_specs=[],
-            metric_expressions=[],
-        )
+        ) == [fact_node, dim_a_node, dim_b_node]
 
-        assert fact_node in nodes_for_ctes
-        assert dim_a_node in nodes_for_ctes
-        assert dim_b_node in nodes_for_ctes
-
-        assert needed_columns_by_node["test.dim_a"] == {"x", "id"}
-        # q must be present even though it was never explicitly requested —
-        # it's referenced in dim_a's SQL as b_alias.q. x rides along because
-        # dim_a writes it bare; keeping a column dim_b lacks costs nothing.
-        assert needed_columns_by_node["test.dim_b"] == {"p", "q", "id", "x"}
-
-    def test_parent_directly_references_dim_no_alias(self):
-        """
-        Case 1: parent_node's SQL directly selects a column from a dimension
-        node without an alias (test.dim_a.extra_col).  That column must appear
-        in needed_columns_by_node for that dimension even if it was not
-        explicitly requested as a dimension attribute.
-        """
+    def test_local_dimension_adds_no_join_cte(self):
+        """A dimension on the fact itself has no join path to walk."""
         fact_node = MagicMock()
         fact_node.name = "test.fact"
         fact_node.type = NodeType.TRANSFORM
-        # Parent selects test.dim_a.extra_col directly — nobody requests it
-        fact_node.current.query = (
-            "SELECT id, val, test.dim_a.extra_col "
-            "FROM test.source "
-            "JOIN test.dim_a ON test.source.id = test.dim_a.id"
-        )
-        fact_node.current.dimension_links = []
-
-        dim_a_node = MagicMock()
-        dim_a_node.name = "test.dim_a"
-        dim_a_node.type = NodeType.DIMENSION
-        dim_a_node.current.query = "SELECT id, x, extra_col FROM test.src_a"
-
-        link_fact_to_dim_a = MagicMock()
-        link_fact_to_dim_a.dimension = dim_a_node
-        link_fact_to_dim_a.join_sql = "test.fact.id = test.dim_a.id"
-        link_fact_to_dim_a.node_revision.name = "test.fact"
 
         ctx = MagicMock()
-        ctx.temporal_partition_columns = {}
-        ctx.nodes = {"test.dim_a": dim_a_node}
-        ctx.get_parsed_query.side_effect = lambda node: parse(node.current.query)
-
-        resolved_dimensions = [
-            ResolvedDimension(
-                original_ref="test.dim_a.x",
-                node_name="test.dim_a",
-                column_name="x",
-                role=None,
-                join_path=JoinPath(
-                    links=[link_fact_to_dim_a],
-                    target_dimension=dim_a_node,
-                ),
-                is_local=False,
-            ),
-        ]
-
-        _, needed_columns_by_node = collect_cte_nodes_and_needed_columns(
-            ctx=ctx,
-            parent_node=fact_node,
-            resolved_dimensions=resolved_dimensions,
-            grain_col_specs=[],
-            metric_expressions=[],
-        )
-
-        # x requested, id from join key, extra_col from parent's SQL body, and
-        # val because the parent writes it bare with dim_a in scope
-        assert needed_columns_by_node["test.dim_a"] == {"x", "id", "extra_col", "val"}
-
-    def test_source_node_excluded_from_nodes_for_ctes(self):
-        """
-        SOURCE-type nodes must not appear in nodes_for_ctes — they map to
-        physical tables and don't need CTEs.
-        """
-        source_node = MagicMock()
-        source_node.name = "test.src"
-        source_node.type = NodeType.SOURCE
-        source_node.current.dimension_links = []
-
-        ctx = MagicMock()
-        ctx.temporal_partition_columns = {}
         ctx.nodes = {}
-        ctx.get_parsed_query.side_effect = lambda node: parse(node.current.query)
-
-        nodes_for_ctes, needed_columns_by_node = collect_cte_nodes_and_needed_columns(
-            ctx=ctx,
-            parent_node=source_node,
-            resolved_dimensions=[],
-            grain_col_specs=[],
-            metric_expressions=[],
-        )
-
-        assert source_node not in nodes_for_ctes
-        assert needed_columns_by_node == {}
-
-    def test_metric_expressions_contribute_to_parent_needed_cols(self):
-        """
-        Columns referenced inside metric expressions must be included in
-        parent_node's needed columns so filter_cte_projection keeps them.
-        """
-        fact_node = MagicMock()
-        fact_node.name = "test.fact"
-        fact_node.type = NodeType.TRANSFORM
-        fact_node.current.query = "SELECT id, revenue, cost FROM test.src"
-        fact_node.current.dimension_links = []
-
-        ctx = MagicMock()
-        ctx.temporal_partition_columns = {}
-        ctx.nodes = {}
-        ctx.get_parsed_query.side_effect = lambda node: parse(node.current.query)
-
-        metric_expr = parse("SELECT revenue - cost").select.projection[0]
-
-        _, needed_columns_by_node = collect_cte_nodes_and_needed_columns(
-            ctx=ctx,
-            parent_node=fact_node,
-            resolved_dimensions=[],
-            grain_col_specs=[],
-            metric_expressions=[("profit", metric_expr)],
-        )
-
-        assert "revenue" in needed_columns_by_node["test.fact"]
-        assert "cost" in needed_columns_by_node["test.fact"]
-
-    def test_local_dimension_contributes_to_parent_needed_cols(self):
-        """
-        Local dimensions (columns directly on the fact table, no join required)
-        must be added to parent_node's needed columns, not to a joined dim node.
-        """
-        fact_node = MagicMock()
-        fact_node.name = "test.fact"
-        fact_node.type = NodeType.TRANSFORM
-        fact_node.current.query = "SELECT id, val, region FROM test.src"
-        fact_node.current.dimension_links = []
-
-        ctx = MagicMock()
-        ctx.temporal_partition_columns = {}
-        ctx.nodes = {}
-        ctx.get_parsed_query.side_effect = lambda node: parse(node.current.query)
 
         resolved_dimensions = [
             ResolvedDimension(
@@ -2601,12 +2404,130 @@ class TestCollectCteNodesAndNeededColumns:
             ),
         ]
 
-        _, needed_columns_by_node = collect_cte_nodes_and_needed_columns(
+        assert collect_cte_nodes(
             ctx=ctx,
             parent_node=fact_node,
             resolved_dimensions=resolved_dimensions,
-            grain_col_specs=[],
-            metric_expressions=[],
+        ) == [fact_node]
+
+    def test_source_node_excluded(self):
+        """
+        SOURCE-type nodes must not appear in nodes_for_ctes — they map to
+        physical tables and don't need CTEs.
+        """
+        source_node = MagicMock()
+        source_node.name = "test.src"
+        source_node.type = NodeType.SOURCE
+
+        ctx = MagicMock()
+        ctx.nodes = {}
+
+        assert (
+            collect_cte_nodes(
+                ctx=ctx,
+                parent_node=source_node,
+                resolved_dimensions=[],
+            )
+            == []
         )
 
-        assert "region" in needed_columns_by_node["test.fact"]
+
+class TestPruneCteProjections:
+    """
+    Tests for ``prune_cte_projections`` on an already-assembled query.
+    """
+
+    @staticmethod
+    def _pruned(sql: str) -> str:
+        query = parse(sql)
+        prune_cte_projections(query)
+        return str(query)
+
+    def test_qualified_reference_keeps_only_what_is_read(self):
+        pruned = self._pruned(
+            "WITH a AS (SELECT id, keep, drop_me FROM t) SELECT x.keep FROM a AS x",
+        )
+        assert "keep" in pruned
+        assert "drop_me" not in pruned
+
+    def test_cte_name_qualifier_resolves_like_an_alias(self):
+        pruned = self._pruned(
+            "WITH a AS (SELECT id, keep, drop_me FROM t) SELECT a.keep FROM a",
+        )
+        assert "keep" in pruned
+        assert "drop_me" not in pruned
+
+    def test_bare_reference_is_kept_in_every_cte_in_scope(self):
+        """
+        Nothing says which side supplies a bare column, so both keep it.
+        """
+        pruned = self._pruned(
+            "WITH a AS (SELECT id, shared, drop_me FROM t1), "
+            "b AS (SELECT id, shared, also_drop FROM t2) "
+            "SELECT shared FROM a JOIN b ON a.id = b.id",
+        )
+        assert pruned.count("shared") == 3
+        assert "drop_me" not in pruned
+        assert "also_drop" not in pruned
+
+    def test_struct_path_keeps_the_first_segment(self):
+        """
+        For ``x.line_item.target_sets`` the producer must project ``line_item``,
+        the segment right after the qualifier — not the leaf.
+        """
+        pruned = self._pruned(
+            "WITH a AS (SELECT line_item, drop_me FROM t) "
+            "SELECT x.line_item.target_sets FROM a AS x",
+        )
+        assert "line_item" in pruned
+        assert "drop_me" not in pruned
+
+    def test_union_arms_are_pruned_together(self):
+        """
+        A set-operation CTE keeps the same positions in every arm, so the arms
+        stay union-compatible.
+        """
+        pruned = self._pruned(
+            "WITH a AS ("
+            "SELECT id, keep, drop_me FROM t1 "
+            "UNION ALL "
+            "SELECT id, keep, drop_me FROM t2"
+            ") SELECT x.keep FROM a AS x",
+        )
+        assert pruned.count("keep") == 3
+        assert "drop_me" not in pruned
+
+    def test_star_passes_its_own_demand_through(self):
+        """
+        A star re-exposes whatever its source has, so a CTE that stars a source
+        asks of it exactly what its own readers ask.
+        """
+        pruned = self._pruned(
+            "WITH a AS (SELECT id, keep, drop_me FROM t), "
+            "b AS (SELECT * FROM a) "
+            "SELECT y.keep FROM b AS y",
+        )
+        assert "keep" in pruned
+        assert "drop_me" not in pruned
+
+    def test_star_with_unknown_demand_keeps_everything(self):
+        """
+        The outer select has no readers to narrow it, so a star there leaves its
+        source whole.
+        """
+        pruned = self._pruned(
+            "WITH a AS (SELECT id, keep, untouched FROM t) SELECT * FROM a",
+        )
+        assert "untouched" in pruned
+
+    def test_group_by_position_is_renumbered(self):
+        pruned = self._pruned(
+            "WITH a AS (SELECT drop_me, keep, COUNT(1) AS n FROM t GROUP BY 2) "
+            "SELECT x.keep, x.n FROM a AS x",
+        )
+        # ``drop_me`` sits at position 1 and no GROUP BY entry points at it.
+        assert "drop_me" not in pruned
+        assert "GROUP BY  1" in pruned
+
+    def test_query_without_ctes_is_untouched(self):
+        assert self._pruned("SELECT a FROM t") == str(parse("SELECT a FROM t"))

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -3679,16 +3679,7 @@ class TestTemporalFilterPushdown:
             WITH v3_order_details AS (
               SELECT
                 o.order_id,
-                oi.line_number,
-                o.customer_id,
-                o.order_date,
-                o.from_location_id,
-                o.to_location_id,
-                o.status,
-                oi.product_id,
-                oi.quantity,
-                oi.unit_price,
-                oi.quantity * oi.unit_price AS line_total
+                o.order_date
               FROM default.v3.orders o JOIN default.v3.order_items oi ON o.order_id = oi.order_id
             ),
             v3_orders_by_date AS (
@@ -6202,8 +6193,7 @@ class TestOuterJoinFilterSafety:
             WITH v3_dates_with_orders AS (
                 SELECT
                     d.date_id,
-                    o.order_id,
-                    o.status
+                    o.order_id
                 FROM (SELECT * FROM default.v3.orders o WHERE o.status = 'completed') o
                 RIGHT OUTER JOIN default.v3.dates d ON o.order_date = d.date_id
             )
@@ -6320,16 +6310,9 @@ class TestUpstreamFilterOnlyPushdown:
             v3_order_details AS (
                 SELECT
                     o.order_id,
-                    oi.line_number,
-                    o.customer_id,
-                    o.order_date,
-                    o.from_location_id,
-                    o.to_location_id,
-                    o.status,
                     oi.product_id,
                     oi.quantity,
-                    oi.unit_price,
-                    oi.quantity * oi.unit_price AS line_total
+                    oi.unit_price
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
                 WHERE oi.product_id = 7
@@ -6337,7 +6320,6 @@ class TestUpstreamFilterOnlyPushdown:
             v3_order_details_wrapper_filter_only AS (
                 SELECT
                     order_id,
-                    product_id,
                     quantity * unit_price AS line_total
                 FROM v3_order_details
                 WHERE product_id = 7
@@ -6579,7 +6561,7 @@ class TestUpstreamFilterOnlyPushdown:
             sql,
             """
             WITH v3_status_events AS (
-                SELECT log_id, raw_status AS event_status
+                SELECT log_id
                 FROM default.v3.status_log
                 WHERE raw_status = 'OPEN'
             )
@@ -6858,17 +6840,11 @@ class TestUpstreamFilterOnlyPushdown:
             ),
             v3_order_details AS (
                 SELECT
-                    o.order_id,
-                    oi.line_number,
                     o.customer_id,
                     o.order_date,
-                    o.from_location_id,
-                    o.to_location_id,
-                    o.status,
                     oi.product_id,
                     oi.quantity,
-                    oi.unit_price,
-                    oi.quantity * oi.unit_price AS line_total
+                    oi.unit_price
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
                 WHERE oi.product_id = 7
@@ -6877,7 +6853,6 @@ class TestUpstreamFilterOnlyPushdown:
                 SELECT
                     customer_id,
                     order_date,
-                    product_id,
                     quantity * unit_price AS line_total
                 FROM v3_order_details
                 WHERE product_id = 7
@@ -7956,7 +7931,7 @@ class TestFilterPushdownScope:
             sql,
             """
             WITH v3_events_with_date AS (
-              SELECT account_id, event_type, audit_date
+              SELECT account_id, event_type
               FROM default.v3.audit_log_txlink_unlinked AS s
               WHERE audit_date >= 20260101
             ),
@@ -8055,7 +8030,7 @@ class TestFilterPushdownScope:
             sql,
             """
             WITH v3_events_double_link AS (
-              SELECT account_id, event_type, audit_date
+              SELECT account_id, event_type
               FROM default.v3.audit_log_txlinkdouble AS s
               WHERE audit_date >= 20260101
                 AND s.audit_date >= 20260101
@@ -9074,7 +9049,7 @@ class TestParentCteFilterLanding:
             """
             WITH
             v3_events_by_window_multi AS (
-                SELECT e.account_id, e.event_date, e.value, w.window
+                SELECT e.account_id, e.value, w.window
                 FROM default.v3.events_multi_filter AS e
                 CROSS JOIN default.v3.obs_windows AS w
                 WHERE w.window IN ('1-35') AND e.event_date >= 20260101
@@ -9156,11 +9131,11 @@ class TestParentCteFilterLanding:
             """
             WITH
             v3_events_union AS (
-                SELECT account_id, event_date, value, 'a' AS branch
+                SELECT value, 'a' AS branch
                 FROM default.v3.events_setop
                 WHERE event_date >= 20260101
                 UNION ALL
-                SELECT account_id, event_date, value, 'b' AS branch
+                SELECT value, 'b' AS branch
                 FROM default.v3.events_setop
             )
             SELECT t1.branch, SUM(t1.value) value_sum_HASH
@@ -9429,7 +9404,7 @@ class TestParentCteFilterLanding:
             sql,
             """
             WITH v3_events_with_side AS (
-              SELECT e.account_id, s.measure_date
+              SELECT e.account_id
               FROM default.v3.events_left_join_primary AS e
               LEFT JOIN (
                 SELECT *
@@ -9547,7 +9522,7 @@ class TestParentCteFilterLanding:
             sql,
             """
             WITH v3_events_with_nested_self AS (
-              SELECT a.account_id, a.event_date
+              SELECT a.account_id
               FROM default.v3.events_nested_self_ref AS a
               LEFT JOIN (
                 SELECT rev.account_id, rev.lifecycle_id
@@ -9746,7 +9721,7 @@ class TestParentCteFilterLanding:
               WHERE column_b = 20260101
             ),
             v3_fact_transform_dual AS (
-              SELECT account_id, column_a, value
+              SELECT account_id, value
               FROM default.v3.fact_dual
               WHERE column_a = 20260101
             )
@@ -10469,7 +10444,7 @@ class TestParentCteFilterLanding:
               WHERE window_label = 'demo'
             ),
             v3_alias_collide_xform AS (
-              SELECT a.account_id, a.window_label
+              SELECT a.account_id
               FROM (
                 SELECT a.account_id, a.event_date, a.value, w.window_label
                 FROM default.v3.events_alias_collide AS a

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -5818,8 +5818,7 @@ class TestMetricsSQLEdgeCases:
             result["sql"],
             """
             WITH v3_order_details AS (
-                SELECT o.customer_id, o.status,
-                       oi.quantity * oi.unit_price AS line_total
+                SELECT o.status, oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id
                 WHERE o.customer_id = 42
@@ -6511,7 +6510,7 @@ class TestReferenceDimensionResolution:
             """
             WITH
             v3_page_views_enriched AS (
-              SELECT view_id, page_type
+              SELECT view_id
               FROM default.v3.page_views
               WHERE page_type = 'checkout'
             ),
@@ -6567,7 +6566,7 @@ class TestMetricOnDimensionNode:
             """
             WITH
             v3_product AS (
-              SELECT category, subcategory, price
+              SELECT category, price
               FROM default.v3.products
               WHERE subcategory = 'phones'
             ),

--- a/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
+++ b/datajunction-server/tests/construction/build_v3/preagg_substitution_test.py
@@ -1014,7 +1014,6 @@ class TestExternalPreAggRouting:
             """
             WITH v3_order_details AS (
                 SELECT o.status,
-                       oi.product_id,
                        oi.quantity * oi.unit_price AS line_total
                 FROM default.v3.orders o
                 JOIN default.v3.order_items oi ON o.order_id = oi.order_id

--- a/datajunction-server/tests/construction/build_v3/projection_invariant.py
+++ b/datajunction-server/tests/construction/build_v3/projection_invariant.py
@@ -1,0 +1,78 @@
+"""
+The invariant every generated query must hold: whatever a CTE reads from
+another CTE, that other CTE projects.
+
+``prune_cte_projections`` trims each CTE to what its readers ask for, so this is
+the oracle for whether a trim went too far. It needs nothing but the SQL text.
+"""
+
+from collections.abc import Iterator
+from typing import cast
+
+from datajunction_server.sql.parsing import ast
+from datajunction_server.sql.parsing.backends.antlr4 import parse
+
+
+def _projected_names(cte: ast.Query) -> set[str]:
+    """Names a CTE exposes, taking the first branch of any set operation."""
+    names = set()
+    for expression in cte.select.projection:
+        names.add(cast(ast.Aliasable, expression).alias_or_name.name)
+    return names
+
+
+def _branches(select: ast.SelectExpression) -> list[ast.SelectExpression]:
+    """Each arm of a set operation, or the select itself when there is none."""
+    branches = []
+    branch: ast.SelectExpression | None = select
+    while branch is not None:
+        branches.append(branch)
+        branch = branch.set_op.right if branch.set_op else None
+    return branches
+
+
+def _branch_columns(branch: ast.SelectExpression) -> Iterator[ast.Column]:
+    """Columns of one arm, not those of the arms unioned after it."""
+    parts = [
+        *branch.projection,
+        *branch.group_by,
+        *([branch.from_] if branch.from_ else []),
+        *([branch.where] if branch.where else []),
+        *([branch.having] if branch.having else []),
+    ]
+    for part in parts:
+        yield from part.find_all(ast.Column)
+
+
+def unprojected_references(sql: str) -> set[str]:
+    """
+    Find every column a CTE reads from another CTE that is not projected there.
+
+    Each arm of a set operation is read on its own, so a bare column in an arm
+    drawing on a single CTE is charged to that CTE. Returns
+    ``<producing cte>.<column>`` for each reference the producer does not
+    project, so an empty set means the query is internally consistent.
+    """
+    query = parse(sql)
+    ctes = {cte.alias_or_name.name: cte for cte in query.ctes}
+
+    missing = set()
+    for scope in [*query.ctes, query]:
+        for branch in _branches(scope.select):
+            tables = list(branch.from_.find_all(ast.Table)) if branch.from_ else []
+            sources = {
+                (table.alias.name if table.alias else table.name.name): ctes[
+                    table.name.name
+                ]
+                for table in tables
+                if table.name.name in ctes
+            }
+            lone_source = (
+                next(iter(sources.values())) if len(tables) == 1 and sources else None
+            )
+            for column in _branch_columns(branch):
+                qualifier, _, name = column.identifier().rpartition(".")
+                producer = sources.get(qualifier) if qualifier else lone_source
+                if producer is not None and name not in _projected_names(producer):
+                    missing.add(f"{producer.alias_or_name.name}.{name}")
+    return missing

--- a/datajunction-server/tests/construction/build_v3/projection_invariant.py
+++ b/datajunction-server/tests/construction/build_v3/projection_invariant.py
@@ -31,17 +31,42 @@ def _branches(select: ast.SelectExpression) -> list[ast.SelectExpression]:
     return branches
 
 
-def _branch_columns(branch: ast.SelectExpression) -> Iterator[ast.Column]:
-    """Columns of one arm, not those of the arms unioned after it."""
-    parts = [
-        *branch.projection,
-        *branch.group_by,
-        *([branch.from_] if branch.from_ else []),
-        *([branch.where] if branch.where else []),
-        *([branch.having] if branch.having else []),
+def _branch_columns(
+    branch: ast.SelectExpression,
+) -> Iterator[tuple[ast.Column, bool]]:
+    """
+    Columns of one arm, not those of the arms unioned after it.
+
+    Each column is flagged with whether it sits in a clause that may name the
+    select's own output aliases rather than a column of its source.
+    """
+    keyed = [
+        *((part, False) for part in branch.projection),
+        *((part, False) for part in branch.group_by),
+        *([(branch.from_, False)] if branch.from_ else []),
+        *([(branch.where, True)] if branch.where else []),
+        *([(branch.having, True)] if branch.having else []),
     ]
-    for part in parts:
-        yield from part.find_all(ast.Column)
+    for part, may_use_output_alias in keyed:
+        for column in part.find_all(ast.Column):
+            yield column, may_use_output_alias
+
+
+def _output_aliases(branch: ast.SelectExpression) -> set[str]:
+    """
+    Names this arm introduces with an explicit ``AS``.
+
+    A filter DJ pushes into a CTE can land on such a name — the alias is the
+    only handle the column has once the underlying expression is not projected
+    under its own name. Charging it to the source would be wrong: the source
+    never had a column by that name.
+    """
+    names = set()
+    for expression in branch.projection:
+        alias = getattr(expression, "alias", None)
+        if alias is not None:
+            names.add(alias.name)
+    return names
 
 
 def unprojected_references(sql: str) -> set[str]:
@@ -70,9 +95,14 @@ def unprojected_references(sql: str) -> set[str]:
             lone_source = (
                 next(iter(sources.values())) if len(tables) == 1 and sources else None
             )
-            for column in _branch_columns(branch):
+            aliases = _output_aliases(branch)
+            for column, may_use_output_alias in _branch_columns(branch):
                 qualifier, _, name = column.identifier().rpartition(".")
                 producer = sources.get(qualifier) if qualifier else lone_source
-                if producer is not None and name not in _projected_names(producer):
+                if producer is None:
+                    continue
+                if not qualifier and may_use_output_alias and name in aliases:
+                    continue
+                if name not in _projected_names(producer):
                     missing.add(f"{producer.alias_or_name.name}.{name}")
     return missing

--- a/datajunction-server/tests/construction/build_v3/set_operations_test.py
+++ b/datajunction-server/tests/construction/build_v3/set_operations_test.py
@@ -80,11 +80,11 @@ class TestSetOperationTransforms:
             """
             WITH
             v3_orders_unified AS (
-              SELECT order_id, customer_id, order_date, status
+              SELECT order_id, status
               FROM default.v3.orders
               WHERE status = 'completed'
               UNION ALL
-              SELECT order_id, customer_id, order_date, status
+              SELECT order_id, status
               FROM default.v3.orders
               WHERE status = 'shipped'
             ),
@@ -129,11 +129,11 @@ class TestSetOperationTransforms:
             """
             WITH
             v3_orders_unified AS (
-              SELECT order_id, customer_id, order_date, status
+              SELECT order_id, status
               FROM default.v3.orders
               WHERE status = 'completed' AND status = 'completed'
               UNION ALL
-              SELECT order_id, customer_id, order_date, status
+              SELECT order_id, status
               FROM default.v3.orders
               WHERE status = 'shipped'
             ),


### PR DESCRIPTION
The v3 builder trims each CTE it builds down to the columns that are used downstream. That trimming used to happen while the query was still being built, before the CTEs that would read a given CTE existed, so it worked from a precomputed list of columns that *might* be needed. However, this list kept missing cases, resulting in generated SQL that selected unprojected columns from a source. 

This changes it so that the old logic around column pruning is removed, subsumed with a single-pass column prune that runs once after the query is fully assembled.

#### Removed

- The pruning call inside the per-CTE loop in `collect_node_ctes`.
- The `needed_columns_by_node` map and the parameter passing it to `collect_node_ctes`.
- `_add_transitive_consumer_columns`, which existed only to patch gaps in the enumeration.
- `extract_columns_referenced_from_node` and `extract_join_columns_for_node`

#### Added

Added `prune_cte_projections`, which is called after the query is assembled. It keeps track of the query scopes ordered by reads, then walks the scopes, pruning it down to the columns it needs before recording.
