### PR TITLE
Race condition during deployment

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -133,11 +133,18 @@ from datajunction_server.sql.dag import get_metric_parents_map
 from datajunction_server.typing import UTCDatetime
 from datajunction_server.utils import (
     SEPARATOR,
+    Version,
     get_namespace_from_name,
     get_settings,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _version_key(version: str) -> tuple[int, int]:
+    """A version as a sortable pair, so v10.0 outranks v9.0."""
+    parsed = Version.parse(version)
+    return parsed.major, parsed.minor
 
 
 def _extract_dimension_refs_from_filters(
@@ -3716,6 +3723,13 @@ class DeploymentOrchestrator:
         """Create cube nodes and revisions from validation results without re-validation"""
         nodes, revisions = [], []
         deployment_results = []
+        await self._lock_versions(
+            [
+                node
+                for result in validation_results
+                if (node := self.registry.nodes.get(result.spec.rendered_name))
+            ],
+        )
 
         for result in validation_results:
             cube_spec = cast(CubeSpec, result.spec)
@@ -4762,6 +4776,13 @@ class DeploymentOrchestrator:
     ) -> tuple[list[Node], list[NodeRevision], list[DeploymentResult]]:
         nodes, revisions = [], []
         deployment_results = []
+        await self._lock_versions(
+            [
+                node
+                for result in validation_results
+                if (node := self.registry.nodes.get(result.spec.rendered_name))
+            ],
+        )
         # Use no_autoflush to prevent premature flushing mid-loop (columns without
         # node_revision_id, nodes without IDs). The caller (bulk_deploy_nodes_in_level)
         # does a single session.flush() after collecting all objects.
@@ -5009,6 +5030,50 @@ class DeploymentOrchestrator:
         unfloored, since there a NONE tier can write nothing at all.
         """
         return bump_version(current_version, max(change_tier, ChangeTier.MINOR))
+
+    async def _lock_versions(self, existing: list[Node]) -> None:
+        """Refresh each node's `current_version` from committed state, under a lock.
+
+        A deployment plans against a snapshot, so one that commits in between can
+        take the versions this one planned and the revision insert then fails on
+        `uq_noderevision_version`. Holding the row locks means a concurrent writer
+        has either already committed, or waits behind this deployment.
+
+        We take the highest of `current_version` and the node's revisions, so a
+        node whose `current_version` lags its revisions still earns one of its own.
+        `_version_key` does the comparing: as strings, v10.0 sorts below v9.0.
+        """
+        node_ids = [node.id for node in existing]
+        if not node_ids or self.dry_run:
+            return
+        # no_autoflush: the caller is mid-build on revisions whose columns have no
+        # node_revision_id yet, and a query would otherwise flush them.
+        with self.session.no_autoflush:
+            highest = dict(
+                (
+                    await self.session.execute(
+                        select(Node.id, Node.current_version)
+                        .where(Node.id.in_(node_ids))
+                        .order_by(Node.id)  # a stable lock order between deploys
+                        .with_for_update(),
+                    )
+                ).all(),
+            )
+            revisions = (
+                await self.session.execute(
+                    select(NodeRevision.node_id, NodeRevision.version).where(
+                        NodeRevision.node_id.in_(node_ids),
+                    ),
+                )
+            ).all()
+        for node_id, version in revisions:
+            # A node deleted between planning and the lock has no row to raise,
+            # though its revisions can still come back from the query above.
+            locked = highest.get(node_id)
+            if locked is not None and _version_key(version) > _version_key(locked):
+                highest[node_id] = version
+        for node in existing:
+            node.current_version = highest.get(node.id, node.current_version)
 
     def _create_or_update_node(
         self,

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -8,7 +8,7 @@ from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.orm import selectinload
 
 import datajunction_server.internal.materializations
@@ -17,10 +17,12 @@ from datajunction_server.api.deployments import (
     _normalize_repo_path,
 )
 from datajunction_server.database.availabilitystate import AvailabilityState
+from datajunction_server.database.column import Column as DBColumn
 from datajunction_server.database.materialization import Materialization
-from datajunction_server.database.node import Node, NodeRelationship
+from datajunction_server.database.node import Node, NodeRelationship, NodeRevision
 from datajunction_server.database.tag import Tag
 from datajunction_server.errors import DJInvalidInputException
+from datajunction_server.internal.deployment.orchestrator import DeploymentOrchestrator
 from datajunction_server.internal.git.github_service import GitHubServiceError
 from datajunction_server.models import access
 from datajunction_server.models.deployment import (
@@ -10349,3 +10351,194 @@ class TestCrossParentRatioDeployment:
         response = await client.get(f"/nodes/{namespace}.fd_ratio_cross/")
         assert response.status_code == 200, response.json()
         assert response.json()["status"] == "valid"
+
+
+def _clone_column_list(model, **overrides: str) -> tuple[str, str]:
+    """Quoted column names and the SELECT list that clones a row of `model`."""
+    names = [c.name for c in model.__table__.columns if c.name != "id"]
+    return (
+        ", ".join(f'"{name}"' for name in names),
+        ", ".join(overrides.get(name, f'r."{name}"') for name in names),
+    )
+
+
+async def commit_competing_revision(
+    session_factory,
+    node_name: str,
+    version: str,
+    advance_current: bool = True,
+):
+    """Commit a revision at `version` for `node_name` from another session.
+
+    Stands in for the deployment that wins a race: it clones the node's current
+    revision, and its columns, at the version an in-flight deployment has already
+    planned, and moves `Node.current_version` onto it. Raw SQL so nothing lands in
+    the deploying session's identity map. `advance_current` off leaves
+    `Node.current_version` behind the revision it just wrote.
+    """
+    session = await session_factory()
+    current_revision = (
+        "SELECT rev.id FROM noderevision rev JOIN node n ON n.id = rev.node_id "
+        "WHERE n.name = :name AND rev.version = n.current_version"
+    )
+    names, values = _clone_column_list(NodeRevision, version=f"'{version}'")
+    new_id = (
+        await session.execute(
+            text(
+                f"INSERT INTO noderevision ({names}) SELECT {values} "  # noqa: S608
+                f"FROM noderevision r WHERE r.id = ({current_revision}) RETURNING id",
+            ),
+            {"name": node_name},
+        )
+    ).scalar_one()
+    names, values = _clone_column_list(DBColumn, node_revision_id=str(new_id))
+    await session.execute(
+        text(
+            f'INSERT INTO "column" ({names}) SELECT {values} FROM "column" r '  # noqa: S608
+            f"WHERE r.node_revision_id = ({current_revision})",
+        ),
+        {"name": node_name},
+    )
+    if advance_current:
+        await session.execute(
+            text("UPDATE node SET current_version = :version WHERE name = :name"),
+            {"version": version, "name": node_name},
+        )
+    await session.commit()
+    await session.close()
+
+
+@pytest.mark.xdist_group(name="deployments")
+class TestConcurrentDeploymentVersionBump:
+    """Two deployments to one namespace that overlap in time.
+
+    A deployment plans against a snapshot of `Node.current_version`. When another
+    deployment commits between that snapshot and the revision insert, every version
+    the loser planned is already taken and the bulk insert dies on
+    uq_noderevision_version, failing the whole deploy. The version written has to
+    come from committed state at write time, not from the plan-time snapshot.
+    """
+
+    @pytest.fixture
+    def cube(self):
+        return CubeSpec(
+            name="default.repairs_cube",
+            display_name="Repairs Cube",
+            description="Cube for analyzing repair orders",
+            dimensions=["${prefix}default.hard_hat.state"],
+            metrics=["${prefix}default.avg_length_of_employment"],
+            owners=["dj"],
+        )
+
+    @pytest.fixture
+    def nodes_list(
+        self,
+        cube,
+        default_hard_hats,
+        default_hard_hat,
+        default_us_states,
+        default_us_state,
+        default_avg_length_of_employment,
+    ):
+        return [
+            default_hard_hats,
+            default_hard_hat,
+            default_us_states,
+            default_us_state,
+            default_avg_length_of_employment,
+            cube,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_deploy_bumps_from_committed_version_not_snapshot(
+        self,
+        client,
+        session_factory,
+        cube,
+        nodes_list,
+        default_avg_length_of_employment,
+    ):
+        """
+        Both deployments carry a description-only edit off v1.0, so both compute
+        v1.1. The loser must land v1.2 -- the version after the one the winner
+        committed -- for the regular node and the cube alike, rather than failing
+        the user's deploy on uq_noderevision_version.
+        """
+        namespace = "deploy_version_race"
+        metric_name = f"{namespace}.default.avg_length_of_employment"
+        cube_name = f"{namespace}.default.repairs_cube"
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success", data
+
+        # The winner commits v1.1 for both nodes after the deployment below has
+        # planned, but before it writes any revision.
+        original = DeploymentOrchestrator._execute_deployment_plan
+
+        async def winning_deploy_commits_first(orchestrator, plan):
+            await commit_competing_revision(session_factory, metric_name, "v1.1")
+            await commit_competing_revision(session_factory, cube_name, "v1.1")
+            return await original(orchestrator, plan)
+
+        default_avg_length_of_employment.description = "Average length of employment!"
+        cube.description = "Cube for analyzing repair orders, revised"
+        with patch.object(
+            DeploymentOrchestrator,
+            "_execute_deployment_plan",
+            winning_deploy_commits_first,
+        ):
+            data = await deploy_and_wait(
+                client,
+                DeploymentSpec(namespace=namespace, nodes=nodes_list),
+            )
+        assert data["status"] == "success", data
+
+        assert (await client.get(f"/nodes/{metric_name}/")).json()["version"] == "v1.2"
+        assert (await client.get(f"/nodes/{cube_name}/")).json()["version"] == "v1.2"
+
+    @pytest.mark.asyncio
+    async def test_deploy_bumps_past_highest_revision(
+        self,
+        client,
+        session_factory,
+        cube,
+        nodes_list,
+        default_avg_length_of_employment,
+    ):
+        """
+        A node whose `current_version` lags its highest revision must still earn a
+        free version. v10.0 exists while `current_version` says v9.0, so the deploy
+        has to bump past v10.0 -- which also means comparing versions semantically,
+        since v9.0 sorts above v10.0 as a string. The cloned revisions carry no
+        required-dimension or cube-element rows, so the re-deploy reads as major.
+        """
+        namespace = "deploy_version_strand"
+        metric_name = f"{namespace}.default.avg_length_of_employment"
+        cube_name = f"{namespace}.default.repairs_cube"
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success", data
+
+        for name in (metric_name, cube_name):
+            await commit_competing_revision(session_factory, name, "v9.0")
+            await commit_competing_revision(
+                session_factory,
+                name,
+                "v10.0",
+                advance_current=False,
+            )
+
+        default_avg_length_of_employment.description = "Average length of employment!"
+        cube.description = "Cube for analyzing repair orders, revised"
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success", data
+
+        assert (await client.get(f"/nodes/{metric_name}/")).json()["version"] == "v11.0"
+        assert (await client.get(f"/nodes/{cube_name}/")).json()["version"] == "v11.0"


### PR DESCRIPTION
### Summary

There is a race condition when two deployments are pushing to the same namespace and overlap in time . A deployment reads every node's `current_version` when it loads the registry snapshot and computes the next version from that. If another deployment commits in between, versions that the first one planned could already be taken and the batched revision insert fails on `uq_noderevision_version`.

`_lock_versions` now re-reads `current_version` for the nodes about to be written using `FOR UPDATE`: a concurrent writer has either already committed (and we see its version), or it waits behind the lock until the deployment commits.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
