### PR TITLE
Round-trip a reference link's role through to_spec()

### DIFF
--- a/datajunction-server/datajunction_server/database/column.py
+++ b/datajunction-server/datajunction_server/database/column.py
@@ -137,6 +137,31 @@ class Column(Base):  # type: ignore
             unit=self.unit,
         )
 
+    def to_reference_link_spec(self):
+        """Build the DimensionReferenceLinkSpec for this column's reference
+        dimension link. Only valid when dimension_id and dimension_column
+        are set (i.e. this column has a reference-type dimension link).
+        """
+        from datajunction_server.construction.build_v3.dimensions import (
+            parse_dimension_ref,
+        )
+        from datajunction_server.models.deployment import DimensionReferenceLinkSpec
+        from datajunction_server.utils import SEPARATOR
+
+        # `dimension_column` carries an optional "[role]" suffix (set by
+        # _create_or_update_dimension_link); parse_dimension_ref splits it
+        # back out into `role` so this round-trips to the same spec the role
+        # was authored with, rather than a bare-role, bracket-suffixed one
+        # that never compares equal to it.
+        ref = parse_dimension_ref(
+            f"{self.dimension.name}{SEPARATOR}{self.dimension_column}",
+        )
+        return DimensionReferenceLinkSpec(
+            node_column=self.name,
+            dimension=f"{ref.node_name}{SEPARATOR}{ref.column_name}",
+            role=ref.role,
+        )
+
     def identifier(self) -> tuple[str, ColumnType]:
         """
         Unique identifier for this column.

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -612,6 +612,12 @@ class Node(Base):
                 link.to_spec()
                 for link in self.current.dimension_links  # type: ignore
             ]
+            # Local import: construction.build_v3.dimensions imports Node from
+            # this module, so this can't be a module-level import.
+            from datajunction_server.construction.build_v3.dimensions import (
+                parse_dimension_ref,
+            )
+
             ref_link_specs = []
             for col in sorted_columns:
                 if not (col.dimension_id and col.dimension_column):
@@ -621,15 +627,14 @@ class Node(Base):
                 # into `role` so this round-trips to the same spec the role
                 # was authored with, rather than a bare-role, bracket-suffixed
                 # one that never compares equal to it.
-                dimension_column = col.dimension_column
-                role = None
-                if dimension_column.endswith("]") and "[" in dimension_column:
-                    dimension_column, role = dimension_column[:-1].split("[", 1)
+                ref = parse_dimension_ref(
+                    f"{col.dimension.name}{SEPARATOR}{col.dimension_column}",
+                )
                 ref_link_specs.append(
                     DimensionReferenceLinkSpec(
                         node_column=col.name,
-                        dimension=f"{col.dimension.name}{SEPARATOR}{dimension_column}",
-                        role=role,
+                        dimension=f"{ref.node_name}{SEPARATOR}{ref.column_name}",
+                        role=ref.role,
                     ),
                 )
             col_specs = [col.to_spec() for col in sorted_columns]

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -612,14 +612,26 @@ class Node(Base):
                 link.to_spec()
                 for link in self.current.dimension_links  # type: ignore
             ]
-            ref_link_specs = [
-                DimensionReferenceLinkSpec(
-                    node_column=col.name,
-                    dimension=f"{col.dimension.name}{SEPARATOR}{col.dimension_column}",
+            ref_link_specs = []
+            for col in sorted_columns:
+                if not (col.dimension_id and col.dimension_column):
+                    continue
+                # `col.dimension_column` carries an optional "[role]" suffix
+                # (set by _create_or_update_dimension_link); split it back out
+                # into `role` so this round-trips to the same spec the role
+                # was authored with, rather than a bare-role, bracket-suffixed
+                # one that never compares equal to it.
+                dimension_column = col.dimension_column
+                role = None
+                if dimension_column.endswith("]") and "[" in dimension_column:
+                    dimension_column, role = dimension_column[:-1].split("[", 1)
+                ref_link_specs.append(
+                    DimensionReferenceLinkSpec(
+                        node_column=col.name,
+                        dimension=f"{col.dimension.name}{SEPARATOR}{dimension_column}",
+                        role=role,
+                    ),
                 )
-                for col in sorted_columns
-                if col.dimension_id and col.dimension_column
-            ]
             col_specs = [col.to_spec() for col in sorted_columns]
             extra_kwargs.update(
                 primary_key=[

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -64,7 +64,6 @@ from datajunction_server.errors import (
 from datajunction_server.models.base import labelize
 from datajunction_server.models.deployment import (
     CubeSpec,
-    DimensionReferenceLinkSpec,
     DimensionSpec,
     MaterializationSpec,
     MetricSpec,
@@ -612,31 +611,11 @@ class Node(Base):
                 link.to_spec()
                 for link in self.current.dimension_links  # type: ignore
             ]
-            # Local import: construction.build_v3.dimensions imports Node from
-            # this module, so this can't be a module-level import.
-            from datajunction_server.construction.build_v3.dimensions import (
-                parse_dimension_ref,
-            )
-
-            ref_link_specs = []
-            for col in sorted_columns:
-                if not (col.dimension_id and col.dimension_column):
-                    continue
-                # `col.dimension_column` carries an optional "[role]" suffix
-                # (set by _create_or_update_dimension_link); split it back out
-                # into `role` so this round-trips to the same spec the role
-                # was authored with, rather than a bare-role, bracket-suffixed
-                # one that never compares equal to it.
-                ref = parse_dimension_ref(
-                    f"{col.dimension.name}{SEPARATOR}{col.dimension_column}",
-                )
-                ref_link_specs.append(
-                    DimensionReferenceLinkSpec(
-                        node_column=col.name,
-                        dimension=f"{ref.node_name}{SEPARATOR}{ref.column_name}",
-                        role=ref.role,
-                    ),
-                )
+            ref_link_specs = [
+                col.to_reference_link_spec()
+                for col in sorted_columns
+                if col.dimension_id and col.dimension_column
+            ]
             col_specs = [col.to_spec() for col in sorted_columns]
             extra_kwargs.update(
                 primary_key=[

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1775,6 +1775,87 @@ class TestDeployments:
         )
 
     @pytest.mark.asyncio
+    async def test_redeploy_is_noop_for_role_qualified_reference_link(
+        self,
+        client,
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+    ):
+        """
+        A reference link with a role must redeploy as a noop, since nothing
+        about it changed. `Column.dimension_column` stores the role baked
+        into a "[role]" suffix, and to_spec() must split that back out into
+        the link's own `role` field rather than leaving it in the exported
+        `dimension` string -- otherwise the exported spec never compares
+        equal to the one it was authored from.
+        """
+        namespace = "reference_link_role_noop"
+        dim_spec = DimensionSpec(
+            name="default.hard_hat",
+            description="Hard hat dimension",
+            query="""
+            SELECT
+                hard_hat_id,
+                state
+            FROM ${prefix}default.hard_hats
+            """,
+            primary_key=["hard_hat_id"],
+            owners=["dj"],
+            dimension_links=[
+                DimensionReferenceLinkSpec(
+                    node_column="state",
+                    dimension="${prefix}default.us_state.state_short",
+                    role="home_state",
+                ),
+            ],
+        )
+        nodes_list = [dim_spec, default_hard_hats, default_us_states, default_us_state]
+        link_name = (
+            "reference_link_role_noop.default.hard_hat -> "
+            "reference_link_role_noop.default.us_state[home_state]"
+        )
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success", data
+        assert [
+            result for result in data["results"] if result["name"] == link_name
+        ] == [
+            {
+                "deploy_type": "link",
+                "message": "Reference link successfully deployed",
+                "name": link_name,
+                "operation": "create",
+                "changed_fields": [],
+                "status": "success",
+            },
+        ]
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success", data
+        assert [
+            result
+            for result in data["results"]
+            if result["name"]
+            in (link_name, "reference_link_role_noop.default.hard_hat")
+        ] == [
+            {
+                "deploy_type": "node",
+                "message": "Unchanged",
+                "name": "reference_link_role_noop.default.hard_hat",
+                "operation": "noop",
+                "changed_fields": [],
+                "status": "skipped",
+            },
+        ]
+
+    @pytest.mark.asyncio
     async def test_required_dimension_from_linked_dimension_roundtrips(
         self,
         client,

--- a/datajunction-server/tests/migrations_test.py
+++ b/datajunction-server/tests/migrations_test.py
@@ -47,10 +47,17 @@ def test_migrations_are_current(connection):
     context.configure(connection=connection)
     context.run_migrations()
 
+    def include_object(object_, name, type_, reflected, compare_to):
+        # test_template_status is test-only infrastructure created via raw
+        # SQL by tests/helpers/template_app.py, not part of the app schema.
+        if type_ == "table" and name == "test_template_status":
+            return False
+        return True
+
     # Don't use compare_type due to false positives.
     migrations_state = MigrationContext.configure(
         connection,
-        opts={"compare_type": False},
+        opts={"compare_type": False, "include_object": include_object},
     )
     diff = compare_metadata(migrations_state, target_metadata)
     assert diff == [], "The alembic migrations do not match the models."

--- a/datajunction-server/tests/migrations_test.py
+++ b/datajunction-server/tests/migrations_test.py
@@ -47,17 +47,10 @@ def test_migrations_are_current(connection):
     context.configure(connection=connection)
     context.run_migrations()
 
-    def include_object(object_, name, type_, reflected, compare_to):
-        # test_template_status is test-only infrastructure created via raw
-        # SQL by tests/helpers/template_app.py, not part of the app schema.
-        if type_ == "table" and name == "test_template_status":
-            return False
-        return True
-
     # Don't use compare_type due to false positives.
     migrations_state = MigrationContext.configure(
         connection,
-        opts={"compare_type": False, "include_object": include_object},
+        opts={"compare_type": False},
     )
     diff = compare_metadata(migrations_state, target_metadata)
     assert diff == [], "The alembic migrations do not match the models."


### PR DESCRIPTION
### Summary

Reference links can point to dimension attributes with roles. Internally, DJ stores the role by tacking it onto the end of the stored column reference, like `state[home_state]`. When DJ needs to export a node's definition back out (which it does on every deployment to compare "what's already there" against "what's being deployed") it has to parse that suffix back apart into the column name and the role.

However, there was a bug where the export path was reading the column name but dropping the role suffix. So a link that was originally authored with a role would export without one, and every deployment would see it as "changed" and redeploy it, even when nothing had actually changed.

The fix is to have the export logic parsing the role suffix back out correctly (reusing the same parsing function DJ already uses elsewhere to interpret these references).

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
