### PR TITLE
Fix deployment round-trip gaps

### DIFF
--- a/datajunction-server/datajunction_server/database/dimensionlink.py
+++ b/datajunction-server/datajunction_server/database/dimensionlink.py
@@ -101,6 +101,7 @@ class DimensionLink(Base):
             join_on=self.join_sql,
             join_type=self.join_type if self.join_type else JoinType.LEFT,
             join_cardinality=self.join_cardinality,
+            default_value=self.default_value,
             spark_hints=self.spark_hints,
         )
 

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -4946,6 +4946,13 @@ class DeploymentOrchestrator:
 
         # Track changes to other node fields
         existing_node_spec = await existing.to_spec(self.session)
+        # `to_spec()` never sets `namespace` (the exported name is already
+        # fully qualified), but `NodeSpec.diff()` renders `${prefix}` on both
+        # sides against each spec's own `namespace` -- without this, a
+        # description or custom_metadata value that mentions `${prefix}` as
+        # prose renders here to "" instead of the real namespace, and never
+        # compares equal to the freshly deployed spec.
+        existing_node_spec.namespace = result.spec.namespace
         changed_fields = existing_node_spec.diff(result.spec) if existing else []
 
         # Check if query changed (diff() ignores it, but we want to surface it)

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -4946,12 +4946,7 @@ class DeploymentOrchestrator:
 
         # Track changes to other node fields
         existing_node_spec = await existing.to_spec(self.session)
-        # `to_spec()` never sets `namespace` (the exported name is already
-        # fully qualified), but `NodeSpec.diff()` renders `${prefix}` on both
-        # sides against each spec's own `namespace` -- without this, a
-        # description or custom_metadata value that mentions `${prefix}` as
-        # prose renders here to "" instead of the real namespace, and never
-        # compares equal to the freshly deployed spec.
+        # to_spec() never sets namespace; diff() needs it to render ${prefix}.
         existing_node_spec.namespace = result.spec.namespace
         changed_fields = existing_node_spec.diff(result.spec) if existing else []
 

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -739,12 +739,9 @@ class NodeSpec(NamespacedSpec):
     def diff(self, other: "NodeSpec") -> list[str]:
         """
         Return a list of fields that differ between this and another NodeSpec.
-        Renders ${prefix} placeholders on both sides before comparing. Rendering
-        only `other` would leave `self` (e.g. an exported spec, which stores
-        free-text fields like `description` verbatim, `${prefix}` and all)
-        compared against a rendered value that no longer matches -- a false
-        positive for any node whose description or custom_metadata happens to
-        mention `${prefix}` as prose.
+        Renders ${prefix} on both sides -- rendering only `other` would leave
+        `self` compared against a rendered value it can never match, since
+        `description`/`custom_metadata` store `${prefix}` verbatim.
         """
         return diff(
             self.rendered_spec(),

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -739,11 +739,15 @@ class NodeSpec(NamespacedSpec):
     def diff(self, other: "NodeSpec") -> list[str]:
         """
         Return a list of fields that differ between this and another NodeSpec.
-        Renders ${prefix} placeholders in `other` before comparing so that
-        specs with unresolved prefixes don't produce false positives.
+        Renders ${prefix} placeholders on both sides before comparing. Rendering
+        only `other` would leave `self` (e.g. an exported spec, which stores
+        free-text fields like `description` verbatim, `${prefix}` and all)
+        compared against a rendered value that no longer matches -- a false
+        positive for any node whose description or custom_metadata happens to
+        mention `${prefix}` as prose.
         """
         return diff(
-            self,
+            self.rendered_spec(),
             other.rendered_spec(),
             ignore_fields=["name", "namespace", "query", "columns"],
         )

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -2031,6 +2031,89 @@ class TestDeployments:
         ]
 
     @pytest.mark.asyncio
+    async def test_full_redeploy_is_noop(
+        self,
+        client,
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+    ):
+        """
+        A namespace covering source/dimension/transform/metric/cube, join and
+        reference links (one with a role, one with a default_value), a
+        required dimension pulled from a linked dimension, and a description
+        mentioning `${prefix}` as prose -- deployed twice with no changes --
+        must come back fully noop the second time. Regression test for the
+        combination of export round-trip bugs found in required_dimensions,
+        reference link roles, join link default_value, and description/
+        custom_metadata rendering.
+        """
+        hard_hat = DimensionSpec(
+            name="default.hard_hat",
+            description="Hard hat dimension. See also ${prefix}default.us_state.",
+            query="SELECT hard_hat_id, state FROM ${prefix}default.hard_hats",
+            primary_key=["hard_hat_id"],
+            owners=["dj"],
+            custom_metadata={"see_also": "${prefix}default.us_state"},
+            dimension_links=[
+                DimensionJoinLinkSpec(
+                    dimension_node="${prefix}default.us_state",
+                    join_type="left",
+                    join_on=(
+                        "${prefix}default.hard_hat.state = "
+                        "${prefix}default.us_state.state_short"
+                    ),
+                    default_value="Unknown",
+                ),
+                DimensionReferenceLinkSpec(
+                    node_column="state",
+                    dimension="${prefix}default.us_state.state_short",
+                    role="home_state",
+                ),
+            ],
+        )
+        num_hard_hats = MetricSpec(
+            name="default.num_hard_hats",
+            node_type=NodeType.METRIC,
+            query="SELECT COUNT(*) FROM ${prefix}default.hard_hat",
+            required_dimensions=["${prefix}default.us_state.state_name"],
+            owners=["dj"],
+        )
+        repairs_cube = CubeSpec(
+            name="default.hard_hat_cube",
+            description="See also ${prefix}default.num_hard_hats.",
+            dimensions=["${prefix}default.us_state.state_name"],
+            metrics=["${prefix}default.num_hard_hats"],
+            owners=["dj"],
+        )
+        nodes = [
+            default_hard_hats,
+            default_us_states,
+            default_us_state,
+            hard_hat,
+            num_hard_hats,
+            repairs_cube,
+        ]
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace="full_redeploy_noop", nodes=nodes),
+        )
+        assert data["status"] == "success", data["results"]
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace="full_redeploy_noop", nodes=nodes),
+        )
+        assert data["status"] == "success", data["results"]
+        assert all(result["operation"] == "noop" for result in data["results"]), data[
+            "results"
+        ]
+        assert all(result["changed_fields"] == [] for result in data["results"]), data[
+            "results"
+        ]
+
+    @pytest.mark.asyncio
     async def test_deploy_reconciles_external_preaggregation(
         self,
         client,

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1856,6 +1856,86 @@ class TestDeployments:
         ]
 
     @pytest.mark.asyncio
+    async def test_redeploy_is_noop_for_join_link_with_default_value(
+        self,
+        client,
+        default_hard_hats,
+        default_us_states,
+        default_us_state,
+    ):
+        """
+        A join link with a `default_value` must redeploy as a noop, since
+        nothing about it changed. `DimensionLink.to_spec()` must include
+        `default_value` -- otherwise the exported spec always reports it as
+        None and never compares equal to the one it was authored from.
+        """
+        namespace = "join_link_default_value_noop"
+        dim_spec = DimensionSpec(
+            name="default.hard_hat",
+            description="Hard hat dimension",
+            query="""
+            SELECT
+                hard_hat_id,
+                state
+            FROM ${prefix}default.hard_hats
+            """,
+            primary_key=["hard_hat_id"],
+            owners=["dj"],
+            dimension_links=[
+                DimensionJoinLinkSpec(
+                    dimension_node="${prefix}default.us_state",
+                    join_type="left",
+                    join_on="${prefix}default.hard_hat.state = ${prefix}default.us_state.state_short",
+                    default_value="Unknown",
+                ),
+            ],
+        )
+        nodes_list = [dim_spec, default_hard_hats, default_us_states, default_us_state]
+        link_name = (
+            "join_link_default_value_noop.default.hard_hat -> "
+            "join_link_default_value_noop.default.us_state"
+        )
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success", data
+        assert [
+            result for result in data["results"] if result["name"] == link_name
+        ] == [
+            {
+                "deploy_type": "link",
+                "message": "Join link successfully deployed",
+                "name": link_name,
+                "operation": "create",
+                "changed_fields": [],
+                "status": "success",
+            },
+        ]
+
+        data = await deploy_and_wait(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=nodes_list),
+        )
+        assert data["status"] == "success", data
+        assert [
+            result
+            for result in data["results"]
+            if result["name"]
+            in (link_name, "join_link_default_value_noop.default.hard_hat")
+        ] == [
+            {
+                "deploy_type": "node",
+                "message": "Unchanged",
+                "name": "join_link_default_value_noop.default.hard_hat",
+                "operation": "noop",
+                "changed_fields": [],
+                "status": "skipped",
+            },
+        ]
+
+    @pytest.mark.asyncio
     async def test_required_dimension_from_linked_dimension_roundtrips(
         self,
         client,

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -503,6 +503,45 @@ def test_dimension_join_link_spec_with_join_cardinality():
     assert hash(default_link) != hash(fanout_link)
 
 
+def test_diff_does_not_flag_description_mentioning_prefix():
+    """
+    `NodeSpec.diff()` renders `${prefix}` on both sides before comparing.
+
+    An exported spec's `description`/`custom_metadata` keep any `${prefix}`
+    substring verbatim -- those fields are stored exactly as authored, never
+    rendered. Rendering only the incoming spec (not the exported one) would
+    replace `${prefix}` on one side but not the other, so a description that
+    happens to mention a sibling node via `${prefix}` would never compare
+    equal to itself.
+    """
+    namespace = "test"
+    description = "See also ${prefix}other_node for context."
+    custom_metadata = {"see_also": "${prefix}other_node"}
+
+    exported = DimensionSpec(
+        name=f"{namespace}.some_node",
+        namespace=namespace,
+        query="SELECT 1 AS id",
+        primary_key=["id"],
+        description=description,
+        custom_metadata=custom_metadata,
+    )
+    declared = DimensionSpec(
+        name="some_node",
+        namespace=namespace,
+        query="SELECT 1 AS id",
+        primary_key=["id"],
+        description=description,
+        custom_metadata=custom_metadata,
+        owners=["someone_else"],
+    )
+
+    changed = exported.diff(declared)
+    assert "description" not in changed
+    assert "custom_metadata" not in changed
+    assert changed == ["owners"]
+
+
 def test_source_spec_with_dimension_link_default_value():
     """Test SourceSpec with dimension_links including default_value."""
     source_spec = SourceSpec(


### PR DESCRIPTION
There were a few gaps when running comparisons between deployments:
* Include each dimension link's `default_value`.
* A node's description or metadata can mention another node by name using a placeholder (`${prefix}`) that gets filled in with the real namespace path at deploy time. A description that happened to mention a sibling node this way would never match its own past self, and got flagged as changed every time.
