### PR TITLE
Pass branch-deploy signal into cube materialization scheduling

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -2393,6 +2393,7 @@ class DeploymentOrchestrator:
             if swap:
                 if swap.rebuilt_names:
                     self._rebuilt_cubes.add(new_revision.name)
+                swap.is_branch_deploy = await self._is_branch_deploy()
                 self._cube_materialization_swaps.append(swap)
 
     def _declared_materializations(self) -> dict[str, list[MaterializationSpec]]:
@@ -2701,6 +2702,8 @@ class DeploymentOrchestrator:
                     # take the replacements down with it if those had already been
                     # scheduled.
                     self._cube_materialization_swaps.append(
+                        # No `rebuilt_names`, so this swap never reaches
+                        # `.schedule()` -- it only stops the superseded workflow.
                         CubeMaterializationSwap(
                             cube_name=revision.name,
                             previous_version=revision.version,
@@ -2720,6 +2723,7 @@ class DeploymentOrchestrator:
                         new_version=revision.version,
                         rebuilt_names=[entry.materialization.name for entry in changed],
                         superseded=[],
+                        is_branch_deploy=await self._is_branch_deploy(),
                     ),
                 )
             for entry in reconciled:
@@ -2804,6 +2808,8 @@ class DeploymentOrchestrator:
         if await backfill_recorded(self.session, materialization, span[0]):
             return
         self._cube_materialization_swaps.append(
+            # No `rebuilt_names`; this call already returned above whenever
+            # `_is_branch_deploy()` is true, so this swap is always main.
             CubeMaterializationSwap(
                 cube_name=revision.name,
                 previous_version=revision.version,
@@ -2881,6 +2887,8 @@ class DeploymentOrchestrator:
             ),
         )
         self._cube_materialization_swaps.append(
+            # No `rebuilt_names`, so this swap never reaches `.schedule()` --
+            # a teardown only stops workflows, it does not start one.
             CubeMaterializationSwap(
                 cube_name=revision.name,
                 previous_version=revision.version,

--- a/datajunction-server/datajunction_server/internal/materializations.py
+++ b/datajunction-server/datajunction_server/internal/materializations.py
@@ -418,6 +418,10 @@ class CubeMaterializationSwap:
     # cube's declared coverage against what its datasource already holds.
     backfill: CoverageBackfill | None = None
 
+    # Whether this swap belongs to a branch-preview deploy, so the query service
+    # can be told at schedule time rather than re-deriving it.
+    is_branch_deploy: bool = False
+
 
 @dataclass
 class CubeMaterializationSwapOutcome:
@@ -782,6 +786,7 @@ async def apply_cube_materialization_swap(
                 materialization_names=swap.rebuilt_names,
                 query_service_client=query_service_client,
                 request_headers=request_headers,
+                is_branch_deploy=swap.is_branch_deploy,
             )
         except Exception as exc:
             _logger.warning(
@@ -1238,6 +1243,7 @@ async def schedule_materialization_jobs(
     materialization_names: list[str],
     query_service_client: QueryServiceClient,
     request_headers: dict[str, str] | None = None,
+    is_branch_deploy: bool = False,
 ) -> dict[str, MaterializationInfo]:
     """
     Schedule recurring materialization jobs
@@ -1261,6 +1267,7 @@ async def schedule_materialization_jobs(
                 materialization,
                 query_service_client,
                 request_headers=request_headers,
+                is_branch_deploy=is_branch_deploy,
             )
     await record_workflow_names(session, materializations, materialization_to_output)
     return materialization_to_output

--- a/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/cube_materialization.py
@@ -41,6 +41,8 @@ class DefaultCubeMaterialization(MaterializationJob):
         self,
         materialization: Materialization,
         query_service_client: QueryServiceClient,
+        request_headers: dict[str, str] | None = None,
+        is_branch_deploy: bool = False,
     ):
         """
         Since this is a settings-only dummy job, we do nothing in this stage.
@@ -60,6 +62,7 @@ class DruidMaterializationJob(MaterializationJob):
         materialization: Materialization,
         query_service_client: QueryServiceClient,
         request_headers: dict[str, str] | None = None,
+        is_branch_deploy: bool = False,
     ) -> MaterializationInfo:
         """
         Use the query service to kick off the materialization setup.
@@ -134,6 +137,7 @@ class DruidCubeMaterializationJob(DruidMaterializationJob, MaterializationJob):
         materialization: Materialization,
         query_service_client: QueryServiceClient,
         request_headers: dict[str, str] | None = None,
+        is_branch_deploy: bool = False,
     ) -> MaterializationInfo:
         """
         Use the query service to kick off the materialization setup.
@@ -164,6 +168,7 @@ class DruidCubeMaterializationJob(DruidMaterializationJob, MaterializationJob):
                 platform=cube_config.platform,
                 measures_materializations=cube_config.measures_materializations,
                 combiners=cube_config.combiners,
+                is_branch_deploy=is_branch_deploy,
             ),
             request_headers=request_headers,
         )

--- a/datajunction-server/datajunction_server/materialization/jobs/materialization_job.py
+++ b/datajunction-server/datajunction_server/materialization/jobs/materialization_job.py
@@ -59,6 +59,8 @@ class MaterializationJob(abc.ABC):
         self,
         materialization: Materialization,
         query_service_client: QueryServiceClient,
+        request_headers: dict[str, str] | None = None,
+        is_branch_deploy: bool = False,
     ) -> MaterializationInfo:
         """
         Schedules the materialization job, typically done by calling a separate service
@@ -80,6 +82,7 @@ class SparkSqlMaterializationJob(  # pragma: no cover
         materialization: Materialization,
         query_service_client: QueryServiceClient,
         request_headers: dict[str, str] | None = None,
+        is_branch_deploy: bool = False,
     ) -> MaterializationInfo:
         """
         Placeholder for the actual implementation.

--- a/datajunction-server/datajunction_server/models/cube_materialization.py
+++ b/datajunction-server/datajunction_server/models/cube_materialization.py
@@ -571,6 +571,11 @@ class DruidCubeMaterializationInput(BaseModel):
     # possible for metrics at different levels.
     combiners: list[CombineMaterialization]
 
+    # True when scheduled against a branch-preview deployment rather than main,
+    # so the query service can decide how to target its run (e.g. avoid
+    # gap-closing backfills against today's date).
+    is_branch_deploy: bool = False
+
 
 # =============================================================================
 # V2: Pre-agg based cube materialization

--- a/datajunction-server/tests/internal/materializations_test.py
+++ b/datajunction-server/tests/internal/materializations_test.py
@@ -283,6 +283,7 @@ def test_stop_materialization_workflows_reports_every_failure():
 def _swap(
     rebuilt_names: list[str],
     backfill: CoverageBackfill | None = None,
+    is_branch_deploy: bool = False,
 ) -> CubeMaterializationSwap:
     """A swap with one superseded materialization and the given rebuilt names."""
     return CubeMaterializationSwap(
@@ -298,6 +299,7 @@ def _swap(
             ),
         ],
         backfill=backfill,
+        is_branch_deploy=is_branch_deploy,
     )
 
 
@@ -334,12 +336,44 @@ async def test_apply_cube_swap_reports_a_scheduled_push():
             materialization_names=["druid_cube_v3"],
             query_service_client=query_service_client,
             request_headers={"cookie": "a-cookie"},
+            is_branch_deploy=False,
         ),
     ]
     assert query_service_client.deactivate_workflows.call_args_list == [
         mock.call(
             workflow_names=["cube_workflow_1"],
             request_headers={"cookie": "a-cookie"},
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_apply_cube_swap_threads_branch_deploy_through_to_scheduling():
+    """
+    A swap computed on a branch-preview deploy tells the query service so, rather
+    than leaving it to assume main.
+    """
+    query_service_client = mock.MagicMock()
+    session = mock.MagicMock()
+
+    with mock.patch(
+        "datajunction_server.internal.materializations.schedule_materialization_jobs",
+        new=mock.AsyncMock(),
+    ) as schedule:
+        await apply_cube_materialization_swap(
+            session,
+            _swap(["druid_cube_v3"], is_branch_deploy=True),
+            query_service_client,
+        )
+
+    assert schedule.call_args_list == [
+        mock.call(
+            session,
+            node_revision_id=42,
+            materialization_names=["druid_cube_v3"],
+            query_service_client=query_service_client,
+            request_headers=None,
+            is_branch_deploy=True,
         ),
     ]
 


### PR DESCRIPTION
### Summary

When calling the query service for a cube materialization, we should pass on the branch-deploy signal. This can be used by the query service to take different actions based on whether it's a branch deploy or a main deploy.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
