### PR TITLE
Fail deployment when a declared column doesn't match any query output column

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/validation.py
+++ b/datajunction-server/datajunction_server/internal/deployment/validation.py
@@ -493,6 +493,10 @@ class NodeSpecBulkValidator:
                     err
                     for err in [
                         self._check_inferred_columns(inferred_columns),
+                        self._check_declared_columns_exist(
+                            spec,
+                            validation.output_columns,
+                        ),
                         self._check_primary_key(inferred_columns, spec),
                         self._check_metric_query(spec, spec.query_ast),
                     ]
@@ -595,6 +599,36 @@ class NodeSpecBulkValidator:
             return DJError(  # pragma: no cover
                 code=ErrorCode.INVALID_SQL_QUERY,
                 message="No columns could be inferred from the SQL query.",
+            )
+        return None
+
+    @staticmethod
+    def _check_declared_columns_exist(
+        spec: NodeSpec,
+        output_columns: list,
+    ) -> DJError | None:
+        """
+        Check that every declared column in the spec actually appears in the
+        query's output. A declared column that doesn't match any output column
+        is silently dropped (its metadata is never applied), so this is
+        surfaced as an error instead.
+        """
+        declared_names = {
+            col.name
+            for col in (
+                spec.columns if hasattr(spec, "columns") and spec.columns else []
+            )
+        }
+        output_names = {name for name, _ in output_columns}
+        unmatched = sorted(declared_names - output_names)
+        if unmatched:
+            return DJError(
+                code=ErrorCode.INVALID_COLUMN,
+                message=(
+                    f"Declared column(s) {unmatched} on node {spec.rendered_name} "
+                    "do not match any column produced by the query. Check for a "
+                    "missing or mismatched column alias."
+                ),
             )
         return None
 

--- a/datajunction-server/tests/internal/deployment/validation_test.py
+++ b/datajunction-server/tests/internal/deployment/validation_test.py
@@ -254,6 +254,37 @@ class TestValidateQuery:
                 )
 
     @pytest.mark.asyncio
+    async def test_validate_query_node_flags_unmatched_declared_column(
+        self,
+        validation_context: ValidationContext,
+    ):
+        """A declared column that doesn't match any query output column is invalid.
+
+        Otherwise its metadata (display_name/description) is silently dropped
+        and the node churns a version bump on every redeploy.
+        """
+        spec = TransformSpec(
+            name="transform",
+            query="SELECT id, name FROM test.parent",
+            description="A test transform",
+            mode="published",
+            columns=[
+                ColumnSpec(name="id"),
+                ColumnSpec(name="full_name", display_name="Full Name"),
+            ],
+        )
+        validator = NodeSpecBulkValidator(validation_context)
+        result = validator.validate_query_node(spec)
+
+        assert result.status == NodeStatus.INVALID
+        error_codes = [e.code for e in result.errors]
+        assert ErrorCode.INVALID_COLUMN in error_codes
+        message = next(
+            e.message for e in result.errors if e.code == ErrorCode.INVALID_COLUMN
+        )
+        assert "full_name" in message
+
+    @pytest.mark.asyncio
     async def test_validate_query_node_flags_hardcoded_namespace(
         self,
         session: AsyncSession,


### PR DESCRIPTION
If a declared column doesn't match any query output columns, we should mark the deployment as failed rather than allowing it to go forward.