### PR TITLE
Check a base-db marker instead of connecting to the template

### DIFF
--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -38,6 +38,7 @@ from fastapi_cache import FastAPICache
 from fastapi_cache.backends.inmemory import InMemoryBackend
 from httpx import AsyncClient
 from psycopg import connect
+from psycopg.errors import UndefinedTable
 from pytest_mock import MockerFixture
 from sqlalchemy import event, text
 from sqlalchemy.dialects.postgresql import insert
@@ -413,12 +414,23 @@ def database_exists(postgres, dbname: str) -> bool:
 
 def template_is_populated(postgres, dbname: str) -> bool:
     """
-    Whether ``dbname`` exists *and* actually holds a schema.
+    Whether ``dbname`` exists *and* finished building, per the marker row
+    ``mark_template_populated`` (tests/helpers/template_app.py) writes on the
+    base database once population completes.
 
-    Existence alone is not enough. A build that dies after CREATE DATABASE but
-    before loading anything leaves a database that looks usable and is not, and
-    on a shared server nothing cleans it up -- every later run then fails
-    somewhere downstream with an opaque UndefinedTable.
+    Checked against that marker rather than by connecting to ``dbname``
+    itself: ``clone_database_from_template`` runs ``pg_terminate_backend``
+    against every connection to the template right before cloning from it,
+    on every clone, from every worker, for the life of the run. A check
+    connection made straight to the template is a legitimate target of that
+    call whenever the timing overlaps, and gets killed as collateral damage
+    (psycopg.errors.AdminShutdown) -- a marker on the base database is never
+    a database name ``pg_terminate_backend`` is aimed at.
+
+    Existence alone is not enough even with the marker: a build that died
+    after ``CREATE DATABASE`` but before loading anything (or before this
+    marker existed) leaves a database that looks usable and is not, and on a
+    shared server nothing cleans it up.
     """
     if not database_exists(postgres, dbname):
         return False
@@ -426,15 +438,19 @@ def template_is_populated(postgres, dbname: str) -> bool:
     with connect(
         host=url.hostname,
         port=url.port,
-        dbname=dbname,
+        dbname=url.path.lstrip("/"),
         user=url.username,
         password=url.password,
         autocommit=True,
     ) as conn:
-        row = conn.execute(
-            "SELECT count(*) FROM pg_tables WHERE schemaname = 'public'",
-        ).fetchone()
-    return bool(row and row[0] > 0)
+        try:
+            row = conn.execute(
+                "SELECT 1 FROM test_template_status WHERE template_name = %s",
+                (dbname,),
+            ).fetchone()
+        except UndefinedTable:
+            return False
+    return row is not None
 
 
 def require_shared_template(postgres, dbname: str, how_to_build: str) -> None:

--- a/datajunction-server/tests/conftest.py
+++ b/datajunction-server/tests/conftest.py
@@ -414,23 +414,12 @@ def database_exists(postgres, dbname: str) -> bool:
 
 def template_is_populated(postgres, dbname: str) -> bool:
     """
-    Whether ``dbname`` exists *and* finished building, per the marker row
-    ``mark_template_populated`` (tests/helpers/template_app.py) writes on the
-    base database once population completes.
+    Whether `dbname` exists and finished building, per the marker row
+    `mark_template_populated` writes on the base database.
 
-    Checked against that marker rather than by connecting to ``dbname``
-    itself: ``clone_database_from_template`` runs ``pg_terminate_backend``
-    against every connection to the template right before cloning from it,
-    on every clone, from every worker, for the life of the run. A check
-    connection made straight to the template is a legitimate target of that
-    call whenever the timing overlaps, and gets killed as collateral damage
-    (psycopg.errors.AdminShutdown) -- a marker on the base database is never
-    a database name ``pg_terminate_backend`` is aimed at.
-
-    Existence alone is not enough even with the marker: a build that died
-    after ``CREATE DATABASE`` but before loading anything (or before this
-    marker existed) leaves a database that looks usable and is not, and on a
-    shared server nothing cleans it up.
+    Checked via the marker instead of connecting to `dbname` directly,
+    since `clone_database_from_template` calls `pg_terminate_backend`
+    against connections to the template before cloning it.
     """
     if not database_exists(postgres, dbname):
         return False

--- a/datajunction-server/tests/helpers/populate_preaggs_template.py
+++ b/datajunction-server/tests/helpers/populate_preaggs_template.py
@@ -20,7 +20,11 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from helpers.template_app import configure_database_env, template_app_client
+from helpers.template_app import (
+    configure_database_env,
+    mark_template_populated,
+    template_app_client,
+)
 
 db_url = sys.argv[1]
 reader_db_url = configure_database_env(db_url)
@@ -96,6 +100,7 @@ async def main() -> None:
             preagg_ids.append(response.json()["preaggs"][0]["id"])
         await session.commit()
 
+    mark_template_populated(db_url)
     print("PREAGG_IDS " + json.dumps(preagg_ids))
 
 

--- a/datajunction-server/tests/helpers/populate_template.py
+++ b/datajunction-server/tests/helpers/populate_template.py
@@ -27,6 +27,7 @@ from examples import COLUMN_MAPPINGS, EXAMPLES, SERVICE_SETUP
 from helpers.template_app import (
     configure_database_env,
     create_schema,
+    mark_template_populated,
     template_app_client,
 )
 
@@ -137,6 +138,7 @@ async def main():
         await load_examples_in_client(test_client, examples_to_load)
         print("Examples loaded")
 
+    mark_template_populated(template_db_url)
     print("Template database populated successfully!")
 
 

--- a/datajunction-server/tests/helpers/template_app.py
+++ b/datajunction-server/tests/helpers/template_app.py
@@ -45,17 +45,12 @@ def configure_database_env(db_url: str) -> str:
 
 def mark_template_populated(template_db_url: str) -> None:
     """
-    Record that the template at ``template_db_url`` finished building, via a
-    marker row on the base ``dj`` database -- never on the template itself.
+    Record that the template at `template_db_url` finished building, via a
+    marker row on the base `dj` database, not the template itself.
 
-    ``clone_database_from_template`` (conftest.py) runs
-    ``pg_terminate_backend`` against every connection to the template right
-    before cloning from it, on every clone, from every worker, for the life
-    of the run. A reader that connects straight to the template to check
-    whether it is populated is a legitimate target of that call whenever the
-    timing overlaps. Writing (and later reading) a marker on the base
-    database instead means the check never touches a database name that
-    ``pg_terminate_backend`` is ever aimed at.
+    `clone_database_from_template` calls `pg_terminate_backend` against
+    connections to the template before cloning it, so a reader connected
+    straight to the template risks getting killed as collateral damage.
     """
     template_name = urlparse(template_db_url).path.lstrip("/")
     url = urlparse(template_db_url)

--- a/datajunction-server/tests/helpers/template_app.py
+++ b/datajunction-server/tests/helpers/template_app.py
@@ -20,8 +20,10 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
+from psycopg import connect
 
 TEST_SECRET = "a-fake-secretkey"
 TEST_ISSUER = "http://localhost:8000/"
@@ -39,6 +41,41 @@ def configure_database_env(db_url: str) -> str:
     os.environ["WRITER_DB__URI"] = db_url
     os.environ["READER_DB__URI"] = reader_db_url
     return reader_db_url
+
+
+def mark_template_populated(template_db_url: str) -> None:
+    """
+    Record that the template at ``template_db_url`` finished building, via a
+    marker row on the base ``dj`` database -- never on the template itself.
+
+    ``clone_database_from_template`` (conftest.py) runs
+    ``pg_terminate_backend`` against every connection to the template right
+    before cloning from it, on every clone, from every worker, for the life
+    of the run. A reader that connects straight to the template to check
+    whether it is populated is a legitimate target of that call whenever the
+    timing overlaps. Writing (and later reading) a marker on the base
+    database instead means the check never touches a database name that
+    ``pg_terminate_backend`` is ever aimed at.
+    """
+    template_name = urlparse(template_db_url).path.lstrip("/")
+    url = urlparse(template_db_url)
+    with connect(
+        host=url.hostname,
+        port=url.port,
+        dbname="dj",
+        user=url.username,
+        password=url.password,
+        autocommit=True,
+    ) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS test_template_status ("
+            "template_name text PRIMARY KEY, populated_at timestamptz NOT NULL DEFAULT now())",
+        )
+        conn.execute(
+            "INSERT INTO test_template_status (template_name) VALUES (%s) "
+            "ON CONFLICT (template_name) DO UPDATE SET populated_at = now()",
+            (template_name,),
+        )
 
 
 def build_settings(db_url: str, reader_db_url: str) -> Any:

--- a/datajunction-server/tests/migrations_test.py
+++ b/datajunction-server/tests/migrations_test.py
@@ -47,10 +47,17 @@ def test_migrations_are_current(connection):
     context.configure(connection=connection)
     context.run_migrations()
 
+    def include_object(object_, name, type_, reflected, compare_to):
+        # test_template_status is test-only infrastructure created via raw
+        # SQL by tests/helpers/template_app.py, not part of the app schema.
+        if type_ == "table" and name == "test_template_status":
+            return False
+        return True
+
     # Don't use compare_type due to false positives.
     migrations_state = MigrationContext.configure(
         connection,
-        opts={"compare_type": False},
+        opts={"compare_type": False, "include_object": include_object},
     )
     diff = compare_metadata(migrations_state, target_metadata)
     assert diff == [], "The alembic migrations do not match the models."


### PR DESCRIPTION
### Summary

The tests share a Postgres server across parallel workers, and each worker clones a pre-populated "template" database to get its own private copy to test against. Before cloning, we have to disconnect anyone still connected to that template (Postgres won't allow cloning a database while something's connected to it).

However, checking whether a template was ready to be cloned involved connecting to the template itself and querying it. But that's the same database everyone's disconnect calls are aimed at, so a checking the connection could get caught by another worker's disconnect at just the wrong moment and be killed mid-query, surfacing as `psycopg.errors.AdminShutdown`. This showed up as an intermittent CI flake, since it depended on timing across concurrent workers.

The fix is to stop checking readiness by connecting to the template. Instead, once a template finishes populating, we write a row recording that into a small status table on the main database. Readiness is then checked by reading that row instead of connecting to the template, so there's no longer any database where a check and a disconnect can collide.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [x] `make check` passes
- [x] `make test` shows 100% unit test coverage

### Deployment Plan

ASAP as I see many such intermittent test failures