### PR TITLE
Stable load order for column attributes 

### DIFF
--- a/datajunction-server/datajunction_server/database/column.py
+++ b/datajunction-server/datajunction_server/database/column.py
@@ -85,6 +85,11 @@ class Column(Base):  # type: ignore
         back_populates="column",
         lazy="selectin",
         cascade="all,delete",
+        # A selectin load with no ORDER BY lets the database return a column's
+        # attributes in a different order on each load, which surfaces as a
+        # spurious diff anywhere the list is serialized positionally -- the node
+        # history view being the visible one.
+        order_by="ColumnAttribute.id",
     )
     measure_id: Mapped[int | None] = mapped_column(
         ForeignKey(


### PR DESCRIPTION
### Summary

The attributes relationship is a selectin load with no `ORDER BY`, so the database is free to return a column's attributes in a different order on each load. This makes a cube's history show edits it never had, because the comparison was taking into account order.

Ordering by id is enough. Note that this doesn't change anything for node spec comparison: `to_spec` goes through `attribute_names()`, which already sorts.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
