### PR TITLE
Support `--format json` on `dj push`

### DIFF
--- a/datajunction-clients/python/datajunction/cli.py
+++ b/datajunction-clients/python/datajunction/cli.py
@@ -47,6 +47,7 @@ class DJCLI:
         verbose: bool = False,
         force: bool = False,
         allow_empty: bool = False,
+        format: str = "text",
     ):
         """
         Alias for deploy without dryrun.
@@ -57,6 +58,7 @@ class DJCLI:
             verbose=verbose,
             force=force,
             allow_empty=allow_empty,
+            format=format,
         )
 
     def dryrun(
@@ -916,7 +918,7 @@ class DJCLI:
             type=str,
             default="text",
             choices=["text", "json"],
-            help="Output format for dry run (default: text)",
+            help="Output format for the deployment result (default: text)",
         )
         # Deployment source tracking flags
         push_parser.add_argument(
@@ -1523,12 +1525,17 @@ class DJCLI:
                     verbose=args.verbose,
                     force=args.force,
                     allow_empty=args.allow_empty,
+                    format=args.format,
                 )
             except DJDeploymentFailure:
-                # Errors already displayed in the deployment panel
+                # Errors already displayed in the deployment panel (or, in
+                # --format json mode, in the JSON already printed to stdout)
                 raise SystemExit(1)
             except DJClientException as exc:
-                Console().print(f"[red bold]ERROR:[/red bold] {exc}")
+                if args.format == "json":
+                    print(json.dumps({"error": str(exc)}, indent=2))
+                else:
+                    Console().print(f"[red bold]ERROR:[/red bold] {exc}")
                 raise SystemExit(1)
         elif args.command == "generate-codeowners":
             count = DeploymentService.build_codeowners(

--- a/datajunction-clients/python/datajunction/deployment.py
+++ b/datajunction-clients/python/datajunction/deployment.py
@@ -140,11 +140,13 @@ class DeploymentService:
         verbose: bool = False,
         force: bool = False,
         allow_empty: bool = False,
+        format: str = "text",
     ):
         """
         Push a local project to a namespace.
         """
         console = console or self.console
+        as_json = format == "json"
 
         deployment_spec, file_errors = self._reconstruct_deployment_spec(source_path)
 
@@ -161,13 +163,14 @@ class DeploymentService:
                 branch,
             )
 
-        print_deployment_header(
-            mode="push",
-            namespace=deployment_spec["namespace"],
-            console=console,
-            repo=source.get("repository"),
-            branch=source.get("branch") or branch,
-        )
+        if not as_json:
+            print_deployment_header(
+                mode="push",
+                namespace=deployment_spec["namespace"],
+                console=console,
+                repo=source.get("repository"),
+                branch=source.get("branch") or branch,
+            )
 
         # Apply git config in the normal push flow. Skip only when the
         # caller passed an explicit ``namespace`` equal to the project's
@@ -186,10 +189,11 @@ class DeploymentService:
                     parent_namespace=parent_namespace or None,
                 )
             except Exception as e:  # pylint: disable=broad-except
-                console.print(
-                    f"[yellow]Warning: could not set git config on namespace "
-                    f"'{deployment_spec['namespace']}': {e}[/yellow]",
-                )
+                if not as_json:
+                    console.print(
+                        f"[yellow]Warning: could not set git config on namespace "
+                        f"'{deployment_spec['namespace']}': {e}[/yellow]",
+                    )
         if force:
             deployment_spec["force"] = True
         if allow_empty:
@@ -211,25 +215,30 @@ class DeploymentService:
                     raise DJClientException("Deployment timed out after 5 minutes")
 
         deployment = DeploymentInfo.from_dict(deployment_data)
-        print_results(
-            deployment_uuid,
-            deployment,
-            console,
-            verbose=verbose,
-        )
+        if as_json:
+            print(json.dumps(deployment_data, indent=2))
+        else:
+            print_results(
+                deployment_uuid,
+                deployment,
+                console,
+                verbose=verbose,
+            )
         if deployment.status == DeploymentStatus.SUCCESS:
             invalid_results = [
                 r for r in deployment.results if r.status == ResultStatus.INVALID
             ]
             if invalid_results:
-                console.print(
-                    "\nDeployment finished: [bold yellow]SUCCESS with invalid nodes[/bold yellow]",
-                )
+                if not as_json:
+                    console.print(
+                        "\nDeployment finished: [bold yellow]SUCCESS with invalid nodes[/bold yellow]",
+                    )
                 raise DJDeploymentFailure(
                     project_name=deployment_spec.get("namespace", source_path),
                     errors=[r.__dict__ for r in invalid_results],
                 )
-            console.print("\nDeployment finished: [bold green]SUCCESS[/bold green]")
+            if not as_json:
+                console.print("\nDeployment finished: [bold green]SUCCESS[/bold green]")
         if deployment.status == DeploymentStatus.FAILED:
             errors = [
                 r
@@ -241,10 +250,11 @@ class DeploymentService:
                 errors=[r.__dict__ for r in (errors if errors else deployment.results)],
             )
         if file_errors:
-            console.print()
-            console.rule("[red bold]Errors[/red bold]", style="red", align="left")
-            for err in file_errors:
-                console.print(f"[red]  {err}[/red]")
+            if not as_json:
+                console.print()
+                console.rule("[red bold]Errors[/red bold]", style="red", align="left")
+                for err in file_errors:
+                    console.print(f"[red]  {err}[/red]")
             raise DJClientException(
                 "Fix file name mismatches before deploying.",
             )

--- a/datajunction-clients/python/tests/test_cli.py
+++ b/datajunction-clients/python/tests/test_cli.py
@@ -2447,6 +2447,28 @@ class TestDeploymentFailureExitsWithCode1:
                     cli.run()
                 assert exc_info.value.code == 1
 
+    def test_push_generic_client_error_format_json(self, tmp_path, capsys):
+        """A non-deployment error in --format json mode prints a JSON error object."""
+        from datajunction.cli import DJCLI
+        from datajunction.exceptions import DJClientException
+
+        cli = DJCLI(builder_client=mock.MagicMock())
+        with patch.object(
+            cli,
+            "push",
+            side_effect=DJClientException("Connection refused"),
+        ):
+            with patch.object(
+                sys,
+                "argv",
+                ["dj", "push", str(tmp_path), "--format", "json"],
+            ):
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.run()
+                assert exc_info.value.code == 1
+        printed = json.loads(capsys.readouterr().out)
+        assert printed == {"error": "Connection refused"}
+
 
 class TestGenerateCodeowners:
     """Tests for `dj generate-codeowners` and DeploymentService.build_codeowners."""

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -1070,6 +1070,38 @@ def test_push_raises_on_success_with_invalid_nodes(monkeypatch, tmp_path):
     assert exc_info.value.errors[0]["name"] == "foo.bar"
 
 
+def test_push_format_json_raises_on_success_with_invalid_nodes(monkeypatch, tmp_path):
+    """Same as above in --format json mode: still raises, and skips the rich
+    text warning (the JSON dump already carries the invalid-node status)."""
+    (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "foo"}))
+    (tmp_path / "bar.yaml").write_text(yaml.safe_dump({"name": "foo.bar"}))
+
+    invalid_results = [
+        {
+            "deploy_type": "node",
+            "name": "foo.bar",
+            "operation": "create",
+            "status": "invalid",
+            "message": "One or more metrics are INVALID",
+        },
+    ]
+    client = MagicMock()
+    client.deploy.return_value = {
+        "uuid": "456",
+        "status": "success",
+        "results": invalid_results,
+        "namespace": "foo",
+    }
+
+    svc = DeploymentService(client, console=Console(file=io.StringIO()))
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+    with pytest.raises(DJDeploymentFailure) as exc_info:
+        svc.push(tmp_path, format="json")
+
+    assert exc_info.value.errors[0]["name"] == "foo.bar"
+
+
 @pytest.mark.timeout(2)
 def test_push_raises_after_polling_to_failure(monkeypatch, tmp_path):
     (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "ns"}))
@@ -1736,6 +1768,47 @@ class TestPushBranchDetection:
         assert "Warning" in out.getvalue()
         client.deploy.assert_called_once()
 
+    def test_push_git_config_failure_is_silent_in_format_json(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        """Same as above in --format json mode: the warning is suppressed so
+        it doesn't pollute the JSON on stdout."""
+        (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "project.main"}))
+        (tmp_path / "my_node.yaml").write_text(
+            yaml.safe_dump({"name": "project.my_node"}),
+        )
+
+        monkeypatch.delenv("DJ_DEPLOY_REPO", raising=False)
+        monkeypatch.setattr(
+            DeploymentService,
+            "_detect_git_branch",
+            staticmethod(lambda cwd=None: "main"),
+        )
+        monkeypatch.setattr(
+            DeploymentService,
+            "_detect_git_repo",
+            staticmethod(lambda cwd=None: None),
+        )
+        monkeypatch.setattr(time, "sleep", lambda _: None)
+
+        client = MagicMock()
+        client._set_namespace_git_config.side_effect = Exception("network error")
+        client.deploy.return_value = {"uuid": "abc", "status": "success", "results": []}
+        client.check_deployment.return_value = {
+            "uuid": "abc",
+            "status": "success",
+            "results": [],
+        }
+
+        out = io.StringIO()
+        svc = DeploymentService(client, console=Console(file=out))
+        svc.push(tmp_path, format="json")
+
+        assert "Warning" not in out.getvalue()
+        client.deploy.assert_called_once()
+
 
 def test_djdeploymentfailure_str_with_errors():
     exc = DJDeploymentFailure(
@@ -1778,6 +1851,28 @@ def test_push_raises_on_file_name_mismatch(monkeypatch, tmp_path):
 
     with pytest.raises(DJClientException, match="Fix file name mismatches"):
         svc.push(tmp_path)
+
+
+def test_push_format_json_raises_on_file_name_mismatch(monkeypatch, tmp_path):
+    """Same as above in --format json mode: still raises, and skips the rich
+    text error rule/listing (nothing to print — the JSON on stdout is the
+    deployment result, not the file-name-mismatch warnings)."""
+    (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "foo"}))
+    (tmp_path / "wrong.yaml").write_text(yaml.safe_dump({"name": "foo.bar"}))
+
+    client = MagicMock()
+    client.deploy.return_value = {
+        "uuid": "abc",
+        "status": "success",
+        "results": [],
+        "namespace": "foo",
+    }
+
+    svc = DeploymentService(client, console=Console(file=io.StringIO()))
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+    with pytest.raises(DJClientException, match="Fix file name mismatches"):
+        svc.push(tmp_path, format="json")
 
 
 def test_collect_nodes_skips_validation_for_unnamed_node(tmp_path):

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 import io
+import json
 from pathlib import Path
 import time
 import zipfile
@@ -889,6 +890,37 @@ def test_push_waits_until_success(monkeypatch, tmp_path):
 
     client.deploy.assert_called_once()
     client.check_deployment.assert_called()
+
+
+def test_push_format_json_prints_deployment_data(monkeypatch, tmp_path, capsys):
+    """push(format="json") must print the raw deployment dict to stdout
+    instead of the rich text panel, so a caller (e.g. a CI script posting
+    a PR comment) can parse the wet-run result."""
+    (tmp_path / "dj.yaml").write_text(yaml.safe_dump({"namespace": "foo"}))
+    (tmp_path / "bar.yaml").write_text(yaml.safe_dump({"name": "foo.bar"}))
+
+    client = MagicMock()
+    client.deploy.return_value = {
+        "uuid": "abc",
+        "status": "success",
+        "results": [
+            {
+                "name": "foo.bar",
+                "operation": "update",
+                "status": "success",
+                "changed_fields": ["query"],
+            },
+        ],
+        "namespace": "foo",
+    }
+
+    svc = DeploymentService(client, console=Console(file=io.StringIO()))
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+    svc.push(tmp_path, format="json")
+
+    printed = json.loads(capsys.readouterr().out)
+    assert printed == client.deploy.return_value
 
 
 def test_push_force_sets_flag_in_spec(monkeypatch, tmp_path):


### PR DESCRIPTION
`dj push --format json` looked like it would work, but the flag was ignored. However, `--format json` only worked under the dryrun path with `dj push --dryrun --format json`.

This wires `--format json` through the real push as well, so it prints the same structured deployment result as JSON on stdout instead of the rich text panel. This is needed for any consumers that want to parse a deployment result programmatically.