### PR TITLE
Always export required dimensions in fully-qualified `node.column` form

### DIFF
--- a/datajunction-server/datajunction_server/api/helpers.py
+++ b/datajunction-server/datajunction_server/api/helpers.py
@@ -317,7 +317,9 @@ def _resolve_required_dimensions(
     invalid_required_dimensions: set[str] = set()
     matched_columns: list[Column] = []
 
-    parent_col_map = {col.name: col for col in parent_columns}
+    parent_cols_by_name: dict[str, list[Column]] = {}
+    for col in parent_columns:
+        parent_cols_by_name.setdefault(col.name, []).append(col)
 
     # Separate full paths from short names
     # full_paths: {dim_node_name: [(full_path, col_name), ...]}
@@ -337,10 +339,13 @@ def _resolve_required_dimensions(
             short_names.append(required_dim)
 
     for short_name in short_names:
-        if short_name in parent_col_map:
-            matched_columns.append(parent_col_map[short_name])
+        matches = parent_cols_by_name.get(short_name, [])
+        if len(matches) == 1:
+            matched_columns.append(matches[0])
         else:
-            invalid_required_dimensions.add(short_name)  # pragma: no cover
+            # No match, or the same short name exists on more than one direct
+            # parent -- ambiguous, so it must be qualified as `node.column`.
+            invalid_required_dimensions.add(short_name)
 
     for dim_node_name, paths in full_paths.items():
         dim_node = dim_nodes.get(dim_node_name)

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -659,23 +659,17 @@ class Node(Base):
                 legacy_from_md,
             )
 
-            # A required dimension that is a direct column on a parent node is
-            # exported as its bare column name (portable as-is). One that lives on
-            # a node elsewhere on the graph (e.g. a linked dimension) is exported
-            # as its fully-qualified `node.column` path, so a re-deploy into a
-            # different namespace can still find it — the bare name would fail to
-            # resolve against the parents. Prefix parameterization (`${prefix}`) is
-            # applied later, in get_node_specs_for_export, and only for in-deploy
-            # nodes. Only touch ``parents`` when there are required dims to classify.
-            required_dimensions_spec: list[str] = []
-            if self.current.required_dimensions:
-                parent_names = {parent.name for parent in self.current.parents}
-                required_dimensions_spec = sorted(
-                    col.name
-                    if col.node_revision.name in parent_names
-                    else col.full_name()
-                    for col in self.current.required_dimensions
-                )
+            # Every required dimension is exported as its fully-qualified
+            # `node.column` path, whether it's a direct parent's column or one
+            # reached via a dimension link -- so a re-deploy into a different
+            # namespace can still find it, and so the two sides of a diff never
+            # have to agree on which node counts as a "parent" to compare equal
+            # (see `MetricSpec.canonical_required_dimensions`). Prefix
+            # parameterization (`${prefix}`) is applied later, in
+            # get_node_specs_for_export, and only for in-deploy nodes.
+            required_dimensions_spec: list[str] = sorted(
+                col.full_name() for col in self.current.required_dimensions
+            )
             extra_kwargs.update(
                 required_dimensions=required_dimensions_spec,
                 direction=self.current.metric_metadata.direction

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -659,14 +659,7 @@ class Node(Base):
                 legacy_from_md,
             )
 
-            # Every required dimension is exported as its fully-qualified
-            # `node.column` path, whether it's a direct parent's column or one
-            # reached via a dimension link -- so a re-deploy into a different
-            # namespace can still find it, and so the two sides of a diff never
-            # have to agree on which node counts as a "parent" to compare equal
-            # (see `MetricSpec.canonical_required_dimensions`). Prefix
-            # parameterization (`${prefix}`) is applied later, in
-            # get_node_specs_for_export, and only for in-deploy nodes.
+            # Every required dimension is exported as its fully-qualified `node.column` path.
             required_dimensions_spec: list[str] = sorted(
                 col.full_name() for col in self.current.required_dimensions
             )

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -1133,17 +1133,6 @@ class MetricSpec(NodeSpec):
         Required dimensions rewritten so the two ways of naming the same column
         compare equal.
 
-        The export side (`NodeRevision.to_spec`) always emits the
-        fully-qualified `node.column` form, so a qualified entry here already
-        is canonical and is left untouched -- there's no need to reason about
-        which node counts as a "parent" to fold it down, which is exactly the
-        asymmetry that made this comparison unreliable for a required
-        dimension reached via a dimension link rather than a direct query
-        parent. A bare column name is only ever an author-facing shorthand for
-        a column on one of the metric's own (direct, single) query parents, so
-        it's upgraded to the same qualified form when that parent is
-        unambiguous:
-
             ns.date_dim.dateint  ->  ns.date_dim.dateint  (already canonical)
             currency_code        ->  ns.orders_fact.currency_code  (single parent)
             currency_code        ->  currency_code  (zero or multiple parents: ambiguous, left as-is)

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -1133,33 +1133,40 @@ class MetricSpec(NodeSpec):
         Required dimensions rewritten so the two ways of naming the same column
         compare equal.
 
-        A column on one of the metric's own parents can be authored either way,
-        and only the bare form is ever exported, so those fold down. Anything
-        else is left alone. For a metric reading from ``ns.orders_fact``::
+        The export side (`NodeRevision.to_spec`) always emits the
+        fully-qualified `node.column` form, so a qualified entry here already
+        is canonical and is left untouched -- there's no need to reason about
+        which node counts as a "parent" to fold it down, which is exactly the
+        asymmetry that made this comparison unreliable for a required
+        dimension reached via a dimension link rather than a direct query
+        parent. A bare column name is only ever an author-facing shorthand for
+        a column on one of the metric's own (direct, single) query parents, so
+        it's upgraded to the same qualified form when that parent is
+        unambiguous:
 
-            ns.orders_fact.currency_code  ->  currency_code   (a parent's column)
-            currency_code                 ->  currency_code   (already bare)
-            ns.date_dim.dateint           ->  ns.date_dim.dateint  (not a parent)
+            ns.date_dim.dateint  ->  ns.date_dim.dateint  (already canonical)
+            currency_code        ->  ns.orders_fact.currency_code  (single parent)
+            currency_code        ->  currency_code  (zero or multiple parents: ambiguous, left as-is)
 
         Parents come from the spec's own query, so this needs no session.
         """
+        required_dims = self.rendered_required_dimensions
+        if all(SEPARATOR in required_dim for required_dim in required_dims):
+            return required_dims
+
         from datajunction_server.internal.deployment.utils import (
             extract_upstream_candidates,
         )
-
-        required_dims = self.rendered_required_dimensions
-        if not any(SEPARATOR in required_dim for required_dim in required_dims):
-            return required_dims
 
         parents = (
             extract_upstream_candidates(self.query_ast, is_metric=True)
             if self.query_ast is not None
             else set()
         )
+        sole_parent = next(iter(parents)) if len(parents) == 1 else None
         return [
-            required_dim.rsplit(SEPARATOR, 1)[1]
-            if SEPARATOR in required_dim
-            and required_dim.rsplit(SEPARATOR, 1)[0] in parents
+            f"{sole_parent}{SEPARATOR}{required_dim}"
+            if SEPARATOR not in required_dim and sole_parent is not None
             else required_dim
             for required_dim in required_dims
         ]

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -10809,6 +10809,150 @@ class TestRequiredDimensionsRedeployIdempotence:
         assert response.json()["version"] == "v1.0"
 
     @pytest.mark.asyncio
+    async def test_redeploy_is_noop_for_linked_dimension_column_multi_segment_namespace(
+        self,
+        client,
+    ):
+        """Same shape as `test_redeploy_is_noop_for_linked_dimension_column`, but
+        under a dotted (git-branch-shaped) namespace and with the parent having
+        several dimension_links, reproducing the real semantic-shared churn on
+        `can_stream_accounts_28d` / `dt_date_d_v2.dateint`."""
+        namespace = "rd_multi.linked_dim_branch"
+
+        def _nodes():
+            return [
+                SourceSpec(
+                    name="rd_date_raw",
+                    description="Raw date",
+                    catalog="default",
+                    schema="roads",
+                    table="rd_date_raw",
+                    columns=[ColumnSpec(name="dateint", type="int")],
+                    dimension_links=[],
+                    owners=["dj"],
+                ),
+                DimensionSpec(
+                    name="rd_date_dim",
+                    description="Date dimension",
+                    query="SELECT dateint FROM ${prefix}rd_date_raw",
+                    primary_key=["dateint"],
+                    dimension_links=[],
+                    owners=["dj"],
+                ),
+                SourceSpec(
+                    name="rd_geo_raw",
+                    description="Raw geo",
+                    catalog="default",
+                    schema="roads",
+                    table="rd_geo_raw",
+                    columns=[ColumnSpec(name="country_iso_code", type="string")],
+                    dimension_links=[],
+                    owners=["dj"],
+                ),
+                DimensionSpec(
+                    name="rd_geo_dim",
+                    description="Geo dimension",
+                    query="SELECT country_iso_code FROM ${prefix}rd_geo_raw",
+                    primary_key=["country_iso_code"],
+                    dimension_links=[],
+                    owners=["dj"],
+                ),
+                SourceSpec(
+                    name="rd_orders_raw",
+                    description="Raw orders",
+                    catalog="default",
+                    schema="roads",
+                    table="rd_orders_raw",
+                    columns=[
+                        ColumnSpec(name="order_id", type="bigint"),
+                        ColumnSpec(name="account_id", type="bigint"),
+                        ColumnSpec(name="dateint", type="int"),
+                        ColumnSpec(name="country_iso_code", type="string"),
+                    ],
+                    dimension_links=[],
+                    owners=["dj"],
+                ),
+                TransformSpec(
+                    name="rd_orders_fact",
+                    description="Orders fact",
+                    query=(
+                        "SELECT order_id, account_id, dateint, country_iso_code "
+                        "FROM ${prefix}rd_orders_raw"
+                    ),
+                    dimension_links=[
+                        DimensionJoinLinkSpec(
+                            dimension_node="${prefix}rd_date_dim",
+                            join_type="left",
+                            join_on=(
+                                "${prefix}rd_orders_fact.dateint = "
+                                "${prefix}rd_date_dim.dateint"
+                            ),
+                        ),
+                        DimensionJoinLinkSpec(
+                            dimension_node="${prefix}rd_date_dim",
+                            join_type="left",
+                            join_on=(
+                                "${prefix}rd_orders_fact.account_id = "
+                                "${prefix}rd_date_dim.dateint"
+                            ),
+                            role="rd_account_signup_date",
+                        ),
+                        DimensionJoinLinkSpec(
+                            dimension_node="${prefix}rd_geo_dim",
+                            join_type="left",
+                            join_on=(
+                                "${prefix}rd_orders_fact.country_iso_code = "
+                                "${prefix}rd_geo_dim.country_iso_code"
+                            ),
+                            role="rd_signup_country",
+                        ),
+                    ],
+                    owners=["dj"],
+                ),
+                MetricSpec(
+                    name="rd_num_orders",
+                    display_name="Rd Num Orders",
+                    description="Number of orders",
+                    query="SELECT count(order_id) FROM ${prefix}rd_orders_fact",
+                    required_dimensions=["${prefix}rd_date_dim.dateint"],
+                    owners=["dj"],
+                ),
+            ]
+
+        metric_name = f"{namespace}.rd_num_orders"
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=_nodes()),
+        )
+        assert data["status"] == "success", data
+        response = await client.get(f"/nodes/{metric_name}/")
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v1.0"
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=_nodes()),
+        )
+        assert data["status"] == "success", data
+        assert [
+            result for result in data["results"] if result["name"] == metric_name
+        ] == [
+            {
+                "deploy_type": "node",
+                "message": "Unchanged",
+                "name": metric_name,
+                "operation": "noop",
+                "changed_fields": [],
+                "status": "skipped",
+            },
+        ], data["results"]
+
+        response = await client.get(f"/nodes/{metric_name}/")
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v1.0"
+
+    @pytest.mark.asyncio
     async def test_metadata_edit_on_qualified_metric_is_minor(self, client):
         """The change tier is folded from `changed_fields`, so a qualified
         required dimension tagging along there drags a metadata-only edit up to
@@ -10845,3 +10989,102 @@ class TestRequiredDimensionsRedeployIdempotence:
         response = await client.get(f"/nodes/{metric_name}/")
         assert response.status_code == 200, response.json()
         assert response.json()["version"] == "v1.1"
+
+    @pytest.mark.asyncio
+    async def test_redeploy_is_noop_for_linked_dimension_column(self, client):
+        """A required dimension one hop out via a dimension_link (not a direct
+        query parent) should also redeploy as a noop. Reproduces the churn seen
+        with `${prefix}dt_date_d_v2.dateint`-shaped required dimensions."""
+        namespace = "rd_linked_dim"
+
+        def _nodes():
+            return [
+                SourceSpec(
+                    name="rd_date_raw",
+                    description="Raw date",
+                    catalog="default",
+                    schema="roads",
+                    table="rd_date_raw",
+                    columns=[ColumnSpec(name="dateint", type="int")],
+                    dimension_links=[],
+                    owners=["dj"],
+                ),
+                DimensionSpec(
+                    name="rd_date_dim",
+                    description="Date dimension",
+                    query="SELECT dateint FROM ${prefix}rd_date_raw",
+                    primary_key=["dateint"],
+                    dimension_links=[],
+                    owners=["dj"],
+                ),
+                SourceSpec(
+                    name="rd_orders_raw",
+                    description="Raw orders",
+                    catalog="default",
+                    schema="roads",
+                    table="rd_orders_raw",
+                    columns=[
+                        ColumnSpec(name="order_id", type="bigint"),
+                        ColumnSpec(name="dateint", type="int"),
+                    ],
+                    dimension_links=[],
+                    owners=["dj"],
+                ),
+                TransformSpec(
+                    name="rd_orders_fact",
+                    description="Orders fact",
+                    query="SELECT order_id, dateint FROM ${prefix}rd_orders_raw",
+                    dimension_links=[
+                        DimensionJoinLinkSpec(
+                            dimension_node="${prefix}rd_date_dim",
+                            join_type="inner",
+                            join_on=(
+                                "${prefix}rd_orders_fact.dateint = "
+                                "${prefix}rd_date_dim.dateint"
+                            ),
+                        ),
+                    ],
+                    owners=["dj"],
+                ),
+                MetricSpec(
+                    name="rd_num_orders",
+                    display_name="Rd Num Orders",
+                    description="Number of orders",
+                    query="SELECT count(order_id) FROM ${prefix}rd_orders_fact",
+                    required_dimensions=["${prefix}rd_date_dim.dateint"],
+                    owners=["dj"],
+                ),
+            ]
+
+        metric_name = f"{namespace}.rd_num_orders"
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=_nodes()),
+        )
+        assert data["status"] == "success", data
+        response = await client.get(f"/nodes/{metric_name}/")
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v1.0"
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=_nodes()),
+        )
+        assert data["status"] == "success", data
+        assert [
+            result for result in data["results"] if result["name"] == metric_name
+        ] == [
+            {
+                "deploy_type": "node",
+                "message": "Unchanged",
+                "name": metric_name,
+                "operation": "noop",
+                "changed_fields": [],
+                "status": "skipped",
+            },
+        ], data["results"]
+
+        response = await client.get(f"/nodes/{metric_name}/")
+        assert response.status_code == 200, response.json()
+        assert response.json()["version"] == "v1.0"

--- a/datajunction-server/tests/api/helpers_test.py
+++ b/datajunction-server/tests/api/helpers_test.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import selectinload
 
 from datajunction_server.api import helpers
 from datajunction_server.api.helpers import (
+    _resolve_required_dimensions,
     dedupe_cube_elements,
     find_required_dimensions,
 )
@@ -302,3 +303,21 @@ async def test_find_required_dimensions_full_path_match(
 
     assert len(matched_cols) == 1
     assert matched_cols[0].name == "month"
+
+
+def test_resolve_required_dimensions_short_name_ambiguous_across_parents():
+    """
+    A short name that matches a column on more than one direct parent must be
+    flagged invalid rather than silently resolved to one of them.
+    """
+    orders_currency = Column(name="currency_code")
+    refunds_currency = Column(name="currency_code")
+
+    invalid_dims, matched_cols = _resolve_required_dimensions(
+        required_dimensions=["currency_code"],
+        parent_columns=[orders_currency, refunds_currency],
+        dim_nodes={},
+    )
+
+    assert invalid_dims == {"currency_code"}
+    assert matched_cols == []


### PR DESCRIPTION
### Summary

Required dimensions should have a single canonical form -- this PR sets it up so that it's always exported as the fully-qualified `node.column` path. An unqualified column name from the YAML is only ever author-facing shorthand for a column on the metric's own direct query parent, so it gets upgraded to the qualified form when that parent is unambiguous, and left as-is otherwise.

### Test Plan
- [ ] PR has an associated issue: #
- [x] make check passes
- [x] make test shows 100% unit test coverage

### Deployment Plan
N/A