### PR TITLE
Fix deployment churn around required dimensions 

### DIFF
--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -1127,6 +1127,58 @@ class MetricSpec(NodeSpec):
             for required_dim in (self.required_dimensions or [])
         ]
 
+    @property
+    def canonical_required_dimensions(self) -> list[str]:
+        """
+        Required dimensions rewritten so the two ways of naming the same column
+        compare equal.
+
+        A column on one of the metric's own parents can be authored either way,
+        and only the bare form is ever exported, so those fold down. Anything
+        else is left alone. For a metric reading from ``ns.orders_fact``::
+
+            ns.orders_fact.currency_code  ->  currency_code   (a parent's column)
+            currency_code                 ->  currency_code   (already bare)
+            ns.date_dim.dateint           ->  ns.date_dim.dateint  (not a parent)
+
+        Parents come from the spec's own query, so this needs no session.
+        """
+        from datajunction_server.internal.deployment.utils import (
+            extract_upstream_candidates,
+        )
+
+        required_dims = self.rendered_required_dimensions
+        if not any(SEPARATOR in required_dim for required_dim in required_dims):
+            return required_dims
+
+        parents = (
+            extract_upstream_candidates(self.query_ast, is_metric=True)
+            if self.query_ast is not None
+            else set()
+        )
+        return [
+            required_dim.rsplit(SEPARATOR, 1)[1]
+            if SEPARATOR in required_dim
+            and required_dim.rsplit(SEPARATOR, 1)[0] in parents
+            else required_dim
+            for required_dim in required_dims
+        ]
+
+    def diff(self, other: "NodeSpec") -> list[str]:
+        """
+        Diffs `required_dimensions` on its canonical form, so the two spellings
+        of a parent column don't read as a change and inflate the change tier.
+        """
+        changed = super().diff(other)
+        if (
+            "required_dimensions" in changed
+            and isinstance(other, MetricSpec)
+            and set(self.canonical_required_dimensions)
+            == set(other.canonical_required_dimensions)
+        ):
+            changed.remove("required_dimensions")
+        return changed
+
     def model_dump(self, **kwargs):  # pragma: no cover
         base = super().model_dump(**kwargs)
         base["unit"] = self.unit
@@ -1159,11 +1211,11 @@ class MetricSpec(NodeSpec):
             super().__eq__(other)
             and self.query_ast.compare(other.query_ast)
             and normalize_sequence(
-                self.rendered_required_dimensions,
+                self.canonical_required_dimensions,
                 preserve_order=False,
             )
             == normalize_sequence(
-                other.rendered_required_dimensions,
+                other.canonical_required_dimensions,
                 preserve_order=False,
             )
             and eq_or_fallback(self.direction, other.direction, MetricDirection.NEUTRAL)

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -10542,3 +10542,138 @@ class TestConcurrentDeploymentVersionBump:
 
         assert (await client.get(f"/nodes/{metric_name}/")).json()["version"] == "v11.0"
         assert (await client.get(f"/nodes/{cube_name}/")).json()["version"] == "v11.0"
+
+
+@pytest.mark.xdist_group(name="deployments")
+class TestRequiredDimensionsRedeployIdempotence:
+    """A metric whose `required_dimensions` point at a column on its own parent
+    re-deploys as a noop, whichever of the two accepted spellings it was
+    authored in. The bare case is the control: it passed before the fix too,
+    since the bare name is what the export already emits."""
+
+    def _nodes(self, required_dimensions):
+        return [
+            SourceSpec(
+                name="rd_orders_raw",
+                description="Raw orders",
+                catalog="default",
+                schema="roads",
+                table="rd_orders_raw",
+                columns=[
+                    ColumnSpec(name="order_id", type="bigint"),
+                    ColumnSpec(name="currency_code", type="string"),
+                ],
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            TransformSpec(
+                name="rd_orders_fact",
+                description="Orders fact",
+                query="SELECT order_id, currency_code FROM ${prefix}rd_orders_raw",
+                dimension_links=[],
+                owners=["dj"],
+            ),
+            MetricSpec(
+                name="rd_num_orders",
+                # Named so an inferred display_name doesn't turn up in `changed_fields`.
+                display_name="Rd Num Orders",
+                description="Number of orders",
+                query="SELECT count(order_id) FROM ${prefix}rd_orders_fact",
+                required_dimensions=required_dimensions,
+                owners=["dj"],
+            ),
+        ]
+
+    @pytest.mark.parametrize(
+        "namespace, required_dimensions",
+        [
+            ("rd_bare", ["currency_code"]),
+            ("rd_qualified", ["${prefix}rd_orders_fact.currency_code"]),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_redeploy_is_noop(self, client, namespace, required_dimensions):
+        nodes = self._nodes(required_dimensions)
+        metric_name = f"{namespace}.rd_num_orders"
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert [
+            result for result in data["results"] if result["name"] == metric_name
+        ] == [
+            {
+                "deploy_type": "node",
+                "message": "Created metric (v1.0)",
+                "name": metric_name,
+                "operation": "create",
+                "changed_fields": [],
+                "status": "success",
+            },
+        ]
+
+        response = await client.get(f"/nodes/{metric_name}/")
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v1.0"
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=self._nodes(required_dimensions)),
+        )
+        assert data["status"] == "success", data
+        assert [
+            result for result in data["results"] if result["name"] == metric_name
+        ] == [
+            {
+                "deploy_type": "node",
+                "message": "Unchanged",
+                "name": metric_name,
+                "operation": "noop",
+                "changed_fields": [],
+                "status": "skipped",
+            },
+        ]
+
+        response = await client.get(f"/nodes/{metric_name}/")
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v1.0"
+
+    @pytest.mark.asyncio
+    async def test_metadata_edit_on_qualified_metric_is_minor(self, client):
+        """The change tier is folded from `changed_fields`, so a qualified
+        required dimension tagging along there drags a metadata-only edit up to
+        MAJOR."""
+        namespace = "rd_qualified_minor"
+        nodes = self._nodes(["${prefix}rd_orders_fact.currency_code"])
+        metric_name = f"{namespace}.rd_num_orders"
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+
+        nodes[-1].description = "Number of orders, revised"
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes),
+        )
+        assert data["status"] == "success", data
+        assert [
+            result for result in data["results"] if result["name"] == metric_name
+        ] == [
+            {
+                "deploy_type": "node",
+                "message": "Updated metric (v1.1)\n└─ Updated description",
+                "name": metric_name,
+                "operation": "update",
+                "changed_fields": ["description"],
+                "status": "success",
+            },
+        ]
+
+        response = await client.get(f"/nodes/{metric_name}/")
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v1.1"


### PR DESCRIPTION
### Summary

During deployment, were cases where valid required dimensions on a metric were always reported as having changed, causing a major version bump on the metric each time. This was because there can be more than one way of representing a required dimension. For example, for a metric node defined on the `my_fact` transform, both of these required dimensions definitions mean the same thing:
```
${prefix}my_fact.currency_code
currency_code 
```

Behind the scenes, we were converting authored `required_dimensions: ['${prefix}my_fact.currency_code']` to  `required_dimensions: ['currency_code']`, but these were never re-normalized for comparison, so they were always treated as unequal, causing churn.

The fix here is to always normalize required dimensions before comparing. This PR does so by building `canonical_required_dimensions`.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
