### PR TITLE
UI should surface materialization revisions correctly

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -1030,6 +1030,7 @@ def get_node_revision_materialization(
                 MaterializationConfigInfoUnified(
                     **materialization_config_output.model_dump(),
                     **info.model_dump(),
+                    node_version=node_revision.version,
                 ),
             )
     return materializations

--- a/datajunction-server/datajunction_server/models/materialization.py
+++ b/datajunction-server/datajunction_server/models/materialization.py
@@ -288,6 +288,12 @@ class MaterializationConfigInfoUnified(
     Materialization config + info
     """
 
+    # The node revision's own version string, not derivable from `config` for every
+    # job type (e.g. DruidCubeMaterializationJob's config has no `cube` field), so a
+    # caller listing materializations `include_all_revisions=True` can tell which
+    # revision each one belongs to without a separate lookup.
+    node_version: str
+
 
 class SparkConf(RootModel):
     """Spark configuration"""

--- a/datajunction-server/tests/api/files/materializations_test/spark_sql.full.materializations.json
+++ b/datajunction-server/tests/api/files/materializations_test/spark_sql.full.materializations.json
@@ -131,5 +131,6 @@
    "urls":[
       "http://fake.url/job"
    ],
-   "workflow_names":[]
+   "workflow_names":[],
+   "node_version":"v1.1"
 }

--- a/datajunction-server/tests/api/files/materializations_test/spark_sql.full.partition.materializations.json
+++ b/datajunction-server/tests/api/files/materializations_test/spark_sql.full.partition.materializations.json
@@ -131,5 +131,6 @@
    "urls":[
       "http://fake.url/job"
    ],
-   "workflow_names":[]
+   "workflow_names":[],
+   "node_version":"v1.1"
 }

--- a/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/NodeMaterializationTab.jsx
@@ -43,8 +43,10 @@ export default function NodeMaterializationTab({
 
   const materializationsByRevision = useMemo(() => {
     return filteredMaterializations.reduce((acc, mat) => {
-      // Extract version from materialization config
-      const matVersion = mat.config?.cube?.version || node?.version;
+      // `config.cube.version` is absent for most job types (e.g. Druid cube
+      // jobs), so it silently grouped every materialization under the current
+      // node version regardless of which revision it actually belongs to.
+      const matVersion = mat.node_version || node?.version;
 
       if (!acc[matVersion]) {
         acc[matVersion] = [];
@@ -137,7 +139,7 @@ export default function NodeMaterializationTab({
     // Determine which versions have only inactive materializations
     const versionHasOnlyInactive = {};
     rawMaterializations.forEach(mat => {
-      const matVersion = mat.config?.cube?.version || node.version;
+      const matVersion = mat.node_version || node.version;
       if (!versionHasOnlyInactive[matVersion]) {
         versionHasOnlyInactive[matVersion] = {
           hasActive: false,
@@ -205,7 +207,7 @@ export default function NodeMaterializationTab({
 
     // Check if latest version has any materializations (including inactive ones)
     const hasLatestVersionMaterialization = rawMaterializations.some(mat => {
-      const matVersion = mat.config?.cube?.version || node?.version;
+      const matVersion = mat.node_version || node?.version;
       return matVersion === node?.version;
     });
 

--- a/datajunction-ui/src/app/pages/NodePage/__tests__/NodeMaterializationTab.test.jsx
+++ b/datajunction-ui/src/app/pages/NodePage/__tests__/NodeMaterializationTab.test.jsx
@@ -187,4 +187,41 @@ describe('<NodeMaterializationTab />', () => {
       expect(link).toHaveAttribute('href', `https://www.foobar.com/dashboard`);
     });
   });
+
+  it('groups a materialization by its own node_version, not the current node version', async () => {
+    // DruidCubeMaterializationJob configs (and most other job types) have no
+    // `config.cube`, so grouping must key off `node_version` from the API.
+    mockDjClient.materializations.mockReturnValue([
+      {
+        name: 'druid_cube_v3',
+        config: {},
+        schedule: '@daily',
+        job: 'DruidCubeMaterializationJob',
+        backfills: [],
+        strategy: 'incremental_time',
+        output_tables: ['table1'],
+        urls: ['https://example.com/'],
+        deactivated_at: null,
+        node_version: 'v1.0',
+      },
+    ]);
+    mockDjClient.availabilityStates.mockReturnValue([]);
+    mockDjClient.materializationInfo.mockReturnValue({
+      job_types: [],
+      strategies: [],
+    });
+
+    render(
+      <NodeMaterializationTab
+        node={{ ...mockNode, version: 'v2.0' }}
+        djClient={mockDjClient}
+      />,
+    );
+    await waitFor(() => {
+      // Belongs to v1.0, not the node's current version (v2.0).
+      expect(screen.getByText('v1.0')).toBeInTheDocument();
+      expect(screen.queryByText('v2.0 (latest)')).not.toBeInTheDocument();
+      expect(screen.getByText('Druid Cube')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
### Summary

The UI was showing an old, orphaned materialization as if it belonged to the live revision, and the materialization delete button was using the same wrong version, causing deletes to fail with a confusing not-found error.

`node_version` is now recorded server-side for each materialization, and the UI groups and deletes by that instead of falling back to the node's current version.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
