### PR TITLE
Reject unstorable join links instead of 500ing

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -111,6 +111,8 @@ from datajunction_server.models.deployment import (
 from datajunction_server.models.dimensionlink import (
     JoinLinkInput,
     LinkType,
+    misplaced_node_column_message,
+    missing_join_on_message,
 )
 from datajunction_server.models.hierarchy import HierarchyLevelInput
 from datajunction_server.models.history import ActivityType
@@ -2140,6 +2142,20 @@ class DeploymentOrchestrator:
                 link_spec.rendered_dimension_node,
             )
 
+        if link_spec.type == LinkType.JOIN:
+            problems = self._join_link_problems(
+                cast(DimensionJoinLinkSpec, link_spec),
+                node_spec.rendered_name,
+            )
+            if problems:
+                return DeploymentResult(
+                    name=link_name,
+                    deploy_type=DeploymentResult.Type.LINK,
+                    status=DeploymentResult.Status.FAILED,
+                    operation=DeploymentResult.Operation.CREATE,
+                    message="\n".join(problems),
+                )
+
         if node.current and node.current.status == NodeStatus.INVALID:
             # Node is INVALID (no columns / bad SQL). Write the link aspirationally
             # so it's already present once the node is fixed.
@@ -2172,6 +2188,22 @@ class DeploymentOrchestrator:
             dimension_node=dimension_node,
         )
 
+    @staticmethod
+    def _join_link_problems(
+        link_spec: DimensionJoinLinkSpec,
+        node_name: str,
+    ) -> list[str]:
+        """List reasons a join link cannot be stored."""
+        dimension_node = link_spec.rendered_dimension_node
+        problems = []
+        if link_spec.node_column:
+            problems.append(
+                misplaced_node_column_message(node_name, dimension_node),
+            )
+        if not link_spec.rendered_join_on and link_spec.join_type != JoinType.CROSS:
+            problems.append(missing_join_on_message(node_name, dimension_node))
+        return problems
+
     def _create_missing_node_link_result(
         self,
         link_name: str,
@@ -2199,7 +2231,8 @@ class DeploymentOrchestrator:
                 dimension_node=join_link.rendered_dimension_node,
                 join_type=join_link.join_type,
                 join_cardinality=join_link.join_cardinality,
-                join_on=join_link.rendered_join_on,
+                # A CROSS join has no ON clause, but join_sql is NOT NULL.
+                join_on=join_link.rendered_join_on or "",
                 role=join_link.role,
                 default_value=join_link.default_value,
                 spark_hints=join_link.spark_hints,

--- a/datajunction-server/datajunction_server/internal/deployment/validation.py
+++ b/datajunction-server/datajunction_server/internal/deployment/validation.py
@@ -27,7 +27,11 @@ from datajunction_server.models.deployment import (
     LinkableNodeSpec,
     NodeSpec,
 )
-from datajunction_server.models.dimensionlink import JoinType
+from datajunction_server.models.dimensionlink import (
+    JoinType,
+    misplaced_node_column_message,
+    missing_join_on_message,
+)
 from datajunction_server.models.node import NodeStatus, NodeType
 from datajunction_server.sql.dag import get_dimensions
 from datajunction_server.sql.parsing.ast import fast_parse_mode
@@ -209,11 +213,9 @@ class NodeSpecBulkValidator:
                         result.errors.append(
                             DJError(
                                 code=ErrorCode.INVALID_COLUMN,
-                                message=(
-                                    f"Dimension link from {node_name} to "
-                                    f"{link.rendered_dimension_node} sets node_column, "
-                                    "which only applies to reference links. Express the "
-                                    "join in join_on instead."
+                                message=misplaced_node_column_message(
+                                    node_name,
+                                    link.rendered_dimension_node,
                                 ),
                             ),
                         )
@@ -224,12 +226,9 @@ class NodeSpecBulkValidator:
                         result.errors.append(
                             DJError(
                                 code=ErrorCode.INVALID_COLUMN,
-                                message=(
-                                    f"Dimension link from {node_name} to "
-                                    f"{link.rendered_dimension_node} has no join_on "
-                                    "clause. Set join_on to the equality between this "
-                                    "node's foreign key column(s) and the dimension's "
-                                    "primary key."
+                                message=missing_join_on_message(
+                                    node_name,
+                                    link.rendered_dimension_node,
                                 ),
                             ),
                         )

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -107,6 +107,7 @@ from datajunction_server.models.dimensionlink import (
     JoinLinkInput,
     JoinType,
     LinkDimensionIdentifier,
+    missing_join_on_message,
 )
 from datajunction_server.models.history import status_change_history
 from datajunction_server.models.materialization import (
@@ -3175,6 +3176,10 @@ async def validate_complex_dimension_link(
             message=f"Cannot link dimension to a node of type {dimension_node.type}. "
             "Must be a dimension node.",
         )
+    if not link_input.join_on and link_input.join_type != JoinType.CROSS:
+        raise DJInvalidInputException(
+            message=missing_join_on_message(node.name, link_input.dimension_node),  # type: ignore
+        )
 
     if (
         dimension_node.current.catalog is not None  # type: ignore
@@ -3334,12 +3339,14 @@ async def upsert_complex_dimension_link(
         if link.dimension_id == dimension_node.id and link.role == link_input.role  # type: ignore
     ]
     activity_type = ActivityType.CREATE
+    # A CROSS join has no ON clause, but join_sql is NOT NULL.
+    join_sql = link_input.join_on or ""
 
     if existing_link:
         # Update the existing dimension link
         activity_type = ActivityType.UPDATE
         dimension_link = existing_link[0]
-        dimension_link.join_sql = link_input.join_on
+        dimension_link.join_sql = join_sql
         dimension_link.join_type = DimensionLink.parse_join_type(
             join_relation.join_type,
         )
@@ -3351,7 +3358,7 @@ async def upsert_complex_dimension_link(
         dimension_link = DimensionLink(
             node_revision_id=new_revision.id,  # type: ignore
             dimension_id=dimension_node.id,  # type: ignore
-            join_sql=link_input.join_on,
+            join_sql=join_sql,
             join_type=DimensionLink.parse_join_type(join_relation.join_type),
             join_cardinality=link_input.join_cardinality,
             role=link_input.role,

--- a/datajunction-server/datajunction_server/models/dimensionlink.py
+++ b/datajunction-server/datajunction_server/models/dimensionlink.py
@@ -49,6 +49,23 @@ class LinkType(StrEnum):
     REFERENCE = "reference"
 
 
+def missing_join_on_message(node_name: str, dimension_node: str) -> str:
+    """Error text for a join link with no join_on."""
+    return (
+        f"Dimension link from {node_name} to {dimension_node} has no join_on "
+        "clause. Set join_on to the equality between this node's foreign key "
+        "column(s) and the dimension's primary key."
+    )
+
+
+def misplaced_node_column_message(node_name: str, dimension_node: str) -> str:
+    """Error text for node_column on a join link."""
+    return (
+        f"Dimension link from {node_name} to {dimension_node} sets node_column, "
+        "which only applies to reference links. Express the join in join_on instead."
+    )
+
+
 class LinkDimensionIdentifier(BaseModel):
     """
     Input for linking a dimension to a node

--- a/datajunction-server/tests/api/dimension_links_test.py
+++ b/datajunction-server/tests/api/dimension_links_test.py
@@ -182,6 +182,49 @@ async def test_link_dimension_with_errors(
     )
 
 
+@pytest.mark.asyncio
+async def test_link_dimension_without_join_on(
+    dimensions_link_client: AsyncClient,
+):
+    """
+    A join link with no join_on cannot be stored, so it is rejected up front.
+    """
+    response = await dimensions_link_client.post(
+        "/nodes/default.events/link",
+        json={
+            "dimension_node": "default.users",
+            "join_cardinality": "many_to_one",
+        },
+    )
+    assert response.status_code == 422
+    assert response.json()["message"] == (
+        "Dimension link from default.events to default.users has no join_on "
+        "clause. Set join_on to the equality between this node's foreign key "
+        "column(s) and the dimension's primary key."
+    )
+
+
+@pytest.mark.asyncio
+async def test_link_dimension_with_cross_join(
+    dimensions_link_client: AsyncClient,
+):
+    """
+    A CROSS join has no ON clause, so it stores an empty join_sql.
+    """
+    response = await dimensions_link_client.post(
+        "/nodes/default.events/link",
+        json={
+            "dimension_node": "default.users",
+            "join_type": "cross",
+        },
+    )
+    assert response.status_code == 201
+    assert response.json()["message"] == (
+        "Dimension node default.users has been successfully linked to node "
+        "default.events."
+    )
+
+
 @pytest.fixture
 def link_events_to_users_without_role(
     dimensions_link_client: AsyncClient,

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -2631,6 +2631,73 @@ async def test_deploy_reference_link_on_invalid_node(
 
 
 @pytest.mark.asyncio
+async def test_deploy_join_link_without_join_on(
+    session,
+    mock_deployment_context,
+):
+    """A join link with no join_on and a stray node_column is rejected, not written."""
+    node = await Node.get_by_name(session, "default.repair_orders")
+    dimension_node = await Node.get_by_name(session, "default.hard_hat")
+    node.current.status = NodeStatus.INVALID
+
+    link_spec = DimensionJoinLinkSpec(
+        dimension_node="default.hard_hat",
+        node_column="hard_hat_id",
+    )
+    link_spec.namespace = "default"
+    source_spec = SourceSpec(
+        name="repair_orders",
+        namespace="default",
+        catalog="default",
+        schema="roads",
+        table="repair_orders",
+        columns=[],
+    )
+
+    orch = DeploymentOrchestrator(
+        deployment_spec=DeploymentSpec(namespace="default", nodes=[]),
+        deployment_id="join-link-test",
+        session=session,
+        context=mock_deployment_context,
+        dry_run=True,
+    )
+    orch.registry.nodes[node.name] = node
+    orch.registry.nodes[dimension_node.name] = dimension_node
+
+    result = await orch._process_node_dimension_link(
+        node_spec=source_spec,
+        link_spec=link_spec,
+    )
+    # join_sql is NOT NULL, so a written link would fail here.
+    await session.flush()
+
+    assert result.status == DeploymentResult.Status.FAILED
+    assert result.operation == DeploymentResult.Operation.CREATE
+    assert result.name == "default.repair_orders -> default.hard_hat"
+    assert result.message == (
+        "Dimension link from default.repair_orders to default.hard_hat sets "
+        "node_column, which only applies to reference links. Express the join "
+        "in join_on instead.\n"
+        "Dimension link from default.repair_orders to default.hard_hat has no "
+        "join_on clause. Set join_on to the equality between this node's "
+        "foreign key column(s) and the dimension's primary key."
+    )
+
+
+def test_cross_join_link_needs_no_join_on():
+    """A CROSS join has no ON clause, so it is stored as-is."""
+    link_spec = DimensionJoinLinkSpec(
+        dimension_node="default.hard_hat",
+        join_type=JoinType.CROSS,
+    )
+    problems = DeploymentOrchestrator._join_link_problems(
+        link_spec,
+        "default.repair_orders",
+    )
+    assert problems == []
+
+
+@pytest.mark.asyncio
 async def test_delete_nodes_bulk_deletes_existing_node(
     session,
     current_user,


### PR DESCRIPTION
### Summary

A join link written with no `join_on` will result in an unhandled `IntegrityError` on `POST /deployments/impact`. While validation caught the malformed spec, the orchestrator wrote the link anyway on the INVALID-node path, so the message never reached the user.

`_process_node_dimension_link` now checks a join link before any write and returns a `FAILED` DeploymentResult.

`POST /nodes/{name}/link` had the same issue with a missing `join_on`.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
