### PR TITLE
feat: endpoint for dimensional values

### DIFF
--- a/datajunction-server/datajunction_server/api/djsql.py
+++ b/datajunction-server/datajunction_server/api/djsql.py
@@ -3,6 +3,8 @@ Data related APIs.
 """
 
 import logging
+from dataclasses import dataclass
+from typing import Literal
 
 from fastapi import Depends, Query, Request
 from pydantic import BaseModel
@@ -49,19 +51,39 @@ class TranslatedDJSQL(BaseModel):
     dialect: str
 
 
-def selects_from_metrics(select: ast.SelectExpression) -> bool:
-    """Check if a SELECT sources from the 'metrics' table."""
-    return (
-        select.from_ is not None
-        and len(select.from_.relations) == 1
-        and len(select.from_.relations[0].extensions) == 0
-        and str(select.from_.relations[0].primary).lower() == "metrics"
-    )
+@dataclass(frozen=True)
+class ParsedDJSQL:
+    """Validated DJ SQL components and selected pseudo-table."""
+
+    source: Literal["metrics", "dimensions"]
+    metrics: list[str]
+    dimensions: list[str]
+    filters: list[str]
+    orderby: list[str]
+    limit: int | None
+
+
+def get_pseudo_table(
+    select: ast.SelectExpression,
+) -> Literal["metrics", "dimensions"] | None:
+    """Return the single unjoined pseudo-table selected by the query."""
+    if (
+        select.from_ is None
+        or len(select.from_.relations) != 1
+        or select.from_.relations[0].extensions
+    ):
+        return None
+    table = str(select.from_.relations[0].primary).lower()
+    if table == "metrics":
+        return "metrics"
+    if table == "dimensions":
+        return "dimensions"
+    return None
 
 
 def parse_dj_sql(
     query: str,
-) -> tuple[list[str], list[str], list[str], list[str], int | None]:
+) -> ParsedDJSQL:
     """
     Parse a DJ SQL query and extract metrics, dimensions, filters, orderby, limit.
 
@@ -75,17 +97,17 @@ def parse_dj_sql(
             LIMIT 10
 
     Returns:
-        Tuple of (metrics, dimensions, filters, orderby, limit)
+        Parsed pseudo-table and query components.
 
     Note: Validation of metric/dimension nodes is delegated to build_metrics_sql.
     """
     tree = parse(query)
     select = tree.select
 
-    if not selects_from_metrics(select):
+    source = get_pseudo_table(select)
+    if source is None:
         raise DJInvalidInputException(
-            "DJ SQL queries must SELECT FROM metrics. "
-            "Example: SELECT metric1, dim1 FROM metrics GROUP BY dim1",
+            "DJ SQL queries must SELECT FROM metrics or dimensions.",
         )
 
     # Validate no unsupported clauses
@@ -94,12 +116,9 @@ def parse_dj_sql(
             "HAVING, LATERAL VIEWS, and SET OPERATIONS are not allowed in DJ SQL queries.",
         )
 
-    # Extract dimensions from GROUP BY
-    dimensions = [str(exp) for exp in select.group_by]
+    group_by = [str(exp) for exp in select.group_by]
 
-    # Extract metrics: projection columns that are not in GROUP BY dimensions
-    # Validation that these are actual metric nodes is delegated to build_metrics_sql
-    metrics = []
+    projected = []
     for col in select.projection:
         # Remove the alias first, if one was set
         if isinstance(col, ast.Alias):
@@ -116,8 +135,22 @@ def parse_dj_sql(
                 f"Only direct columns are allowed in DJ SQL queries, found: {col}",
             )
 
-        if col_ident not in dimensions:
-            metrics.append(col_ident)
+        projected.append(col_ident)
+
+    if source == "metrics":
+        dimensions = group_by
+        metrics = [column for column in projected if column not in dimensions]
+        if not metrics:
+            raise DJInvalidInputException(
+                "DJ SQL queries selecting FROM metrics require at least one metric",
+            )
+    else:
+        dimensions = projected
+        metrics = []
+        if group_by and set(group_by) != set(dimensions):
+            raise DJInvalidInputException(
+                "GROUP BY for dimension queries must match the projected dimensions",
+            )
 
     # Extract filters from WHERE
     filters = [str(select.where)] if select.where else []
@@ -139,7 +172,7 @@ def parse_dj_sql(
                 f"LIMIT must be an integer, got: {select.limit}",
             ) from exc
 
-    return metrics, dimensions, filters, orderby, limit
+    return ParsedDJSQL(source, metrics, dimensions, filters, orderby, limit)
 
 
 @router.get("/djsql/", response_model=TranslatedDJSQL)
@@ -165,10 +198,13 @@ async def get_sql_for_djsql(
     LIMIT 10
     ```
 
+    Dimension domains use ``SELECT <dim> FROM dimensions``; ``DISTINCT`` is
+    implicit and ``GROUP BY`` may be omitted.
+
     Returns the generated SQL that can be executed against your data warehouse.
     """
     # Parse the DJ SQL query (validation delegated to build_metrics_sql)
-    metrics, dimensions, filters, orderby, limit = parse_dj_sql(query)
+    parsed = parse_dj_sql(query)
 
     # Map dialect string to enum (None means use builder default)
     dialect_enum: Dialect | None = None
@@ -183,11 +219,11 @@ async def get_sql_for_djsql(
     # Build SQL using v3 builder
     result = await build_metrics_sql(
         session=session,
-        metrics=metrics,
-        dimensions=dimensions,
-        filters=filters,
-        orderby=orderby if orderby else None,
-        limit=limit,
+        metrics=parsed.metrics,
+        dimensions=parsed.dimensions,
+        filters=parsed.filters,
+        orderby=parsed.orderby or None,
+        limit=parsed.limit,
         dialect=dialect_enum,
     )
     _logger.info(
@@ -223,23 +259,23 @@ async def _build_djsql_query(
     ``/djsql/data``, ``/djsql/stream/``, ``/data/``) emit identical SQL for
     the same metrics + dimensions.
     """
-    metrics, dimensions, filters, orderby, limit = parse_dj_sql(query)
+    parsed = parse_dj_sql(query)
     execution_ctx = await resolve_dialect_and_engine_for_metrics(
         session=session,
-        metrics=metrics,
-        dimensions=dimensions,
+        metrics=parsed.metrics,
+        dimensions=parsed.dimensions,
         use_materialized=use_materialized,
         engine_name=engine_name,
         engine_version=engine_version,
-        filters=filters if filters else None,
+        filters=parsed.filters or None,
     )
     generated_sql = await build_metrics_sql(
         session=session,
-        metrics=metrics,
-        dimensions=dimensions,
-        filters=filters if filters else None,
-        orderby=orderby if orderby else None,
-        limit=limit,
+        metrics=parsed.metrics,
+        dimensions=parsed.dimensions,
+        filters=parsed.filters or None,
+        orderby=parsed.orderby or None,
+        limit=parsed.limit,
         dialect=execution_ctx.dialect,
         use_materialized=use_materialized,
     )

--- a/datajunction-server/datajunction_server/api/semantic_layer.py
+++ b/datajunction-server/datajunction_server/api/semantic_layer.py
@@ -21,7 +21,10 @@ from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.database.user import User
 from datajunction_server.errors import DJException
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
-from datajunction_server.internal.sql import generate_metrics_sql
+from datajunction_server.internal.sql import (
+    generate_dimensions_sql,
+    generate_metrics_sql,
+)
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.utils import get_current_user, get_session
 
@@ -398,22 +401,27 @@ async def _generate_sql(
 
     request_filters = [_filter_to_sql(f) for f in payload.filters]
 
-    # Delegate to the shared metrics-SQL core (the same helper ``/sql/metrics/v3``
-    # uses). Pinning the view's cube via ``matched_cube`` makes the dialect
-    # resolve from that cube's own availability and applies its stored
-    # ``cube_filters``; ``dialect=None`` lets the helper do that resolution.
-    generated_sql = await generate_metrics_sql(
-        session,
-        metrics=payload.metrics,
-        dimensions=payload.dimensions,
-        filters=request_filters,
-        matched_cube=cube_rev,
-        orderby=orderby,
-        limit=limit,
-        use_materialized=True,
-        dialect=None,
-        endpoint="/semantic-layer/views/sql",
-    )
+    if payload.metrics:
+        generated_sql = await generate_metrics_sql(
+            session,
+            metrics=payload.metrics,
+            dimensions=payload.dimensions,
+            filters=request_filters,
+            matched_cube=cube_rev,
+            orderby=orderby,
+            limit=limit,
+            endpoint="/semantic-layer/views/sql",
+        )
+    else:
+        generated_sql = await generate_dimensions_sql(
+            session,
+            dimensions=payload.dimensions,
+            filters=request_filters,
+            matched_cube=cube_rev,
+            orderby=orderby,
+            limit=limit,
+            endpoint="/semantic-layer/views/sql",
+        )
     # ``generated_sql.sql`` renders via ``to_sql(query, dialect)``, which already
     # applies DJ's dialect rules and transpiles to the resolved dialect, so it is
     # execution-ready for the caller (which runs it directly). We return the

--- a/datajunction-server/datajunction_server/api/semantic_layer.py
+++ b/datajunction-server/datajunction_server/api/semantic_layer.py
@@ -451,12 +451,8 @@ async def generate_query_sql(
             400,
             f"`limit` {payload.limit} exceeds the maximum of {MAX_ROW_LIMIT}.",
         )
-    if not payload.metrics:
-        return _problem(
-            400,
-            "A query must request at least one metric. Dimension-only queries "
-            "(distinct values) are not supported on this endpoint.",
-        )
+    if not payload.metrics and not payload.dimensions:
+        return _problem(400, "A query must request at least one metric or dimension.")
     try:
         cube_node = await Node.get_cube_by_name(session, view_name)
         if cube_node is None or cube_node.current is None:

--- a/datajunction-server/datajunction_server/api/sql.py
+++ b/datajunction-server/datajunction_server/api/sql.py
@@ -30,7 +30,10 @@ from datajunction_server.internal.caching.query_cache_manager import (
     QueryCacheManager,
     QueryRequestParams,
 )
-from datajunction_server.internal.sql import generate_metrics_sql
+from datajunction_server.internal.sql import (
+    generate_dimensions_sql,
+    generate_metrics_sql,
+)
 from datajunction_server.models.dialect import Dialect
 from datajunction_server.models.metric import TranslatedSQL, V3TranslatedSQL
 from datajunction_server.models.node_type import NodeType
@@ -567,6 +570,68 @@ async def get_combined_measures_sql_v3(
 
 
 @router.get(
+    "/sql/dimensions/v3/",
+    response_model=V3TranslatedSQL,
+    name="Get Dimensions SQL V3",
+    tags=["sql", "v3"],
+)
+async def get_dimensions_sql_v3(
+    dimensions: list[str] = Query([]),
+    filters: list[str] = Query(
+        [],
+        description="Filters layered on top of any stored cube filters",
+    ),
+    cube: str | None = Query(
+        None,
+        description="Optional cube whose metrics define the reachable value domain",
+    ),
+    orderby: list[str] = Query([]),
+    limit: int | None = Query(None),
+    use_materialized: bool = Query(True),
+    dialect: Dialect | None = Query(None),
+    query_params: str = Query("{}", description="Query parameters"),
+    *,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> V3TranslatedSQL:
+    """Generate distinct dimension SQL.
+
+    Without a cube, queries the dimension-bearing node directly. With a cube,
+    uses all cube metrics and combines stored and request filters with ``AND``.
+    """
+    if not dimensions:
+        raise DJInvalidInputException("At least one dimension is required")
+
+    result = await generate_dimensions_sql(
+        session,
+        dimensions=dimensions,
+        filters=filters,
+        cube=cube,
+        orderby=orderby or None,
+        limit=limit,
+        use_materialized=use_materialized,
+        dialect=dialect,
+        query_parameters=json.loads(query_params) or None,
+    )
+    return V3TranslatedSQL(
+        sql=result.sql,
+        columns=[
+            V3ColumnMetadata(
+                name=col.name,
+                type=str(col.type),
+                semantic_name=col.semantic_name,
+                semantic_type=col.semantic_type,
+            )
+            for col in result.columns
+        ],
+        dialect=result.dialect,
+        cube_name=result.cube_name,
+        scan_estimate=result.scan_estimate,
+        warnings=result.warnings,
+    )
+
+
+@router.get(
     "/sql/metrics/v3/",
     response_model=V3TranslatedSQL,
     name="Get Metrics SQL V3",
@@ -644,6 +709,9 @@ async def get_metrics_sql_v3(
             Set to False when generating SQL for materialization refresh to avoid
             circular references.
     """
+    if not metrics and not cube:
+        raise DJInvalidInputException("At least one metric is required")
+
     # Shared metrics-SQL core (cube pinning, cube_filters prepend, dialect
     # auto-resolve, build_metrics_sql, and the build-latency metrics + [SQL] log).
     # Also used by the semantic-layer endpoint.

--- a/datajunction-server/datajunction_server/construction/build_v3/builder.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/builder.py
@@ -250,6 +250,7 @@ async def setup_build_context(
     include_temporal_filters: bool = False,
     lookback_window: str | None = None,
     matched_cube: NodeRevision | None = None,
+    require_metrics: bool = True,
 ) -> BuildContext:
     """
     Create and initialize a BuildContext with all setup done.
@@ -270,6 +271,7 @@ async def setup_build_context(
         use_materialized: Whether to use materialized tables
         include_temporal_filters: Whether to include temporal partition filters from cube
         lookback_window: Lookback window for temporal filters
+        require_metrics: Whether an empty metric list should be rejected
 
     Returns:
         Fully initialized BuildContext
@@ -311,9 +313,10 @@ async def setup_build_context(
     # Load all required nodes (metrics + explicit dimensions + filter dimensions)
     await load_nodes(ctx)
 
-    # Validate we have at least one metric
-    if not ctx.metrics:
+    if not ctx.metrics and require_metrics:
         raise DJInvalidInputException("At least one metric is required")
+    if not ctx.metrics:
+        return ctx
 
     # Decompose metrics and group by parent node
     ctx.metric_groups, ctx.decomposed_metrics = await decompose_and_group_metrics(ctx)
@@ -508,6 +511,8 @@ async def build_metrics_sql(
     """
     Build metrics SQL for a set of metrics and dimensions.
 
+    With no metrics, returns distinct attributes from one dimension-bearing node.
+
     Metrics SQL applies final metric expressions on top of measures, including
     handling derived metrics. It produces a single executable query with the
     following layers:
@@ -567,7 +572,17 @@ async def build_metrics_sql(
         dialect=dialect,
         use_materialized=use_materialized,
         lookback_window=lookback_window,
+        require_metrics=False,
     )
+
+    if not metrics:
+        # Imported lazily because node_query also uses the shared ordering helper
+        # from this module.
+        from datajunction_server.construction.build_v3.node_query import (
+            build_dimension_sql_v3,
+        )
+
+        return build_dimension_sql_v3(ctx, orderby, limit, query_parameters)
 
     # Frame-aware live window lookback: when a requested metric carries a row/
     # range window frame and a filter narrows the order dimension, expand the

--- a/datajunction-server/datajunction_server/construction/build_v3/builder.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/builder.py
@@ -250,7 +250,6 @@ async def setup_build_context(
     include_temporal_filters: bool = False,
     lookback_window: str | None = None,
     matched_cube: NodeRevision | None = None,
-    require_metrics: bool = True,
 ) -> BuildContext:
     """
     Create and initialize a BuildContext with all setup done.
@@ -271,8 +270,6 @@ async def setup_build_context(
         use_materialized: Whether to use materialized tables
         include_temporal_filters: Whether to include temporal partition filters from cube
         lookback_window: Lookback window for temporal filters
-        require_metrics: Whether an empty metric list should be rejected
-
     Returns:
         Fully initialized BuildContext
     """
@@ -313,8 +310,6 @@ async def setup_build_context(
     # Load all required nodes (metrics + explicit dimensions + filter dimensions)
     await load_nodes(ctx)
 
-    if not ctx.metrics and require_metrics:
-        raise DJInvalidInputException("At least one metric is required")
     if not ctx.metrics:
         return ctx
 
@@ -387,6 +382,9 @@ async def build_measures_sql(
         GeneratedMeasuresSQL with one GrainGroupSQL per aggregation level,
         plus context and decomposed metrics for efficient reuse by build_metrics_sql
     """
+    if not metrics:
+        raise DJInvalidInputException("At least one metric is required")
+
     # Setup context (loads nodes, decomposes metrics, adds dimensions from expressions)
     ctx = await setup_build_context(
         session=session,
@@ -572,7 +570,6 @@ async def build_metrics_sql(
         dialect=dialect,
         use_materialized=use_materialized,
         lookback_window=lookback_window,
-        require_metrics=False,
     )
 
     if not metrics:

--- a/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
@@ -303,8 +303,8 @@ async def resolve_dialect_and_engine_for_metrics(
        matching cube with availability exists:
        - Use the cube's availability catalog's engine matching dialect_override (or
          the first engine if none match)
-    2. Otherwise, fall back to the first metric's catalog's default engine,
-       filtered by dialect_override if provided
+    2. Otherwise, fall back to the first metric's catalog, or for a metricless
+       query the first dimension node's catalog, filtered by dialect_override.
 
     Args:
         session: Database session
@@ -383,16 +383,19 @@ async def resolve_dialect_and_engine_for_metrics(
                     cube=cube,
                 )
 
-    if not metrics:
+    if not metrics and not dimensions:
         raise DJInvalidInputException(
-            "At least one metric is required.",
+            "At least one metric or dimension is required.",
             http_status_code=422,
         )
 
-    # Fallback: use first metric's catalog's default engine
+    # Fall back to the first requested metric or dimension's catalog.
+    anchor_name = (
+        metrics[0] if metrics else parse_dimension_ref(dimensions[0]).node_name
+    )
     node = await Node.get_by_name(
         session,
-        metrics[0],
+        anchor_name,
         raise_if_not_exists=True,
         options=[
             joinedload(Node.current).options(
@@ -403,11 +406,11 @@ async def resolve_dialect_and_engine_for_metrics(
         ],
     )
     if not node:  # pragma: no cover
-        raise ValueError(f"Metric not found: {metrics[0]}")
+        raise ValueError(f"Query node not found: {anchor_name}")
 
     catalog_name = node.current.catalog.name if node.current.catalog else None
     if not catalog_name:  # pragma: no cover
-        raise ValueError(f"Metric {metrics[0]} has no catalog")
+        raise ValueError(f"Query node {anchor_name} has no catalog")
 
     # Resolve engine: when no dialect is explicitly requested, prefer Trino.
     # Fall back to the catalog's first engine if no Trino engine exists.
@@ -430,10 +433,10 @@ async def resolve_dialect_and_engine_for_metrics(
         Dialect(engine.dialect) if engine.dialect else Dialect.TRINO
     )
     logger.info(
-        "[BuildV3] Resolved dialect=%s engine=%s from metric %s catalog=%s",
+        "[BuildV3] Resolved dialect=%s engine=%s from query node %s catalog=%s",
         dialect,
         engine.name,
-        metrics[0],
+        anchor_name,
         catalog_name,
     )
 

--- a/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
@@ -527,6 +527,9 @@ async def build_sql_from_cube(
     Returns:
         GeneratedSQL with the query and column metadata.
     """
+    if not metrics:
+        raise DJInvalidInputException("At least one metric is required")
+
     # Import here to avoid circular dependency
     from datajunction_server.construction.build_v3.builder import setup_build_context
 

--- a/datajunction-server/datajunction_server/construction/build_v3/node_query.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/node_query.py
@@ -32,6 +32,9 @@ from datajunction_server.construction.build_v3.dimensions import (
     parse_dimension_ref,
     resolve_dimensions,
 )
+from datajunction_server.construction.build_v3.filters import (
+    parse_and_resolve_filters,
+)
 from datajunction_server.construction.build_v3.loaders import (
     batch_load_nodes_with_dependencies,
     find_upstream_node_names,
@@ -46,6 +49,9 @@ from datajunction_server.construction.build_v3.measures import (
     collect_cte_nodes_and_needed_columns,
     outer_only_filter_refs,
 )
+from datajunction_server.construction.build_v3.materialization import (
+    get_table_reference_parts_with_materialization,
+)
 from datajunction_server.construction.build_v3.types import (
     BuildContext,
     ColumnMetadata,
@@ -55,6 +61,7 @@ from datajunction_server.construction.build_v3.types import (
 )
 from datajunction_server.construction.build_v3.utils import (
     add_dimensions_from_filters,
+    get_column_type,
     get_cte_name,
 )
 from datajunction_server.database.column import Column as DBColumn
@@ -70,6 +77,98 @@ from datajunction_server.models.node_type import NodeType
 from datajunction_server.sql.parsing import ast
 
 logger = logging.getLogger(__name__)
+
+
+def build_dimension_sql_v3(
+    ctx: BuildContext,
+    orderby: list[str] | None = None,
+    limit: int | None = None,
+    query_parameters: dict[str, Any] | None = None,
+) -> GeneratedSQL:
+    """Build ``SELECT DISTINCT`` for attributes from one dimension node."""
+    requested = [dim for dim in ctx.dimensions if dim not in ctx.filter_dimensions]
+    refs = [parse_dimension_ref(dim) for dim in ctx.dimensions]
+    node_names = {ref.node_name for ref in refs}
+    if not requested or len(node_names) != 1:
+        raise DJInvalidInputException(
+            "Metricless queries require dimension attributes from exactly one node",
+        )
+
+    node_name = refs[0].node_name
+    dimension_node = ctx.nodes[node_name]
+    if dimension_node.type not in {
+        NodeType.SOURCE,
+        NodeType.TRANSFORM,
+        NodeType.DIMENSION,
+    }:
+        raise DJInvalidInputException(
+            f"Metricless queries cannot select attributes from `{node_name}`",
+        )
+
+    requested_refs = [parse_dimension_ref(dim) for dim in requested]
+    available = {column.name for column in dimension_node.current.columns}  # type: ignore[union-attr]
+    missing = [ref.column_name for ref in refs if ref.column_name not in available]
+    if missing:
+        raise DJInvalidInputException(
+            f"Dimension `{node_name}` does not contain columns: {missing}",
+        )
+
+    cte_pairs, _, _ = collect_node_ctes(ctx, [dimension_node])
+    table_parts, _ = get_table_reference_parts_with_materialization(
+        ctx,
+        dimension_node,
+    )
+    dimension_table = ".".join(table_parts)
+    aliases = {dim: parse_dimension_ref(dim).column_name for dim in ctx.dimensions}
+    output_aliases = [ctx.alias_registry.register(dim) for dim in requested]
+    projection: list[Any] = []
+    for ref, output_alias in zip(requested_refs, output_aliases):
+        column = ast.Column(name=ast.Name(ref.column_name))
+        if output_alias != ref.column_name:
+            column.set_alias(ast.Name(output_alias))
+            column.set_as(True)
+        projection.append(column)
+    query = ast.Query(
+        select=ast.Select(
+            projection=projection,
+            from_=ast.From.Table(dimension_table),
+            where=parse_and_resolve_filters(
+                ctx.filters,
+                aliases,
+                nodes=ctx.nodes,
+            )
+            if ctx.filters
+            else None,
+            quantifier="DISTINCT",
+        ),
+    )
+    for cte_name, cte_body in cte_pairs:
+        cte_body.to_cte(ast.Name(cte_name), query)
+    query.ctes = [cte_body for _, cte_body in cte_pairs]
+
+    if query_parameters:
+        substitute_query_params(query, query_parameters)
+    return apply_orderby_limit(
+        GeneratedSQL(
+            query=query,
+            columns=[
+                ColumnMetadata(
+                    name=output_alias,
+                    semantic_name=dim,
+                    type=get_column_type(dimension_node, ref.column_name),
+                    semantic_type="dimension",
+                )
+                for dim, ref, output_alias in zip(
+                    requested,
+                    requested_refs,
+                    output_aliases,
+                )
+            ],
+            dialect=ctx.dialect,
+        ),
+        orderby,
+        limit,
+    )
 
 
 async def build_node_sql_v3(

--- a/datajunction-server/datajunction_server/construction/build_v3/node_query.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/node_query.py
@@ -13,6 +13,7 @@ dim-link resolution.
 """
 
 import logging
+from copy import deepcopy
 from typing import Any, cast
 
 from sqlalchemy import select
@@ -79,6 +80,47 @@ from datajunction_server.sql.parsing import ast
 logger = logging.getLogger(__name__)
 
 
+def project_dimension_values_sql(
+    generated: GeneratedSQL,
+    dimensions: list[str],
+    orderby: list[str] | None = None,
+    limit: int | None = None,
+) -> GeneratedSQL:
+    """Project distinct dimensions from a fact-scoped metrics query."""
+    columns_by_name = {column.semantic_name: column for column in generated.columns}
+    columns = [columns_by_name[dimension] for dimension in dimensions]
+
+    inner = deepcopy(generated.query)
+    inner.parenthesized = True
+    inner.alias = ast.Name("dimension_values")
+    inner.as_ = True
+    query = ast.Query(
+        select=ast.Select(
+            projection=[
+                ast.Column(
+                    name=ast.Name(column.name),
+                    _table=ast.Table(ast.Name("dimension_values")),
+                )
+                for column in columns
+            ],
+            from_=ast.From(relations=[ast.Relation(primary=inner)]),
+            quantifier="DISTINCT",
+        ),
+    )
+    return apply_orderby_limit(
+        GeneratedSQL(
+            query=query,
+            columns=columns,
+            dialect=generated.dialect,
+            cube_name=generated.cube_name,
+            scan_estimate=generated.scan_estimate,
+            warnings=generated.warnings,
+        ),
+        orderby,
+        limit,
+    )
+
+
 def build_dimension_sql_v3(
     ctx: BuildContext,
     orderby: list[str] | None = None,
@@ -95,7 +137,11 @@ def build_dimension_sql_v3(
         )
 
     node_name = refs[0].node_name
-    dimension_node = ctx.nodes[node_name]
+    dimension_node = ctx.nodes.get(node_name)
+    if dimension_node is None:
+        raise DJInvalidInputException(f"Dimension node `{node_name}` does not exist")
+    # Direct-domain queries need a relational node. Metrics are aggregate
+    # expressions, while unmaterialized cubes have no query body of their own.
     if dimension_node.type not in {
         NodeType.SOURCE,
         NodeType.TRANSFORM,

--- a/datajunction-server/datajunction_server/internal/sql.py
+++ b/datajunction-server/datajunction_server/internal/sql.py
@@ -225,18 +225,17 @@ async def generate_metrics_sql(
             matched_cube = cube_node.current
 
     if matched_cube is not None:
-        if matched_cube.cube_filters:
+        if matched_cube.cube_filters and (metrics or not dimensions):
             merged_filters = list(matched_cube.cube_filters) + merged_filters
-        if not metrics:
+        if not metrics and not dimensions:
             metrics = matched_cube.cube_node_metrics
-            if not dimensions:
-                dimensions = matched_cube.cube_node_dimensions
+            dimensions = matched_cube.cube_node_dimensions
 
         # A pinned cube bypasses find_matching_cube's coverage check. When that
         # cube will actually back the build (materialized, Druid or auto-dialect),
         # verify it covers every filtered dimension so we fail loud here instead
         # of emitting Druid SQL that references a column the cube table lacks.
-        if use_materialized and dialect in (None, Dialect.DRUID):
+        if metrics and use_materialized and dialect in (None, Dialect.DRUID):
             await validate_pinned_cube_covers_filters(
                 session,
                 matched_cube,
@@ -252,7 +251,7 @@ async def generate_metrics_sql(
             metrics=metrics,
             dimensions=dimensions,
             use_materialized=use_materialized,
-            matched_cube=matched_cube,
+            matched_cube=matched_cube if metrics else None,
             filters=merged_filters,
         )
         resolved_dialect = execution_ctx.dialect

--- a/datajunction-server/datajunction_server/internal/sql.py
+++ b/datajunction-server/datajunction_server/internal/sql.py
@@ -225,7 +225,7 @@ async def generate_metrics_sql(
             matched_cube = cube_node.current
 
     if matched_cube is not None:
-        if matched_cube.cube_filters and (metrics or not dimensions):
+        if matched_cube.cube_filters:
             merged_filters = list(matched_cube.cube_filters) + merged_filters
         if not metrics and not dimensions:
             metrics = matched_cube.cube_node_metrics

--- a/datajunction-server/datajunction_server/internal/sql.py
+++ b/datajunction-server/datajunction_server/internal/sql.py
@@ -188,6 +188,8 @@ async def generate_metrics_sql(
     dialect: Dialect | None = None,
     query_parameters: dict[str, Any] | None = None,
     endpoint: str = "/sql/metrics/v3/",
+    populate_cube_metrics: bool = True,
+    query_type: str | None = None,
 ) -> "BuildV3GeneratedSQL":
     """
     Shared core for the "generate SQL for specific metrics" flow, used by both the
@@ -198,8 +200,8 @@ async def generate_metrics_sql(
         provided, load the cube directly (pins it so ``find_matching_cube`` can't
         pick a different / differently-filtered materialization).
       - If a cube revision is in play, prepend its stored ``cube_filters`` to the
-        request filters (and fall back to the cube's full metric/dimension set for
-        a bare cube query with no explicit metrics/dimensions).
+        request filters. Metrics callers also fall back to the cube's metrics when
+        none are explicit; dimensions callers disable that behavior.
       - If ``dialect`` is None, auto-resolve it via
         ``resolve_dialect_and_engine_for_metrics``; adopt that resolver's cube only
         when no cube was otherwise provided (mirrors the canonical endpoint).
@@ -227,9 +229,10 @@ async def generate_metrics_sql(
     if matched_cube is not None:
         if matched_cube.cube_filters:
             merged_filters = list(matched_cube.cube_filters) + merged_filters
-        if not metrics and not dimensions:
+        if not metrics and populate_cube_metrics:
             metrics = matched_cube.cube_node_metrics
-            dimensions = matched_cube.cube_node_dimensions
+            if not dimensions:
+                dimensions = matched_cube.cube_node_dimensions
 
         # A pinned cube bypasses find_matching_cube's coverage check. When that
         # cube will actually back the build (materialized, Druid or auto-dialect),
@@ -273,7 +276,8 @@ async def generate_metrics_sql(
     )
 
     elapsed_ms = (time.monotonic() - _t0) * 1000
-    _tags = {"query_type": "metrics", "query_version": "v3"}
+    query_type = query_type or ("metrics" if metrics else "dimensions")
+    _tags = {"query_type": query_type, "query_version": "v3"}
     provider = get_metrics_provider()
     provider.timer("dj.sql.build_latency_ms", elapsed_ms, _tags)
     provider.counter("dj.sql.requests", tags=_tags)
@@ -288,7 +292,7 @@ async def generate_metrics_sql(
         elapsed_ms,
         extra={
             "endpoint": endpoint,
-            "query_type": "metrics",
+            "query_type": query_type,
             "query_version": "v3",
             "metrics": metrics,
             "dimensions": dimensions,
@@ -297,6 +301,72 @@ async def generate_metrics_sql(
         },
     )
     return result
+
+
+async def generate_dimensions_sql(
+    session: AsyncSession,
+    *,
+    dimensions: list[str],
+    filters: list[str] | None = None,
+    cube: str | None = None,
+    matched_cube: NodeRevision | None = None,
+    orderby: list[str] | None = None,
+    limit: int | None = None,
+    use_materialized: bool = True,
+    dialect: Dialect | None = None,
+    query_parameters: dict[str, Any] | None = None,
+    endpoint: str = "/sql/dimensions/v3/",
+) -> "BuildV3GeneratedSQL":
+    """Generate direct-domain or cube-scoped distinct dimension values."""
+    if cube and matched_cube is None:
+        cube_node = await Node.get_cube_by_name(session, cube)
+        if cube_node:
+            matched_cube = cube_node.current
+
+    if matched_cube is None:
+        return await generate_metrics_sql(
+            session,
+            metrics=[],
+            dimensions=dimensions,
+            filters=filters,
+            orderby=orderby,
+            limit=limit,
+            use_materialized=use_materialized,
+            dialect=dialect,
+            query_parameters=query_parameters,
+            endpoint=endpoint,
+            populate_cube_metrics=False,
+            query_type="dimensions",
+        )
+
+    from datajunction_server.construction.build_v3.node_query import (
+        project_dimension_values_sql,
+    )
+    from datajunction_server.construction.build_v3.utils import (
+        extract_filter_dimension_refs,
+    )
+
+    cube_filters = list(matched_cube.cube_filters or [])
+    merged_filters = cube_filters + list(filters or [])
+    required_dimensions = set(dimensions) | set(
+        extract_filter_dimension_refs(merged_filters),
+    )
+    cube_covers_query = required_dimensions.issubset(
+        set(matched_cube.cube_node_dimensions),
+    )
+    generated = await generate_metrics_sql(
+        session,
+        metrics=list(matched_cube.cube_node_metrics),
+        dimensions=dimensions,
+        filters=filters if cube_covers_query else merged_filters,
+        matched_cube=matched_cube if cube_covers_query else None,
+        use_materialized=use_materialized,
+        dialect=dialect,
+        query_parameters=query_parameters,
+        endpoint=endpoint,
+        query_type="dimensions",
+    )
+    return project_dimension_values_sql(generated, dimensions, orderby, limit)
 
 
 async def build_sql_for_multiple_metrics(

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -1235,32 +1235,6 @@ async def test_cube_filters_merged_with_request_filters(
 
 
 @pytest.mark.asyncio
-async def test_cube_filters_applied_to_metricless_queries(
-    client_with_repairs_cube: AsyncClient,
-):
-    """Metricless cube queries preserve stored filters or reject cross-node ones."""
-    response = await client_with_repairs_cube.get(
-        "/sql/metrics/v3/",
-        params={
-            "dimensions": ["default.hard_hat.state"],
-            "cube": "default.repairs_cube",
-        },
-    )
-    assert response.status_code == 200
-    assert "state = 'AZ'" in response.json()["sql"]
-
-    response = await client_with_repairs_cube.get(
-        "/sql/metrics/v3/",
-        params={
-            "dimensions": ["default.dispatcher.company_name"],
-            "cube": "default.repairs_cube",
-        },
-    )
-    assert response.status_code == 422
-    assert "exactly one node" in response.json()["message"]
-
-
-@pytest.mark.asyncio
 async def test_cube_filters_applied_in_v3_sql_via_cube_param(
     client_with_repairs_cube: AsyncClient,
 ):

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -1235,6 +1235,32 @@ async def test_cube_filters_merged_with_request_filters(
 
 
 @pytest.mark.asyncio
+async def test_cube_filters_applied_to_metricless_queries(
+    client_with_repairs_cube: AsyncClient,
+):
+    """Metricless cube queries preserve stored filters or reject cross-node ones."""
+    response = await client_with_repairs_cube.get(
+        "/sql/metrics/v3/",
+        params={
+            "dimensions": ["default.hard_hat.state"],
+            "cube": "default.repairs_cube",
+        },
+    )
+    assert response.status_code == 200
+    assert "state = 'AZ'" in response.json()["sql"]
+
+    response = await client_with_repairs_cube.get(
+        "/sql/metrics/v3/",
+        params={
+            "dimensions": ["default.dispatcher.company_name"],
+            "cube": "default.repairs_cube",
+        },
+    )
+    assert response.status_code == 422
+    assert "exactly one node" in response.json()["message"]
+
+
+@pytest.mark.asyncio
 async def test_cube_filters_applied_in_v3_sql_via_cube_param(
     client_with_repairs_cube: AsyncClient,
 ):

--- a/datajunction-server/tests/api/djql_test.py
+++ b/datajunction-server/tests/api/djql_test.py
@@ -302,9 +302,8 @@ async def test_get_djsql_metric_table_exception(
         "/djsql/data/",
         params={"query": query},
     )
-    assert (
-        response.json()["message"] == "DJ SQL queries must SELECT FROM metrics. "
-        "Example: SELECT metric1, dim1 FROM metrics GROUP BY dim1"
+    assert response.json()["message"] == (
+        "DJ SQL queries must SELECT FROM metrics or dimensions."
     )
 
 

--- a/datajunction-server/tests/api/semantic_layer_test.py
+++ b/datajunction-server/tests/api/semantic_layer_test.py
@@ -388,12 +388,20 @@ async def test_semantic_endpoints_end_to_end(client: AsyncClient):
     )
     assert resp.status_code == 400, resp.text
 
-    # Dimension-only queries are rejected at the boundary (400).
-    resp = await client.post(
-        f"/semantic/views/{view}/sql",
-        json={"query": {"metrics": [], "dimensions": ["sem.region.region_name"]}},
+    # Dimension-only queries return the dimension's distinct values.
+    resp = await _expect(
+        await client.post(
+            f"/semantic/views/{view}/sql",
+            json={
+                "query": {
+                    "metrics": [],
+                    "dimensions": ["sem.region.region_name"],
+                },
+            },
+        ),
+        200,
     )
-    assert resp.status_code == 400, resp.text
+    assert "DISTINCT" in resp.json()["sql"]
 
     # Unknown view -> 404.
     resp = await client.post(

--- a/datajunction-server/tests/api/semantic_layer_test.py
+++ b/datajunction-server/tests/api/semantic_layer_test.py
@@ -476,6 +476,16 @@ async def test_generate_sql_rejects_limit_over_max(client: AsyncClient):
     assert str(MAX_ROW_LIMIT) in resp.json()["detail"]
 
 
+@pytest.mark.asyncio
+async def test_generate_sql_rejects_empty_query(client: AsyncClient):
+    resp = await client.post(
+        "/semantic/views/any_view/sql",
+        json={"query": {}},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "at least one metric or dimension" in resp.json()["detail"]
+
+
 # ---------------------------------------------------------------------------
 # get_view unknown-view 404 (the ``cube_node is None`` branch)
 # ---------------------------------------------------------------------------

--- a/datajunction-server/tests/construction/build_v3/cube_matcher_test.py
+++ b/datajunction-server/tests/construction/build_v3/cube_matcher_test.py
@@ -19,6 +19,7 @@ from datajunction_server.construction.build_v3.cube_matcher import (
     build_sql_from_cube,
     build_synthetic_grain_group,
     find_matching_cube,
+    resolve_dialect_and_engine_for_metrics,
     validate_pinned_cube_covers_filters,
 )
 from datajunction_server.construction.build_v3.decomposition import (
@@ -77,6 +78,17 @@ def test_materialized_dimension_lookup_preserves_roles():
         )
         == "date_id_ship"
     )
+
+
+@pytest.mark.asyncio
+async def test_resolve_dialect_requires_metric_or_dimension():
+    with pytest.raises(DJInvalidInputException, match="metric or dimension"):
+        await resolve_dialect_and_engine_for_metrics(
+            session=None,  # type: ignore[arg-type]
+            metrics=[],
+            dimensions=[],
+            use_materialized=False,
+        )
 
 
 class TestExtractFilterDimensionRefs:
@@ -1210,6 +1222,18 @@ class TestFindMatchingCube:
 
 class TestBuildSqlFromCube:
     """Tests for build_sql_from_cube function."""
+
+    @pytest.mark.asyncio
+    async def test_requires_metric(self):
+        with pytest.raises(DJInvalidInputException, match="At least one metric"):
+            await build_sql_from_cube(
+                session=None,  # type: ignore[arg-type]
+                cube=None,  # type: ignore[arg-type]
+                metrics=[],
+                dimensions=[],
+                filters=None,
+                dialect=Dialect.TRINO,
+            )
 
     @pytest.mark.asyncio
     async def test_builds_sql_from_cube_single_metric(

--- a/datajunction-server/tests/construction/build_v3/djsql_test.py
+++ b/datajunction-server/tests/construction/build_v3/djsql_test.py
@@ -7,6 +7,8 @@ to executable SQL using the build_v3 metrics SQL builder.
 
 import pytest
 
+from datajunction_server.api.djsql import _build_djsql_query
+
 from . import assert_sql_equal
 
 
@@ -296,9 +298,7 @@ class TestDJSQLValidation:
 
     @pytest.mark.asyncio
     async def test_no_metrics_in_select(self, client_with_build_v3):
-        """
-        Test that DJ SQL requires at least one metric.
-        """
+        """Dimension-only queries use the dimensions pseudo-table."""
         response = await client_with_build_v3.get(
             "/djsql/",
             params={
@@ -311,8 +311,84 @@ class TestDJSQLValidation:
             },
         )
 
-        assert response.status_code == 422  # Validation error - no metrics
-        assert "metric" in response.json()["message"].lower()
+        assert response.status_code == 422
+        assert "require at least one metric" in response.json()["message"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("include_group_by", [False, True])
+    async def test_dimensions_pseudo_table(
+        self,
+        client_with_build_v3,
+        include_group_by,
+    ):
+        group_by = "GROUP BY v3.customer.name" if include_group_by else ""
+        response = await client_with_build_v3.get(
+            "/djsql/",
+            params={
+                "query": f"""
+                    SELECT v3.customer.name
+                    FROM dimensions
+                    WHERE v3.customer.name != 'Unknown'
+                    {group_by}
+                    ORDER BY v3.customer.name DESC
+                    LIMIT 5
+                """,
+                "dialect": "spark",
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        assert_sql_equal(
+            response.json()["sql"],
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name, email, registration_date, location_id
+                FROM default.v3.customers
+            )
+            SELECT DISTINCT name
+            FROM v3_customer
+            WHERE name != 'Unknown'
+            ORDER BY name DESC
+            LIMIT 5
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_dimensions_pseudo_table_rejects_mismatched_group_by(
+        self,
+        client_with_build_v3,
+    ):
+        response = await client_with_build_v3.get(
+            "/djsql/",
+            params={
+                "query": """
+                    SELECT v3.customer.name
+                    FROM dimensions
+                    GROUP BY v3.customer.email
+                """,
+            },
+        )
+
+        assert response.status_code == 422
+        assert "must match" in response.json()["message"]
+
+    @pytest.mark.asyncio
+    async def test_dimensions_pseudo_table_shared_data_path(
+        self,
+        client_with_build_v3,
+        session,
+    ):
+        generated, execution = await _build_djsql_query(
+            session=session,
+            query="SELECT v3.customer.name FROM dimensions",
+            use_materialized=True,
+            engine_name=None,
+            engine_version=None,
+        )
+
+        assert "DISTINCT" in generated.sql
+        assert generated.columns[0].semantic_name == "v3.customer.name"
+        assert execution.catalog_name == "default"
 
     @pytest.mark.asyncio
     async def test_column_not_in_group_by(self, client_with_build_v3):

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -120,8 +120,11 @@ class TestMeasuresSQLEndpoint:
         assert response.status_code >= 400
 
     @pytest.mark.asyncio
-    async def test_metrics_v3_no_metrics_raises_422(self, client_with_build_v3):
-        """GET /sql/metrics/v3/ with no metrics must return 422, not a 500 IndexError."""
+    async def test_metrics_v3_no_metrics_returns_distinct_dimensions(
+        self,
+        client_with_build_v3,
+    ):
+        """GET /sql/metrics/v3/ supports dimension-only queries."""
         response = await client_with_build_v3.get(
             "/sql/metrics/v3/",
             params={
@@ -129,8 +132,8 @@ class TestMeasuresSQLEndpoint:
                 "dimensions": ["v3.order_details.status"],
             },
         )
-        assert response.status_code == 422
-        assert "metric" in response.json()["message"].lower()
+        assert response.status_code == 200
+        assert "DISTINCT" in response.json()["sql"]
 
     @pytest.mark.asyncio
     async def test_nonexistent_metric_raises_error(self, client_with_build_v3):

--- a/datajunction-server/tests/construction/build_v3/measures_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/measures_sql_test.py
@@ -120,11 +120,8 @@ class TestMeasuresSQLEndpoint:
         assert response.status_code >= 400
 
     @pytest.mark.asyncio
-    async def test_metrics_v3_no_metrics_returns_distinct_dimensions(
-        self,
-        client_with_build_v3,
-    ):
-        """GET /sql/metrics/v3/ supports dimension-only queries."""
+    async def test_metrics_v3_no_metrics_raises_422(self, client_with_build_v3):
+        """GET /sql/metrics/v3/ requires at least one metric."""
         response = await client_with_build_v3.get(
             "/sql/metrics/v3/",
             params={
@@ -132,8 +129,8 @@ class TestMeasuresSQLEndpoint:
                 "dimensions": ["v3.order_details.status"],
             },
         )
-        assert response.status_code == 200
-        assert "DISTINCT" in response.json()["sql"]
+        assert response.status_code == 422
+        assert "metric" in response.json()["message"].lower()
 
     @pytest.mark.asyncio
     async def test_nonexistent_metric_raises_error(self, client_with_build_v3):

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -5,6 +5,75 @@ from . import assert_sql_equal
 
 class TestMetricsSQLBasic:
     @pytest.mark.asyncio
+    async def test_dimension_only_query(self, client_with_build_v3):
+        """Attributes from one dimension produce their distinct combinations."""
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "dimensions": ["v3.customer.name", "v3.customer.email"],
+                "filters": ["v3.customer.name != 'Unknown'"],
+                "orderby": ["v3.customer.name"],
+                "limit": 10,
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        result = response.json()
+        assert_sql_equal(
+            result["sql"],
+            """
+            WITH v3_customer AS (
+                SELECT customer_id, name, email, registration_date, location_id
+                FROM default.v3.customers
+            )
+            SELECT DISTINCT name, email
+            FROM v3_customer
+            WHERE name != 'Unknown'
+            ORDER BY name
+            LIMIT 10
+            """,
+        )
+        assert result["columns"] == [
+            {
+                "name": "name",
+                "type": "string",
+                "semantic_entity": "v3.customer.name",
+                "semantic_type": "dimension",
+            },
+            {
+                "name": "email",
+                "type": "string",
+                "semantic_entity": "v3.customer.email",
+                "semantic_type": "dimension",
+            },
+        ]
+
+    @pytest.mark.asyncio
+    async def test_dimension_only_query_rejects_multiple_nodes(
+        self,
+        client_with_build_v3,
+    ):
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={
+                "dimensions": ["v3.customer.name", "v3.product.category"],
+            },
+        )
+
+        assert response.status_code == 422, response.json()
+        assert "exactly one node" in response.json()["message"]
+
+    @pytest.mark.asyncio
+    async def test_dimension_only_query_from_transform(self, client_with_build_v3):
+        response = await client_with_build_v3.get(
+            "/sql/metrics/v3/",
+            params={"dimensions": ["v3.order_details.status"]},
+        )
+
+        assert response.status_code == 200, response.json()
+        assert "DISTINCT" in response.json()["sql"]
+
+    @pytest.mark.asyncio
     async def test_basic_metrics_sql(self, client_with_build_v3):
         """Test that metrics SQL endpoint returns valid SQL."""
         response = await client_with_build_v3.get(

--- a/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
+++ b/datajunction-server/tests/construction/build_v3/metrics_sql_test.py
@@ -5,10 +5,17 @@ from . import assert_sql_equal
 
 class TestMetricsSQLBasic:
     @pytest.mark.asyncio
+    async def test_dimension_only_query_requires_dimensions(self, client_with_build_v3):
+        response = await client_with_build_v3.get("/sql/dimensions/v3/")
+
+        assert response.status_code == 422
+        assert "at least one dimension" in response.json()["message"].lower()
+
+    @pytest.mark.asyncio
     async def test_dimension_only_query(self, client_with_build_v3):
         """Attributes from one dimension produce their distinct combinations."""
         response = await client_with_build_v3.get(
-            "/sql/metrics/v3/",
+            "/sql/dimensions/v3/",
             params={
                 "dimensions": ["v3.customer.name", "v3.customer.email"],
                 "filters": ["v3.customer.name != 'Unknown'"],
@@ -49,12 +56,110 @@ class TestMetricsSQLBasic:
         ]
 
     @pytest.mark.asyncio
+    async def test_cube_scoped_dimension_query(self, client_with_build_v3):
+        """Cube metrics scope values; cube and request filters combine."""
+        create = await client_with_build_v3.post(
+            "/nodes/cube/",
+            json={
+                "name": "v3.filtered_revenue_cube",
+                "metrics": ["v3.total_revenue"],
+                "dimensions": [
+                    "v3.product.category",
+                    "v3.product.subcategory",
+                ],
+                "filters": ["v3.product.category = 'Electronics'"],
+                "mode": "published",
+                "description": "Filtered cube for dimension value SQL",
+            },
+        )
+        assert create.status_code == 201, create.json()
+
+        response = await client_with_build_v3.get(
+            "/sql/dimensions/v3/",
+            params={
+                "dimensions": ["v3.product.category"],
+                "filters": ["v3.product.subcategory = 'Smartphones'"],
+                "cube": "v3.filtered_revenue_cube",
+            },
+        )
+        assert response.status_code == 200, response.json()
+        assert_sql_equal(
+            response.json()["sql"],
+            """
+            SELECT DISTINCT dimension_values.category
+            FROM (
+              WITH v3_order_details AS (
+                SELECT oi.product_id, oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+              ),
+              v3_product AS (
+                SELECT product_id, category, subcategory
+                FROM default.v3.products
+                WHERE category = 'Electronics' AND subcategory = 'Smartphones'
+              ),
+              order_details_0 AS (
+                SELECT t2.category, SUM(t1.line_total) line_total_sum_e1f61696
+                FROM v3_order_details t1
+                LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+                WHERE t2.category = 'Electronics'
+                  AND t2.subcategory = 'Smartphones'
+                GROUP BY t2.category
+              )
+              SELECT order_details_0.category AS category,
+                SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+              FROM order_details_0
+              WHERE order_details_0.category = 'Electronics'
+              GROUP BY order_details_0.category
+            ) AS dimension_values
+            """,
+        )
+        assert [column["semantic_entity"] for column in response.json()["columns"]] == [
+            "v3.product.category",
+        ]
+
+        availability = await client_with_build_v3.post(
+            "/data/v3.filtered_revenue_cube/availability/",
+            json={
+                "catalog": "default",
+                "schema_": "v3",
+                "table": "filtered_revenue_cube",
+                "valid_through_ts": 1010129120,
+            },
+        )
+        assert availability.status_code in (200, 201), availability.json()
+
+        materialized = await client_with_build_v3.get(
+            "/sql/dimensions/v3/",
+            params={
+                "dimensions": ["v3.product.category"],
+                "cube": "v3.filtered_revenue_cube",
+                "dialect": "druid",
+            },
+        )
+        assert materialized.status_code == 200, materialized.json()
+        assert "filtered_revenue_cube" in materialized.json()["sql"]
+        assert "default.v3.products" not in materialized.json()["sql"]
+
+        response = await client_with_build_v3.get(
+            "/sql/dimensions/v3/",
+            params={
+                "dimensions": ["v3.customer.name[customer]"],
+                "cube": "v3.filtered_revenue_cube",
+            },
+        )
+        assert response.status_code == 200, response.json()
+        assert "v3_customer" in response.json()["sql"]
+        assert "category = 'Electronics'" in response.json()["sql"]
+        assert "filtered_revenue_cube" not in response.json()["sql"]
+
+    @pytest.mark.asyncio
     async def test_dimension_only_query_rejects_multiple_nodes(
         self,
         client_with_build_v3,
     ):
         response = await client_with_build_v3.get(
-            "/sql/metrics/v3/",
+            "/sql/dimensions/v3/",
             params={
                 "dimensions": ["v3.customer.name", "v3.product.category"],
             },
@@ -64,14 +169,109 @@ class TestMetricsSQLBasic:
         assert "exactly one node" in response.json()["message"]
 
     @pytest.mark.asyncio
-    async def test_dimension_only_query_from_transform(self, client_with_build_v3):
+    async def test_dimension_only_query_ignores_unknown_cube(
+        self,
+        client_with_build_v3,
+    ):
         response = await client_with_build_v3.get(
-            "/sql/metrics/v3/",
-            params={"dimensions": ["v3.order_details.status"]},
+            "/sql/dimensions/v3/",
+            params={
+                "dimensions": ["v3.customer.name"],
+                "cube": "v3.missing_cube",
+            },
         )
 
         assert response.status_code == 200, response.json()
         assert "DISTINCT" in response.json()["sql"]
+
+    @pytest.mark.asyncio
+    async def test_dimension_only_query_from_transform(self, client_with_build_v3):
+        response = await client_with_build_v3.get(
+            "/sql/dimensions/v3/",
+            params={"dimensions": ["v3.order_details.status"]},
+        )
+
+        assert response.status_code == 200, response.json()
+        assert_sql_equal(
+            response.json()["sql"],
+            """
+            WITH v3_order_details AS (
+                SELECT o.order_id, oi.line_number, o.customer_id, o.order_date,
+                    o.from_location_id, o.to_location_id, o.status, oi.product_id,
+                    oi.quantity, oi.unit_price,
+                    oi.quantity * oi.unit_price AS line_total
+                FROM default.v3.orders o
+                JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+            )
+            SELECT DISTINCT status
+            FROM v3_order_details
+            """,
+        )
+
+    @pytest.mark.asyncio
+    async def test_dimension_only_query_rejects_missing_node_with_explicit_dialect(
+        self,
+        client_with_build_v3,
+    ):
+        response = await client_with_build_v3.get(
+            "/sql/dimensions/v3/",
+            params={
+                "dimensions": ["missing.dimension.attribute"],
+                "dialect": "trino",
+            },
+        )
+
+        assert response.status_code == 422, response.json()
+        assert "does not exist" in response.json()["message"]
+
+    @pytest.mark.asyncio
+    async def test_dimension_only_query_rejects_missing_attribute(
+        self,
+        client_with_build_v3,
+    ):
+        response = await client_with_build_v3.get(
+            "/sql/dimensions/v3/",
+            params={
+                "dimensions": ["v3.customer.missing"],
+                "dialect": "trino",
+            },
+        )
+
+        assert response.status_code == 422, response.json()
+        assert "does not contain columns" in response.json()["message"]
+
+    @pytest.mark.asyncio
+    async def test_dimension_only_query_rejects_metric_node(
+        self,
+        client_with_build_v3,
+    ):
+        response = await client_with_build_v3.get(
+            "/sql/dimensions/v3/",
+            params={
+                "dimensions": ["v3.total_revenue.value"],
+                "dialect": "trino",
+            },
+        )
+
+        assert response.status_code == 422, response.json()
+        assert "cannot select attributes" in response.json()["message"]
+
+    @pytest.mark.asyncio
+    async def test_dimension_only_query_aliases_roles_and_accepts_parameters(
+        self,
+        client_with_build_v3,
+    ):
+        response = await client_with_build_v3.get(
+            "/sql/dimensions/v3/",
+            params={
+                "dimensions": ["v3.customer.name[buyer]"],
+                "query_params": '{"unused": "value"}',
+            },
+        )
+
+        assert response.status_code == 200, response.json()
+        assert response.json()["columns"][0]["name"] == "name_buyer"
+        assert "name AS name_buyer" in response.json()["sql"]
 
     @pytest.mark.asyncio
     async def test_basic_metrics_sql(self, client_with_build_v3):

--- a/datajunction-server/tests/internal/deployment/test_type_inference.py
+++ b/datajunction-server/tests/internal/deployment/test_type_inference.py
@@ -2491,6 +2491,18 @@ class TestUnresolvedNamespaceDiagnostic:
 class TestCoverageGaps:
     """Tests targeting specific uncovered branches in type_inference.py."""
 
+    def test_unresolved_references_are_deduplicated(self):
+        result = validate_node_query(
+            "SELECT missing + missing AS doubled FROM default.orders",
+            _col_map(ORDERS_COLS),
+        )
+
+        assert any(
+            "Unresolved column reference(s): missing." in error
+            for error in result.errors
+        )
+        assert not any("missing, missing" in error for error in result.errors)
+
     def test_inline_table_parens_with_alias_list_resolves_columns(self):
         """(VALUES (1), (2)) AS t(x) — parenthesized-VALUES + alias list
         currently parses with both node.alias and node.name None, so the


### PR DESCRIPTION
### Summary

<!-- What's this change about? -->

For the [semantic layer API](https://github.com/betodealmeida/sl-rest-api/blob/main/SPEC.md#post-viewsview_namevalues) we need to expose an endpoint that returns distinct values for a given dimension, in order to populate dropdowns:

```
POST /views/{view_name}/values

{
    "additional_configuration": {},
    "dimension": "sales.region",
    "filters":   []
}
```

This PR adds a new endpoint at `/sql/dimensions/v3/`, for symmetry with the existing `/sql/metrics/v3/` endpoint. The new endpoint can be used to return the distinct combination of dimension attributes from a single dimension node, producing a query like:

```sql
SELECT DISTINCT dim1, ..., dimn FROM dim_node_table;
```

A following PR will implement the actual endpoint for the semantic layer API, leveraging the code path from this PR.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
