### PR TITLE
Fix column pruning for when table aliases are used in subqueries and for `USING` or `NATURAL JOIN`

### DIFF
--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -999,28 +999,37 @@ def _joins_naturally(arm: ast.SelectExpression) -> bool:
     return any(join.natural for join in arm.find_all(ast.Join))
 
 
-def _arm_sources(
+def _enclosing_selects(
+    node: ast.Node,
+    outermost: ast.SelectExpression,
+) -> list[ast.SelectExpression]:
+    """The selects a node sits in, innermost first, ending at outermost."""
+    chain: list[ast.SelectExpression] = []
+    current = node.parent
+    while current is not None:
+        if isinstance(current, ast.SelectExpression):
+            chain.append(current)
+            if current is outermost:
+                break
+        current = current.parent
+    return chain
+
+
+def _select_bindings(
     arm: ast.SelectExpression,
     cte_names: set[str],
-) -> tuple[dict[str, str], set[str]]:
+) -> tuple[dict[ast.SelectExpression, dict[str, str]], set[str]]:
     """
-    Resolve the qualifiers an arm uses for CTEs, and name the CTEs it reads.
+    Map each select to its CTE bindings, and the CTEs the statement reads.
 
-    FROM a AS x JOIN b over CTEs a and b gives
-    ({"a": "a", "x": "a", "b": "b"}, {"a", "b"}) -- a table answers to its
-    alias and to its own name.
-
-    A qualifier two tables claim is dropped, since a subquery can reuse an
-    alias for another CTE:
+    A select's map covers only its own FROM, keyed by alias and table name, so
+    a subquery reusing an alias shadows the outer binding instead of
+    overwriting it:
 
         FROM a AS x WHERE EXISTS (SELECT 1 FROM b AS x ...)
-
-    x means a outside and b inside, so it resolves to neither and its columns
-    go to every CTE read. The read set is returned separately so it stays
-    whole when a qualifier drops.
+        {outer: {"a": "a", "x": "a"}, EXISTS: {"b": "b", "x": "b"}}
     """
-    sources: dict[str, str] = {}
-    shadowed: set[str] = set()
+    bindings: dict[ast.SelectExpression, dict[str, str]] = {arm: {}}
     read: set[str] = set()
     for part in _arm_parts(arm):
         for table in part.find_all(ast.Table):
@@ -1028,41 +1037,57 @@ def _arm_sources(
             if name not in cte_names:
                 continue
             read.add(name)
-            qualifiers = [name]
+            owner = _enclosing_selects(table, arm)
+            # Detached tables go in the outermost map.
+            bound = bindings.setdefault(owner[0] if owner else arm, {})
+            bound[name] = name
             if alias := _table_alias(table):
-                qualifiers.append(alias.identifier(quotes=False))
-            for qualifier in qualifiers:
-                if sources.setdefault(qualifier, name) != name:
-                    shadowed.add(qualifier)
-    for qualifier in shadowed:
-        del sources[qualifier]
-    return sources, read
+                bound[alias.identifier(quotes=False)] = name
+    return bindings, read
 
 
-def _record_arm_demands(
+def _record_column_use(
+    node: ast.Node,
+    qualifier: str | None,
+    wanted: str,
     arm: ast.SelectExpression,
-    sources: dict[str, str],
-    bare_targets: set[str],
+    bindings: dict[ast.SelectExpression, dict[str, str]],
+    read: set[str],
     live: dict[str, set[str]],
 ) -> None:
     """
-    Charge each column an arm reads to the CTE that has to project it.
+    Resolve a column to its CTE and mark it live.
+    """
+    if qualifier is not None:
+        for select in _enclosing_selects(node, arm):
+            bound = bindings.get(select, {}).get(qualifier)
+            if bound is not None:
+                live[bound].add(wanted)
+                return
+    for target in read:
+        live[target].add(wanted)
 
-    A qualified reference goes to the CTE its qualifier names, and the column
-    wanted there is the segment right after the qualifier — for a struct path
-    like ``p.line_item.target_sets`` the producer projects ``line_item``, not
-    the leaf. A reference with no qualifier we recognize goes to every CTE in
-    scope: which one supplies it is only knowable after compilation, and
-    keeping a name a CTE does not have is a no-op.
+
+def _record_select_uses(
+    arm: ast.SelectExpression,
+    bindings: dict[ast.SelectExpression, dict[str, str]],
+    read: set[str],
+    live: dict[str, set[str]],
+) -> None:
+    """
+    Resolve every column a select reads to its CTE and mark it live.
+
+    The column wanted is the segment right after the qualifier -- for a struct
+    path like p.line_item.target_sets the producer projects line_item, not the
+    leaf.
 
     A qualifier reaches us two ways. Dotted into the name is the parsed form,
     and it can carry further struct segments. Hung off the column as a table is
     what the builder produces for its own projections and GROUP BY, and there
     the column name stands alone.
 
-    A USING column is a column name on the join rather than a column
-    reference, and both sides must project it. JOIN b USING (id) charges id
-    to every CTE in scope, the same as an unqualified reference.
+    When a column is referenced in USING, both sides of the join must project
+    it.
     """
     for part in _arm_parts(arm):
         for column in part.find_all(ast.Column):
@@ -1071,16 +1096,26 @@ def _record_arm_demands(
             wanted = segments[1] if len(segments) > 1 else segments[0]
             if qualifier is None:
                 qualifier = column_table_name(column)
-            if qualifier in sources:
-                live[sources[qualifier]].add(wanted)
-            else:
-                for target in bare_targets:
-                    live[target].add(wanted)
+            _record_column_use(
+                column,
+                qualifier,
+                wanted,
+                arm,
+                bindings,
+                read,
+                live,
+            )
         for criteria in part.find_all(ast.JoinCriteria):
             for joined in criteria.using or []:
-                wanted = joined.identifier(quotes=False)
-                for target in bare_targets:
-                    live[target].add(wanted)
+                _record_column_use(
+                    criteria,
+                    None,
+                    joined.identifier(quotes=False),
+                    arm,
+                    bindings,
+                    read,
+                    live,
+                )
 
 
 def _scopes_readers_first(
@@ -1101,7 +1136,7 @@ def _scopes_readers_first(
     for key, scope in scopes.items():
         producers: set[str] = set()
         for arm in _set_op_arms(scope.select):
-            producers.update(_arm_sources(arm, cte_names)[1])
+            producers.update(_select_bindings(arm, cte_names)[1])
         producers.discard(key)
         reads[key] = producers
 
@@ -1176,8 +1211,8 @@ def prune_cte_projections(query: ast.Query) -> None:
                     _apply_keep_positions(arm, keep)
 
         for arm in _set_op_arms(scope.select):
-            sources, read = _arm_sources(arm, cte_names)
-            _record_arm_demands(arm, sources, read, live)
+            bindings, read = _select_bindings(arm, cte_names)
+            _record_select_uses(arm, bindings, read, live)
             if _joins_naturally(arm):
                 # Its join key is the columns both sides share.
                 unprunable.update(read)

--- a/datajunction-server/datajunction_server/construction/build_v3/cte.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cte.py
@@ -994,27 +994,55 @@ def _table_alias(table: ast.Table) -> ast.Name | None:
     return None
 
 
-def _arm_sources(arm: ast.SelectExpression, cte_names: set[str]) -> dict[str, str]:
-    """
-    Map every qualifier an arm can use for a CTE to that CTE's name.
+def _joins_naturally(arm: ast.SelectExpression) -> bool:
+    """Whether the arm has a NATURAL JOIN."""
+    return any(join.natural for join in arm.find_all(ast.Join))
 
-    A table can be addressed by its alias or by the CTE name itself, so both
-    land in the map.
+
+def _arm_sources(
+    arm: ast.SelectExpression,
+    cte_names: set[str],
+) -> tuple[dict[str, str], set[str]]:
+    """
+    Resolve the qualifiers an arm uses for CTEs, and name the CTEs it reads.
+
+    FROM a AS x JOIN b over CTEs a and b gives
+    ({"a": "a", "x": "a", "b": "b"}, {"a", "b"}) -- a table answers to its
+    alias and to its own name.
+
+    A qualifier two tables claim is dropped, since a subquery can reuse an
+    alias for another CTE:
+
+        FROM a AS x WHERE EXISTS (SELECT 1 FROM b AS x ...)
+
+    x means a outside and b inside, so it resolves to neither and its columns
+    go to every CTE read. The read set is returned separately so it stays
+    whole when a qualifier drops.
     """
     sources: dict[str, str] = {}
+    shadowed: set[str] = set()
+    read: set[str] = set()
     for part in _arm_parts(arm):
         for table in part.find_all(ast.Table):
             name = table.name.identifier(quotes=False)
-            if name in cte_names:
-                sources[name] = name
-                if alias := _table_alias(table):
-                    sources[alias.identifier(quotes=False)] = name
-    return sources
+            if name not in cte_names:
+                continue
+            read.add(name)
+            qualifiers = [name]
+            if alias := _table_alias(table):
+                qualifiers.append(alias.identifier(quotes=False))
+            for qualifier in qualifiers:
+                if sources.setdefault(qualifier, name) != name:
+                    shadowed.add(qualifier)
+    for qualifier in shadowed:
+        del sources[qualifier]
+    return sources, read
 
 
 def _record_arm_demands(
     arm: ast.SelectExpression,
     sources: dict[str, str],
+    bare_targets: set[str],
     live: dict[str, set[str]],
 ) -> None:
     """
@@ -1031,8 +1059,11 @@ def _record_arm_demands(
     and it can carry further struct segments. Hung off the column as a table is
     what the builder produces for its own projections and GROUP BY, and there
     the column name stands alone.
+
+    A USING column is a column name on the join rather than a column
+    reference, and both sides must project it. JOIN b USING (id) charges id
+    to every CTE in scope, the same as an unqualified reference.
     """
-    bare_targets = set(sources.values())
     for part in _arm_parts(arm):
         for column in part.find_all(ast.Column):
             segments = column.identifier(quotes=False).split(SEPARATOR)
@@ -1043,6 +1074,11 @@ def _record_arm_demands(
             if qualifier in sources:
                 live[sources[qualifier]].add(wanted)
             else:
+                for target in bare_targets:
+                    live[target].add(wanted)
+        for criteria in part.find_all(ast.JoinCriteria):
+            for joined in criteria.using or []:
+                wanted = joined.identifier(quotes=False)
                 for target in bare_targets:
                     live[target].add(wanted)
 
@@ -1065,7 +1101,7 @@ def _scopes_readers_first(
     for key, scope in scopes.items():
         producers: set[str] = set()
         for arm in _set_op_arms(scope.select):
-            producers.update(_arm_sources(arm, cte_names).values())
+            producers.update(_arm_sources(arm, cte_names)[1])
         producers.discard(key)
         reads[key] = producers
 
@@ -1140,15 +1176,18 @@ def prune_cte_projections(query: ast.Query) -> None:
                     _apply_keep_positions(arm, keep)
 
         for arm in _set_op_arms(scope.select):
-            sources = _arm_sources(arm, cte_names)
-            _record_arm_demands(arm, sources, live)
+            sources, read = _arm_sources(arm, cte_names)
+            _record_arm_demands(arm, sources, read, live)
+            if _joins_naturally(arm):
+                # Its join key is the columns both sides share.
+                unprunable.update(read)
             if not any(_is_star(item) for item in arm.projection):
                 continue
             # A star names no columns of its own: it re-exposes whatever its
             # source has. So a CTE that stars a source passes its own demand
             # straight through. Where that demand is unknown — the outer
             # select, or a CTE nobody reads — the source keeps everything.
-            starred = set(sources.values())
+            starred = set(read)
             if key and key not in unprunable and live[key]:
                 for target in starred:
                     live[target].update(live[key])

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -2619,11 +2619,6 @@ class TestPruneCteProjections:
         return " ".join(str(query).split())
 
     def test_a_shadowed_alias_does_not_prune_the_outer_source(self):
-        """
-        ``x`` names ``a`` outside and ``b`` inside the EXISTS. Resolving it to
-        one of them drops the other's column: charging ``x.keep`` to ``b``
-        prunes ``keep`` out of ``a``, which the outer select still reads.
-        """
         assert self._compact(
             "WITH a AS (SELECT id, keep FROM t1), b AS (SELECT marker FROM t2) "
             "SELECT x.keep, id FROM a AS x "
@@ -2636,10 +2631,6 @@ class TestPruneCteProjections:
         )
 
     def test_using_columns_are_kept_on_both_sides(self):
-        """
-        A ``USING`` column is named nowhere else, so pruning it away leaves the
-        join criteria referring to a column neither side projects.
-        """
         assert self._compact(
             "WITH a AS (SELECT id, keep, drop_me FROM t1), "
             "b AS (SELECT id, marker FROM t2) "
@@ -2650,11 +2641,33 @@ class TestPruneCteProjections:
             "SELECT a.keep FROM a JOIN b USING (id)"
         )
 
+    def test_a_shadowed_alias_resolves_per_select(self):
+        assert self._compact(
+            "WITH a AS (SELECT id, keep FROM t1), "
+            "b AS (SELECT keep, marker FROM t2) "
+            "SELECT x.keep, id FROM a AS x "
+            "WHERE EXISTS (SELECT 1 FROM b AS x WHERE x.marker = 1)",
+        ) == (
+            "WITH a AS ( SELECT id, keep FROM t1 ), "
+            "b AS ( SELECT marker FROM t2 ) "
+            "SELECT x.keep, id FROM a AS x "
+            "WHERE EXISTS (SELECT 1 FROM b AS x WHERE x.marker = 1)"
+        )
+
+    def test_a_subquery_reads_an_outer_alias(self):
+        assert self._compact(
+            "WITH a AS (SELECT id, keep, drop_me FROM t1), "
+            "b AS (SELECT id, ref, marker FROM t2) "
+            "SELECT x.keep FROM a AS x "
+            "WHERE EXISTS (SELECT 1 FROM b WHERE b.ref = x.id)",
+        ) == (
+            "WITH a AS ( SELECT id, keep FROM t1 ), "
+            "b AS ( SELECT ref FROM t2 ) "
+            "SELECT x.keep FROM a AS x "
+            "WHERE EXISTS (SELECT 1 FROM b WHERE b.ref = x.id)"
+        )
+
     def test_a_natural_join_keeps_both_sides_whole(self):
-        """
-        A natural join's criteria is whatever names the two sides share, so a
-        pruned column is not a dropped column -- it is a dropped join key.
-        """
         assert self._compact(
             "WITH a AS (SELECT id, keep FROM t1), "
             "b AS (SELECT id, marker FROM t2) "

--- a/datajunction-server/tests/construction/build_v3/helpers_test.py
+++ b/datajunction-server/tests/construction/build_v3/helpers_test.py
@@ -2611,6 +2611,60 @@ class TestPruneCteProjections:
     def test_query_without_ctes_is_untouched(self):
         assert self._pruned("SELECT a FROM t") == str(parse("SELECT a FROM t"))
 
+    @staticmethod
+    def _compact(sql: str) -> str:
+        """The pruned SQL with runs of whitespace collapsed to one space."""
+        query = parse(sql)
+        prune_cte_projections(query)
+        return " ".join(str(query).split())
+
+    def test_a_shadowed_alias_does_not_prune_the_outer_source(self):
+        """
+        ``x`` names ``a`` outside and ``b`` inside the EXISTS. Resolving it to
+        one of them drops the other's column: charging ``x.keep`` to ``b``
+        prunes ``keep`` out of ``a``, which the outer select still reads.
+        """
+        assert self._compact(
+            "WITH a AS (SELECT id, keep FROM t1), b AS (SELECT marker FROM t2) "
+            "SELECT x.keep, id FROM a AS x "
+            "WHERE EXISTS (SELECT 1 FROM b AS x WHERE x.marker = 1)",
+        ) == (
+            "WITH a AS ( SELECT id, keep FROM t1 ), "
+            "b AS ( SELECT marker FROM t2 ) "
+            "SELECT x.keep, id FROM a AS x "
+            "WHERE EXISTS (SELECT 1 FROM b AS x WHERE x.marker = 1)"
+        )
+
+    def test_using_columns_are_kept_on_both_sides(self):
+        """
+        A ``USING`` column is named nowhere else, so pruning it away leaves the
+        join criteria referring to a column neither side projects.
+        """
+        assert self._compact(
+            "WITH a AS (SELECT id, keep, drop_me FROM t1), "
+            "b AS (SELECT id, marker FROM t2) "
+            "SELECT a.keep FROM a JOIN b USING (id)",
+        ) == (
+            "WITH a AS ( SELECT id, keep FROM t1 ), "
+            "b AS ( SELECT id FROM t2 ) "
+            "SELECT a.keep FROM a JOIN b USING (id)"
+        )
+
+    def test_a_natural_join_keeps_both_sides_whole(self):
+        """
+        A natural join's criteria is whatever names the two sides share, so a
+        pruned column is not a dropped column -- it is a dropped join key.
+        """
+        assert self._compact(
+            "WITH a AS (SELECT id, keep FROM t1), "
+            "b AS (SELECT id, marker FROM t2) "
+            "SELECT a.keep FROM a NATURAL JOIN b",
+        ) == (
+            "WITH a AS ( SELECT id, keep FROM t1 ), "
+            "b AS ( SELECT id, marker FROM t2 ) "
+            "SELECT a.keep FROM a NATURAL JOIN b"
+        )
+
 
 class TestProjectionInvariantOracle:
     """


### PR DESCRIPTION
### Summary

Fixes some bugs with #2496 thanks @betodealmeida!

#### Bug 1: table alias reused inside a subquery

The pass builds one lookup of table alias → block by reading the `FROM` clauses. But it reads the `FROM` clauses inside subqueries too, into the same lookup, so if a subquery reuses an alias for a different block, the subquery's version overwrites the outer one.
```sql
WITH a AS (SELECT id, keep FROM t1),
     b AS (SELECT marker FROM t2)
SELECT x.keep, id
FROM a AS x
WHERE EXISTS (SELECT 1 FROM b AS x WHERE x.marker = 1)
```
The outer query's `x` refers to `a`. The EXISTS subquery's `x` refers to `b`. The lookup ends up saying `x` means `b`, so when the pass sees `x.keep` in the outer select it credits `keep` to `b` and concludes `a` doesn't need `keep` and prunes it:
```sql
WITH a AS (SELECT id FROM t1),          -- keep is gone
     b AS (SELECT marker FROM t2)
SELECT x.keep, id                        -- but this still reads it
FROM a AS x
WHERE EXISTS (SELECT 1 FROM b AS x WHERE x.marker = 1)
```

#### Bug 2: join columns from `USING`

`USING (id)` names a column that both sides of the join must have. In the parse tree those names aren't stored as column references and the pass finds columns by scanning for column references. Example:
```sql
WITH a AS (SELECT id, keep FROM t1),
     b AS (SELECT id, marker FROM t2)
SELECT a.keep FROM a JOIN b USING (id)
```
Only `a.keep` looks used and `id` is pruned:
```
WITH a AS (SELECT keep FROM t1),        -- id is gone
     b AS (SELECT id, marker FROM t2)
SELECT a.keep FROM a JOIN b USING (id)   -- fails since it's joining on a column a doesn't have
```

The same issue comes up when using `NATURAL JOIN` -- it joins on every column name the two sides happen to share. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
