### PR TITLE
Handle invalid cube partition declarations

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -407,6 +407,28 @@ class DeploymentOrchestrator:
                 return author
         return self.context.current_user.username
 
+    def _warn_about_unmatched_cube_columns(self) -> None:
+        """
+        Warn about `columns:` entries naming no column of the cube. The comparison
+        ignores them; without this the partition the author declared would just
+        silently do nothing.
+        """
+        for spec in self.deployment_spec.nodes:
+            if not isinstance(spec, CubeSpec):
+                continue
+            for unmatched in spec.unmatched_column_names:
+                self.warnings.append(
+                    DJError(
+                        code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
+                        message=(
+                            f"Cube '{spec.name}' declares column '{unmatched}', "
+                            f"which is not one of its columns, so the settings on "
+                            f"it have no effect. A cube's columns are its metrics "
+                            f"and dimensions, named exactly as they appear there."
+                        ),
+                    ),
+                )
+
     async def execute(self) -> DeploymentExecuteResult:
         """
         Validate and deploy all resources and nodes into the specified namespace.
@@ -431,6 +453,8 @@ class DeploymentOrchestrator:
             len(self.deployment_spec.nodes),
             self.deployment_spec.namespace,
         )
+
+        self._warn_about_unmatched_cube_columns()
 
         result = DeploymentExecuteResult(results=[], downstream_impacts=[])
         try:
@@ -4963,17 +4987,13 @@ class DeploymentOrchestrator:
             existing_node_spec,
             CubeSpec,
         ):
-            incoming_partitions = {
-                col.name: col.partition
-                for col in result.spec.rendered_columns
-                if col.partition
-            }
-            existing_partitions = {
-                col.name: col.partition
-                for col in existing_node_spec.rendered_columns
-                if col.partition
-            }
-            if incoming_partitions != existing_partitions:
+            from datajunction_server.semantic_fingerprints.normalization import (
+                normalize_cube_columns,
+            )
+
+            if normalize_cube_columns(
+                result.spec.matched_rendered_columns,
+            ) != normalize_cube_columns(existing_node_spec.matched_rendered_columns):
                 changed_fields = changed_fields + ["columns"]
 
         if changed_fields:

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -1341,6 +1341,27 @@ class CubeSpec(NodeSpec):
             rendered.append(rendered_col)
         return rendered
 
+    @property
+    def matched_rendered_columns(self) -> list["ColumnSpec"]:
+        """
+        The ``columns:`` entries naming a column this cube has, keyed the same way
+        the deploy keys them: `Column.cube_element_name`, so a metric or dimension
+        as written, with its `[role]` suffix. Anything else is never persisted, so
+        comparing it would report a change on every deploy.
+        """
+        cube_columns = set(self.rendered_metrics) | set(self.rendered_dimensions)
+        return [col for col in self.rendered_columns if col.name in cube_columns]
+
+    @property
+    def unmatched_column_names(self) -> list[str]:
+        """
+        Names in ``columns:`` that are not columns of this cube, and so are ignored.
+        """
+        cube_columns = set(self.rendered_metrics) | set(self.rendered_dimensions)
+        return [
+            col.name for col in self.rendered_columns if col.name not in cube_columns
+        ]
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, CubeSpec):
             return False
@@ -1372,8 +1393,8 @@ class CubeSpec(NodeSpec):
         )
 
         return normalize_cube_columns(
-            self.rendered_columns,
-        ) == normalize_cube_columns(other.rendered_columns)
+            self.matched_rendered_columns,
+        ) == normalize_cube_columns(other.matched_rendered_columns)
 
 
 NodeUnion = Annotated[

--- a/datajunction-server/datajunction_server/semantic_fingerprints/normalization.py
+++ b/datajunction-server/datajunction_server/semantic_fingerprints/normalization.py
@@ -178,7 +178,7 @@ def normalize_field(
         )
     if field == "columns":
         if isinstance(spec, CubeSpec):
-            return normalize_cube_columns(spec.rendered_columns)
+            return normalize_cube_columns(spec.matched_rendered_columns)
         return normalize_columns(
             resolved_columns
             if isinstance(spec, SourceSpec) and resolved_columns is not None

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -8216,6 +8216,174 @@ class TestDeploymentHistoryTracking:
 
 
 @pytest.mark.xdist_group(name="deployments")
+class TestCubeRedeployIdempotence:
+    """A cube spec deployed twice must not churn a new version."""
+
+    @pytest.mark.asyncio
+    async def test_partitioned_cube_redeploy_is_a_noop(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        Deploying an unchanged cube that declares a column partition is a noop.
+
+        The cube branch of the deployment diff compares the partitions on the
+        incoming spec's columns against the partitions on the existing spec's.
+        If a declared partition never lands on the stored cube column, the two
+        sides can never agree, so every deploy reports ``columns`` changed --
+        and ``columns`` is unclassified, so it bumps a MAJOR version. The cube
+        then gains a version on every deploy of the namespace forever, with
+        nothing about it having changed.
+        """
+        namespace = "cube_redeploy_idempotence"
+        cube = CubeSpec(
+            name="${prefix}default.repairs_cube",
+            display_name="Repairs Cube",
+            description="Cube for analyzing repair orders",
+            dimensions=[
+                "${prefix}default.hard_hat.state",
+                "${prefix}default.hard_hat.hire_date",
+            ],
+            metrics=["${prefix}default.avg_length_of_employment"],
+            owners=["dj"],
+            columns=[
+                ColumnSpec(
+                    name="${prefix}default.hard_hat.hire_date",
+                    partition=PartitionSpec(
+                        type=PartitionType.TEMPORAL,
+                        granularity=Granularity.DAY,
+                        format="yyyyMMdd",
+                    ),
+                ),
+            ],
+        )
+        upstreams = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+        ]
+
+        def deployment() -> DeploymentSpec:
+            return DeploymentSpec(
+                namespace=namespace,
+                nodes=[spec.model_copy(deep=True) for spec in upstreams]
+                + [cube.model_copy(deep=True)],
+            )
+
+        first = await deploy_and_wait(client, deployment())
+        assert first["status"] == "success", first["results"]
+
+        cube_name = f"{namespace}.default.repairs_cube"
+        version_after_first = (await client.get(f"/nodes/{cube_name}/")).json()[
+            "version"
+        ]
+
+        second = await deploy_and_wait(client, deployment())
+        assert second["status"] == "success", second
+        cube_result = next(
+            result for result in second["results"] if result["name"] == cube_name
+        )
+        assert cube_result["changed_fields"] == [], cube_result["message"]
+        assert cube_result["operation"] == "noop"
+
+        version_after_second = (await client.get(f"/nodes/{cube_name}/")).json()[
+            "version"
+        ]
+        assert version_after_second == version_after_first
+
+    @pytest.mark.asyncio
+    async def test_partition_on_a_non_cube_column_does_not_churn(
+        self,
+        client,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        """
+        A partition declared on a name that is not one of the cube's columns must
+        not make every redeploy look like a change.
+
+        ``rendered_columns`` keeps whatever the spec declared, but only names that
+        match a real cube column can be persisted. A declaration that matches
+        nothing therefore sits in ``incoming_partitions`` and never appears in
+        ``existing_partitions``, so the two can never agree: each deploy reports
+        ``columns`` changed, and because ``columns`` is unclassified it takes a
+        MAJOR version. The cube then gains a version on every deploy forever.
+        """
+        namespace = "cube_redeploy_phantom_partition"
+        cube = CubeSpec(
+            name="${prefix}default.repairs_cube",
+            display_name="Repairs Cube",
+            description="Cube for analyzing repair orders",
+            dimensions=[
+                "${prefix}default.hard_hat.state",
+                "${prefix}default.hard_hat.hire_date",
+            ],
+            metrics=["${prefix}default.avg_length_of_employment"],
+            owners=["dj"],
+            columns=[
+                ColumnSpec(
+                    # Deliberately not a cube column: the cube's column is
+                    # ``default.hard_hat.hire_date``, fully qualified.
+                    name="hire_date",
+                    partition=PartitionSpec(
+                        type=PartitionType.TEMPORAL,
+                        granularity=Granularity.DAY,
+                        format="yyyyMMdd",
+                    ),
+                ),
+            ],
+        )
+        upstreams = [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+        ]
+
+        def deployment() -> DeploymentSpec:
+            return DeploymentSpec(
+                namespace=namespace,
+                nodes=[spec.model_copy(deep=True) for spec in upstreams]
+                + [cube.model_copy(deep=True)],
+            )
+
+        first = await deploy_and_wait(client, deployment())
+        assert first["status"] == "success", first["results"]
+
+        cube_name = f"{namespace}.default.repairs_cube"
+        version_after_first = (await client.get(f"/nodes/{cube_name}/")).json()[
+            "version"
+        ]
+
+        second = await deploy_and_wait(client, deployment())
+        cube_result = next(
+            result for result in second["results"] if result["name"] == cube_name
+        )
+        assert cube_result["changed_fields"] == [], cube_result["message"]
+
+        version_after_second = (await client.get(f"/nodes/{cube_name}/")).json()[
+            "version"
+        ]
+        assert version_after_second == version_after_first
+
+        # The declaration is ignored, but the author is told it is.
+        assert any(
+            "declares column 'hire_date'" in warning["message"]
+            for warning in second["warnings"]
+        ), second["warnings"]
+
+
 class TestDeploymentColumnOrdering:
     """Tests for column ordering in deployments"""
 


### PR DESCRIPTION
### Summary

Declaring `columns:` with a partition on a cube works for attaching temporal partitions, but if a column doesn't match any cube elements, DJ doesn't raise an error. Instead, since the change can't be persisted to the database, any comparisons when deploying a cube will flag a diff with the existing version, causing each deploy to report that columns have changed. This causes the cube to take on new major version for every deploy, even though nothing changed.

There are two primary issues:
1. Unnecessary churn in cube versions.
2. The cube's temporal partition never takes effect and the user isn't told about it.

The fix is to ignore column declarations that don't match any cube elements and log a warning for the user upon deployment. Any valid column declarations are unaffected.


### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
