### PR TITLE
Drain in-flight `/mcp` requests on shutdown

### DIFF
--- a/datajunction-server/datajunction_server/mcp/transport.py
+++ b/datajunction-server/datajunction_server/mcp/transport.py
@@ -13,6 +13,8 @@ Lifecycle:
   contexts where the lifespan never fires (e.g. ASGITransport-based tests
   without ``LifespanManager``), the manager is started lazily on the first
   request.
+- On lifespan exit the mount stops taking requests and waits up to
+  ``drain_timeout`` seconds for in-flight ones to respond.
 - Tools call ``get_mcp_session()`` to read the per-request ``AsyncSession``.
 """
 
@@ -30,6 +32,7 @@ from contextlib import (
 
 from fastapi import FastAPI
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from starlette.responses import PlainTextResponse
 from starlette.routing import Mount
 from starlette.types import Receive, Scope, Send
 
@@ -38,6 +41,9 @@ from datajunction_server.mcp.server import app as mcp_app
 from datajunction_server.utils import get_session_manager
 
 logger = logging.getLogger(__name__)
+
+# Well under gunicorn's 30s graceful timeout.
+DRAIN_TIMEOUT = 5.0
 
 # Re-export for convenience — tools and tests import from this module.
 __all__ = ["get_mcp_session", "mount_mcp"]
@@ -48,6 +54,7 @@ def mount_mcp(
     path: str = "/mcp",
     *,
     request_context: Callable[[Scope], AbstractContextManager[object]] | None = None,
+    drain_timeout: float = DRAIN_TIMEOUT,
 ) -> None:
     """Mount the MCP HTTP transport on ``app`` at ``path``.
 
@@ -60,6 +67,9 @@ def mount_mcp(
     can bind additional request-scoped ContextVars — e.g. an identity-aware
     query-service-client provider. The contextmanager is entered before the MCP
     request is handled and exited (even on error) afterward.
+
+    ``drain_timeout``: seconds to wait on lifespan exit for in-flight requests
+    to respond before the session manager tears their streams down.
 
     Must be called once during app construction.
     """
@@ -89,7 +99,13 @@ def mount_mcp(
             lazy_started = True
             logger.info("MCP session manager started lazily (no lifespan)")
 
-    async def asgi_handler(scope: Scope, receive: Receive, send: Send) -> None:
+    # In-flight request tracking, so shutdown can wait them out.
+    in_flight = 0
+    idle = asyncio.Event()
+    idle.set()
+    draining = False
+
+    async def handle_scope(scope: Scope, receive: Receive, send: Send) -> None:
         """Wrap MCP request handling with a DB session bound to a ContextVar."""
         if scope["type"] != "http":  # pragma: no cover
             await ensure_started()
@@ -111,6 +127,35 @@ def mount_mcp(
             finally:
                 _session_var.reset(token)
 
+    async def asgi_handler(scope: Scope, receive: Receive, send: Send) -> None:
+        """Count the request, or turn it away while draining."""
+        nonlocal in_flight
+        if draining:
+            response = PlainTextResponse("Server shutting down", status_code=503)
+            await response(scope, receive, send)
+            return
+
+        in_flight += 1
+        idle.clear()
+        try:
+            await handle_scope(scope, receive, send)
+        finally:
+            in_flight -= 1
+            if in_flight == 0:
+                idle.set()
+
+    async def drain_requests() -> None:
+        """Wait for in-flight MCP requests to respond."""
+        nonlocal draining
+        draining = True
+        if idle.is_set():
+            return
+        logger.info("Draining %d MCP requests", in_flight)
+        try:
+            await asyncio.wait_for(idle.wait(), drain_timeout)
+        except TimeoutError:
+            logger.warning("Dropping %d MCP requests still in flight", in_flight)
+
     app.router.routes.append(Mount(path, app=asgi_handler))
 
     # Compose the MCP manager's task-group lifespan with whatever the app
@@ -124,7 +169,10 @@ def mount_mcp(
             started_via_lifespan = True
             try:
                 async with original_lifespan(_app):
-                    yield
+                    try:
+                        yield
+                    finally:
+                        await drain_requests()
             finally:
                 started_via_lifespan = False
 

--- a/datajunction-server/tests/dj_mcp/test_transport.py
+++ b/datajunction-server/tests/dj_mcp/test_transport.py
@@ -2,6 +2,8 @@
 Tests for the MCP HTTP transport — ``mount_mcp`` and its lifespan integration.
 """
 
+import asyncio
+
 import httpx
 import pytest
 import pytest_asyncio
@@ -84,6 +86,127 @@ async def test_mount_mcp_invokes_request_context_per_request() -> None:
 
     assert events == ["enter", "exit"]
     assert seen_scope["type"] == "http"
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drains_in_flight(monkeypatch) -> None:
+    """Lifespan shutdown waits for every in-flight MCP request to respond."""
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+    from starlette.responses import PlainTextResponse
+
+    events: list[str] = []
+    entered: list[str] = []
+
+    async def slow_handler(_self, scope, receive, send):
+        wait = scope["query_string"].decode().removeprefix("wait=")
+        entered.append(wait)
+        await asyncio.sleep(float(wait))
+        await PlainTextResponse("ok")(scope, receive, send)
+        events.append(wait)
+
+    monkeypatch.setattr(StreamableHTTPSessionManager, "handle_request", slow_handler)
+
+    app = FastAPI()
+    transport.mount_mcp(app)
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        follow_redirects=True,
+    ) as client:
+        lifespan = app.router.lifespan_context(app)
+        await lifespan.__aenter__()
+        requests = [
+            asyncio.create_task(client.post(f"/mcp/?wait={wait}"))
+            for wait in ("0.05", "0.2")
+        ]
+        while len(entered) < 2:
+            await asyncio.sleep(0.01)
+        await lifespan.__aexit__(None, None, None)
+        events.append("lifespan done")
+        responses = await asyncio.gather(*requests)
+
+    assert events == ["0.05", "0.2", "lifespan done"]
+    assert [(r.status_code, r.text) for r in responses] == [(200, "ok"), (200, "ok")]
+
+
+@pytest.mark.asyncio
+async def test_drain_gives_up_after_timeout(monkeypatch) -> None:
+    """Shutdown stops waiting once the drain timeout passes."""
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+    from starlette.responses import PlainTextResponse
+
+    events: list[str] = []
+    started = asyncio.Event()
+
+    async def slow_handler(_self, scope, receive, send):
+        started.set()
+        await asyncio.sleep(0.3)
+        await PlainTextResponse("ok")(scope, receive, send)
+        events.append("request done")
+
+    monkeypatch.setattr(StreamableHTTPSessionManager, "handle_request", slow_handler)
+
+    app = FastAPI()
+    transport.mount_mcp(app, drain_timeout=0.01)
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        follow_redirects=True,
+    ) as client:
+        lifespan = app.router.lifespan_context(app)
+        await lifespan.__aenter__()
+        request = asyncio.create_task(client.post("/mcp/"))
+        await started.wait()
+        await lifespan.__aexit__(None, None, None)
+        events.append("lifespan done")
+        await request
+
+    assert events == ["lifespan done", "request done"]
+
+
+@pytest.mark.asyncio
+async def test_drain_rejects_new_requests(monkeypatch) -> None:
+    """While draining, a new MCP request gets 503 instead of a dropped stream."""
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+    from starlette.responses import PlainTextResponse
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocking_handler(_self, scope, receive, send):
+        started.set()
+        await release.wait()
+        await PlainTextResponse("ok")(scope, receive, send)
+
+    monkeypatch.setattr(
+        StreamableHTTPSessionManager,
+        "handle_request",
+        blocking_handler,
+    )
+
+    app = FastAPI()
+    transport.mount_mcp(app, drain_timeout=0.01)
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        follow_redirects=True,
+    ) as client:
+        lifespan = app.router.lifespan_context(app)
+        await lifespan.__aenter__()
+        first = asyncio.create_task(client.post("/mcp/"))
+        await started.wait()
+        await lifespan.__aexit__(None, None, None)
+        late = await client.post("/mcp/")
+        release.set()
+        first_response = await first
+
+    assert late.status_code == 503
+    assert late.text == "Server shutting down"
+    assert first_response.status_code == 200
+    assert first_response.text == "ok"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

On SIGTERM the streamable-HTTP session manager cancelled its task group while `/mcp` requests were still streaming, so each one returned without finishing its response.

The mount now counts in-flight requests, so when the lifespan exits it stops taking new ones, and waits up to five seconds for the rest to respond before the session manager tears the streams down. This is well below gunicorn's 30s graceful timeout, so a slow drain can never cost the worker a SIGKILL.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
