### PR TITLE
fixed_grain for level metrics

### DIFF
--- a/datajunction-clients/python/datajunction/skills/datajunction-semantic-model/SKILL.md
+++ b/datajunction-clients/python/datajunction/skills/datajunction-semantic-model/SKILL.md
@@ -297,6 +297,7 @@ Same shape for MoM (`month_code`), QoQ (`quarter_code`), YoY (`year`).
 | `direction` | ❌ Optional | `higher_is_better` / `lower_is_better` / `neutral` | Indicates performance direction |
 | `unit` | ❌ Optional | `dollar` / `unitless` / **⚠️ NOT `count`** | Server rejects `count` — use `unitless` |
 | `mode` | ❌ Optional | `draft` / `published` | Default: `published` |
+| `fixed_grain` | ❌ Optional | List of dimension names | Grain the aggregate is computed at; omit for query grain, `[]` for global |
 | `required_dimensions` | ❌ Optional | List of dimension names | For time-based / windowed metrics |
 | `owners` | ❌ Optional but strongly recommended | List of email addresses | Prefer team emails |
 

--- a/datajunction-server/datajunction_server/alembic/versions/2026_09_04_0000-fg0001fixedgrain_add_fixed_grain_to_noderevision.py
+++ b/datajunction-server/datajunction_server/alembic/versions/2026_09_04_0000-fg0001fixedgrain_add_fixed_grain_to_noderevision.py
@@ -1,0 +1,27 @@
+"""
+Add fixed_grain to node revisions
+
+Revision ID: fg0001fixedgrain
+Revises: rg0001reaggregate
+Create Date: 2026-09-04 00:00:00.000000+00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "fg0001fixedgrain"
+down_revision = "rg0001reaggregate"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "noderevision",
+        sa.Column("fixed_grain", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("noderevision", "fixed_grain")

--- a/datajunction-server/datajunction_server/api/graphql/dataloaders.py
+++ b/datajunction-server/datajunction_server/api/graphql/dataloaders.py
@@ -353,9 +353,8 @@ async def batch_load_extracted_measures(
             list(nr_to_name.values()),
         )
 
-        # 3) Bulk-load Node objects for the full ancestor set. We only need
-        # name, type, and current.query — everything else is noloaded so this
-        # is a narrow query. noload(Node.created_by/Node.tags) are safe because
+        # 3) Bulk-load Node objects for the full ancestor set.
+        # noload(Node.created_by/Node.tags) are safe because
         # MetricComponentExtractor never reads them.
         nodes_cache: dict[str, DBNode] = {}
         if all_names:
@@ -372,10 +371,16 @@ async def batch_load_extracted_measures(
                     noload(DBNode.tags),
                     joinedload(DBNode.current).options(
                         noload(DBNodeRevision.created_by),
+                        # Must name every field `_build_metric_data_from_cache`
+                        # reads. An omitted one is deferred, and reading a
+                        # deferred field here raises MissingGreenlet, which the
+                        # loop below turns into a null `extractedMeasures`.
                         load_only(
+                            DBNodeRevision.fixed_grain,
                             DBNodeRevision.id,
                             DBNodeRevision.name,
                             DBNodeRevision.query,
+                            DBNodeRevision.reaggregate,
                         ),
                     ),
                 )

--- a/datajunction-server/datajunction_server/api/graphql/scalars/node.py
+++ b/datajunction-server/datajunction_server/api/graphql/scalars/node.py
@@ -414,6 +414,15 @@ class NodeRevision:
     required_dimensions: list[Column] | None = None
 
     @strawberry.field
+    def fixed_grain(self, root: DBNodeRevision) -> list[str] | None:
+        """
+        The grain this metric's aggregate is computed at.
+        """
+        if root.type != NodeType.METRIC:
+            return None
+        return root.fixed_grain
+
+    @strawberry.field
     def reaggregate(self, root: DBNodeRevision) -> ReaggregateSpec | None:
         """
         Metric reaggregation declaration.

--- a/datajunction-server/datajunction_server/api/graphql/schema.graphql
+++ b/datajunction-server/datajunction_server/api/graphql/schema.graphql
@@ -8,6 +8,7 @@ type AggregationRule {
   type: Aggregability!
   level: [String!]
   reaggregate: DimensionReaggregateRule
+  fixedGrain: [String!]
 }
 
 type Attribute {
@@ -403,6 +404,7 @@ type NodeRevision {
   dimensionLinks: [DimensionLink!]!
   availability: AvailabilityState
   materializations: [MaterializationConfig!]
+  fixedGrain: [String!]
   reaggregate: ReaggregateSpec
   primaryKey: [String!]!
   metricMetadata: MetricMetadata

--- a/datajunction-server/datajunction_server/construction/build_v3/builder.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/builder.py
@@ -21,6 +21,7 @@ from datajunction_server.construction.build_v3.cube_matcher import (
 )
 from datajunction_server.construction.build_v3.decomposition import (
     decompose_and_group_metrics,
+    missing_fixed_grain_dimensions,
     missing_reaggregate_dimensions,
 )
 from datajunction_server.construction.build_v3.dimensions import parse_dimension_ref
@@ -326,7 +327,13 @@ async def setup_build_context(
         ctx.decomposed_metrics.values(),
         output_dimensions_after_expression_scan,
     )
-    for dimension in internal_reaggregate_dimensions:
+    # Appended only so `load_nodes` pulls in the join path: `ctx.dimensions` is
+    # reset below and the dimension travels on the grain group instead.
+    internal_fixed_grain_dimensions = missing_fixed_grain_dimensions(
+        ctx.decomposed_metrics.values(),
+        output_dimensions_after_expression_scan,
+    )
+    for dimension in internal_reaggregate_dimensions + internal_fixed_grain_dimensions:
         if dimension not in ctx.dimensions:
             ctx.dimensions.append(dimension)
 
@@ -347,6 +354,7 @@ async def setup_build_context(
             missing_dim_nodes
             or internally_added_roots
             or internal_reaggregate_dimensions
+            or internal_fixed_grain_dimensions
         ):
             await load_nodes(ctx)
     finally:

--- a/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/cube_matcher.py
@@ -81,6 +81,10 @@ def _cube_dimension_covers_reaggregate_dimension(
 ) -> bool:
     """
     Return whether a cube dimension materializes a protected dimension.
+
+    Nothing here is specific to reaggregate — `fixed_grain` reuses it for its
+    partition dimension. Worth renaming to `_cube_dimension_covers` once both
+    features have landed.
     """
     if _reaggregate_dimension_requested(protected_dimension, [cube_dimension]):
         return True
@@ -180,6 +184,49 @@ async def _reaggregate_requirements_for_metrics_if_needed(
     if not await _metric_graph_has_reaggregate(session, metrics):
         return []
     return await _reaggregate_requirements_for_metrics(session, metrics, dimensions)
+
+
+# (metric name, dimension the cube must retain)
+FixedGrainRequirement = tuple[str, str]
+
+
+def _fixed_grain_requirements_for_cube_metrics(
+    cube: NodeRevision,
+    metrics: list[str],
+) -> list[FixedGrainRequirement]:
+    """
+    Partition dimensions the requested metrics need this cube to carry.
+    """
+    metric_names = set(metrics)
+    requirements: list[FixedGrainRequirement] = [
+        (metric_revision.name, dimension)
+        for metric_revision in cube.metric_node_revisions()
+        if metric_revision
+        and metric_revision.name in metric_names
+        and metric_revision.fixed_grain
+        for dimension in metric_revision.fixed_grain
+    ]
+    return list(dict.fromkeys(requirements))
+
+
+def missing_fixed_grain_requirements(
+    cube: NodeRevision,
+    metrics: list[str],
+) -> list[FixedGrainRequirement]:
+    """
+    Partition dimensions a cube does not materialize.
+
+    A global grain (`[]`) requires nothing, so it is always covered.
+    """
+    cube_dims = set(cube.cube_dimensions())
+    return [
+        requirement
+        for requirement in _fixed_grain_requirements_for_cube_metrics(cube, metrics)
+        if not any(
+            _cube_dimension_covers_reaggregate_dimension(requirement[1], cube_dim)
+            for cube_dim in cube_dims
+        )
+    ]
 
 
 def _reaggregate_requirements_for_cube_metrics(
@@ -529,6 +576,7 @@ async def find_matching_cube(
         if candidate_cubes
         else []
     )
+
     # Find the best matching cube (smallest grain that covers all dimensions)
     best_match: NodeRevision | None = None
     best_grain_size = float("inf")
@@ -576,6 +624,13 @@ async def find_matching_cube(
                 f"[BuildV3] Cube {cube_rev.name} dims {cube_dims} "
                 f"don't cover reaggregate requirements "
                 f"{_format_reaggregate_requirements(missing_reaggregate_requirements)}",
+            )
+            continue
+        missing_grain = missing_fixed_grain_requirements(cube_rev, metrics)
+        if missing_grain:
+            logger.debug(
+                f"[BuildV3] Cube {cube_rev.name} dims {cube_dims} "
+                f"don't cover fixed_grain partition(s) {missing_grain}",
             )
             continue
 

--- a/datajunction-server/datajunction_server/construction/build_v3/decomposition.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/decomposition.py
@@ -371,6 +371,22 @@ def _reaggregate_dimension_requested(
     return False
 
 
+def missing_fixed_grain_dimensions(
+    decomposed_metrics: Iterable[DecomposedMetricInfo],
+    requested_dimensions: list[str],
+) -> list[str]:
+    """
+    Partition dimensions needed as private grain but absent from output grain.
+    """
+    missing: list[str] = []
+    for decomposed in decomposed_metrics:
+        for component in decomposed.components:
+            for dimension in component.rule.fixed_grain or []:
+                if dimension not in requested_dimensions and dimension not in missing:
+                    missing.append(dimension)
+    return missing
+
+
 def missing_reaggregate_dimensions(
     decomposed_metrics: Iterable[DecomposedMetricInfo],
     requested_dimensions: list[str],

--- a/datajunction-server/datajunction_server/construction/build_v3/loaders.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/loaders.py
@@ -87,6 +87,7 @@ async def batch_load_nodes_with_dependencies(
                     NodeRevision.name,
                     NodeRevision.query,
                     NodeRevision.schema_,
+                    NodeRevision.fixed_grain,
                     NodeRevision.reaggregate,
                     NodeRevision.table,
                 ),

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -2042,6 +2042,7 @@ def build_grain_group_sql(
     # This is needed for metrics SQL to correctly reference component columns
     component_aliases: dict[str, str] = {}
     reaggregate_dimension_aliases: dict[str, str] = {}
+    fixed_grain_dimension_aliases: dict[str, str] = {}
     internal_dimension_aliases: dict[str, str] = {}
 
     if output_dimension_refs:
@@ -2056,6 +2057,15 @@ def build_grain_group_sql(
         dimension_alias = ctx.alias_registry.register(dimension_ref)
         reaggregate_dimension_aliases[component_name] = dimension_alias
         internal_dimension_aliases[dimension_ref] = dimension_alias
+
+    # A declared partition needs a column in this CTE. It only becomes an output
+    # column if the caller also asked for it; otherwise it is private grain.
+    for _fg_metric_node, fg_component in grain_group.components:
+        for dimension_ref in fg_component.rule.fixed_grain or []:
+            dimension_alias = ctx.alias_registry.register(dimension_ref)
+            fixed_grain_dimension_aliases[dimension_ref] = dimension_alias
+            if dimension_ref not in (output_dimension_refs or ()):
+                internal_dimension_aliases[dimension_ref] = dimension_alias
 
     for metric_node, component in grain_group.components:
         metrics_covered.add(metric_node.name)
@@ -2421,6 +2431,7 @@ def build_grain_group_sql(
         metrics=list(metrics_covered),
         parent_name=grain_group.parent_node.name,
         component_aliases=component_aliases,
+        fixed_grain_dimension_aliases=fixed_grain_dimension_aliases,
         reaggregate_dimension_aliases=reaggregate_dimension_aliases,
         is_merged=grain_group.is_merged,
         component_aggregabilities=grain_group.component_aggregabilities,

--- a/datajunction-server/datajunction_server/construction/build_v3/measures.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/measures.py
@@ -73,6 +73,7 @@ from datajunction_server.construction.build_v3.utils import (
     make_name,
 )
 from datajunction_server.database.node import Node
+from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.internal.scan_estimation import calculate_scan_estimate
 from datajunction_server.models.decompose import Aggregability, MetricComponent
 from datajunction_server.models.node_type import NodeType
@@ -2006,6 +2007,23 @@ def build_grain_group_sql(
         GrainGroupSQL with SQL and metadata for this grain group
     """
     parent_node = grain_group.parent_node
+    query_grain = (
+        output_dimension_refs
+        if output_dimension_refs is not None
+        else set(ctx.dimensions)
+    )
+
+    # Validate before pre-aggregation matching, whose successful path returns
+    # early. The physical source does not change the required output grain.
+    for fixed_grain_metric, component in grain_group.components:
+        for dimension_ref in component.rule.fixed_grain or []:
+            if dimension_ref not in query_grain:
+                raise DJInvalidInputException(
+                    f"Metric `{fixed_grain_metric.name}` declares "
+                    f"`fixed_grain` on `{dimension_ref}`, which is not a "
+                    "requested output dimension. Add it to the query's "
+                    "dimensions before requesting this metric.",
+                )
 
     # Check for matching pre-aggregation
     if ctx.use_materialized and ctx.available_preaggs:
@@ -2042,7 +2060,10 @@ def build_grain_group_sql(
     # This is needed for metrics SQL to correctly reference component columns
     component_aliases: dict[str, str] = {}
     reaggregate_dimension_aliases: dict[str, str] = {}
-    fixed_grain_dimension_aliases: dict[str, str] = {}
+    fixed_grain_partition_aliases: dict[str, str] = {}
+    # Protected reaggregate dimensions this CTE projects privately, under an
+    # internal alias, so the metrics layer can collapse them without
+    # exposing them as output columns.
     internal_dimension_aliases: dict[str, str] = {}
 
     if output_dimension_refs:
@@ -2058,14 +2079,11 @@ def build_grain_group_sql(
         reaggregate_dimension_aliases[component_name] = dimension_alias
         internal_dimension_aliases[dimension_ref] = dimension_alias
 
-    # A declared partition needs a column in this CTE. It only becomes an output
-    # column if the caller also asked for it; otherwise it is private grain.
-    for _fg_metric_node, fg_component in grain_group.components:
-        for dimension_ref in fg_component.rule.fixed_grain or []:
-            dimension_alias = ctx.alias_registry.register(dimension_ref)
-            fixed_grain_dimension_aliases[dimension_ref] = dimension_alias
-            if dimension_ref not in (output_dimension_refs or ()):
-                internal_dimension_aliases[dimension_ref] = dimension_alias
+    for _, component in grain_group.components:
+        for dimension_ref in component.rule.fixed_grain or []:
+            fixed_grain_partition_aliases[dimension_ref] = ctx.alias_registry.register(
+                dimension_ref
+            )
 
     for metric_node, component in grain_group.components:
         metrics_covered.add(metric_node.name)
@@ -2431,7 +2449,7 @@ def build_grain_group_sql(
         metrics=list(metrics_covered),
         parent_name=grain_group.parent_node.name,
         component_aliases=component_aliases,
-        fixed_grain_dimension_aliases=fixed_grain_dimension_aliases,
+        fixed_grain_partition_aliases=fixed_grain_partition_aliases,
         reaggregate_dimension_aliases=reaggregate_dimension_aliases,
         is_merged=grain_group.is_merged,
         component_aggregabilities=grain_group.component_aggregabilities,
@@ -2470,7 +2488,13 @@ def process_metric_group(
 
     # Analyze grain groups - split by aggregability
     output_dimensions = list(ctx.dimensions)
-    output_dimension_refs = set(output_dimensions)
+    dimensions_already_present = set(output_dimensions)
+    # A filter-only dimension sits in ctx.dimensions for join resolution but
+    # never reaches the final projection, so it isn't a real output ref --
+    # otherwise a fixed_grain dimension mentioned only in a filter would
+    # look like a legitimate output and skip the check in
+    # `build_grain_group_sql` that refuses it.
+    output_dimension_refs = dimensions_already_present - ctx.filter_dimensions
     grain_groups = analyze_grain_groups(metric_group, output_dimensions)
 
     # Merge compatible grain groups from same parent into single CTEs
@@ -2491,7 +2515,7 @@ def process_metric_group(
             for dimension_ref in dict.fromkeys(
                 grain_group.reaggregate_component_dimensions.values(),
             )
-            if dimension_ref not in output_dimension_refs
+            if dimension_ref not in dimensions_already_present
         ]
         ctx.dimensions = output_dimensions + internal_dimensions
         try:

--- a/datajunction-server/datajunction_server/construction/build_v3/metrics.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/metrics.py
@@ -403,6 +403,48 @@ def _build_metric_aggregation(
     return expr_ast
 
 
+def validate_fixed_grain_query_shape(
+    decomposed: DecomposedMetricInfo,
+    grain_group_count: int = 1,
+) -> None:
+    """
+    Refuse a query whose shape cannot express the declared partition.
+
+    The window itself is already in the combiner, put there during decomposition,
+    and a partition dimension the query did not ask for is added to the grain by
+    the same mechanism that serves `required_dimensions`. What is left is the one
+    shape that still cannot work.
+    """
+    # Read off the component rules, not the node revision: decomposition
+    # attaches the declaration to the one broadcastable component, so consumers
+    # see it without reaching back into the graph. A derived metric's components
+    # are the union across its parents, so the declaring one need not be first.
+    fixed_grain = next(
+        (
+            comp.rule.fixed_grain
+            for comp in decomposed.components
+            if comp.rule.fixed_grain
+        ),
+        None,
+    )
+    if not fixed_grain:
+        return
+
+    metric_name = decomposed.metric_node.name
+    # Across grain groups the enclosing SELECT groups positionally over a COALESCE
+    # of the shared dimensions, so a partition naming one group's column is
+    # ungrouped there and the engine rejects it.
+    if grain_group_count > 1:
+        raise DJInvalidInputException(
+            f"Metric `{metric_name}` declares a non-empty `fixed_grain` and "
+            "cannot be combined with metrics from another fact table in one "
+            "query: the joined result groups over a `COALESCE` of the shared "
+            "dimensions, so a partition naming one side's column is not grouped "
+            "and the engine rejects it. Query it on its own, or use a global "
+            "grain (`fixed_grain: []`), which partitions by nothing.",
+        )
+
+
 def _build_pre_agg_wrapper_cte(
     alias: str,
     gg: GrainGroupSQL,
@@ -814,8 +856,13 @@ def process_base_metrics(
                     column_name=col_name,
                 )
 
-            # Qualify dimension refs with this grain group's CTE alias
-            qualified_dim_refs = qualify_dimension_refs(dimension_aliases, alias)
+            # Qualify dimension refs with this grain group's CTE alias. The
+            # group's private grain is merged in so a declared partition
+            # resolves even though it is not an output dimension.
+            qualified_dim_refs = qualify_dimension_refs(
+                {**dimension_aliases, **gg.fixed_grain_dimension_aliases},
+                alias,
+            )
             replace_dimension_refs_in_ast(expr_ast, qualified_dim_refs)
             metric_exprs[metric_name] = MetricExprInfo(
                 expr_ast=expr_ast,
@@ -1994,6 +2041,13 @@ def generate_metrics_sql(
         base_grain_groups,
         skip_pre_agg=will_have_base_metrics_cte,
     )
+    # Counted over base groups only: a window grain group is a second group for
+    # the SAME fact table, which is not the cross-fact case this refuses.
+    for fixed_grain_candidate in decomposed_metrics.values():
+        validate_fixed_grain_query_shape(
+            fixed_grain_candidate,
+            len(base_grain_groups),
+        )
     _validate_reaggregate_base_group_join_safety(base_grain_groups)
 
     # Build dimension info and projection

--- a/datajunction-server/datajunction_server/construction/build_v3/metrics.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/metrics.py
@@ -856,11 +856,9 @@ def process_base_metrics(
                     column_name=col_name,
                 )
 
-            # Qualify dimension refs with this grain group's CTE alias. The
-            # group's private grain is merged in so a declared partition
-            # resolves even though it is not an output dimension.
+            # Qualify dimension refs with this grain group's CTE alias.
             qualified_dim_refs = qualify_dimension_refs(
-                {**dimension_aliases, **gg.fixed_grain_dimension_aliases},
+                {**dimension_aliases, **gg.fixed_grain_partition_aliases},
                 alias,
             )
             replace_dimension_refs_in_ast(expr_ast, qualified_dim_refs)

--- a/datajunction-server/datajunction_server/construction/build_v3/types.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/types.py
@@ -320,6 +320,11 @@ class GrainGroupSQL:
     # Maps component.name -> protected dimension column alias emitted by this CTE.
     reaggregate_dimension_aliases: dict[str, str] = field(default_factory=dict)
 
+    # Declared partition dimensions this CTE emits as private grain columns.
+    # Maps dimension ref -> column alias, so the broadcast can partition on a
+    # dimension the caller never asked to see.
+    fixed_grain_dimension_aliases: dict[str, str] = field(default_factory=dict)
+
     # Merge tracking: when True, aggregations happen in final SELECT, not in CTE
     is_merged: bool = False
 

--- a/datajunction-server/datajunction_server/construction/build_v3/types.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/types.py
@@ -320,10 +320,9 @@ class GrainGroupSQL:
     # Maps component.name -> protected dimension column alias emitted by this CTE.
     reaggregate_dimension_aliases: dict[str, str] = field(default_factory=dict)
 
-    # Declared partition dimensions this CTE emits as private grain columns.
-    # Maps dimension ref -> column alias, so the broadcast can partition on a
-    # dimension the caller never asked to see.
-    fixed_grain_dimension_aliases: dict[str, str] = field(default_factory=dict)
+    # Column alias for every declared partition dimension. For metrics.py to
+    # reference when building the broadcast window.
+    fixed_grain_partition_aliases: dict[str, str] = field(default_factory=dict)
 
     # Merge tracking: when True, aggregations happen in final SELECT, not in CTE
     is_merged: bool = False

--- a/datajunction-server/datajunction_server/construction/build_v3/utils.py
+++ b/datajunction-server/datajunction_server/construction/build_v3/utils.py
@@ -272,8 +272,18 @@ def add_dimensions_from_metric_expressions(
     existing_dims = set(ctx.dimensions)
     for metric_name, decomposed in decomposed_metrics.items():
         combiner_ast = decomposed.combiner_ast
+        # A declared partition is carried as private grain, added after the
+        # output dimensions are fixed. Promoting it here would put a column the
+        # caller never asked for into the result.
+        partition_dims = {
+            dimension
+            for component in decomposed.components
+            for dimension in component.rule.fixed_grain or []
+        }
         for col in combiner_ast.find_all(ast.Column):
             full_name = get_column_full_name(col)
+            if full_name in partition_dims:
+                continue
             _try_add_dim_to_ctx(full_name, ctx, existing_dims, "metric expression")
 
         # Also scan the original metric query for window function ORDER BY dimension refs.

--- a/datajunction-server/datajunction_server/database/node.py
+++ b/datajunction-server/datajunction_server/database/node.py
@@ -680,6 +680,7 @@ class Node(Base):
             extra_kwargs.update(
                 required_dimensions=required_dimensions_spec,
                 reaggregate=parse_reaggregate_spec(self.current.reaggregate),
+                fixed_grain=self.current.fixed_grain,
                 direction=self.current.metric_metadata.direction
                 if self.current.metric_metadata
                 else None,
@@ -1723,6 +1724,13 @@ class NodeRevision(
         uselist=False,
     )
 
+    # Omitted means the query grain; `[]` means the global grain.
+    fixed_grain: Mapped[list[str] | None] = mapped_column(
+        JSON,
+        nullable=True,
+        default=None,
+    )
+
     # Declares how a metric should roll up across dimensions.
     # Stored as JSON here and validated at the API/deployment boundaries.
     reaggregate: Mapped[dict[str, Any] | None] = mapped_column(
@@ -2075,6 +2083,12 @@ class NodeRevision(
             raise DJInvalidInputException(
                 f"Node {self.name} of type {self.type} cannot have "
                 "bound dimensions which are only for metrics.",
+            )
+
+        if self.type != NodeType.METRIC and self.fixed_grain is not None:
+            raise DJInvalidInputException(
+                f"Node {self.name} of type {self.type} cannot have "
+                "a fixed_grain, which is only for metrics.",
             )
 
         if self.type != NodeType.METRIC and self.reaggregate:

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -1965,16 +1965,22 @@ class DeploymentOrchestrator:
         # parent classification — these are ordering edges, not parents.
         ordering_graph = {name: list(deps) for name, deps in plan.node_graph.items()}
         for node_spec in plan.to_deploy:
-            if isinstance(node_spec, MetricSpec) and node_spec.required_dimensions:
-                for required_dim in node_spec.rendered_required_dimensions:
-                    if SEPARATOR not in required_dim:
-                        continue
-                    dim_node = required_dim.rsplit(SEPARATOR, 1)[0]
-                    if dim_node == node_spec.rendered_name:  # pragma: no cover
-                        continue
-                    deps = ordering_graph.setdefault(node_spec.rendered_name, [])
-                    if dim_node not in deps:
-                        deps.append(dim_node)
+            if not isinstance(node_spec, MetricSpec):
+                continue
+            # A fixed grain names dimensions the same way, and needs them to
+            # exist for the same reason.
+            ordering_dims = list(node_spec.rendered_required_dimensions or []) + list(
+                node_spec.rendered_fixed_grain or [],
+            )
+            for required_dim in ordering_dims:
+                if SEPARATOR not in required_dim:
+                    continue
+                dim_node = required_dim.rsplit(SEPARATOR, 1)[0]
+                if dim_node == node_spec.rendered_name:  # pragma: no cover
+                    continue
+                deps = ordering_graph.setdefault(node_spec.rendered_name, [])
+                if dim_node not in deps:
+                    deps.append(dim_node)
 
         # Order nodes topologically based on dependencies
         levels = topological_levels(ordering_graph, ascending=False)
@@ -5371,6 +5377,7 @@ class DeploymentOrchestrator:
             new_revision.reaggregate = dump_reaggregate_spec(
                 metric_spec.rendered_reaggregate,
             )
+            new_revision.fixed_grain = metric_spec.rendered_fixed_grain
         return new_revision
 
     def _resolve_metric_unit(

--- a/datajunction-server/datajunction_server/internal/deployment/validation.py
+++ b/datajunction-server/datajunction_server/internal/deployment/validation.py
@@ -527,6 +527,10 @@ class NodeSpecBulkValidator:
             if reaggregate_error is not None:
                 errors.append(reaggregate_error)
 
+            fixed_grain_error = self._check_fixed_grain_dimensions(spec)
+            if fixed_grain_error is not None:
+                errors.append(fixed_grain_error)
+
             cross_fact_error = self._check_cross_fact_dimensions(spec)
             if cross_fact_error is not None:
                 errors.append(cross_fact_error)  # pragma: no cover
@@ -680,6 +684,10 @@ class NodeSpecBulkValidator:
                     if SEPARATOR in rule.dimension:
                         dim_node_name = rule.dimension.rsplit(SEPARATOR, 1)[0]
                         req_dim_node_names.add(dim_node_name)
+            for grain_dim in getattr(spec, "rendered_fixed_grain", None) or []:
+                if SEPARATOR in grain_dim:
+                    dim_node_name = grain_dim.rsplit(SEPARATOR, 1)[0]
+                    req_dim_node_names.add(dim_node_name)
 
         self._all_dim_nodes = dict(self.context.dependency_nodes)
 
@@ -839,6 +847,44 @@ class NodeSpecBulkValidator:
                 "reaggregate dimensions that are not on parent nodes."
             ),
             debug={"invalid_reaggregate_dimensions": list(invalid)},
+        )
+
+    def _check_fixed_grain_dimensions(self, spec: NodeSpec) -> DJError | None:
+        """
+        Validate that a declared fixed grain resolves to real dimensions.
+
+        `[]` is a legitimate declaration (the global grain) with nothing to
+        resolve.
+        """
+        fixed_grain = getattr(spec, "rendered_fixed_grain", None)
+        if not fixed_grain:
+            return None
+
+        dep_names = self.context.node_graph.get(spec.rendered_name, [])
+        parent_columns = [
+            col
+            for dep_name in dep_names
+            for dep_node in [self.context.dependency_nodes.get(dep_name)]
+            if dep_node and dep_node.current
+            for col in dep_node.current.columns
+        ]
+
+        invalid, _ = _resolve_required_dimensions(
+            list(fixed_grain),
+            parent_columns,
+            self._all_dim_nodes,
+        )
+
+        if not invalid:
+            return None
+
+        return DJError(
+            code=ErrorCode.INVALID_COLUMN,
+            message=(
+                "Node definition declares a fixed grain referencing columns "
+                "that are not on parent nodes."
+            ),
+            debug={"invalid_fixed_grain_dimensions": list(invalid)},
         )
 
     async def _prefetch_metric_dimensions(

--- a/datajunction-server/datajunction_server/internal/deployment/validation.py
+++ b/datajunction-server/datajunction_server/internal/deployment/validation.py
@@ -16,6 +16,7 @@ from datajunction_server.database.dimensionlink import DimensionLink
 from datajunction_server.database.node import Node, NodeRevision
 from datajunction_server.errors import (
     DJError,
+    DJInvalidInputException,
     ErrorCode,
 )
 from datajunction_server.internal.deployment.type_inference import validate_node_query
@@ -33,6 +34,7 @@ from datajunction_server.models.reaggregate import (
     unsupported_dimension_reaggregate_functions,
 )
 from datajunction_server.sql.dag import get_dimensions
+from datajunction_server.sql.decompose import validate_fixed_grain_shape
 from datajunction_server.sql.parsing.ast import fast_parse_mode
 from datajunction_server.sql.parsing.backends.antlr4 import ast, parse_rule
 from datajunction_server.sql.parsing.types import ListType, MapType, StructType
@@ -531,6 +533,10 @@ class NodeSpecBulkValidator:
             if fixed_grain_error is not None:
                 errors.append(fixed_grain_error)
 
+            fixed_grain_shape_error = self._check_fixed_grain_shape(spec)
+            if fixed_grain_shape_error is not None:
+                errors.append(fixed_grain_shape_error)
+
             cross_fact_error = self._check_cross_fact_dimensions(spec)
             if cross_fact_error is not None:
                 errors.append(cross_fact_error)  # pragma: no cover
@@ -881,11 +887,32 @@ class NodeSpecBulkValidator:
         return DJError(
             code=ErrorCode.INVALID_COLUMN,
             message=(
-                "Node definition declares a fixed grain referencing columns "
-                "that are not on parent nodes."
+                "Node definition declares a fixed grain referencing "
+                "dimension columns that could not be resolved."
             ),
             debug={"invalid_fixed_grain_dimensions": list(invalid)},
         )
+
+    def _check_fixed_grain_shape(self, spec: NodeSpec) -> DJError | None:
+        """
+        Validate that a declared fixed grain can attach to the metric's own
+        aggregate (e.g. rejects `COUNT(DISTINCT ...)` with a fixed_grain).
+
+        `is not None`, not truthiness: `[]` still needs its shape checked --
+        it has no dimension to resolve but can still name an unsupported
+        aggregate. A derived metric's query has no aggregate of its own, so
+        it is left to query time (see `validate_fixed_grain_shape`).
+        """
+        fixed_grain = getattr(spec, "rendered_fixed_grain", None)
+        query = getattr(spec, "rendered_query", None)
+        if fixed_grain is None or not query:
+            return None
+
+        try:
+            validate_fixed_grain_shape(query, list(fixed_grain))
+        except DJInvalidInputException as exc:
+            return DJError(code=ErrorCode.INVALID_METRIC, message=str(exc))
+        return None
 
     async def _prefetch_metric_dimensions(
         self,

--- a/datajunction-server/datajunction_server/internal/namespaces.py
+++ b/datajunction-server/datajunction_server/internal/namespaces.py
@@ -1230,6 +1230,7 @@ def _metric_project_config(node: Node, namespace_requested: str) -> dict:
         "tags": [tag.name for tag in node.tags],
         "required_dimensions": [dim.name for dim in node.current.required_dimensions],
         "reaggregate": node.current.reaggregate,
+        "fixed_grain": node.current.fixed_grain,
         "direction": (
             node.current.metric_metadata.direction.name.lower()
             if node.current.metric_metadata and node.current.metric_metadata.direction
@@ -1642,6 +1643,18 @@ async def get_node_specs_for_export(
                         namespace_suffixes,
                     )
                     for required_dim in metric_spec.required_dimensions
+                ]
+            if metric_spec.fixed_grain:
+                # Parameterized so a copied namespace partitions on its own
+                # dimension rather than the parent's.
+                metric_spec.fixed_grain = [
+                    _inject_prefix_for_cube_ref(
+                        dim,
+                        namespace,
+                        parent_namespace,
+                        namespace_suffixes,
+                    )
+                    for dim in metric_spec.fixed_grain
                 ]
             if metric_spec.reaggregate:
                 for rule in metric_spec.reaggregate.rules:
@@ -2302,8 +2315,14 @@ def _node_spec_to_yaml_dict(node_spec, include_all_columns=False) -> dict:
         ):
             data[list_key] = sorted(data[list_key])
 
-    # Remove empty lists/dicts for cleaner YAML
-    data = {k: v for k, v in data.items() if v or v == 0 or v is False}
+    # Remove empty lists/dicts for cleaner YAML. `fixed_grain` is exempt: `[]`
+    # is the global grain and absent is the query grain, so dropping an empty
+    # one rewrites the metric into a different number under the same name.
+    data = {
+        k: v
+        for k, v in data.items()
+        if v or v == 0 or v is False or (k == "fixed_grain" and v is not None)
+    }
 
     # Clean up multiline strings by stripping trailing whitespace from each line
     # Use LiteralScalarString to force literal block style (|) for multiline queries

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -129,6 +129,7 @@ from datajunction_server.models.node import (
     NodeStatus,
     UpdateNode,
 )
+from datajunction_server.models.fixed_grain import fixed_grain_identity
 from datajunction_server.models.node_type import NodeType
 from datajunction_server.models.query import QueryCreate
 from datajunction_server.models.reaggregate import dump_reaggregate_spec
@@ -595,6 +596,9 @@ async def create_node_revision(
             if node_type == NodeType.METRIC
             else None
         ),
+        # Passed through for every node type so `extra_validation` can reject
+        # it, rather than silently dropping a declaration the author wrote.
+        fixed_grain=data.fixed_grain,
         created_by_id=current_user.id,
         custom_metadata=data.custom_metadata,
     )
@@ -1176,6 +1180,7 @@ async def copy_to_new_node(
         required_dimensions=list(old_revision.required_dimensions),
         metric_metadata=old_revision.metric_metadata,
         reaggregate=old_revision.reaggregate,
+        fixed_grain=old_revision.fixed_grain,
         cube_elements=list(old_revision.cube_elements),
         cube_filters=old_revision.cube_filters,
         status=old_revision.status,
@@ -2554,6 +2559,7 @@ def copy_existing_node_revision(old_revision: NodeRevision, current_user: User):
         required_dimensions=list(old_revision.required_dimensions),
         metric_metadata=old_revision.metric_metadata,
         reaggregate=old_revision.reaggregate,
+        fixed_grain=old_revision.fixed_grain,
         dimension_links=[
             DimensionLink(
                 dimension_id=link.dimension_id,
@@ -2776,6 +2782,15 @@ async def create_new_revision_from_existing(
         and {col.name for col in old_revision.required_dimensions}
         != set(data.required_dimensions)
     )
+    # An explicit null clears the grain, an absent one carries it forward; both
+    # arrive as `None`, so `model_fields_set` is what separates them.
+    fixed_grain_was_set = bool(data and "fixed_grain" in data.model_fields_set)
+    new_fixed_grain = (
+        data.fixed_grain if fixed_grain_was_set else old_revision.fixed_grain
+    )
+    fixed_grain_changes = fixed_grain_was_set and fixed_grain_identity(
+        old_revision.fixed_grain,
+    ) != fixed_grain_identity(new_fixed_grain)
     reaggregate_was_set = bool(
         data and "reaggregate" in data.model_fields_set,
     )
@@ -2790,6 +2805,7 @@ async def create_new_revision_from_existing(
         or pk_changes
         or required_dim_changes
         or reaggregate_changes
+        or fixed_grain_changes
     )
 
     # If nothing has changed, do not create the new node revision
@@ -2846,6 +2862,7 @@ async def create_new_revision_from_existing(
             if reaggregate_was_set
             else old_revision.reaggregate
         ),
+        fixed_grain=new_fixed_grain,
         dimension_links=[
             DimensionLink(
                 dimension_id=link.dimension_id,

--- a/datajunction-server/datajunction_server/internal/nodes.py
+++ b/datajunction-server/datajunction_server/internal/nodes.py
@@ -908,7 +908,7 @@ async def _derive_frozen_measures_impl(
                 upstream_revision_id=upstream_revision_id,
                 expression=measure.expression,
                 aggregation=measure.aggregation,
-                rule=measure.rule,
+                rule=_frozen_measure_rule(measure.rule),
                 used_by_node_revisions=[],
             )
             session.add(frozen_measure)
@@ -1045,16 +1045,31 @@ async def derive_frozen_measures_bulk(
             frozen_measure.used_by_node_revisions.append(rev)
 
 
+# Declarations that ride on the aggregation rule but are not part of a measure's
+# identity, so two metrics differing only in grain share one frozen measure.
+#
+# Comparison and persistence must agree on this set. When they drift, the stored
+# rule depends on whichever metric happened to create the measure first.
+_METRIC_LEVEL_RULE_FIELDS = frozenset({"reaggregate", "fixed_grain"})
+
+
 def _aggregation_rule_identity(rule: DecomposeAggregationRule) -> dict[str, Any]:
     """Return the stable JSON shape used for frozen-measure rule comparison."""
-    return rule.model_dump(mode="json", exclude_none=True, exclude={"reaggregate"})
+    # `[]` survives `exclude_none`, keeping the global grain distinct from absent.
+    return rule.model_dump(
+        mode="json",
+        exclude_none=True,
+        exclude=set(_METRIC_LEVEL_RULE_FIELDS),
+    )
 
 
 def _frozen_measure_rule(rule: DecomposeAggregationRule) -> DecomposeAggregationRule:
     """
     Return the metric-independent rule persisted on a shared frozen measure.
     """
-    return rule.model_copy(update={"reaggregate": None})
+    return rule.model_copy(
+        update={field: None for field in _METRIC_LEVEL_RULE_FIELDS},
+    )
 
 
 def _raise_if_frozen_measure_conflicts(

--- a/datajunction-server/datajunction_server/internal/validation.py
+++ b/datajunction-server/datajunction_server/internal/validation.py
@@ -364,6 +364,7 @@ async def validate_node_data(
         reaggregate_spec = parse_reaggregate_spec(validated_node.reaggregate)
         invalid_reaggregate_dimensions: set[str] = set()
         invalid_reaggregate_functions: list[str] = []
+        invalid_fixed_grain_dimensions: set[str] = set()
         if reaggregate_spec and reaggregate_spec.rules:
             (
                 invalid_reaggregate_dimensions,
@@ -376,10 +377,19 @@ async def validate_node_data(
             invalid_reaggregate_functions = unsupported_dimension_reaggregate_functions(
                 reaggregate_spec,
             )
+        # Truthiness, not `is not None`: `[]` is the global grain, which names
+        # no dimension and so has nothing to resolve.
+        if validated_node.fixed_grain:
+            invalid_fixed_grain_dimensions, _ = await find_required_dimensions(
+                session,
+                list(validated_node.fixed_grain),
+                parent_columns,
+            )
     except MissingGreenlet:
         invalid_required_dimensions = set()
         invalid_reaggregate_dimensions = set()
         invalid_reaggregate_functions = []
+        invalid_fixed_grain_dimensions = set()
         node_validator.required_dimensions = []
 
     if (
@@ -388,6 +398,7 @@ async def validate_node_data(
         or invalid_required_dimensions
         or invalid_reaggregate_dimensions
         or invalid_reaggregate_functions
+        or invalid_fixed_grain_dimensions
     ):
         # update status
         node_validator.status = NodeStatus.INVALID
@@ -471,12 +482,31 @@ async def validate_node_data(
             if invalid_reaggregate_functions
             else []
         )
+        invalid_fixed_grain_dimensions_error = (
+            [
+                DJError(
+                    code=ErrorCode.INVALID_COLUMN,
+                    message=(
+                        "Node definition declares a fixed grain referencing "
+                        "columns that are not on parent nodes."
+                    ),
+                    debug={
+                        "invalid_fixed_grain_dimensions": list(
+                            invalid_fixed_grain_dimensions,
+                        ),
+                    },
+                ),
+            ]
+            if invalid_fixed_grain_dimensions
+            else []
+        )
         errors = (
             missing_parents_error
             + type_inference_error
             + invalid_required_dimensions_error
             + invalid_reaggregate_dimensions_error
             + invalid_reaggregate_functions_error
+            + invalid_fixed_grain_dimensions_error
         )
         node_validator.errors.extend(errors)
 
@@ -771,6 +801,7 @@ async def validate_node_data_v2(
     reaggregate_spec = parse_reaggregate_spec(validated_node.reaggregate)
     invalid_reaggregate_dimensions: set[str] = set()
     invalid_reaggregate_functions: list[str] = []
+    invalid_fixed_grain_dimensions: set[str] = set()
     if reaggregate_spec and reaggregate_spec.rules:
         (
             invalid_reaggregate_dimensions,
@@ -783,6 +814,13 @@ async def validate_node_data_v2(
         invalid_reaggregate_functions = unsupported_dimension_reaggregate_functions(
             reaggregate_spec,
         )
+    # Truthiness, not `is not None`: `[]` is the global grain.
+    if validated_node.fixed_grain:
+        invalid_fixed_grain_dimensions, _ = await find_required_dimensions(
+            session,
+            list(validated_node.fixed_grain),
+            parent_columns,
+        )
 
     # --- Step 12: final error assembly for missing parents + invalid required
     #              dims (matches legacy code shapes).
@@ -791,6 +829,7 @@ async def validate_node_data_v2(
         or invalid_required_dimensions
         or invalid_reaggregate_dimensions
         or invalid_reaggregate_functions
+        or invalid_fixed_grain_dimensions
     ):
         node_validator.status = NodeStatus.INVALID
         if node_validator.missing_parents_map:
@@ -834,6 +873,21 @@ async def validate_node_data_v2(
                     debug={
                         "invalid_reaggregate_dimensions": list(
                             invalid_reaggregate_dimensions,
+                        ),
+                    },
+                ),
+            )
+        if invalid_fixed_grain_dimensions:
+            node_validator.errors.append(
+                DJError(
+                    code=ErrorCode.INVALID_COLUMN,
+                    message=(
+                        "Node definition declares a fixed grain referencing "
+                        "columns that are not on parent nodes."
+                    ),
+                    debug={
+                        "invalid_fixed_grain_dimensions": list(
+                            invalid_fixed_grain_dimensions,
                         ),
                     },
                 ),

--- a/datajunction-server/datajunction_server/internal/validation.py
+++ b/datajunction-server/datajunction_server/internal/validation.py
@@ -11,6 +11,7 @@ from datajunction_server.database.column import Column, ColumnAttribute
 from datajunction_server.errors import (
     DJError,
     DJException,
+    DJInvalidInputException,
     DJInvalidMetricQueryException,
     ErrorCode,
 )
@@ -27,6 +28,7 @@ from datajunction_server.models.reaggregate import (
     parse_reaggregate_spec,
     unsupported_dimension_reaggregate_functions,
 )
+from datajunction_server.sql.decompose import validate_fixed_grain_shape
 from datajunction_server.sql.parsing import ast
 from datajunction_server.sql.parsing.backends.antlr4 import SqlSyntaxError, parse
 from datajunction_server.sql.parsing.backends.exceptions import DJParseException
@@ -365,6 +367,7 @@ async def validate_node_data(
         invalid_reaggregate_dimensions: set[str] = set()
         invalid_reaggregate_functions: list[str] = []
         invalid_fixed_grain_dimensions: set[str] = set()
+        unsupported_fixed_grain_shape: str | None = None
         if reaggregate_spec and reaggregate_spec.rules:
             (
                 invalid_reaggregate_dimensions,
@@ -385,11 +388,23 @@ async def validate_node_data(
                 list(validated_node.fixed_grain),
                 parent_columns,
             )
+        # `is not None` here: unlike the dimension check above, `[]` still
+        # needs its shape checked -- e.g. COUNT(DISTINCT ...) with `[]` has
+        # no dimension to resolve but still can't carry a broadcast.
+        if validated_node.fixed_grain is not None:
+            try:
+                validate_fixed_grain_shape(
+                    validated_node.query,  # type: ignore
+                    list(validated_node.fixed_grain),
+                )
+            except DJInvalidInputException as exc:
+                unsupported_fixed_grain_shape = str(exc)
     except MissingGreenlet:
         invalid_required_dimensions = set()
         invalid_reaggregate_dimensions = set()
         invalid_reaggregate_functions = []
         invalid_fixed_grain_dimensions = set()
+        unsupported_fixed_grain_shape = None
         node_validator.required_dimensions = []
 
     if (
@@ -399,6 +414,7 @@ async def validate_node_data(
         or invalid_reaggregate_dimensions
         or invalid_reaggregate_functions
         or invalid_fixed_grain_dimensions
+        or unsupported_fixed_grain_shape
     ):
         # update status
         node_validator.status = NodeStatus.INVALID
@@ -488,7 +504,7 @@ async def validate_node_data(
                     code=ErrorCode.INVALID_COLUMN,
                     message=(
                         "Node definition declares a fixed grain referencing "
-                        "columns that are not on parent nodes."
+                        "dimension columns that could not be resolved."
                     ),
                     debug={
                         "invalid_fixed_grain_dimensions": list(
@@ -500,6 +516,16 @@ async def validate_node_data(
             if invalid_fixed_grain_dimensions
             else []
         )
+        unsupported_fixed_grain_shape_error = (
+            [
+                DJError(
+                    code=ErrorCode.INVALID_METRIC,
+                    message=unsupported_fixed_grain_shape,
+                ),
+            ]
+            if unsupported_fixed_grain_shape
+            else []
+        )
         errors = (
             missing_parents_error
             + type_inference_error
@@ -507,6 +533,7 @@ async def validate_node_data(
             + invalid_reaggregate_dimensions_error
             + invalid_reaggregate_functions_error
             + invalid_fixed_grain_dimensions_error
+            + unsupported_fixed_grain_shape_error
         )
         node_validator.errors.extend(errors)
 
@@ -821,6 +848,18 @@ async def validate_node_data_v2(
             list(validated_node.fixed_grain),
             parent_columns,
         )
+    # `is not None` here: unlike the dimension check above, `[]` still needs
+    # its shape checked -- e.g. COUNT(DISTINCT ...) with `[]` has no
+    # dimension to resolve but still can't carry a broadcast.
+    unsupported_fixed_grain_shape: str | None = None
+    if validated_node.fixed_grain is not None:
+        try:
+            validate_fixed_grain_shape(
+                validated_node.query,  # type: ignore
+                list(validated_node.fixed_grain),
+            )
+        except DJInvalidInputException as exc:
+            unsupported_fixed_grain_shape = str(exc)
 
     # --- Step 12: final error assembly for missing parents + invalid required
     #              dims (matches legacy code shapes).
@@ -830,6 +869,7 @@ async def validate_node_data_v2(
         or invalid_reaggregate_dimensions
         or invalid_reaggregate_functions
         or invalid_fixed_grain_dimensions
+        or unsupported_fixed_grain_shape
     ):
         node_validator.status = NodeStatus.INVALID
         if node_validator.missing_parents_map:
@@ -883,13 +923,20 @@ async def validate_node_data_v2(
                     code=ErrorCode.INVALID_COLUMN,
                     message=(
                         "Node definition declares a fixed grain referencing "
-                        "columns that are not on parent nodes."
+                        "dimension columns that could not be resolved."
                     ),
                     debug={
                         "invalid_fixed_grain_dimensions": list(
                             invalid_fixed_grain_dimensions,
                         ),
                     },
+                ),
+            )
+        if unsupported_fixed_grain_shape:
+            node_validator.errors.append(
+                DJError(
+                    code=ErrorCode.INVALID_METRIC,
+                    message=unsupported_fixed_grain_shape,
                 ),
             )
         if invalid_reaggregate_functions:

--- a/datajunction-server/datajunction_server/models/decompose.py
+++ b/datajunction-server/datajunction_server/models/decompose.py
@@ -56,6 +56,9 @@ class AggregationRule(BaseModel):
     type: Aggregability = Aggregability.NONE
     level: list[str] | None = None
     reaggregate: DimensionReaggregateRule | None = None
+    # Carried on the rule rather than read off the node revision so that every
+    # consumer of a component can see it without reaching back to the graph.
+    fixed_grain: list[str] | None = None
 
 
 class MetricComponent(BaseModel):

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -25,6 +25,7 @@ from datajunction_server.models.dimensionlink import (
     LinkType,
     SparkJoinStrategy,
 )
+from datajunction_server.models.fixed_grain import fixed_grain_identity
 from datajunction_server.models.impact import DownstreamImpact
 from datajunction_server.models.materialization import (
     DEFAULT_CUBE_RETENTION,
@@ -1023,6 +1024,8 @@ class MetricSpec(NodeSpec):
     # Excluded from serialization so it's never exported.
     columns: list[ColumnSpec] | None = Field(default=None, exclude=True)
     required_dimensions: list[str] | None = None  # Field(default_factory=list)
+    # Omitted means the query grain; `[]` means the global grain.
+    fixed_grain: list[str] | None = None
     reaggregate: ReaggregateSpec | None = None
     direction: MetricDirection | None = None
     unit_enum: MetricUnit | None = Field(default=None, exclude=True)
@@ -1040,6 +1043,8 @@ class MetricSpec(NodeSpec):
         "columns": ChangeTier.NONE,
         # Required dimensions constrain which queries the metric can answer.
         "required_dimensions": ChangeTier.MAJOR,
+        # Where the aggregate is computed -- changes the number, not its label.
+        "fixed_grain": ChangeTier.MAJOR,
         "reaggregate": ChangeTier.MAJOR,
         # Everything below is presentation metadata on the metric's single output
         # column -- the same set the PATCH path already treats as minor via
@@ -1054,6 +1059,8 @@ class MetricSpec(NodeSpec):
     FIELD_ORDER_CHANGE_TIERS: ClassVar[dict[str, ChangeTier]] = {
         "columns": ChangeTier.NONE,
         "required_dimensions": ChangeTier.NONE,
+        # A grain is a partition, so reordering carries no meaning.
+        "fixed_grain": ChangeTier.NONE,
     }
 
     # Class-level adapter used by __init__ to eagerly validate structured
@@ -1113,6 +1120,21 @@ class MetricSpec(NodeSpec):
         if self.unit_enum is None or self.unit_enum == MetricUnit.UNKNOWN:
             return None
         return self.unit_enum.value.name.lower()
+
+    @property
+    def rendered_fixed_grain(self) -> list[str] | None:
+        """
+        Fixed grain with `${prefix}` resolved to this spec's namespace.
+
+        `[]` is preserved rather than folded to `None`: query grain and global
+        grain are different declarations.
+        """
+        if self.fixed_grain is None:
+            return None
+        return [
+            render_prefixes(dim, self.namespace) if "${prefix}" in dim else dim
+            for dim in self.fixed_grain
+        ]
 
     @property
     def rendered_required_dimensions(self) -> list[str]:
@@ -1180,6 +1202,17 @@ class MetricSpec(NodeSpec):
             == set(other.canonical_required_dimensions)
         ):
             changed.remove("required_dimensions")
+
+        # `_values_differ` compares the raw field as a set, so it sees no change
+        # between `None` (query grain) and `[]` (global grain). Decide on the
+        # rendered value, the same one `__eq__` compares.
+        if (
+            isinstance(other, MetricSpec)
+            and "fixed_grain" not in changed
+            and fixed_grain_identity(self.rendered_fixed_grain)
+            != fixed_grain_identity(other.rendered_fixed_grain)
+        ):
+            changed.append("fixed_grain")
         return changed
 
     @property
@@ -1245,6 +1278,8 @@ class MetricSpec(NodeSpec):
                 preserve_order=False,
             )
             and self.rendered_reaggregate == other.rendered_reaggregate
+            and fixed_grain_identity(self.rendered_fixed_grain)
+            == fixed_grain_identity(other.rendered_fixed_grain)
             and eq_or_fallback(self.direction, other.direction, MetricDirection.NEUTRAL)
             and self._normalized_unit() == other._normalized_unit()
             and self.significant_digits == other.significant_digits

--- a/datajunction-server/datajunction_server/models/fixed_grain.py
+++ b/datajunction-server/datajunction_server/models/fixed_grain.py
@@ -1,0 +1,18 @@
+"""
+Semantics of a metric's declared fixed grain.
+
+`fixed_grain` is tri-state and every consumer has to honour the same three
+rules, so they live here rather than being restated at each boundary:
+
+- `None` means the query grain (no declaration).
+- `[]` means the global grain, and must stay distinct from `None`.
+- Dimension order and duplicates are irrelevant: the declaration becomes a
+  `PARTITION BY` set.
+"""
+
+
+def fixed_grain_identity(grain: list[str] | None) -> frozenset[str] | None:
+    """
+    The value to compare when deciding whether two declarations differ.
+    """
+    return None if grain is None else frozenset(grain)

--- a/datajunction-server/datajunction_server/models/metric.py
+++ b/datajunction-server/datajunction_server/models/metric.py
@@ -52,6 +52,7 @@ class Metric(BaseModel):
     unit: dict | None = None
     required_dimensions: list[str]
     reaggregate: ReaggregateSpec | None = None
+    fixed_grain: list[str] | None = None
 
     # Whether the metric is a single aggregation call (a "measure") that can map
     # 1:1 to a column in an externally-built pre-aggregation table. Derived/ratio
@@ -107,6 +108,7 @@ class Metric(BaseModel):
             ),
             required_dimensions=[dim.name for dim in node.current.required_dimensions],
             reaggregate=node.current.reaggregate,
+            fixed_grain=node.current.fixed_grain,
             is_measure=node.current.is_measure,
             incompatible_druid_functions=incompatible_druid_functions,
             measures=measures,

--- a/datajunction-server/datajunction_server/models/node.py
+++ b/datajunction-server/datajunction_server/models/node.py
@@ -879,6 +879,8 @@ class MetricNodeFields(BaseModel):
     """
 
     required_dimensions: list[str] | None = None
+    # Grain the aggregate is computed at; omitted means the query grain.
+    fixed_grain: list[str] | None = None
     reaggregate: ReaggregateSpec | None = None
     metric_metadata: MetricMetadataInput | None = None
 
@@ -1035,6 +1037,7 @@ class NodeRevisionOutput(BaseModel):
     materializations: list[MaterializationConfigOutput]
     parents: list[NodeNameOutput]
     metric_metadata: MetricMetadataOutput | None = None
+    fixed_grain: list[str] | None = None
     reaggregate: ReaggregateSpec | None = None
     dimension_links: list[LinkDimensionOutput] | None = None
     custom_metadata: dict | None = None
@@ -1068,6 +1071,7 @@ class NodeOutput(GenericNodeOutputModel):
     materializations: list[MaterializationConfigOutput]
     parents: list[NodeNameOutput]
     metric_metadata: MetricMetadataOutput | None = None
+    fixed_grain: list[str] | None = None
     reaggregate: ReaggregateSpec | None = None
     dimension_links: list[LinkDimensionOutput] = Field(default_factory=list)
     created_at: UTCDatetime

--- a/datajunction-server/datajunction_server/semantic_fingerprints/normalization.py
+++ b/datajunction-server/datajunction_server/semantic_fingerprints/normalization.py
@@ -158,6 +158,21 @@ def normalize_cube_columns(columns: list[ColumnSpec] | None) -> dict[str, Any]:
     }
 
 
+def normalize_fixed_grain(grain: list[str] | None) -> list[str] | None:
+    """
+    The fingerprint form of a declared grain.
+
+    Ordering and de-duplication go through `normalize_sequence` so this field is
+    canonicalised exactly like every other sequence field -- sorting on the raw
+    string instead diverges for any value JSON has to escape. `None` is returned
+    untouched: unlike other optional lists it must not collapse to `[]`, which is
+    a different declaration (the global grain, not the query grain).
+    """
+    if grain is None:
+        return None
+    return normalize_sequence(normalize_value(grain), preserve_order=False)
+
+
 def normalize_field(
     spec: NodeSpec,
     field: str,
@@ -190,6 +205,8 @@ def normalize_field(
             spec.dimension_links,
             preserve_order=preserve_order,
         )
+    if field == "fixed_grain":
+        return normalize_fixed_grain(value)
     if field == "unit_enum" and isinstance(spec, MetricSpec):
         return normalize_value(spec._normalized_unit())
     if field == "direction" and isinstance(spec, MetricSpec):

--- a/datajunction-server/datajunction_server/semantic_fingerprints/v1.py
+++ b/datajunction-server/datajunction_server/semantic_fingerprints/v1.py
@@ -45,7 +45,7 @@ _FIELDS_BY_SPEC_TYPE: dict[type[NodeSpec], tuple[str, ...]] = {
         "primary_key",
         "query",
     ),
-    MetricSpec: ("query", "required_dimensions", "reaggregate"),
+    MetricSpec: ("query", "required_dimensions", "reaggregate", "fixed_grain"),
     CubeSpec: ("metrics", "dimensions", "filters", "columns"),
 }
 

--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -771,12 +771,10 @@ class MetricData:
 # =============================================================================
 
 
-# Window functions that return their input unchanged when every row in the
-# frame holds the same value — which is exactly what a broadcast produces. An
-# unrecognised function is treated as accumulating, so the guard fails closed.
-_IDEMPOTENT_OVER_A_CONSTANT = frozenset(
-    {"MAX", "MIN", "AVG", "FIRST_VALUE", "ANY_VALUE"},
-)
+# AVG of one repeated value returns that value, unlike SUM. But it only
+# sees one value per frame if the window's own partition covers the
+# declared grain -- see `_window_covers_the_grain`.
+_SAFE_ONLY_WHEN_THE_WINDOW_COVERS_THE_GRAIN = frozenset({"AVG"})
 
 
 def _is_windowed_aggregate(func: ast.Function) -> bool:
@@ -785,31 +783,69 @@ def _is_windowed_aggregate(func: ast.Function) -> bool:
         return False
     try:
         dj_function = func.function()
-    except Exception:  # pragma: no cover - unknown functions are not aggregates
+    except KeyError:  # pragma: no cover - unknown functions are not aggregates
         return False
     return bool(dj_function and dj_function.is_aggregation)
 
 
-def _names_accumulated_by_a_window(query_ast: ast.Query) -> set[str]:
+def _window_covers_the_grain(
+    fixed_grain: list[str],
+    partition_cols: set[str],
+) -> bool:
     """
-    Names a window frame would accumulate.
+    Whether a window's own partition preserves a name's declared grain.
 
-    Only arguments count, and only of functions that actually accumulate. A
-    broadcast is safe as a divisor beside a window (`SUM(x) OVER (...) / total`),
-    safe in `ORDER BY` or `PARTITION BY`, and safe under `MAX`/`AVG`, which
-    return a row-constant column unchanged. It is corrupted only when a frame
-    sums or counts it.
+    The global grain (`[]`) is constant on every row and therefore always
+    covered. A non-empty grain is covered only when the window names every
+    one of its dimensions in its own `PARTITION BY`.
+    """
+    return not fixed_grain or set(fixed_grain) <= partition_cols
+
+
+def _names_accumulated_by_a_window(
+    query_ast: ast.Query,
+) -> tuple[set[str], dict[str, list[set[str]]]]:
+    """
+    Names a window frame would accumulate, split into two groups.
+
+    The first is accumulated no matter what -- a plain `SUM`/`COUNT`-style
+    window on it is never safe, regardless of any grain. The second is only
+    unsafe if the name's *own* declared grain isn't covered by that window's
+    partition, so it can't be decided here: a name with no `fixed_grain` of
+    its own can still inherit one from a metric it's derived from, and that
+    isn't known until decomposition resolves it. The second value maps each
+    such name to every partition-by column set it appeared under, for the
+    caller to check once it knows the name's real grain.
+
+    Safe either way: a plain divisor, `ORDER BY`/`PARTITION BY`, and any
+    `is_duplication_invariant` function (same test the fan-out guard uses).
     """
     accumulated: set[str] = set()
+    grain_sensitive: dict[str, list[set[str]]] = {}
     for func in query_ast.find_all(ast.Function):
         if func.over is None:
             continue
-        if func.name.name.upper() in _IDEMPOTENT_OVER_A_CONSTANT:
+        if is_duplication_invariant(func):
             continue
-        for arg in func.args:
-            for col in arg.find_all(ast.Column):
-                accumulated.add(col.identifier())
-    return accumulated
+        fn_name = func.name.name.upper()
+        names = {
+            col.identifier() for arg in func.args for col in arg.find_all(ast.Column)
+        }
+        if fn_name in _SAFE_ONLY_WHEN_THE_WINDOW_COVERS_THE_GRAIN:
+            # A bare column only -- `DATE_TRUNC('month', date_id)` groups
+            # several `date_id` values together, so a column nested inside a
+            # transformation doesn't preserve the grain the way naming it
+            # directly does.
+            partition_cols = {
+                expr.identifier()
+                for expr in func.over.partition_by
+                if isinstance(expr, ast.Column)
+            }
+            for name in names:
+                grain_sensitive.setdefault(name, []).append(partition_cols)
+            continue
+        accumulated |= names
+    return accumulated, grain_sensitive
 
 
 def _dimension_column(dimension: str) -> ast.Column:
@@ -867,6 +903,27 @@ def _broadcast_in_combiner(
         "Unsupported fixed_grain metric shape: could not find the component "
         "merge expression in the metric combiner.",
     )
+
+
+def validate_fixed_grain_shape(query: str, fixed_grain: list[str]) -> None:
+    """
+    Raise if a base metric's own aggregate can't carry a declared fixed grain.
+
+    For write-time use, so e.g. `COUNT(DISTINCT ...)` with a fixed_grain
+    fails at creation rather than only when queried. A derived metric's
+    query has no aggregate of its own -- that case is left to query time,
+    where the error names the real problem (a grain belongs on the base).
+    """
+    query_ast = parse(query)
+    has_aggregate = any(
+        (dj_function := func.function()) and dj_function.is_aggregation
+        for func in query_ast.find_all(ast.Function)
+    )
+    if has_aggregate:
+        MetricComponentExtractor(0)._extract_base(
+            query_ast,
+            fixed_grain=fixed_grain,
+        )
 
 
 class MetricComponentExtractor:
@@ -973,7 +1030,9 @@ class MetricComponentExtractor:
         all_components = []
         components_tracker = set()
         base_metrics_data = {}
-        accumulated_by_window = _names_accumulated_by_a_window(query_ast)
+        accumulated_by_window, grain_sensitive_windows = _names_accumulated_by_a_window(
+            query_ast,
+        )
 
         for base_metric in metric_data.base_metrics:
             # Check if this parent metric is itself a derived metric
@@ -1047,37 +1106,61 @@ class MetricComponentExtractor:
             # Checked on the extracted components, not this parent's own
             # declaration: decomposition recurses through derived parents, so a
             # grain declared two levels down still arrives on a component here.
-            #
+            # The same applies to the AVG-class check below -- `base_metric`
+            # itself may declare no grain and only inherit one this way.
+            # A metric can combine components with *different* declared
+            # grains (e.g. one global, one per-category) -- check every
+            # distinct one, not just the first found, or an unsafe window on
+            # a later component's grain would slip through unchecked.
+            effective_fixed_grains = [
+                comp.rule.fixed_grain
+                for comp in base_components
+                if comp.rule.fixed_grain is not None
+            ]
+
             # A derived metric is only at risk when the frame actually
             # accumulates the parent; referencing it beside a window is fine.
             # A base metric has no reference to match, so the hazard is its own
             # aggregate already carrying a window — not a window anywhere in the
             # query, which `SUM(x - LAG(x) OVER (...))` has quite legitimately.
-            windowed_over_the_grain = (
-                base_metric.name in accumulated_by_window
-                if metric_data.is_derived
-                else any(
+            if metric_data.is_derived:
+                windowed_over_the_grain = (
+                    base_metric.name in accumulated_by_window
+                    or any(
+                        not _window_covers_the_grain(
+                            fixed_grain,
+                            partition_cols,
+                        )
+                        for fixed_grain in effective_fixed_grains
+                        for partition_cols in grain_sensitive_windows.get(
+                            base_metric.name,
+                            [],
+                        )
+                    )
+                )
+            else:
+                windowed_over_the_grain = any(
                     _is_windowed_aggregate(func)
                     for func in parse(base_metric.query).find_all(ast.Function)
                 )
-            )
-            if windowed_over_the_grain and any(
-                comp.rule.fixed_grain is not None for comp in base_components
-            ):
-                raise DJInvalidInputException(
-                    f"Metric `{base_metric.name}` declares `fixed_grain` (or is "
-                    "derived from one), so its own aggregate is already windowed "
-                    "and cannot be broadcast on top of that."
-                    if not metric_data.is_derived
-                    else (
+
+            if windowed_over_the_grain and effective_fixed_grains:
+                if metric_data.is_derived:
+                    message = (
                         f"Metric `{base_metric.name}` declares `fixed_grain` (or "
                         "is derived from one), so a frame cannot accumulate it: "
                         "its value is the same on every row of the partition, and "
                         "the frame would add that same value once per row. "
                         "Referencing it beside a window is fine — for example "
                         "dividing a windowed metric by it."
-                    ),
-                )
+                    )
+                else:
+                    message = (
+                        f"Metric `{base_metric.name}` declares `fixed_grain` (or is "
+                        "derived from one), so its own aggregate is already windowed "
+                        "and cannot be broadcast on top of that."
+                    )
+                raise DJInvalidInputException(message)
 
             for comp in base_components:
                 if comp.name not in components_tracker:

--- a/datajunction-server/datajunction_server/sql/decompose.py
+++ b/datajunction-server/datajunction_server/sql/decompose.py
@@ -754,6 +754,7 @@ class BaseMetricData:
     name: str
     query: str
     reaggregate: ReaggregateSpec | dict | None = None
+    fixed_grain: list[str] | None = None
 
 
 @dataclass
@@ -768,6 +769,104 @@ class MetricData:
 # =============================================================================
 # Metric Component Extractor
 # =============================================================================
+
+
+# Window functions that return their input unchanged when every row in the
+# frame holds the same value — which is exactly what a broadcast produces. An
+# unrecognised function is treated as accumulating, so the guard fails closed.
+_IDEMPOTENT_OVER_A_CONSTANT = frozenset(
+    {"MAX", "MIN", "AVG", "FIRST_VALUE", "ANY_VALUE"},
+)
+
+
+def _is_windowed_aggregate(func: ast.Function) -> bool:
+    """Whether ``func`` is an aggregate carrying its own OVER clause."""
+    if func.over is None:
+        return False
+    try:
+        dj_function = func.function()
+    except Exception:  # pragma: no cover - unknown functions are not aggregates
+        return False
+    return bool(dj_function and dj_function.is_aggregation)
+
+
+def _names_accumulated_by_a_window(query_ast: ast.Query) -> set[str]:
+    """
+    Names a window frame would accumulate.
+
+    Only arguments count, and only of functions that actually accumulate. A
+    broadcast is safe as a divisor beside a window (`SUM(x) OVER (...) / total`),
+    safe in `ORDER BY` or `PARTITION BY`, and safe under `MAX`/`AVG`, which
+    return a row-constant column unchanged. It is corrupted only when a frame
+    sums or counts it.
+    """
+    accumulated: set[str] = set()
+    for func in query_ast.find_all(ast.Function):
+        if func.over is None:
+            continue
+        if func.name.name.upper() in _IDEMPOTENT_OVER_A_CONSTANT:
+            continue
+        for arg in func.args:
+            for col in arg.find_all(ast.Column):
+                accumulated.add(col.identifier())
+    return accumulated
+
+
+def _dimension_column(dimension: str) -> ast.Column:
+    """
+    A column node naming a dimension reference.
+
+    Built rather than parsed. A grain entry is a dimension reference, not SQL,
+    so interpolating it into a `SELECT` would both accept things that are not
+    references (`a, b` silently truncating to `a`) and reject things that are:
+    the role syntax in `v3.date.date_id[order]` is not valid SQL at all.
+    """
+    *namespace_parts, column = dimension.split(".")
+    namespace: ast.Name | None = None
+    for part in namespace_parts:
+        namespace = ast.Name(part, namespace=namespace)
+    return ast.Column(name=ast.Name(column, namespace=namespace))
+
+
+def _broadcast_in_combiner(
+    query_ast: ast.Query,
+    component_name: str,
+    merge_function: str,
+    fixed_grain: list[str],
+) -> None:
+    """
+    Re-merge the component's aggregate as a window, in place in the combiner.
+
+    The merge call is replaced where it sits rather than the whole combiner being
+    wrapped: `ROUND(SUM(x), 2)` broadcasts to `ROUND(SUM(SUM(x)) OVER (), 2)`, not
+    to `SUM(ROUND(SUM(x), 2)) OVER ()`, which is a different number.
+
+    Partitions name dimensions in their unresolved form. Each consumer resolves
+    them for itself -- a CTE-qualified column for a query, a bare column for a
+    cube -- through the same replacement every other dimension reference uses.
+    """
+    target = merge_function.upper()
+    partition_by = [
+        cast(ast.Expression, _dimension_column(dimension)) for dimension in fixed_grain
+    ]
+    for func in list(query_ast.find_all(ast.Function)):
+        if func.name.name.upper() != target:
+            continue
+        if not any(
+            col.name and col.name.name == component_name
+            for col in func.find_all(ast.Column)
+        ):
+            continue
+        # Mutated in place: `replace()` and `swap()` leave the projected tree
+        # untouched, so substituting the node into its parent has no effect.
+        func.args = [ast.Function(ast.Name(target), args=func.args)]
+        func.over = ast.Over(partition_by=partition_by)
+        return
+
+    raise DJInvalidInputException(
+        "Unsupported fixed_grain metric shape: could not find the component "
+        "merge expression in the metric combiner.",
+    )
 
 
 class MetricComponentExtractor:
@@ -874,6 +973,7 @@ class MetricComponentExtractor:
         all_components = []
         components_tracker = set()
         base_metrics_data = {}
+        accumulated_by_window = _names_accumulated_by_a_window(query_ast)
 
         for base_metric in metric_data.base_metrics:
             # Check if this parent metric is itself a derived metric
@@ -941,6 +1041,42 @@ class MetricComponentExtractor:
                 base_components, derived_ast = self._extract_base(
                     base_ast,
                     parse_reaggregate_spec(base_metric.reaggregate),
+                    base_metric.fixed_grain,
+                )
+
+            # Checked on the extracted components, not this parent's own
+            # declaration: decomposition recurses through derived parents, so a
+            # grain declared two levels down still arrives on a component here.
+            #
+            # A derived metric is only at risk when the frame actually
+            # accumulates the parent; referencing it beside a window is fine.
+            # A base metric has no reference to match, so the hazard is its own
+            # aggregate already carrying a window — not a window anywhere in the
+            # query, which `SUM(x - LAG(x) OVER (...))` has quite legitimately.
+            windowed_over_the_grain = (
+                base_metric.name in accumulated_by_window
+                if metric_data.is_derived
+                else any(
+                    _is_windowed_aggregate(func)
+                    for func in parse(base_metric.query).find_all(ast.Function)
+                )
+            )
+            if windowed_over_the_grain and any(
+                comp.rule.fixed_grain is not None for comp in base_components
+            ):
+                raise DJInvalidInputException(
+                    f"Metric `{base_metric.name}` declares `fixed_grain` (or is "
+                    "derived from one), so its own aggregate is already windowed "
+                    "and cannot be broadcast on top of that."
+                    if not metric_data.is_derived
+                    else (
+                        f"Metric `{base_metric.name}` declares `fixed_grain` (or "
+                        "is derived from one), so a frame cannot accumulate it: "
+                        "its value is the same on every row of the partition, and "
+                        "the frame would add that same value once per row. "
+                        "Referencing it beside a window is fine — for example "
+                        "dividing a windowed metric by it."
+                    ),
                 )
 
             for comp in base_components:
@@ -1001,6 +1137,16 @@ class MetricComponentExtractor:
                     f"Derived metric `{metric_node.name}` declares reaggregate.",
                 )
 
+            # `is not None`, not truthiness: `[]` is the global grain, and a
+            # derived metric may not declare that either. Guards the cached
+            # path, which serves `/sql/metrics/v3/` and bulk derivation.
+            if metric_node.current.fixed_grain is not None:
+                raise DJInvalidInputException(
+                    "A grain must be declared on a base metric. Derived metric "
+                    f"`{metric_node.name}` declares fixed_grain; declare it on the "
+                    "metric being aggregated and divide by that instead.",
+                )
+
             # Derived metric - base metrics are the parent metrics
             return MetricData(
                 query=metric_node.current.query,
@@ -1010,6 +1156,7 @@ class MetricComponentExtractor:
                         name=parent_name,
                         query=nodes_cache[parent_name].current.query,
                         reaggregate=nodes_cache[parent_name].current.reaggregate,
+                        fixed_grain=nodes_cache[parent_name].current.fixed_grain,
                     )
                     for parent_name in metric_parents
                     if nodes_cache[parent_name].current
@@ -1026,6 +1173,7 @@ class MetricComponentExtractor:
                         name=metric_node.name,
                         query=metric_node.current.query,
                         reaggregate=metric_node.current.reaggregate,
+                        fixed_grain=metric_node.current.fixed_grain,
                     ),
                 ],
             )
@@ -1043,6 +1191,7 @@ class MetricComponentExtractor:
                 Node.name.label("parent_name"),
                 NodeRevision.query.label("parent_query"),
                 NodeRevision.reaggregate.label("parent_reaggregate"),
+                NodeRevision.fixed_grain.label("parent_fixed_grain"),
             )
             .select_from(NodeRelationship)
             .join(Node, NodeRelationship.parent_id == Node.id)
@@ -1064,6 +1213,7 @@ class MetricComponentExtractor:
             select(
                 NodeRevision.query,
                 NodeRevision.reaggregate,
+                NodeRevision.fixed_grain,
                 Node.name,
             )
             .join(Node, NodeRevision.node_id == Node.id)
@@ -1081,6 +1231,15 @@ class MetricComponentExtractor:
                     "Semi-additive metrics must be base metrics in V1. "
                     f"Derived metric `{this_row.name}` declares reaggregate.",
                 )
+            # Same rule on the uncached path, which serves `GET /metrics/{name}`
+            # and the create-time background task. Neither guard covers the
+            # other's callers, so both are load-bearing.
+            if this_row.fixed_grain is not None:
+                raise DJInvalidInputException(
+                    "A grain must be declared on a base metric. Derived metric "
+                    f"`{this_row.name}` declares fixed_grain; declare it on the "
+                    "metric being aggregated and divide by that instead.",
+                )
 
             # Derived metric - base metrics are the parents
             return MetricData(
@@ -1091,6 +1250,7 @@ class MetricComponentExtractor:
                         name=row.parent_name,
                         query=row.parent_query,
                         reaggregate=row.parent_reaggregate,
+                        fixed_grain=row.parent_fixed_grain,
                     )
                     for row in parent_rows
                 ],
@@ -1105,6 +1265,7 @@ class MetricComponentExtractor:
                         name=this_row.name,
                         query=this_row.query,
                         reaggregate=this_row.reaggregate,
+                        fixed_grain=this_row.fixed_grain,
                     ),
                 ],
             )
@@ -1113,6 +1274,7 @@ class MetricComponentExtractor:
         self,
         query_ast: ast.Query,
         reaggregate: ReaggregateSpec | None = None,
+        fixed_grain: list[str] | None = None,
     ) -> tuple[list[MetricComponent], ast.Query]:
         """
         Extract components from a base metric by decomposing aggregations.
@@ -1149,6 +1311,13 @@ class MetricComponentExtractor:
                         "dimension-specific reaggregation requires a "
                         "decomposable aggregation",
                     )
+                if fixed_grain is not None:
+                    # Ignoring the declaration would return the query-grain
+                    # value under a name that claims otherwise.
+                    self._raise_unsupported_fixed_grain_shape(
+                        "a fixed grain requires a decomposable aggregate, and "
+                        "this metric's aggregation cannot be split into measures",
+                    )
                 return [], query_ast
 
             for func, dj_function in agg_funcs:
@@ -1174,7 +1343,58 @@ class MetricComponentExtractor:
         if reaggregate is not None and dimension_reaggregate_rules(reaggregate):
             self._attach_reaggregate_spec(components, reaggregate)
 
+        if fixed_grain is not None:
+            self._attach_fixed_grain_spec(components, fixed_grain, query_ast)
+
         return components, query_ast
+
+    def _attach_fixed_grain_spec(
+        self,
+        components: list[MetricComponent],
+        fixed_grain: list[str],
+        query_ast: ast.Query,
+    ) -> None:
+        """
+        Broadcast the one measure that can carry a declared grain.
+
+        The window goes into the combiner here rather than at SQL build time so
+        that it travels with the decomposed metric. Everything downstream already
+        resolves dimension references and preserves aggregate windows, so both
+        the query path and the SQL stored on a materialized cube pick it up.
+
+        Refusals raised here surface at deploy time for a deployment, but only
+        at SQL build time for a metric created through the API — nothing
+        decomposes it at write time.
+        """
+        if len(components) != 1:
+            self._raise_unsupported_fixed_grain_shape(
+                "a fixed grain requires exactly one component",
+            )
+
+        component = components[0]
+        if (
+            component.rule.type != Aggregability.FULL
+            or component.aggregation is None
+            or component.merge is None
+        ):
+            self._raise_unsupported_fixed_grain_shape(
+                "a fixed grain requires one non-distinct fully-aggregatable "
+                "component, because broadcasting re-applies the merge",
+            )
+
+        component.rule.fixed_grain = fixed_grain
+        _broadcast_in_combiner(
+            query_ast,
+            component.name,
+            cast(str, component.merge),
+            fixed_grain,
+        )
+
+    @staticmethod
+    def _raise_unsupported_fixed_grain_shape(reason: str) -> None:
+        raise DJInvalidInputException(
+            f"Unsupported fixed_grain metric shape: {reason}.",
+        )
 
     def _attach_reaggregate_spec(
         self,

--- a/datajunction-server/tests/api/cubes_test.py
+++ b/datajunction-server/tests/api/cubes_test.py
@@ -3589,6 +3589,7 @@ async def test_cube_materialization_metadata(
                     "rule": {
                         "level": None,
                         "reaggregate": None,
+                        "fixed_grain": None,
                         "type": "full",
                     },
                 },
@@ -3601,6 +3602,7 @@ async def test_cube_materialization_metadata(
                     "rule": {
                         "level": None,
                         "reaggregate": None,
+                        "fixed_grain": None,
                         "type": "full",
                     },
                 },
@@ -3613,6 +3615,7 @@ async def test_cube_materialization_metadata(
                     "rule": {
                         "level": None,
                         "reaggregate": None,
+                        "fixed_grain": None,
                         "type": "full",
                     },
                 },
@@ -3625,6 +3628,7 @@ async def test_cube_materialization_metadata(
                     "rule": {
                         "level": None,
                         "reaggregate": None,
+                        "fixed_grain": None,
                         "type": "full",
                     },
                 },
@@ -3637,6 +3641,7 @@ async def test_cube_materialization_metadata(
                     "rule": {
                         "level": None,
                         "reaggregate": None,
+                        "fixed_grain": None,
                         "type": "full",
                     },
                 },
@@ -3649,6 +3654,7 @@ async def test_cube_materialization_metadata(
                     "rule": {
                         "level": None,
                         "reaggregate": None,
+                        "fixed_grain": None,
                         "type": "full",
                     },
                 },
@@ -3661,6 +3667,7 @@ async def test_cube_materialization_metadata(
                     "rule": {
                         "level": None,
                         "reaggregate": None,
+                        "fixed_grain": None,
                         "type": "full",
                     },
                 },
@@ -3781,6 +3788,7 @@ async def test_cube_materialization_metadata(
                     "rule": {
                         "level": None,
                         "reaggregate": None,
+                        "fixed_grain": None,
                         "type": "full",
                     },
                 },
@@ -4033,7 +4041,12 @@ async def test_cube_materialization_metadata(
                     "grain_alias": None,
                     "aggregation": "COUNT",
                     "merge": "SUM",
-                    "rule": {"type": "full", "level": None, "reaggregate": None},
+                    "rule": {
+                        "type": "full",
+                        "level": None,
+                        "reaggregate": None,
+                        "fixed_grain": None,
+                    },
                 },
                 {
                     "name": "discount_sum_30b84e6c",
@@ -4041,7 +4054,12 @@ async def test_cube_materialization_metadata(
                     "grain_alias": None,
                     "aggregation": "SUM",
                     "merge": "SUM",
-                    "rule": {"type": "full", "level": None, "reaggregate": None},
+                    "rule": {
+                        "type": "full",
+                        "level": None,
+                        "reaggregate": None,
+                        "fixed_grain": None,
+                    },
                 },
                 {
                     "name": "price_count_935e7117",
@@ -4049,7 +4067,12 @@ async def test_cube_materialization_metadata(
                     "grain_alias": None,
                     "aggregation": "COUNT",
                     "merge": "SUM",
-                    "rule": {"type": "full", "level": None, "reaggregate": None},
+                    "rule": {
+                        "type": "full",
+                        "level": None,
+                        "reaggregate": None,
+                        "fixed_grain": None,
+                    },
                 },
                 {
                     "name": "price_discount_sum_e4ba5456",
@@ -4057,7 +4080,12 @@ async def test_cube_materialization_metadata(
                     "grain_alias": None,
                     "aggregation": "SUM",
                     "merge": "SUM",
-                    "rule": {"type": "full", "level": None, "reaggregate": None},
+                    "rule": {
+                        "type": "full",
+                        "level": None,
+                        "reaggregate": None,
+                        "fixed_grain": None,
+                    },
                 },
                 {
                     "name": "price_sum_935e7117",
@@ -4065,7 +4093,12 @@ async def test_cube_materialization_metadata(
                     "grain_alias": None,
                     "aggregation": "SUM",
                     "merge": "SUM",
-                    "rule": {"type": "full", "level": None, "reaggregate": None},
+                    "rule": {
+                        "type": "full",
+                        "level": None,
+                        "reaggregate": None,
+                        "fixed_grain": None,
+                    },
                 },
                 {
                     "name": "repair_order_id_count_bd241964",
@@ -4073,7 +4106,12 @@ async def test_cube_materialization_metadata(
                     "grain_alias": None,
                     "aggregation": "COUNT",
                     "merge": "SUM",
-                    "rule": {"type": "full", "level": None, "reaggregate": None},
+                    "rule": {
+                        "type": "full",
+                        "level": None,
+                        "reaggregate": None,
+                        "fixed_grain": None,
+                    },
                 },
                 {
                     "name": "total_repair_cost_sum_67874507",
@@ -4081,7 +4119,12 @@ async def test_cube_materialization_metadata(
                     "grain_alias": None,
                     "aggregation": "SUM",
                     "merge": "SUM",
-                    "rule": {"type": "full", "level": None, "reaggregate": None},
+                    "rule": {
+                        "type": "full",
+                        "level": None,
+                        "reaggregate": None,
+                        "fixed_grain": None,
+                    },
                 },
                 {
                     "name": "price_sum_252381cf",
@@ -4089,7 +4132,12 @@ async def test_cube_materialization_metadata(
                     "grain_alias": None,
                     "aggregation": "SUM",
                     "merge": "SUM",
-                    "rule": {"type": "full", "level": None, "reaggregate": None},
+                    "rule": {
+                        "type": "full",
+                        "level": None,
+                        "reaggregate": None,
+                        "fixed_grain": None,
+                    },
                 },
             ],
             "timestamp_column": "hire_date",

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -2233,6 +2233,46 @@ class TestDeployments:
             "status": "skipped",
         }
 
+    def test_deploy_fixed_grain_metric_updates(self):
+        """Declaring, changing and clearing a grain each register as a change."""
+        from datajunction_server.models.deployment import ChangeTier, MetricSpec
+
+        query = "SELECT SUM(price) FROM foo.bar.orders"
+        query_grain = MetricSpec(name="m", namespace="foo.bar", query=query)
+        global_grain = MetricSpec(
+            name="m",
+            namespace="foo.bar",
+            query=query,
+            fixed_grain=[],
+        )
+        by_region = MetricSpec(
+            name="m",
+            namespace="foo.bar",
+            query=query,
+            fixed_grain=["foo.bar.region_dim.region"],
+        )
+
+        assert MetricSpec.field_change_tier("fixed_grain") == ChangeTier.MAJOR
+
+        assert "fixed_grain" in query_grain.diff(global_grain)
+        assert "fixed_grain" in global_grain.diff(by_region)
+        assert "fixed_grain" in global_grain.diff(query_grain)
+
+        # Reordering is not a change: a grain is a partition.
+        reordered = MetricSpec(
+            name="m",
+            namespace="foo.bar",
+            query=query,
+            fixed_grain=["b", "a"],
+        )
+        ordered = MetricSpec(
+            name="m",
+            namespace="foo.bar",
+            query=query,
+            fixed_grain=["a", "b"],
+        )
+        assert "fixed_grain" not in ordered.diff(reordered)
+
     @pytest.mark.asyncio
     async def test_deploy_metric_with_update(
         self,

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -4436,6 +4436,78 @@ class TestCopyNodesToNamespace:
         # The query should reference the branch namespace
         assert "copy_test.feature_copy.source_table" in response.json()["query"]
 
+    @pytest.mark.asyncio
+    async def test_branch_copy_preserves_a_fixed_grain(
+        self,
+        client_with_service_setup: AsyncClient,
+    ):
+        """A copied metric keeps its fixed grain.
+
+        Note this covers the global grain only. `[]` names no dimension, so it
+        does not exercise the `${prefix}` reparameterisation in
+        `get_node_specs_for_export` -- that needs a grain naming a full
+        `node.column` path on an in-deploy dimension node, which this fixture
+        has no dimension for.
+        """
+        await client_with_service_setup.post("/namespaces/fg_copy.main")
+
+        response = await client_with_service_setup.post(
+            "/nodes/source/",
+            json={
+                "name": "fg_copy.main.source_table",
+                "description": "Source table to copy",
+                "catalog": "default",
+                "schema_": "test",
+                "table": "source_table",
+                "columns": [
+                    {"name": "id", "type": "int"},
+                    {"name": "region", "type": "string"},
+                ],
+            },
+        )
+        assert response.status_code <= HTTPStatus.CREATED, response.json()
+
+        response = await client_with_service_setup.post(
+            "/nodes/metric/",
+            json={
+                "name": "fg_copy.main.total_id_global",
+                "description": "Total at the global grain",
+                "query": "SELECT SUM(id) FROM fg_copy.main.source_table",
+                "fixed_grain": [],
+            },
+        )
+        assert response.status_code <= HTTPStatus.CREATED, response.json()
+
+        await client_with_service_setup.patch(
+            "/namespaces/fg_copy.main/git",
+            json={"github_repo_path": "myorg/myrepo", "git_branch": "main"},
+        )
+
+        with patch(
+            "datajunction_server.api.branches.GitHubService",
+        ) as mock_github_class:
+            mock_github = MagicMock()
+            mock_github.create_branch = AsyncMock(
+                return_value={
+                    "ref": "refs/heads/feature-fg",
+                    "object": {"sha": "abc123"},
+                },
+            )
+            mock_github_class.return_value = mock_github
+
+            response = await client_with_service_setup.post(
+                "/namespaces/fg_copy.main/branches",
+                json={"branch_name": "feature-fg"},
+            )
+            assert response.status_code == HTTPStatus.CREATED, response.json()
+
+        response = await client_with_service_setup.get(
+            "/nodes/fg_copy.feature_fg.total_id_global/",
+        )
+        assert response.status_code == HTTPStatus.OK, response.json()
+        # The global grain names no dimension, so there is nothing to repoint.
+        assert response.json()["fixed_grain"] == []
+
 
 @pytest.mark.asyncio
 async def test_branch_copy_preserves_invalid_source_status(

--- a/datajunction-server/tests/api/graphql/test_dataloaders.py
+++ b/datajunction-server/tests/api/graphql/test_dataloaders.py
@@ -548,3 +548,64 @@ async def test_attach_git_info_empty_list_short_circuits():
     await _attach_git_info(info, [])
 
     loader.load_many.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_extraction_survives_a_cold_session(session, session_factory):
+    """The batch loader must not need a warm identity map to succeed.
+
+    Its `load_only` has to name every field `_build_metric_data_from_cache`
+    reads; an omitted one is deferred, reading it raises MissingGreenlet, and
+    the loop's `except` turns that into a null `extractedMeasures` rather than
+    an error. The rest of the suite cannot catch this, because `session_context`
+    hands DataLoaders back `request.state.test_session`, whose identity map
+    already holds fully-loaded revisions, so nothing is ever deferred.
+    """
+    from contextlib import asynccontextmanager
+
+    from sqlalchemy import select
+    from sqlalchemy.orm import joinedload
+
+    from datajunction_server.database.node import Node as DBNode
+    from datajunction_server.models.node_type import NodeType
+
+    metric = (
+        (
+            await session.execute(
+                select(DBNode)
+                .where(DBNode.type == NodeType.METRIC)
+                .where(DBNode.name.like("%total_repair_cost%"))
+                .options(joinedload(DBNode.current))
+                .limit(1),
+            )
+        )
+        .unique()
+        .scalars()
+        .first()
+    )
+    assert metric is not None, "examples should provide a single-measure metric"
+    # Only `fixed_grain` is set: reading a deferred attribute raises whatever its
+    # value is, so an omitted `reaggregate` trips this too.
+    metric.current.fixed_grain = []
+    await session.commit()
+
+    @asynccontextmanager
+    async def cold_session(*_args, **_kwargs):
+        opened = await session_factory()
+        try:
+            yield opened
+        finally:
+            await opened.close()
+
+    with patch(
+        "datajunction_server.api.graphql.dataloaders.session_context",
+        cold_session,
+    ):
+        result = await batch_load_extracted_measures(
+            [metric.current.id],
+            MagicMock(),
+        )
+
+    assert result[0] is not None, "extraction was swallowed into None"
+    components, _ = result[0]
+    assert components

--- a/datajunction-server/tests/api/measures_test.py
+++ b/datajunction-server/tests/api/measures_test.py
@@ -293,6 +293,7 @@ async def test_list_frozen_measures(
             "rule": {
                 "level": None,
                 "reaggregate": None,
+                "fixed_grain": None,
                 "type": "full",
             },
             "upstream_revision": {

--- a/datajunction-server/tests/api/metrics_test.py
+++ b/datajunction-server/tests/api/metrics_test.py
@@ -470,6 +470,7 @@ async def test_read_metrics(module__client_with_roads: AsyncClient) -> None:
             "rule": {
                 "level": None,
                 "reaggregate": None,
+                "fixed_grain": None,
                 "type": "full",
             },
         },
@@ -482,6 +483,7 @@ async def test_read_metrics(module__client_with_roads: AsyncClient) -> None:
             "rule": {
                 "level": None,
                 "reaggregate": None,
+                "fixed_grain": None,
                 "type": "full",
             },
         },

--- a/datajunction-server/tests/api/preaggregations_test.py
+++ b/datajunction-server/tests/api/preaggregations_test.py
@@ -742,6 +742,7 @@ class TestGetPreaggregationById:
                 "rule": {
                     "level": None,
                     "reaggregate": None,
+                    "fixed_grain": None,
                     "type": "full",
                 },
                 "used_by_metrics": [
@@ -810,6 +811,7 @@ class TestGetPreaggregationById:
                 "rule": {
                     "level": None,
                     "reaggregate": None,
+                    "fixed_grain": None,
                     "type": "full",
                 },
                 "used_by_metrics": [

--- a/datajunction-server/tests/api/sql_v2_test.py
+++ b/datajunction-server/tests/api/sql_v2_test.py
@@ -1206,6 +1206,7 @@ async def create_metric_distinct_single_column(client: AsyncClient):
             "rule": {
                 "level": ["hard_hat_id"],
                 "reaggregate": None,
+                "fixed_grain": None,
                 "type": "limited",
             },
         },
@@ -1237,6 +1238,7 @@ async def create_metric_distinct_expression(client: AsyncClient):
             "rule": {
                 "level": ["IF(hard_hat_id = 1, 1, 0)"],
                 "reaggregate": None,
+                "fixed_grain": None,
                 "type": "limited",
             },
         },
@@ -1636,6 +1638,7 @@ class TestMeasuresSQLMetricDefinitionsWithDimensions:
                 "rule": {
                     "level": None,
                     "reaggregate": None,
+                    "fixed_grain": None,
                     "type": "full",
                 },
             },
@@ -1701,6 +1704,7 @@ class TestMeasuresSQLMetricDefinitionsWithDimensions:
                 "rule": {
                     "level": ["default.municipality_dim.contact_name"],
                     "reaggregate": None,
+                    "fixed_grain": None,
                     "type": "limited",
                 },
             },
@@ -1810,6 +1814,7 @@ class TestMeasuresSQLMetricDefinitionsWithDimensions:
                         "default.hard_hat.first_name, NULL)",
                     ],
                     "reaggregate": None,
+                    "fixed_grain": None,
                     "type": "limited",
                 },
             },

--- a/datajunction-server/tests/construction/build_v3/fixed_grain_test.py
+++ b/datajunction-server/tests/construction/build_v3/fixed_grain_test.py
@@ -17,6 +17,7 @@ from datajunction_server.models.decompose import Aggregability
 from datajunction_server.models.deployment import ChangeTier, MetricSpec
 from datajunction_server.sql.decompose import MetricComponentExtractor
 from datajunction_server.sql.parsing.backends.antlr4 import parse
+from tests.construction.build_v3 import assert_sql_equal
 
 
 def test_fixed_grain_change_tier_is_major():
@@ -337,8 +338,31 @@ async def test_global_grain_broadcasts_as_an_unpartitioned_window(
     )
     assert response.status_code == 200, response.json()
     sql = response.json()["sql"]
-    assert "SUM(SUM(order_details_0.line_total_sum_e1f61696)) OVER ()" in sql
-    assert "AS total_line_total_bcast" in sql
+    assert_sql_equal(
+        sql,
+        """
+        WITH v3_order_details AS (
+            SELECT
+                o.order_id,
+                oi.quantity * oi.unit_price AS line_total
+            FROM default.v3.orders o
+            JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+        ),
+        order_details_0 AS (
+            SELECT
+                t1.order_id,
+                SUM(t1.line_total) AS line_total_sum_e1f61696
+            FROM v3_order_details t1
+            GROUP BY t1.order_id
+        )
+        SELECT
+            order_details_0.order_id AS order_id,
+            SUM(SUM(order_details_0.line_total_sum_e1f61696)) OVER ()
+                AS total_line_total_bcast
+        FROM order_details_0
+        GROUP BY order_details_0.order_id
+        """,
+    )
 
 
 @pytest.mark.asyncio
@@ -370,8 +394,34 @@ async def test_partitioned_grain_broadcasts_within_the_partition(
     )
     assert response.status_code == 200, response.json()
     sql = response.json()["sql"]
-    assert "PARTITION BY order_details_0.status" in sql
-    assert "AS status_line_total" in sql
+    assert_sql_equal(
+        sql,
+        """
+        WITH v3_order_details AS (
+            SELECT
+                o.order_id,
+                o.status,
+                oi.quantity * oi.unit_price AS line_total
+            FROM default.v3.orders o
+            JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+        ),
+        order_details_0 AS (
+            SELECT
+                t1.status,
+                t1.order_id,
+                SUM(t1.line_total) AS line_total_sum_e1f61696
+            FROM v3_order_details t1
+            GROUP BY t1.status, t1.order_id
+        )
+        SELECT
+            order_details_0.status AS status,
+            order_details_0.order_id AS order_id,
+            SUM(SUM(order_details_0.line_total_sum_e1f61696))
+                OVER (PARTITION BY order_details_0.status) AS status_line_total
+        FROM order_details_0
+        GROUP BY order_details_0.status, order_details_0.order_id
+        """,
+    )
 
 
 @pytest.mark.asyncio
@@ -507,12 +557,46 @@ async def test_ratio_broadcasts_both_metrics_fixed_to_the_same_grain(
     )
     assert response.status_code == 200, response.json()
     sql = response.json()["sql"]
-
-    assert sql.count("PARTITION BY order_details_0.status") == 2, sql
-    for parent in parents:
-        alias = parent.rsplit(".", 1)[-1]
-        windowed = next(line for line in sql.splitlines() if f"AS {alias}" in line)
-        assert "PARTITION BY order_details_0.status" in windowed
+    assert_sql_equal(
+        sql,
+        """
+        WITH v3_order_details AS (
+            SELECT
+                o.order_id,
+                o.status,
+                oi.quantity * oi.unit_price AS line_total
+            FROM default.v3.orders o
+            JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+        ),
+        order_details_0 AS (
+            SELECT
+                t1.status,
+                t1.order_id,
+                SUM(t1.line_total) AS line_total_sum_e1f61696
+            FROM v3_order_details t1
+            GROUP BY t1.status, t1.order_id
+        ),
+        base_metrics AS (
+            SELECT
+                order_details_0.status AS status,
+                order_details_0.order_id AS order_id,
+                SUM(SUM(order_details_0.line_total_sum_e1f61696))
+                    OVER (PARTITION BY order_details_0.status)
+                    AS fixed_status_denominator,
+                SUM(SUM(order_details_0.line_total_sum_e1f61696))
+                    OVER (PARTITION BY order_details_0.status)
+                    AS fixed_status_numerator
+            FROM order_details_0
+            GROUP BY order_details_0.status, order_details_0.order_id
+        )
+        SELECT
+            base_metrics.status AS status,
+            base_metrics.order_id AS order_id,
+            base_metrics.fixed_status_numerator
+                / base_metrics.fixed_status_denominator AS fixed_status_ratio
+        FROM base_metrics
+        """,
+    )
 
 
 @pytest.mark.asyncio
@@ -545,8 +629,93 @@ async def test_partitioned_grain_allowed_beside_a_window_metric(client_with_buil
     )
     assert response.status_code == 200, response.json()
     sql = response.json()["sql"]
-    assert "PARTITION BY order_details_0.category" in sql
-    assert "LEFT OUTER JOIN order_details_week" in sql
+    assert_sql_equal(
+        sql,
+        """
+        WITH v3_date AS (
+            SELECT date_id, week
+            FROM default.v3.dates
+        ),
+        v3_order_details AS (
+            SELECT
+                o.order_date,
+                oi.product_id,
+                oi.quantity * oi.unit_price AS line_total
+            FROM default.v3.orders o
+            JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+        ),
+        v3_product AS (
+            SELECT product_id, category
+            FROM default.v3.products
+        ),
+        order_details_0 AS (
+            SELECT
+                t2.category,
+                COALESCE(t1.order_date, t3.date_id) AS date_id_order,
+                t3.week,
+                SUM(t1.line_total) AS line_total_sum_e1f61696
+            FROM v3_order_details t1
+            LEFT OUTER JOIN v3_product t2 ON t1.product_id = t2.product_id
+            LEFT OUTER JOIN v3_date t3 ON t1.order_date = t3.date_id
+            GROUP BY
+                t2.category,
+                COALESCE(t1.order_date, t3.date_id),
+                t3.week
+        ),
+        base_metrics AS (
+            SELECT
+                order_details_0.category AS category,
+                order_details_0.date_id_order AS date_id_order,
+                order_details_0.week AS week,
+                SUM(SUM(order_details_0.line_total_sum_e1f61696))
+                    OVER (PARTITION BY order_details_0.category)
+                    AS grain_beside_window,
+                SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+            FROM order_details_0
+            GROUP BY
+                order_details_0.category,
+                order_details_0.date_id_order,
+                order_details_0.week
+        ),
+        order_details_week_agg AS (
+            SELECT
+                order_details_0.category AS category,
+                order_details_0.week AS week,
+                SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.category, order_details_0.week
+        ),
+        order_details_week AS (
+            SELECT
+                order_details_week_agg.category AS category,
+                order_details_week_agg.week AS week,
+                (
+                    order_details_week_agg.total_revenue
+                    - LAG(order_details_week_agg.total_revenue, 1) OVER (
+                        PARTITION BY order_details_week_agg.category
+                        ORDER BY order_details_week_agg.week
+                    )
+                ) / NULLIF(
+                    LAG(order_details_week_agg.total_revenue, 1) OVER (
+                        PARTITION BY order_details_week_agg.category
+                        ORDER BY order_details_week_agg.week
+                    ),
+                    0
+                ) * 100 AS wow_revenue_change
+            FROM order_details_week_agg
+        )
+        SELECT
+            base_metrics.category AS category,
+            base_metrics.date_id_order AS date_id_order,
+            base_metrics.week AS week,
+            base_metrics.grain_beside_window AS grain_beside_window,
+            order_details_week.wow_revenue_change AS wow_revenue_change
+        FROM base_metrics
+        LEFT OUTER JOIN order_details_week
+            ON base_metrics.category = order_details_week.category
+            AND base_metrics.week = order_details_week.week
+        """,
+    )
 
 
 @pytest.mark.asyncio
@@ -622,8 +791,33 @@ async def test_broadcast_replaces_the_merge_inside_the_combiner(
     sql = response.json()["sql"]
     # ROUND wraps the broadcast window, not the other way around: rounding
     # before totalling would return a different number.
-    assert "ROUND(SUM(SUM(" in sql.replace(" ", "")
-    assert "SUM(ROUND(" not in sql.replace(" ", "")
+    assert_sql_equal(
+        sql,
+        """
+        WITH v3_order_details AS (
+            SELECT
+                o.order_id,
+                oi.quantity * oi.unit_price AS line_total
+            FROM default.v3.orders o
+            JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+        ),
+        order_details_0 AS (
+            SELECT
+                t1.order_id,
+                SUM(t1.line_total) AS line_total_sum_e1f61696
+            FROM v3_order_details t1
+            GROUP BY t1.order_id
+        )
+        SELECT
+            order_details_0.order_id AS order_id,
+            ROUND(
+                SUM(SUM(order_details_0.line_total_sum_e1f61696)) OVER (),
+                2
+            ) AS rounded_total_global
+        FROM order_details_0
+        GROUP BY order_details_0.order_id
+        """,
+    )
 
 
 class TestFixedGrainGuards:
@@ -827,9 +1021,23 @@ async def test_cube_serves_a_fixed_grain_metric_with_its_broadcast(
     assert response.status_code == 200, response.json()
     sql = response.json()["sql"]
     # Served straight from the cube's own columns -- no fact-table CTEs.
-    assert "FROM cube_with_fixed_grain" in sql
-    assert "FROM v3_order_details" not in sql
-    assert "SUM(SUM(cube_with_fixed_grain_0.line_total_sum_e1f61696)) OVER ()" in sql
+    assert_sql_equal(
+        sql,
+        """
+        WITH cube_with_fixed_grain_0 AS (
+            SELECT
+                category,
+                line_total_sum_e1f61696
+            FROM cube_with_fixed_grain
+        )
+        SELECT
+            cube_with_fixed_grain_0.category AS category,
+            SUM(SUM(cube_with_fixed_grain_0.line_total_sum_e1f61696)) OVER ()
+                AS cube_skip_global
+        FROM cube_with_fixed_grain_0
+        GROUP BY cube_with_fixed_grain_0.category
+        """,
+    )
 
 
 @pytest.mark.asyncio
@@ -1159,8 +1367,41 @@ async def test_window_beside_a_broadcast_divisor_is_allowed(client_with_build_v3
     assert response.status_code == 200, response.json()
     sql = response.json()["sql"]
     # The frame is over the ordinary metric; the broadcast is a plain divisor.
-    assert "ROWS BETWEEN 6 PRECEDING AND CURRENT ROW" in sql
-    assert "/ base_metrics.beside_global" in sql
+    assert_sql_equal(
+        sql,
+        """
+        WITH v3_order_details AS (
+            SELECT
+                o.order_date,
+                oi.quantity * oi.unit_price AS line_total
+            FROM default.v3.orders o
+            JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+        ),
+        order_details_0 AS (
+            SELECT
+                t1.order_date AS date_id_order,
+                SUM(t1.line_total) AS line_total_sum_e1f61696
+            FROM v3_order_details t1
+            GROUP BY t1.order_date
+        ),
+        base_metrics AS (
+            SELECT
+                order_details_0.date_id_order AS date_id_order,
+                SUM(SUM(order_details_0.line_total_sum_e1f61696)) OVER ()
+                    AS beside_global,
+                SUM(order_details_0.line_total_sum_e1f61696) AS total_revenue
+            FROM order_details_0
+            GROUP BY order_details_0.date_id_order
+        )
+        SELECT
+            base_metrics.date_id_order AS date_id_order,
+            SUM(base_metrics.total_revenue) OVER (
+                ORDER BY base_metrics.date_id_order
+                ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
+            ) / base_metrics.beside_global AS trailing_share
+        FROM base_metrics
+        """,
+    )
 
 
 @pytest.mark.asyncio

--- a/datajunction-server/tests/construction/build_v3/fixed_grain_test.py
+++ b/datajunction-server/tests/construction/build_v3/fixed_grain_test.py
@@ -80,16 +80,17 @@ async def test_fixed_grain_round_trips_through_the_api(client_with_build_v3):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("grain", "expected"),
+    ("suffix", "grain", "expected"),
     [
-        (["v3.product.no_such_column"], 422),
-        (["v3.product.category"], 201),
-        ([], 201),
+        ("unresolvable", ["v3.product.no_such_column"], 422),
+        ("resolvable", ["v3.product.category"], 201),
+        ("global", [], 201),
     ],
     ids=["unresolvable", "resolvable", "global-resolves-nothing"],
 )
 async def test_grain_dimensions_are_validated_at_write_time(
     client_with_build_v3,
+    suffix,
     grain,
     expected,
 ):
@@ -102,7 +103,7 @@ async def test_grain_dimensions_are_validated_at_write_time(
     response = await client_with_build_v3.post(
         "/nodes/metric/",
         json={
-            "name": f"v3.write_validated_{abs(hash(str(grain))) % 10000}",
+            "name": f"v3.write_validated_{suffix}",
             "description": "grain validated at write time",
             "query": "SELECT SUM(line_total) FROM v3.order_details",
             "fixed_grain": grain,
@@ -111,7 +112,70 @@ async def test_grain_dimensions_are_validated_at_write_time(
     )
     assert response.status_code == expected, response.json()
     if expected == 422:
-        assert "declares a fixed grain referencing columns" in str(response.json())
+        assert "declares a fixed grain referencing dimension columns" in str(
+            response.json(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_fixed_grain_shape_is_validated_at_write_time(client_with_build_v3):
+    """A non-mergeable aggregate with a fixed_grain is rejected on create.
+
+    Previously this only failed once queried (`GET /sql/metrics/v3/`); the
+    metric would sit `valid` in the meantime with a declaration it could
+    never honor.
+    """
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.distinct_orders_with_grain",
+            "description": "Non-mergeable aggregate with a fixed grain",
+            "query": "SELECT COUNT(DISTINCT order_id) FROM v3.order_details",
+            "fixed_grain": [],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 422, response.json()
+    assert "Unsupported fixed_grain metric shape" in str(response.json())
+
+
+@pytest.mark.asyncio
+async def test_fixed_grain_shape_validate_endpoint_reports_it_too(
+    client_with_build_v3,
+    session,
+):
+    """`POST /nodes/{name}/validate/` also runs the shape check.
+
+    Exercises `validate_node_data_v2`'s branch directly, the same way
+    `test_validate_endpoint_reports_an_unresolvable_grain` does for the
+    dimension check.
+    """
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.grain_shape_goes_bad",
+            "description": "Starts valid, mutated to a bad shape",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": [],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    node = await Node.get_by_name(session, "v3.grain_shape_goes_bad")
+    node.current.query = "SELECT COUNT(DISTINCT order_id) FROM v3.order_details"
+    await session.commit()
+
+    response = await client_with_build_v3.post(
+        "/nodes/v3.grain_shape_goes_bad/validate/",
+    )
+    assert response.status_code == 200, response.json()
+    body = response.json()
+    assert body["status"] == "invalid", body
+    assert any(
+        "Unsupported fixed_grain metric shape" in error["message"]
+        for error in body["errors"]
+    ), body["errors"]
 
 
 @pytest.mark.asyncio
@@ -149,7 +213,7 @@ async def test_validate_endpoint_reports_an_unresolvable_grain(
     body = response.json()
     assert body["status"] == "invalid", body
     assert any(
-        "declares a fixed grain referencing columns" in error["message"]
+        "declares a fixed grain referencing dimension columns" in error["message"]
         for error in body["errors"]
     ), body["errors"]
 
@@ -273,7 +337,8 @@ async def test_global_grain_broadcasts_as_an_unpartitioned_window(
     )
     assert response.status_code == 200, response.json()
     sql = response.json()["sql"]
-    assert "OVER ()" in sql, sql
+    assert "SUM(SUM(order_details_0.line_total_sum_e1f61696)) OVER ()" in sql
+    assert "AS total_line_total_bcast" in sql
 
 
 @pytest.mark.asyncio
@@ -305,7 +370,8 @@ async def test_partitioned_grain_broadcasts_within_the_partition(
     )
     assert response.status_code == 200, response.json()
     sql = response.json()["sql"]
-    assert "PARTITION BY" in sql, sql
+    assert "PARTITION BY order_details_0.status" in sql
+    assert "AS status_line_total" in sql
 
 
 @pytest.mark.asyncio
@@ -422,31 +488,27 @@ async def test_partitioned_grain_allowed_beside_a_window_metric(client_with_buil
         },
     )
     assert response.status_code == 200, response.json()
-    assert "PARTITION BY order_details_0.category" in response.json()["sql"]
+    sql = response.json()["sql"]
+    assert "PARTITION BY order_details_0.category" in sql
+    assert "LEFT OUTER JOIN order_details_week" in sql
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "params",
     [
-        {"dimensions": ["v3.order_details.order_id"]},
-        {
-            "dimensions": ["v3.order_details.order_id"],
-            "filters": ["v3.product.category = 'Electronics'"],
-        },
+        {},
+        {"filters": ["v3.product.category = 'Electronics'"]},
     ],
-    ids=["not-mentioned", "mentioned-only-in-a-filter"],
+    ids=["not-mentioned", "even-pinned-by-an-equality-filter"],
 )
-async def test_grain_absent_from_the_query_is_carried_privately(
-    client_with_build_v3,
-    params,
-):
-    """A partition dimension the caller did not ask for is not in the result.
-
-    It is joined and grouped on so the window has a column to partition by, but
-    projected away — the same private-grain treatment a protected reaggregate
-    dimension gets. Mentioning it only in a filter is the same situation: the
-    filter excludes it from the output, not from the CTE.
+async def test_grain_absent_from_the_query_is_refused(client_with_build_v3, params):
+    """A fixed_grain metric can broadcast only when its grain is contained
+    in the query grain. If `category` is absent, the grains are
+    incompatible: producing one scalar per `order_id` would require widening
+    the output grain or applying a separate collapse operation. This
+    broadcast-only path does neither, even when a filter happens to pin the
+    dimension to one value.
     """
     response = await client_with_build_v3.post(
         "/nodes/metric/",
@@ -462,19 +524,14 @@ async def test_grain_absent_from_the_query_is_carried_privately(
 
     response = await client_with_build_v3.get(
         "/sql/metrics/v3/",
-        params={"metrics": ["v3.grain_needs_category"], **params},
+        params={
+            "metrics": ["v3.grain_needs_category"],
+            "dimensions": ["v3.order_details.order_id"],
+            **params,
+        },
     )
-    assert response.status_code == 200, response.json()
-    body = response.json()
-
-    # The result is exactly what was asked for — no extra column.
-    assert [col["name"] for col in body["columns"]] == [
-        "order_id",
-        "grain_needs_category",
-    ]
-    # And the partition resolved against a real CTE column, not a raw ref.
-    assert "PARTITION BY order_details_0.category" in body["sql"]
-    assert "PARTITION BY v3.product.category" not in body["sql"]
+    assert response.status_code == 422, response.json()
+    assert "not a requested output dimension" in response.json()["message"]
 
 
 @pytest.mark.asyncio
@@ -507,8 +564,10 @@ async def test_broadcast_replaces_the_merge_inside_the_combiner(
     )
     assert response.status_code == 200, response.json()
     sql = response.json()["sql"]
-    assert "ROUND(SUM(SUM(" in sql.replace(" ", ""), sql
-    assert "SUM(ROUND(" not in sql.replace(" ", ""), sql
+    # ROUND wraps the broadcast window, not the other way around: rounding
+    # before totalling would return a different number.
+    assert "ROUND(SUM(SUM(" in sql.replace(" ", "")
+    assert "SUM(ROUND(" not in sql.replace(" ", "")
 
 
 class TestFixedGrainGuards:
@@ -595,8 +654,11 @@ async def test_cube_missing_the_grain_dimension_is_not_used(
     """A cube that dropped the partition dimension cannot express the window.
 
     The broadcast partitions over the cube's own columns, so serving from a cube
-    without that column emits SQL naming a column the table does not have.
-    Skipped rather than refused: the fact table is a correct alternative.
+    without that column would emit SQL naming a column the table does not have.
+    Skipped rather than refused at the cube-matching step: the fact table is a
+    plausible alternative. The fact-table fallback then refuses on its own
+    terms, since `subcategory` isn't requested or filtered there either --
+    the same rule as an unpinned `v3.product.category` elsewhere in this file.
     """
     await _cube_over_a_grain(
         client_with_build_v3,
@@ -619,8 +681,8 @@ async def test_cube_missing_the_grain_dimension_is_not_used(
             "dimensions": ["v3.product.category"],
         },
     )
-    assert response.status_code == 200, response.json()
-    assert "cov_cube_missing" not in response.json()["sql"]
+    assert response.status_code == 422, response.json()
+    assert "not a requested output dimension" in response.json()["message"]
 
 
 @pytest.mark.asyncio
@@ -708,8 +770,10 @@ async def test_cube_serves_a_fixed_grain_metric_with_its_broadcast(
     )
     assert response.status_code == 200, response.json()
     sql = response.json()["sql"]
-    assert "OVER (" in sql, sql
-    assert "cube_with_fixed_grain" in sql, sql
+    # Served straight from the cube's own columns -- no fact-table CTEs.
+    assert "FROM cube_with_fixed_grain" in sql
+    assert "FROM v3_order_details" not in sql
+    assert "SUM(SUM(cube_with_fixed_grain_0.line_total_sum_e1f61696)) OVER ()" in sql
 
 
 @pytest.mark.asyncio
@@ -814,6 +878,186 @@ async def test_only_accumulating_frames_over_a_broadcast_are_refused(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("window_fn", "partition_col", "expected"),
+    [
+        ("AVG", "v3.product.category", 200),
+        ("AVG", "v3.customer.name", 422),
+        ("MAX", "v3.customer.name", 200),
+        ("FIRST_VALUE", "v3.customer.name", 200),
+    ],
+    ids=[
+        "avg-matching-partition-allowed",
+        "avg-mismatched-partition-refused",
+        "max-mismatched-partition-allowed",
+        "first-value-mismatched-partition-allowed",
+    ],
+)
+async def test_avg_over_a_partitioned_grain_requires_a_matching_window(
+    client_with_build_v3,
+    window_fn,
+    partition_col,
+    expected,
+):
+    """AVG must preserve the declared grain; invariant windows need not.
+
+    Every request includes `category`, so a mismatch reaches the window
+    guard rather than failing the output-grain check first.
+    """
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.category_line_total",
+            "description": "Total within category",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": ["v3.product.category"],
+            "mode": "published",
+        },
+    )
+    assert response.status_code in (201, 409), response.json()
+
+    name = f"v3.grain_partition_{window_fn.lower()}_{partition_col.split('.')[-1]}"
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": name,
+            "description": name,
+            "query": (
+                f"SELECT {window_fn}(v3.category_line_total) OVER "
+                f"(PARTITION BY {partition_col})"
+            ),
+            "required_dimensions": [partition_col],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    dimensions = list(dict.fromkeys(["v3.product.category", partition_col]))
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={"metrics": [name], "dimensions": dimensions},
+    )
+    assert response.status_code == expected, response.json()
+
+
+@pytest.mark.asyncio
+async def test_avg_over_a_transformed_partition_column_is_refused(
+    client_with_build_v3,
+):
+    """A transformation on the partition column doesn't count as covering it.
+
+    `PARTITION BY UPPER(category)` groups differently than `PARTITION BY
+    category` -- rows for `Books` and `BOOKS` would share a frame even
+    though they're different categories at the declared grain. Naming the
+    column somewhere inside the expression isn't the same as naming it as
+    the partition itself.
+    """
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.category_line_total_2",
+            "description": "Total within category",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": ["v3.product.category"],
+            "mode": "published",
+        },
+    )
+    assert response.status_code in (201, 409), response.json()
+
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.grain_partition_transformed",
+            "description": "AVG over an uppercased category",
+            "query": (
+                "SELECT AVG(v3.category_line_total_2) OVER "
+                "(PARTITION BY UPPER(v3.product.category))"
+            ),
+            "required_dimensions": ["v3.product.category"],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={
+            "metrics": ["v3.grain_partition_transformed"],
+            "dimensions": ["v3.product.category"],
+        },
+    )
+    assert response.status_code == 422, response.json()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("partition_col", "expected"),
+    [
+        ("v3.product.category", 200),
+        ("v3.customer.name", 422),
+    ],
+    ids=["matching-partition-allowed", "mismatched-partition-refused"],
+)
+async def test_avg_over_an_inherited_grain_checks_the_real_grain(
+    client_with_build_v3,
+    partition_col,
+    expected,
+):
+    """A metric with no `fixed_grain` of its own can still inherit one.
+
+    `v3.scaled_category_total` declares no grain -- it just multiplies
+    `v3.category_line_total_4`, which is fixed at `category`. An `AVG` over
+    it must still be checked against `category`, not treated as safe just
+    because `v3.scaled_category_total` itself has nothing declared.
+    """
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.category_line_total_4",
+            "description": "Total within category",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": ["v3.product.category"],
+            "mode": "published",
+        },
+    )
+    assert response.status_code in (201, 409), response.json()
+
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.scaled_category_total",
+            "description": "Category total, scaled",
+            "query": "SELECT v3.category_line_total_4 * 1.1",
+            "mode": "published",
+        },
+    )
+    assert response.status_code in (201, 409), response.json()
+
+    name = f"v3.grain_inherited_{partition_col.split('.')[-1]}"
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": name,
+            "description": name,
+            "query": (
+                "SELECT AVG(v3.scaled_category_total) OVER "
+                f"(PARTITION BY {partition_col})"
+            ),
+            "required_dimensions": [partition_col],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    dimensions = list(dict.fromkeys(["v3.product.category", partition_col]))
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={"metrics": [name], "dimensions": dimensions},
+    )
+    assert response.status_code == expected, response.json()
+
+
+@pytest.mark.asyncio
 async def test_window_beside_a_broadcast_divisor_is_allowed(client_with_build_v3):
     """A trailing window expressed as a share of a global total.
 
@@ -859,8 +1103,8 @@ async def test_window_beside_a_broadcast_divisor_is_allowed(client_with_build_v3
     assert response.status_code == 200, response.json()
     sql = response.json()["sql"]
     # The frame is over the ordinary metric; the broadcast is a plain divisor.
-    assert "ROWS BETWEEN 6 PRECEDING AND CURRENT ROW" in sql, sql
-    assert "beside_global" in sql, sql
+    assert "ROWS BETWEEN 6 PRECEDING AND CURRENT ROW" in sql
+    assert "/ base_metrics.beside_global" in sql
 
 
 @pytest.mark.asyncio
@@ -904,7 +1148,10 @@ async def test_role_qualified_grain_dimension(client_with_build_v3):
 
     Interpolating it into a `SELECT` to parse it raises, because the role
     brackets are not valid SQL — so the partition column is built directly
-    from the reference instead.
+    from the reference instead. Queried without requesting or filtering it,
+    it's refused for the same reason as an unpinned `v3.product.category`:
+    an order's own date isn't guaranteed unique per whatever grain the query
+    actually asks for.
     """
     response = await client_with_build_v3.post(
         "/nodes/metric/",
@@ -925,8 +1172,8 @@ async def test_role_qualified_grain_dimension(client_with_build_v3):
             "dimensions": ["v3.order_details.order_id"],
         },
     )
-    assert response.status_code == 200, response.json()
-    assert "PARTITION BY order_details_0.date_id_order" in response.json()["sql"]
+    assert response.status_code == 422, response.json()
+    assert "not a requested output dimension" in response.json()["message"]
 
 
 def test_broadcast_skips_a_merge_call_for_another_component():
@@ -969,8 +1216,8 @@ async def test_derived_metric_cannot_declare_a_grain(client_with_build_v3):
             "mode": "published",
         },
     )
-    # Creation succeeds because nothing decomposes the metric yet; the write
-    # boundary does not resolve the declaration (see "Finding I" in the PR body).
+    # Creation succeeds because the write path cannot classify this as derived
+    # without loading and traversing its metric parents.
     assert response.status_code == 201, response.json()
 
     response = await client_with_build_v3.get(

--- a/datajunction-server/tests/construction/build_v3/fixed_grain_test.py
+++ b/datajunction-server/tests/construction/build_v3/fixed_grain_test.py
@@ -1,0 +1,1070 @@
+"""Tests for the `fixed_grain` metric declaration."""
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from datajunction_server.construction.build_v3.cube_matcher import (
+    find_matching_cube,
+)
+from datajunction_server.construction.build_v3.metrics import (
+    validate_fixed_grain_query_shape,
+)
+from datajunction_server.database.node import Node
+from datajunction_server.errors import DJInvalidInputException
+from datajunction_server.models.decompose import Aggregability
+from datajunction_server.models.deployment import ChangeTier, MetricSpec
+from datajunction_server.sql.decompose import MetricComponentExtractor
+from datajunction_server.sql.parsing.backends.antlr4 import parse
+
+
+def test_fixed_grain_change_tier_is_major():
+    """Where an aggregate is computed changes the number it returns."""
+    assert MetricSpec.field_change_tier("fixed_grain") == ChangeTier.MAJOR
+
+
+def test_global_grain_is_not_the_same_declaration_as_query_grain():
+    """`[]` (global grain) and an absent `fixed_grain` (query grain) differ."""
+    query = "SELECT SUM(line_total) FROM v3.order_details"
+    global_grain = MetricSpec(name="m", namespace="v3", query=query, fixed_grain=[])
+    query_grain = MetricSpec(name="m", namespace="v3", query=query)
+
+    assert global_grain.fixed_grain == []
+    assert query_grain.fixed_grain is None
+    assert global_grain != query_grain
+    assert "fixed_grain" in query_grain.diff(global_grain)
+
+
+def test_rendered_fixed_grain_resolves_prefixes():
+    """A parameterized dimension path resolves against the spec's namespace."""
+    spec = MetricSpec(
+        name="m",
+        namespace="v3",
+        query="SELECT SUM(line_total) FROM v3.order_details",
+        fixed_grain=["${prefix}genre_dim.genre", "country"],
+    )
+    assert spec.rendered_fixed_grain == ["v3.genre_dim.genre", "country"]
+
+
+def test_rendered_fixed_grain_preserves_the_empty_list():
+    """`[]` must not collapse to `None` -- they are different declarations."""
+    spec = MetricSpec(
+        name="m",
+        namespace="v3",
+        query="SELECT SUM(line_total) FROM v3.order_details",
+        fixed_grain=[],
+    )
+    assert spec.rendered_fixed_grain == []
+
+
+@pytest.mark.asyncio
+async def test_fixed_grain_round_trips_through_the_api(client_with_build_v3):
+    """Declared on create, stored, and read back."""
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.total_line_total_global",
+            "description": "Total price at the global grain",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": [],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.get("/nodes/v3.total_line_total_global/")
+    assert response.status_code == 200, response.json()
+    assert response.json()["fixed_grain"] == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("grain", "expected"),
+    [
+        (["v3.product.no_such_column"], 422),
+        (["v3.product.category"], 201),
+        ([], 201),
+    ],
+    ids=["unresolvable", "resolvable", "global-resolves-nothing"],
+)
+async def test_grain_dimensions_are_validated_at_write_time(
+    client_with_build_v3,
+    grain,
+    expected,
+):
+    """A grain naming a column that does not exist is rejected on create.
+
+    `reaggregate` is checked on this path too. Without it the node is stored
+    `valid`, `POST /nodes/{name}/validate/` also reports it clean, and the
+    first sign of trouble is a permanent failure at query time.
+    """
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": f"v3.write_validated_{abs(hash(str(grain))) % 10000}",
+            "description": "grain validated at write time",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": grain,
+            "mode": "published",
+        },
+    )
+    assert response.status_code == expected, response.json()
+    if expected == 422:
+        assert "declares a fixed grain referencing columns" in str(response.json())
+
+
+@pytest.mark.asyncio
+async def test_validate_endpoint_reports_an_unresolvable_grain(
+    client_with_build_v3,
+    session,
+):
+    """`POST /nodes/{name}/validate/` must not call a broken node clean.
+
+    Creation now rejects an unresolvable grain, so the way to reach this state
+    is a dimension that disappeared after the fact — which is the situation the
+    endpoint exists to surface.
+    """
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.grain_goes_stale",
+            "description": "Total within category",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": ["v3.product.category"],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    # The grain's dimension stops resolving.
+    node = await Node.get_by_name(session, "v3.grain_goes_stale")
+    node.current.fixed_grain = ["v3.product.no_longer_here"]
+    await session.commit()
+
+    response = await client_with_build_v3.post(
+        "/nodes/v3.grain_goes_stale/validate/",
+    )
+    assert response.status_code == 200, response.json()
+    body = response.json()
+    assert body["status"] == "invalid", body
+    assert any(
+        "declares a fixed grain referencing columns" in error["message"]
+        for error in body["errors"]
+    ), body["errors"]
+
+
+@pytest.mark.asyncio
+async def test_fixed_grain_rejected_on_non_metric_nodes(client_with_build_v3):
+    """A non-metric node declaring `fixed_grain` is rejected at write time."""
+    response = await client_with_build_v3.post(
+        "/nodes/transform/",
+        json={
+            "name": "v3.transform_grain",
+            "description": "Not a metric",
+            "query": "SELECT order_id FROM v3.order_details",
+            "fixed_grain": [],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 422, response.json()
+    assert "only for metrics" in str(response.json())
+
+
+@pytest.mark.asyncio
+async def test_fixed_grain_survives_an_unrelated_patch(client_with_build_v3):
+    """A PATCH that never mentions the grain carries it forward."""
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.total_line_total_kept",
+            "description": "Before",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": [],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.patch(
+        "/nodes/v3.total_line_total_kept/",
+        json={"description": "After"},
+    )
+    assert response.status_code == 200, response.json()
+    assert response.json()["fixed_grain"] == []
+
+
+@pytest.mark.asyncio
+async def test_fixed_grain_cleared_by_explicit_null(client_with_build_v3):
+    """An explicit null returns the metric to the query grain."""
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.total_line_total_cleared",
+            "description": "Global",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": [],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.patch(
+        "/nodes/v3.total_line_total_cleared/",
+        json={"fixed_grain": None},
+    )
+    assert response.status_code == 200, response.json()
+    assert response.json()["fixed_grain"] is None
+
+
+@pytest.mark.asyncio
+async def test_fixed_grain_exposed_in_graphql(client_with_build_v3):
+    """Clients can read the grain, so a BI tool can explain the number."""
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.total_line_total_gql",
+            "description": "Global",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": [],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.post(
+        "/graphql",
+        json={
+            "query": """
+                { findNodes(names: ["v3.total_line_total_gql"]) {
+                    current { fixedGrain }
+                } }
+            """,
+        },
+    )
+    assert response.status_code == 200, response.json()
+    data = response.json()["data"]["findNodes"]
+    assert data[0]["current"]["fixedGrain"] == []
+
+
+@pytest.mark.asyncio
+async def test_global_grain_broadcasts_as_an_unpartitioned_window(
+    client_with_build_v3,
+):
+    """A metric fixed at the global grain is fanned out with `OVER ()`."""
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.total_line_total_bcast",
+            "description": "Total at the global grain",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": [],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={
+            "metrics": ["v3.total_line_total_bcast"],
+            "dimensions": ["v3.order_details.order_id"],
+        },
+    )
+    assert response.status_code == 200, response.json()
+    sql = response.json()["sql"]
+    assert "OVER ()" in sql, sql
+
+
+@pytest.mark.asyncio
+async def test_partitioned_grain_broadcasts_within_the_partition(
+    client_with_build_v3,
+):
+    """A grain of `[status]` totals within status, repeated across finer rows."""
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.status_line_total",
+            "description": "Total within status",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": ["v3.order_details.status"],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={
+            "metrics": ["v3.status_line_total"],
+            "dimensions": [
+                "v3.order_details.status",
+                "v3.order_details.order_id",
+            ],
+        },
+    )
+    assert response.status_code == 200, response.json()
+    sql = response.json()["sql"]
+    assert "PARTITION BY" in sql, sql
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("expression", "broadcast_is_numerator"),
+    [
+        ("v3.ratio_revenue / v3.ratio_total", False),
+        ("v3.ratio_total / v3.ratio_revenue", True),
+    ],
+    ids=["share-of-total", "index-against-total"],
+)
+async def test_ratio_broadcasts_only_the_fixed_grain_operand(
+    client_with_build_v3,
+    expression,
+    broadcast_is_numerator,
+):
+    """The canonical shape from issue #2245: a ratio against a global total.
+
+    Both operands decompose to the *same* measure, so this pins down that the
+    window lands on the fixed-grain side specifically rather than on whichever
+    merge call the combiner happens to reach first.
+    """
+    for name, extra in (
+        ("v3.ratio_revenue", {}),
+        ("v3.ratio_total", {"fixed_grain": []}),
+    ):
+        response = await client_with_build_v3.post(
+            "/nodes/metric/",
+            json={
+                "name": name,
+                "description": name,
+                "query": "SELECT SUM(line_total) FROM v3.order_details",
+                "mode": "published",
+                **extra,
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+    derived = (
+        f"v3.ratio_{'share' if expression.startswith('v3.ratio_revenue') else 'index'}"
+    )
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": derived,
+            "description": "ratio against the global total",
+            "query": f"SELECT {expression}",
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={
+            "metrics": [derived],
+            "dimensions": ["v3.order_details.order_id"],
+        },
+    )
+    assert response.status_code == 200, response.json()
+    sql = response.json()["sql"]
+
+    # Exactly one window in the whole query: both operands decompose to the same
+    # measure, so a second `OVER` would mean the plain one was broadcast too.
+    assert sql.count("OVER (") == 1, sql
+
+    # The window sits on the fixed-grain parent, computed once in the CTE and
+    # referenced by name — not inlined into the ratio.
+    windowed = next(line for line in sql.splitlines() if "OVER (" in line)
+    assert "AS ratio_total" in windowed, windowed
+    plain = next(line for line in sql.splitlines() if "AS ratio_revenue" in line)
+    assert "OVER" not in plain, plain
+
+    # The ratio divides the two parent columns in the declared order.
+    projection = next(
+        line
+        for line in sql.splitlines()
+        if line.strip().endswith(derived.split(".")[1])
+    )
+    numerator, denominator = (
+        ("ratio_total", "ratio_revenue")
+        if broadcast_is_numerator
+        else ("ratio_revenue", "ratio_total")
+    )
+    assert projection.index(numerator) < projection.index(denominator), projection
+
+
+@pytest.mark.asyncio
+async def test_partitioned_grain_allowed_beside_a_window_metric(client_with_build_v3):
+    """A window metric adds a grain group for the SAME fact table.
+
+    The cross-fact refusal must count base grain groups only, or a period-over-
+    period metric alongside a partitioned grain is refused for being on another
+    fact table when it is not.
+    """
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.grain_beside_window",
+            "description": "Total within category",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": ["v3.product.category"],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={
+            # wow_revenue_change is a window metric on the same fact table.
+            "metrics": ["v3.grain_beside_window", "v3.wow_revenue_change"],
+            "dimensions": ["v3.product.category", "v3.date.date_id[order]"],
+        },
+    )
+    assert response.status_code == 200, response.json()
+    assert "PARTITION BY order_details_0.category" in response.json()["sql"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"dimensions": ["v3.order_details.order_id"]},
+        {
+            "dimensions": ["v3.order_details.order_id"],
+            "filters": ["v3.product.category = 'Electronics'"],
+        },
+    ],
+    ids=["not-mentioned", "mentioned-only-in-a-filter"],
+)
+async def test_grain_absent_from_the_query_is_carried_privately(
+    client_with_build_v3,
+    params,
+):
+    """A partition dimension the caller did not ask for is not in the result.
+
+    It is joined and grouped on so the window has a column to partition by, but
+    projected away — the same private-grain treatment a protected reaggregate
+    dimension gets. Mentioning it only in a filter is the same situation: the
+    filter excludes it from the output, not from the CTE.
+    """
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.grain_needs_category",
+            "description": "Total within category",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": ["v3.product.category"],
+            "mode": "published",
+        },
+    )
+    assert response.status_code in (201, 409), response.json()
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={"metrics": ["v3.grain_needs_category"], **params},
+    )
+    assert response.status_code == 200, response.json()
+    body = response.json()
+
+    # The result is exactly what was asked for — no extra column.
+    assert [col["name"] for col in body["columns"]] == [
+        "order_id",
+        "grain_needs_category",
+    ]
+    # And the partition resolved against a real CTE column, not a raw ref.
+    assert "PARTITION BY order_details_0.category" in body["sql"]
+    assert "PARTITION BY v3.product.category" not in body["sql"]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_replaces_the_merge_inside_the_combiner(
+    client_with_build_v3,
+):
+    """The window goes around the aggregate, not around the whole combiner.
+
+    `ROUND(SUM(x), 2)` must broadcast to `ROUND(SUM(SUM(x)) OVER (), 2)`; wrapping
+    the combiner instead rounds before totalling and returns a different number.
+    """
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.rounded_total_global",
+            "description": "Rounded total at the global grain",
+            "query": "SELECT ROUND(SUM(line_total), 2) FROM v3.order_details",
+            "fixed_grain": [],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={
+            "metrics": ["v3.rounded_total_global"],
+            "dimensions": ["v3.order_details.order_id"],
+        },
+    )
+    assert response.status_code == 200, response.json()
+    sql = response.json()["sql"]
+    assert "ROUND(SUM(SUM(" in sql.replace(" ", ""), sql
+    assert "SUM(ROUND(" not in sql.replace(" ", ""), sql
+
+
+class TestFixedGrainGuards:
+    """The seams where a broadcast cannot be expressed, and so must refuse."""
+
+    @staticmethod
+    def _decomposed(fixed_grain, aggregability="full", merge="SUM", ncomp=1):
+        """A minimal stand-in for DecomposedMetricInfo."""
+        rule = SimpleNamespace(fixed_grain=fixed_grain)
+        comps = [
+            SimpleNamespace(name=f"c{i}", merge=merge, rule=rule) for i in range(ncomp)
+        ]
+        return SimpleNamespace(
+            metric_node=SimpleNamespace(name="v3.m"),
+            components=comps,
+            aggregability=Aggregability(aggregability),
+        )
+
+    def test_absent_grain_is_left_alone(self):
+        """No declaration, nothing to validate."""
+        assert validate_fixed_grain_query_shape(self._decomposed(None)) is None
+
+    def test_partitioned_grain_refused_across_grain_groups(self):
+        """A partition naming one group's column is ungrouped in the joined SELECT."""
+        with pytest.raises(DJInvalidInputException) as exc:
+            validate_fixed_grain_query_shape(
+                self._decomposed(["v3.d.x"]),
+                grain_group_count=2,
+            )
+        assert "another fact table" in str(exc.value)
+
+    def test_global_grain_allowed_across_grain_groups(self):
+        """`OVER ()` names no column, so it survives the join unambiguously."""
+        assert (
+            validate_fixed_grain_query_shape(
+                self._decomposed([]),
+                grain_group_count=2,
+            )
+            is None
+        )
+
+
+async def _cube_over_a_grain(client, suffix, grain, cube_dimensions):
+    """A metric with `grain`, a cube with `cube_dimensions`, and availability."""
+    response = await client.post(
+        "/nodes/metric/",
+        json={
+            "name": f"v3.cov_metric_{suffix}",
+            "description": f"cov {suffix}",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": grain,
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+    response = await client.post(
+        "/nodes/cube/",
+        json={
+            "name": f"v3.cov_cube_{suffix}",
+            "metrics": [f"v3.cov_metric_{suffix}"],
+            "dimensions": cube_dimensions,
+            "mode": "published",
+            "description": f"cov cube {suffix}",
+        },
+    )
+    assert response.status_code == 201, response.json()
+    response = await client.post(
+        f"/data/v3.cov_cube_{suffix}/availability/",
+        json={
+            "catalog": "default",
+            "schema_": "analytics",
+            "table": f"cov_cube_{suffix}",
+            "valid_through_ts": int(time.time() * 1000),
+        },
+    )
+    assert response.status_code == 200, response.json()
+
+
+@pytest.mark.asyncio
+async def test_cube_missing_the_grain_dimension_is_not_used(
+    client_with_build_v3,
+    session,
+):
+    """A cube that dropped the partition dimension cannot express the window.
+
+    The broadcast partitions over the cube's own columns, so serving from a cube
+    without that column emits SQL naming a column the table does not have.
+    Skipped rather than refused: the fact table is a correct alternative.
+    """
+    await _cube_over_a_grain(
+        client_with_build_v3,
+        "missing",
+        ["v3.product.subcategory"],
+        ["v3.product.category"],
+    )
+
+    matched = await find_matching_cube(
+        session,
+        metrics=["v3.cov_metric_missing"],
+        dimensions=["v3.product.category"],
+    )
+    assert matched is None
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={
+            "metrics": ["v3.cov_metric_missing"],
+            "dimensions": ["v3.product.category"],
+        },
+    )
+    assert response.status_code == 200, response.json()
+    assert "cov_cube_missing" not in response.json()["sql"]
+
+
+@pytest.mark.asyncio
+async def test_cube_that_keeps_the_grain_dimension_is_still_used(
+    client_with_build_v3,
+    session,
+):
+    """Coverage, not avoidance: a cube carrying the partition is fine to use."""
+    await _cube_over_a_grain(
+        client_with_build_v3,
+        "kept",
+        ["v3.product.category"],
+        ["v3.product.category"],
+    )
+
+    matched = await find_matching_cube(
+        session,
+        metrics=["v3.cov_metric_kept"],
+        dimensions=["v3.product.category"],
+    )
+    assert matched is not None
+    assert matched.name == "v3.cov_cube_kept"
+
+
+@pytest.mark.asyncio
+async def test_cube_serves_a_fixed_grain_metric_with_its_broadcast(
+    client_with_build_v3,
+    session,
+):
+    """A matched cube keeps the broadcast, so it is used rather than skipped.
+
+    The window is applied by `generate_metrics_sql`, which the cube path also
+    goes through, so reading the measure from a cube changes nothing about it.
+    Druid computes the window itself (verified on v37), so the resulting query
+    is servable.
+    """
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.cube_skip_global",
+            "description": "Global total",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": [],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.post(
+        "/nodes/cube/",
+        json={
+            "name": "v3.cube_with_fixed_grain",
+            "metrics": ["v3.cube_skip_global"],
+            "dimensions": ["v3.product.category"],
+            "mode": "published",
+            "description": "Cube over a fixed-grain metric",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.post(
+        "/data/v3.cube_with_fixed_grain/availability/",
+        json={
+            "catalog": "default",
+            "schema_": "analytics",
+            "table": "cube_with_fixed_grain",
+            "valid_through_ts": int(time.time() * 1000),
+        },
+    )
+    assert response.status_code == 200, response.json()
+
+    matched = await find_matching_cube(
+        session,
+        metrics=["v3.cube_skip_global"],
+        dimensions=["v3.product.category"],
+    )
+    assert matched is not None
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={
+            "metrics": ["v3.cube_skip_global"],
+            "dimensions": ["v3.product.category"],
+        },
+    )
+    assert response.status_code == 200, response.json()
+    sql = response.json()["sql"]
+    assert "OVER (" in sql, sql
+    assert "cube_with_fixed_grain" in sql, sql
+
+
+@pytest.mark.asyncio
+async def test_window_metric_over_a_fixed_grain_parent_is_refused(
+    client_with_build_v3,
+):
+    """A broadcast value is repeated across rows, so a frame re-adds it N times."""
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.window_parent_global",
+            "description": "Global total",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": [],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.trailing_over_global",
+            "description": "Rolling sum of a broadcast value",
+            "query": """
+                SELECT
+                    SUM(v3.window_parent_global) OVER (
+                        ORDER BY v3.date.date_id[order]
+                        ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
+                    )
+            """,
+            "required_dimensions": ["v3.date.date_id[order]"],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={
+            "metrics": ["v3.trailing_over_global"],
+            "dimensions": ["v3.date.date_id[order]"],
+        },
+    )
+    assert response.status_code == 422, response.json()
+    message = response.json()["message"]
+    assert "a frame cannot accumulate it" in message
+    # The advice must not describe something the guard itself refuses.
+    assert "Referencing it beside a window is fine" in message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("window_fn", "expected"),
+    [("SUM", 422), ("MAX", 200), ("AVG", 200)],
+    ids=["accumulating-refused", "max-allowed", "avg-allowed"],
+)
+async def test_only_accumulating_frames_over_a_broadcast_are_refused(
+    client_with_build_v3,
+    window_fn,
+    expected,
+):
+    """`MAX`/`AVG` over a row-constant column return it unchanged.
+
+    Only a frame that sums or counts the broadcast re-adds it per row, so those
+    are the only ones worth refusing.
+    """
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.acc_global",
+            "description": "Global total",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": [],
+            "mode": "published",
+        },
+    )
+    assert response.status_code in (201, 409), response.json()
+
+    name = f"v3.acc_{window_fn.lower()}"
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": name,
+            "description": name,
+            "query": (
+                f"SELECT {window_fn}(v3.acc_global) OVER ("
+                "ORDER BY v3.date.date_id[order] "
+                "ROWS BETWEEN 6 PRECEDING AND CURRENT ROW)"
+            ),
+            "required_dimensions": ["v3.date.date_id[order]"],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={"metrics": [name], "dimensions": ["v3.date.date_id[order]"]},
+    )
+    assert response.status_code == expected, response.json()
+
+
+@pytest.mark.asyncio
+async def test_window_beside_a_broadcast_divisor_is_allowed(client_with_build_v3):
+    """A trailing window expressed as a share of a global total.
+
+    The frame is over an ordinary metric; the broadcast is only the divisor, so
+    nothing accumulates it. Refusing this was the original guard's headline
+    false positive — and its own message told the author to write exactly this.
+    """
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.beside_global",
+            "description": "Global total",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": [],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.trailing_share",
+            "description": "Trailing 7d revenue as a share of the global total",
+            "query": (
+                "SELECT SUM(v3.total_revenue) OVER ("
+                "ORDER BY v3.date.date_id[order] "
+                "ROWS BETWEEN 6 PRECEDING AND CURRENT ROW) / v3.beside_global"
+            ),
+            "required_dimensions": ["v3.date.date_id[order]"],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={
+            "metrics": ["v3.trailing_share"],
+            "dimensions": ["v3.date.date_id[order]"],
+        },
+    )
+    assert response.status_code == 200, response.json()
+    sql = response.json()["sql"]
+    # The frame is over the ordinary metric; the broadcast is a plain divisor.
+    assert "ROWS BETWEEN 6 PRECEDING AND CURRENT ROW" in sql, sql
+    assert "beside_global" in sql, sql
+
+
+@pytest.mark.asyncio
+async def test_base_metric_may_window_inside_its_own_aggregate(
+    client_with_build_v3,
+):
+    """A window in the argument is not the metric's aggregate being windowed.
+
+    `SUM(x - LAG(x) OVER (...))` decomposes with the window preserved inside the
+    component; the broadcast then applies on top. Refusing it confuses "has a
+    window somewhere" with "its own aggregate is already windowed".
+    """
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.lag_inside_global",
+            "description": "Global total of a period delta",
+            "query": (
+                "SELECT SUM(line_total - LAG(line_total, 1) OVER "
+                "(ORDER BY order_id)) FROM v3.order_details"
+            ),
+            "fixed_grain": [],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={
+            "metrics": ["v3.lag_inside_global"],
+            "dimensions": ["v3.order_details.order_id"],
+        },
+    )
+    assert response.status_code == 200, response.json()
+
+
+@pytest.mark.asyncio
+async def test_role_qualified_grain_dimension(client_with_build_v3):
+    """`v3.date.date_id[order]` is a dimension reference, not SQL.
+
+    Interpolating it into a `SELECT` to parse it raises, because the role
+    brackets are not valid SQL — so the partition column is built directly
+    from the reference instead.
+    """
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.role_qualified_grain",
+            "description": "Total within order date",
+            "query": "SELECT SUM(line_total) FROM v3.order_details",
+            "fixed_grain": ["v3.date.date_id[order]"],
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={
+            "metrics": ["v3.role_qualified_grain"],
+            "dimensions": ["v3.order_details.order_id"],
+        },
+    )
+    assert response.status_code == 200, response.json()
+    assert "PARTITION BY order_details_0.date_id_order" in response.json()["sql"]
+
+
+def test_broadcast_skips_a_merge_call_for_another_component():
+    """Only the declaring component's merge is windowed.
+
+    A combiner can hold several calls with the same merge name; wrapping the
+    first one found would broadcast the wrong measure.
+    """
+    from datajunction_server.sql.decompose import _broadcast_in_combiner
+
+    query_ast = parse("SELECT SUM(other_sum) + SUM(line_total_sum) FROM t")
+    _broadcast_in_combiner(query_ast, "line_total_sum", "SUM", [])
+
+    rendered = str(query_ast)
+    assert "SUM(SUM(line_total_sum)) OVER ()" in rendered.replace("  ", " "), rendered
+    # The unrelated aggregate is left alone.
+    assert "SUM(SUM(other_sum))" not in rendered, rendered
+
+
+def test_unfindable_merge_expression_is_refused():
+    """A combiner with no recognisable merge call cannot be broadcast."""
+    from datajunction_server.sql.decompose import _broadcast_in_combiner
+
+    query_ast = parse("SELECT MAX(other_col) FROM t")
+    with pytest.raises(DJInvalidInputException) as exc:
+        _broadcast_in_combiner(query_ast, "line_total_sum", "SUM", [])
+    assert "could not find the component merge expression" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_derived_metric_cannot_declare_a_grain(client_with_build_v3):
+    """A derived metric has no aggregate of its own to pin to a grain."""
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": "v3.derived_with_grain",
+            "description": "Arithmetic over two metrics",
+            "query": "SELECT v3.total_revenue / v3.total_quantity",
+            "fixed_grain": [],
+            "mode": "published",
+        },
+    )
+    # Creation succeeds because nothing decomposes the metric yet; the write
+    # boundary does not resolve the declaration (see "Finding I" in the PR body).
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={
+            "metrics": ["v3.derived_with_grain"],
+            "dimensions": ["v3.order_details.order_id"],
+        },
+    )
+    assert response.status_code == 422, response.json()
+    assert "A grain must be declared on a base metric" in response.json()["message"]
+
+
+@pytest.mark.asyncio
+async def test_fixed_grain_is_null_for_non_metric_nodes(client_with_build_v3):
+    """A non-metric node reports a null grain over GraphQL."""
+    response = await client_with_build_v3.post(
+        "/nodes/transform/",
+        json={
+            "name": "v3.grain_null_transform",
+            "description": "Not a metric",
+            "query": "SELECT order_id FROM v3.order_details",
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.post(
+        "/graphql",
+        json={
+            "query": """
+                { findNodes(names: ["v3.grain_null_transform"]) {
+                    current { fixedGrain }
+                } }
+            """,
+        },
+    )
+    assert response.status_code == 200, response.json()
+    data = response.json()["data"]["findNodes"]
+    assert data[0]["current"]["fixedGrain"] is None
+
+
+def test_non_decomposable_metric_cannot_declare_a_grain():
+    """A non-decomposable aggregate yields no components to carry the grain."""
+    extractor = MetricComponentExtractor(1)
+    query_ast = parse("SELECT MIN_BY(a, b) FROM test.parent")
+    components, _ = extractor._extract_base(query_ast)
+    assert components == []
+
+    with pytest.raises(DJInvalidInputException) as exc:
+        extractor._extract_base(
+            parse("SELECT MIN_BY(a, b) FROM test.parent"),
+            None,
+            [],
+        )
+    assert "decomposable aggregate" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_the_broadcast_lives_in_the_combiner(client_with_build_v3, session):
+    """The window is part of the decomposed metric, not added per query.
+
+    Every consumer renders the combiner: the query builder, and cube
+    materialization, which stores it as a string. Putting the window here is
+    what lets a materialized cube serve the metric at all.
+    """
+    from datajunction_server.construction.build_v3.decomposition import (
+        decompose_metric,
+    )
+    from datajunction_server.database.node import Node as DBNode
+
+    for name, grain in (
+        ("v3.combiner_global", []),
+        ("v3.combiner_category", ["v3.product.category"]),
+    ):
+        response = await client_with_build_v3.post(
+            "/nodes/metric/",
+            json={
+                "name": name,
+                "description": name,
+                "query": "SELECT SUM(line_total) FROM v3.order_details",
+                "fixed_grain": grain,
+                "mode": "published",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+    node = await DBNode.get_by_name(session, "v3.combiner_global")
+    decomposed = await decompose_metric(session, node)
+    assert "OVER ()" in str(decomposed.combiner_ast).replace("OVER  ()", "OVER ()")
+
+    node = await DBNode.get_by_name(session, "v3.combiner_category")
+    decomposed = await decompose_metric(session, node)
+    combiner = str(decomposed.combiner_ast)
+    assert "OVER" in combiner and "PARTITION BY" in combiner
+    # Unresolved: each consumer replaces the dimension reference for itself.
+    assert "v3.product.category" in combiner

--- a/datajunction-server/tests/construction/build_v3/fixed_grain_test.py
+++ b/datajunction-server/tests/construction/build_v3/fixed_grain_test.py
@@ -460,6 +460,62 @@ async def test_ratio_broadcasts_only_the_fixed_grain_operand(
 
 
 @pytest.mark.asyncio
+async def test_ratio_broadcasts_both_metrics_fixed_to_the_same_grain(
+    client_with_build_v3,
+):
+    """Each fixed-grain parent keeps its own broadcast in a derived ratio.
+
+    The parents deliberately share one underlying component, exercising the
+    component-deduplication path as well as the common declared grain.
+    """
+    fixed_grain = ["v3.order_details.status"]
+    parents = ("v3.fixed_status_numerator", "v3.fixed_status_denominator")
+    for name in parents:
+        response = await client_with_build_v3.post(
+            "/nodes/metric/",
+            json={
+                "name": name,
+                "description": name,
+                "query": "SELECT SUM(line_total) FROM v3.order_details",
+                "fixed_grain": fixed_grain,
+                "mode": "published",
+            },
+        )
+        assert response.status_code == 201, response.json()
+
+    derived = "v3.fixed_status_ratio"
+    response = await client_with_build_v3.post(
+        "/nodes/metric/",
+        json={
+            "name": derived,
+            "description": "Ratio of metrics fixed to the same grain",
+            "query": f"SELECT {parents[0]} / {parents[1]}",
+            "mode": "published",
+        },
+    )
+    assert response.status_code == 201, response.json()
+
+    response = await client_with_build_v3.get(
+        "/sql/metrics/v3/",
+        params={
+            "metrics": [derived],
+            "dimensions": [
+                "v3.order_details.status",
+                "v3.order_details.order_id",
+            ],
+        },
+    )
+    assert response.status_code == 200, response.json()
+    sql = response.json()["sql"]
+
+    assert sql.count("PARTITION BY order_details_0.status") == 2, sql
+    for parent in parents:
+        alias = parent.rsplit(".", 1)[-1]
+        windowed = next(line for line in sql.splitlines() if f"AS {alias}" in line)
+        assert "PARTITION BY order_details_0.status" in windowed
+
+
+@pytest.mark.asyncio
 async def test_partitioned_grain_allowed_beside_a_window_metric(client_with_build_v3):
     """A window metric adds a grain group for the SAME fact table.
 

--- a/datajunction-server/tests/construction/build_v3/xp_metrics_proposal_test.py
+++ b/datajunction-server/tests/construction/build_v3/xp_metrics_proposal_test.py
@@ -53,9 +53,9 @@ async def test_population_metric_at_unit_grain_is_refused(client_with_build_v3):
     """The allocated population cannot be declared at unit grain.
 
     `COUNT(DISTINCT unit)` is one per unit at unit grain, so summing it gives
-    the population -- but the shape check rejects the distinct aggregate before
-    noticing that its key is the declared grain. The node stores as valid, so
-    the refusal only arrives when someone queries it.
+    the population -- but the shape check rejects the distinct aggregate
+    before noticing that its key is the declared grain. The shape check now
+    runs at write time, so the refusal arrives on creation, not on query.
     """
     client = client_with_build_v3
     created = await create_metric(
@@ -65,12 +65,8 @@ async def test_population_metric_at_unit_grain_is_refused(client_with_build_v3):
         fixed_grain=[UNIT],
         reaggregate={"fn": "sum"},
     )
-    assert created.status_code == 201
-    assert created.json()["status"] == "valid"
-
-    response = await build_sql(client, "v3.xp_allocated_units")
-    assert response.status_code == 422
-    assert response.json()["message"] == (
+    assert created.status_code == 422
+    assert created.json()["message"] == (
         "Unsupported fixed_grain metric shape: a fixed grain requires one "
         "non-distinct fully-aggregatable component, because broadcasting "
         "re-applies the merge."
@@ -85,6 +81,11 @@ async def test_cross_fact_ratio_at_unit_grain_is_refused(client_with_build_v3):
     fact table, so the ratio always spans two grain groups. Any non-empty
     `fixed_grain` on either side refuses the combination, which puts this
     constraint on the proposal's central shape rather than on an edge case.
+
+    The unit dimension is requested here alongside month so the query reaches
+    this refusal at all -- an unrequested `fixed_grain` dimension is refused
+    on its own terms first (see `fixed_grain_test.py`'s
+    `test_grain_absent_from_the_query_is_refused`).
     """
     client = client_with_build_v3
     await create_metric(
@@ -101,7 +102,13 @@ async def test_cross_fact_ratio_at_unit_grain_is_refused(client_with_build_v3):
     )
     assert created.status_code == 201
 
-    response = await build_sql(client, "v3.xp_avg_per_allocated")
+    response = await client.get(
+        "/sql/metrics/v3/",
+        params={
+            "metrics": ["v3.xp_avg_per_allocated"],
+            "dimensions": ["v3.date.month", UNIT],
+        },
+    )
     assert response.status_code == 422
     assert response.json()["message"] == (
         "Metric `v3.xp_activity` declares a non-empty `fixed_grain` and cannot "
@@ -186,27 +193,16 @@ async def test_global_grain_ratio_builds_but_is_a_different_number(
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "A fixed-grain dimension outside the query grain is never projected "
-        "into the measures CTE, so the outer window partitions by a column "
-        "that does not exist. Remove this marker when the CTE emits it."
-    ),
-)
 @pytest.mark.asyncio
-async def test_activity_at_unit_grain_projects_its_partition_column(
+async def test_activity_at_unit_grain_without_the_unit_is_refused(
     client_with_build_v3,
 ):
-    """The unit grain has to reach the CTE the window reads from.
+    """The unit grain has to be part of the query, one way or another.
 
-    `customer_id` is not a requested dimension here, so it is private grain.
-    The generated SQL still partitions by `order_details_0.customer_id`, and
-    that CTE groups by month alone. No engine accepts the result.
-
-    Asserting the whole statement would pin the broken SQL, so this asserts
-    only the invariant it breaks: every column the outer query reads from a
-    CTE has to be projected by it.
+    `customer_id` is not a requested dimension here, so it is an unrequested
+    `fixed_grain` dimension: refused outright, rather than silently
+    generating a window that partitions by a column no CTE projects (the
+    shape this used to produce, and no engine accepted).
     """
     client = client_with_build_v3
     await create_metric(
@@ -218,12 +214,9 @@ async def test_activity_at_unit_grain_projects_its_partition_column(
     )
 
     response = await build_sql(client, "v3.xp_activity_private")
-    assert response.status_code == 200
-    sql = response.json()["sql"]
-
-    assert "PARTITION BY order_details_0.customer_id" in sql
-    cte_body = sql.split("order_details_0 AS (", 1)[1].split(")", 1)[0]
-    assert "customer_id" in cte_body, (
-        "order_details_0 must project customer_id for the window to partition "
-        f"by it, but it selects only:\n{cte_body}"
+    assert response.status_code == 422
+    assert response.json()["message"] == (
+        f"Metric `v3.xp_activity_private` declares `fixed_grain` on `{UNIT}`, "
+        "which is not a requested output dimension. Add it to the query's "
+        "dimensions before requesting this metric."
     )

--- a/datajunction-server/tests/construction/build_v3/xp_metrics_proposal_test.py
+++ b/datajunction-server/tests/construction/build_v3/xp_metrics_proposal_test.py
@@ -1,0 +1,229 @@
+"""Experimentation-metric shapes, from the XP metrics proposal.
+
+An experimentation metric needs three things: what each allocated unit
+contributes, which units are included, and how the contributions combine. DJ
+metrics capture the first and third today; the population is supplied by the
+analysis tool. The proposal writes the population down as a metric too, so an
+experimentation metric becomes a ratio of two unit-grain metrics:
+
+    allocated_units  = COUNT(DISTINCT unit) at unit grain
+    activity         = SUM(measure)         at unit grain
+    xp_metric        = activity / allocated_units
+
+These tests pin what this branch does with that shape. The fixtures stand in
+for the real tables:
+
+    account_id      -> v3.customer.customer_id (linked to both facts)
+    allocation_day  -> v3.page_views_enriched  (the allocated population)
+    some_fact       -> v3.order_details        (the activity)
+"""
+
+import pytest
+
+from tests.construction.build_v3 import assert_sql_equal
+
+UNIT = "v3.customer.customer_id"
+BY_MONTH = {"dimensions": ["v3.date.month"]}
+
+
+async def create_metric(client, name, query, **declarations):
+    """Create a metric and return the response."""
+    return await client.post(
+        "/nodes/metric/",
+        json={
+            "name": name,
+            "description": name,
+            "query": query,
+            "mode": "published",
+            **declarations,
+        },
+    )
+
+
+async def build_sql(client, metric):
+    """Ask for a metric's SQL, grouped by month."""
+    return await client.get(
+        "/sql/metrics/v3/",
+        params={"metrics": [metric], **BY_MONTH},
+    )
+
+
+@pytest.mark.asyncio
+async def test_population_metric_at_unit_grain_is_refused(client_with_build_v3):
+    """The allocated population cannot be declared at unit grain.
+
+    `COUNT(DISTINCT unit)` is one per unit at unit grain, so summing it gives
+    the population -- but the shape check rejects the distinct aggregate before
+    noticing that its key is the declared grain. The node stores as valid, so
+    the refusal only arrives when someone queries it.
+    """
+    client = client_with_build_v3
+    created = await create_metric(
+        client,
+        "v3.xp_allocated_units",
+        "SELECT COUNT(DISTINCT customer_id) FROM v3.page_views_enriched",
+        fixed_grain=[UNIT],
+        reaggregate={"fn": "sum"},
+    )
+    assert created.status_code == 201
+    assert created.json()["status"] == "valid"
+
+    response = await build_sql(client, "v3.xp_allocated_units")
+    assert response.status_code == 422
+    assert response.json()["message"] == (
+        "Unsupported fixed_grain metric shape: a fixed grain requires one "
+        "non-distinct fully-aggregatable component, because broadcasting "
+        "re-applies the merge."
+    )
+
+
+@pytest.mark.asyncio
+async def test_cross_fact_ratio_at_unit_grain_is_refused(client_with_build_v3):
+    """An experimentation metric is a ratio across two facts, which is refused.
+
+    The population comes from the allocation table and the activity from the
+    fact table, so the ratio always spans two grain groups. Any non-empty
+    `fixed_grain` on either side refuses the combination, which puts this
+    constraint on the proposal's central shape rather than on an edge case.
+    """
+    client = client_with_build_v3
+    await create_metric(
+        client,
+        "v3.xp_activity",
+        "SELECT SUM(line_total) FROM v3.order_details",
+        fixed_grain=[UNIT],
+        reaggregate={"fn": "sum"},
+    )
+    created = await create_metric(
+        client,
+        "v3.xp_avg_per_allocated",
+        "SELECT v3.xp_activity / v3.visitor_count",
+    )
+    assert created.status_code == 201
+
+    response = await build_sql(client, "v3.xp_avg_per_allocated")
+    assert response.status_code == 422
+    assert response.json()["message"] == (
+        "Metric `v3.xp_activity` declares a non-empty `fixed_grain` and cannot "
+        "be combined with metrics from another fact table in one query: the "
+        "joined result groups over a `COALESCE` of the shared dimensions, so a "
+        "partition naming one side's column is not grouped and the engine "
+        "rejects it. Query it on its own, or use a global grain "
+        "(`fixed_grain: []`), which partitions by nothing."
+    )
+
+
+@pytest.mark.asyncio
+async def test_global_grain_ratio_builds_but_is_a_different_number(
+    client_with_build_v3,
+):
+    """`fixed_grain: []` is the suggested escape, and answers another question.
+
+    The refusal above points at a global grain. That builds, but `OVER ()`
+    broadcasts the total across every month, so the result is all-time revenue
+    divided by one month's visitors -- not revenue per allocated unit. Pinned
+    here so the difference is not mistaken for a workaround.
+    """
+    client = client_with_build_v3
+    await create_metric(
+        client,
+        "v3.xp_activity_global",
+        "SELECT SUM(line_total) FROM v3.order_details",
+        fixed_grain=[],
+    )
+    await create_metric(
+        client,
+        "v3.xp_avg_global",
+        "SELECT v3.xp_activity_global / v3.visitor_count",
+    )
+
+    response = await build_sql(client, "v3.xp_avg_global")
+    assert response.status_code == 200
+    assert_sql_equal(
+        response.json()["sql"],
+        """
+        WITH
+        v3_date AS (
+        SELECT  date_id,
+        	month 
+         FROM default.v3.dates
+        ),
+        v3_order_details AS (
+        SELECT  o.order_date,
+        	oi.quantity * oi.unit_price AS line_total 
+         FROM default.v3.orders o JOIN default.v3.order_items oi ON o.order_id = oi.order_id
+        ),
+        v3_page_views_enriched AS (
+        SELECT  customer_id,
+        	page_date 
+         FROM default.v3.page_views
+        ),
+        order_details_0 AS (
+        SELECT  t2.month,
+        	SUM(t1.line_total) line_total_sum_e1f61696 
+         FROM v3_order_details t1 LEFT OUTER JOIN v3_date t2 ON t1.order_date = t2.date_id 
+         GROUP BY  t2.month
+        ),
+        page_views_enriched_0 AS (
+        SELECT  t2.month,
+        	t1.customer_id 
+         FROM v3_page_views_enriched t1 LEFT OUTER JOIN v3_date t2 ON t1.page_date = t2.date_id 
+         GROUP BY  t2.month, t1.customer_id
+        ),
+        base_metrics AS (
+        SELECT  COALESCE(order_details_0.month, page_views_enriched_0.month) AS month,
+        	COUNT( DISTINCT page_views_enriched_0.customer_id) AS visitor_count,
+        	SUM(SUM(order_details_0.line_total_sum_e1f61696)) OVER ()  AS xp_activity_global 
+         FROM order_details_0 FULL OUTER JOIN page_views_enriched_0 ON order_details_0.month = page_views_enriched_0.month 
+         GROUP BY  1
+        )
+
+        SELECT  base_metrics.month AS month,
+        	base_metrics.xp_activity_global / base_metrics.visitor_count AS xp_avg_global 
+         FROM base_metrics
+        """,
+        normalize_aliases=True,
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "A fixed-grain dimension outside the query grain is never projected "
+        "into the measures CTE, so the outer window partitions by a column "
+        "that does not exist. Remove this marker when the CTE emits it."
+    ),
+)
+@pytest.mark.asyncio
+async def test_activity_at_unit_grain_projects_its_partition_column(
+    client_with_build_v3,
+):
+    """The unit grain has to reach the CTE the window reads from.
+
+    `customer_id` is not a requested dimension here, so it is private grain.
+    The generated SQL still partitions by `order_details_0.customer_id`, and
+    that CTE groups by month alone. No engine accepts the result.
+
+    Asserting the whole statement would pin the broken SQL, so this asserts
+    only the invariant it breaks: every column the outer query reads from a
+    CTE has to be projected by it.
+    """
+    client = client_with_build_v3
+    await create_metric(
+        client,
+        "v3.xp_activity_private",
+        "SELECT SUM(line_total) FROM v3.order_details",
+        fixed_grain=[UNIT],
+        reaggregate={"fn": "sum"},
+    )
+
+    response = await build_sql(client, "v3.xp_activity_private")
+    assert response.status_code == 200
+    sql = response.json()["sql"]
+
+    assert "PARTITION BY order_details_0.customer_id" in sql
+    cte_body = sql.split("order_details_0 AS (", 1)[1].split(")", 1)[0]
+    assert "customer_id" in cte_body, (
+        "order_details_0 must project customer_id for the window to partition "
+        f"by it, but it selects only:\n{cte_body}"
+    )

--- a/datajunction-server/tests/internal/deployment/validation_test.py
+++ b/datajunction-server/tests/internal/deployment/validation_test.py
@@ -944,6 +944,27 @@ class TestRequiredDimensions:
         assert "test.dim.nonexistent_col" in err.debug["invalid_fixed_grain_dimensions"]
 
     @pytest.mark.asyncio
+    async def test_fixed_grain_shape_rejected_at_deploy_time(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """A non-mergeable aggregate with a fixed grain fails at deploy
+        time too, not only when the metric is later created via the API."""
+        context = self._make_context(session, parent_node)
+        spec = MetricSpec(
+            name="test.metric",
+            query="SELECT COUNT(DISTINCT id) FROM test.parent",
+            fixed_grain=[],
+        )
+        validator = NodeSpecBulkValidator(context)
+        result = validator.validate_query_node(spec)
+
+        assert result.status == NodeStatus.INVALID
+        err = next(e for e in result.errors if e.code == ErrorCode.INVALID_METRIC)
+        assert "Unsupported fixed_grain metric shape" in err.message
+
+    @pytest.mark.asyncio
     async def test_invalid_reaggregate_function(
         self,
         session: AsyncSession,

--- a/datajunction-server/tests/internal/deployment/validation_test.py
+++ b/datajunction-server/tests/internal/deployment/validation_test.py
@@ -853,6 +853,97 @@ class TestRequiredDimensions:
         assert "test.dim.nonexistent_col" in err.debug["invalid_reaggregate_dimensions"]
 
     @pytest.mark.asyncio
+    async def test_valid_fixed_grain_dimension(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """A fixed grain naming a real dimension column resolves."""
+        dim_node = self._make_dim_node("test.dim", ["dateint"])
+        context = self._make_context(session, parent_node)
+        spec = MetricSpec(
+            name="test.metric",
+            query="SELECT SUM(value) FROM test.parent",
+            fixed_grain=["test.dim.dateint"],
+        )
+        validator = NodeSpecBulkValidator(context)
+        validator._all_dim_nodes = {**context.dependency_nodes, "test.dim": dim_node}
+        result = validator.validate_query_node(spec)
+
+        assert result.status == NodeStatus.VALID
+        assert ErrorCode.INVALID_COLUMN not in [e.code for e in result.errors]
+
+    @pytest.mark.asyncio
+    async def test_global_fixed_grain_has_nothing_to_resolve(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """`[]` is a declaration, not an omission -- and names no dimension."""
+        context = self._make_context(session, parent_node)
+        spec = MetricSpec(
+            name="test.metric",
+            query="SELECT SUM(value) FROM test.parent",
+            fixed_grain=[],
+        )
+        validator = NodeSpecBulkValidator(context)
+        result = validator.validate_query_node(spec)
+
+        assert result.status == NodeStatus.VALID
+        assert ErrorCode.INVALID_COLUMN not in [e.code for e in result.errors]
+
+    @pytest.mark.asyncio
+    async def test_fixed_grain_dimension_off_the_query_graph_resolves(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """A grain may name a dimension that is not one of the query's parents.
+
+        Such a node is not in `dependency_nodes`, so it has to be prefetched by
+        name or a valid dimension is reported as an invalid column.
+        """
+        dim_node = self._make_dim_node("test.offgraph_dim", ["dateint"])
+        context = self._make_context(session, parent_node)
+        spec = MetricSpec(
+            name="test.metric",
+            query="SELECT SUM(value) FROM test.parent",
+            fixed_grain=["test.offgraph_dim.dateint"],
+        )
+        validator = NodeSpecBulkValidator(context)
+        validator._all_dim_nodes = {
+            **context.dependency_nodes,
+            "test.offgraph_dim": dim_node,
+        }
+        result = validator.validate_query_node(spec)
+
+        assert result.status == NodeStatus.VALID
+        assert ErrorCode.INVALID_COLUMN not in [e.code for e in result.errors]
+
+    @pytest.mark.asyncio
+    async def test_invalid_fixed_grain_dimension(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+    ):
+        """An unresolvable grain fails at deploy time, not at some later query."""
+        dim_node = self._make_dim_node("test.dim", ["dateint"])
+        context = self._make_context(session, parent_node)
+        spec = MetricSpec(
+            name="test.metric",
+            query="SELECT SUM(value) FROM test.parent",
+            fixed_grain=["test.dim.nonexistent_col"],
+        )
+        validator = NodeSpecBulkValidator(context)
+        validator._all_dim_nodes = {**context.dependency_nodes, "test.dim": dim_node}
+        result = validator.validate_query_node(spec)
+
+        assert result.status == NodeStatus.INVALID
+        err = next(e for e in result.errors if e.code == ErrorCode.INVALID_COLUMN)
+        assert err.debug is not None
+        assert "test.dim.nonexistent_col" in err.debug["invalid_fixed_grain_dimensions"]
+
+    @pytest.mark.asyncio
     async def test_invalid_reaggregate_function(
         self,
         session: AsyncSession,
@@ -956,6 +1047,32 @@ class TestRequiredDimensions:
         assert fetched.current is not None
         col_names = {c.name for c in fetched.current.columns}
         assert "region" in col_names
+
+    @pytest.mark.asyncio
+    async def test_prefetch_fetches_fixed_grain_dim_node_from_db(
+        self,
+        session: AsyncSession,
+        parent_node: Node,
+        dim_node_in_db: Node,
+    ):
+        """A grain may name a dimension that is not one of the query's parents.
+
+        Such a node is absent from `dependency_nodes`, so it has to be fetched
+        by name or the grain is reported as an invalid column.
+        """
+        context = self._make_context(session, parent_node)
+        spec = MetricSpec(
+            name="test.metric",
+            query="SELECT SUM(value) FROM test.parent",
+            # A bare column resolves on the parent and names no node to fetch;
+            # a qualified path does. Both shapes are legal in one grain.
+            fixed_grain=["value", "test.external_dim.region"],
+        )
+        validator = NodeSpecBulkValidator(context)
+
+        await validator._prefetch_required_dimension_nodes([spec])
+
+        assert "test.external_dim" in validator._all_dim_nodes
 
     @pytest.mark.asyncio
     async def test_prefetch_fetches_reaggregate_dim_node_from_db(

--- a/datajunction-server/tests/internal/namespaces_test.py
+++ b/datajunction-server/tests/internal/namespaces_test.py
@@ -22,6 +22,7 @@ from datajunction_server.internal.namespace_locks import (
 from datajunction_server.internal.namespaces import (
     _merge_list_with_key,
     _merge_yaml_preserving_comments,
+    _node_spec_to_yaml_dict,
     create_or_reactivate_namespace,
     get_node_specs_for_export,
     node_spec_to_yaml,
@@ -1137,6 +1138,43 @@ class TestNodeSpecToYaml:
         ]
 
     @pytest.mark.asyncio
+    async def test_metric_fixed_grain_export_injects_dimension_prefix(
+        self,
+        monkeypatch,
+    ):
+        """namespace export parameterizes fixed-grain dimensions."""
+        spec = MetricSpec(
+            name="demo.branch.metrics.region_balance",
+            node_type=NodeType.METRIC,
+            query="SELECT SUM(balance) FROM demo.branch.transforms.accounts",
+            fixed_grain=["demo.branch.dims.region.region_id"],
+        )
+
+        async def to_spec(_session):
+            return spec
+
+        fake_node = SimpleNamespace(
+            name="demo.branch.metrics.region_balance",
+            current=SimpleNamespace(parents=[], status="valid"),
+            to_spec=to_spec,
+        )
+
+        async def namespace_get(_session, _namespace, raise_if_not_exists=False):
+            return SimpleNamespace(parent_namespace="demo.main")
+
+        async def list_all_nodes(_session, _namespace, options=None):
+            return [fake_node]
+
+        monkeypatch.setattr(NodeNamespace, "get", namespace_get)
+        monkeypatch.setattr(NodeNamespace, "list_all_nodes", list_all_nodes)
+
+        exported = await get_node_specs_for_export(SimpleNamespace(), "demo.branch")
+
+        # Without this the copy would partition on the source namespace's
+        # dimension rather than its own.
+        assert exported[0].fixed_grain == ["${prefix}dims.region.region_id"]
+
+    @pytest.mark.asyncio
     async def test_metric_reaggregate_export_injects_dimension_prefix(
         self,
         monkeypatch,
@@ -1220,3 +1258,58 @@ class TestNodeSpecToYaml:
             "mode: published",
             "query: SELECT SUM(rev) FROM ns.transforms.t",
         ]
+
+
+def test_yaml_export_keeps_an_empty_fixed_grain():
+    """`[]` is the global grain, so it must survive the empty-value filter.
+
+    Everything else falsy is dropped for tidiness. Dropping this one turns a
+    globally-grained metric back into a query-grained one with the same name.
+    """
+    from datajunction_server.models.deployment import MetricSpec
+
+    exported = _node_spec_to_yaml_dict(
+        MetricSpec(
+            name="v3.total_revenue",
+            query="SELECT SUM(line_total) FROM v3.order_details",
+            fixed_grain=[],
+        ),
+    )
+    assert exported["fixed_grain"] == []
+
+    # Absent stays absent — the exemption must not invent the key.
+    without = _node_spec_to_yaml_dict(
+        MetricSpec(
+            name="v3.plain_revenue",
+            query="SELECT SUM(line_total) FROM v3.order_details",
+        ),
+    )
+    assert "fixed_grain" not in without
+
+
+def test_merge_keeps_an_empty_fixed_grain_already_in_the_file():
+    """The merge drops keys missing from the new export, so the two interact.
+
+    A `fixed_grain: []` committed to a git-backed namespace must not be deleted
+    by the next sync.
+    """
+    yaml = YAML()
+    existing = yaml.load(
+        "name: v3.total_revenue\ntype: metric\nfixed_grain: []\n",
+    )
+    # Built by the exporter, not by hand: the merge drops keys the export
+    # omits, so the two must be exercised together to catch the real bug.
+    from datajunction_server.models.deployment import MetricSpec
+
+    new_data = _node_spec_to_yaml_dict(
+        MetricSpec(
+            name="v3.total_revenue",
+            query="SELECT SUM(line_total) FROM v3.order_details",
+            fixed_grain=[],
+        ),
+    )
+
+    result = _merge_yaml_preserving_comments(existing, new_data, yaml)
+
+    assert "fixed_grain" in result
+    assert list(result["fixed_grain"]) == []

--- a/datajunction-server/tests/internal/nodes/derive_frozen_measures_test.py
+++ b/datajunction-server/tests/internal/nodes/derive_frozen_measures_test.py
@@ -19,6 +19,7 @@ from datajunction_server.database.user import OAuthProvider, User
 from datajunction_server.errors import DJInvalidInputException
 from datajunction_server.internal.nodes import (
     _raise_if_frozen_measure_conflicts,
+    _derive_frozen_measures_impl,
     derive_frozen_measures_bulk,
 )
 from datajunction_server.models.decompose import (
@@ -72,6 +73,7 @@ async def _make_metric(
     query: str,
     parents: list[Node],
     reaggregate: dict[str, object] | None = None,
+    fixed_grain: list[str] | None = None,
 ) -> Node:
     node = Node(
         name=name,
@@ -86,6 +88,7 @@ async def _make_metric(
         version="v1.0",
         query=query,
         reaggregate=reaggregate,
+        fixed_grain=fixed_grain,
         status=NodeStatus.VALID,
         parents=parents,
         created_by_id=user.id,
@@ -222,6 +225,98 @@ async def test_reaggregate_rule_is_not_persisted_on_shared_frozen_measure(
     assert all(
         fm.rule.reaggregate is None for fm in reaggregate.current.frozen_measures
     )
+
+
+@pytest.mark.asyncio
+async def test_fixed_grain_is_not_persisted_on_shared_frozen_measure(
+    session: AsyncSession,
+    user: User,
+):
+    """A shared FrozenMeasure.rule must not depend on which metric created it.
+
+    The fixed-grain metric is derived FIRST here: if the declaration were
+    persisted, the ordinary metric would later reuse a measure whose stored rule
+    claims a global grain, because identity comparison ignores the field.
+    """
+    src = await _make_source(
+        session,
+        user,
+        "src_fixed_grain_storage",
+        [Column(name="fg_amount", type=ct.DoubleType(), order=0)],
+    )
+    global_grain = await _make_metric(
+        session,
+        user,
+        "m.fg_amount_global",
+        "SELECT SUM(fg_amount) FROM src_fixed_grain_storage",
+        [src],
+        fixed_grain=[],
+    )
+    ordinary = await _make_metric(
+        session,
+        user,
+        "m.fg_amount_total",
+        "SELECT SUM(fg_amount) FROM src_fixed_grain_storage",
+        [src],
+    )
+    await session.refresh(global_grain, ["current"])
+    await session.refresh(ordinary, ["current"])
+
+    await derive_frozen_measures_bulk(session, [global_grain.current.id])
+    await session.commit()
+    await session.refresh(global_grain.current, ["frozen_measures"])
+
+    assert global_grain.current.frozen_measures
+    assert all(
+        fm.rule.fixed_grain is None for fm in global_grain.current.frozen_measures
+    )
+
+    await derive_frozen_measures_bulk(session, [ordinary.current.id])
+    await session.commit()
+    await session.refresh(ordinary.current, ["frozen_measures"])
+
+    assert {fm.name for fm in ordinary.current.frozen_measures} == {
+        fm.name for fm in global_grain.current.frozen_measures
+    }
+    assert all(fm.rule.fixed_grain is None for fm in ordinary.current.frozen_measures)
+
+
+@pytest.mark.asyncio
+async def test_singular_path_also_strips_metric_level_rule_fields(
+    session: AsyncSession,
+    user: User,
+):
+    """The singular path must strip the same fields as the bulk path.
+
+    The two build `FrozenMeasure` at separate call sites; fixing only the bulk
+    one leaves the create/update path persisting a metric-level declaration onto
+    a measure other metrics go on to share.
+    """
+    src = await _make_source(
+        session,
+        user,
+        "src_singular_strip",
+        [Column(name="sing_amount", type=ct.DoubleType(), order=0)],
+    )
+    declared = await _make_metric(
+        session,
+        user,
+        "m.sing_amount_global",
+        "SELECT SUM(sing_amount) FROM src_singular_strip",
+        [src],
+        fixed_grain=[],
+        reaggregate={
+            "rules": [{"dimension": "default.date_dim.date", "fn": "last_value"}],
+        },
+    )
+    await session.refresh(declared, ["current"])
+
+    frozen = await _derive_frozen_measures_impl(declared.current.id, session)
+    await session.commit()
+
+    assert frozen
+    assert all(fm.rule.fixed_grain is None for fm in frozen)
+    assert all(fm.rule.reaggregate is None for fm in frozen)
 
 
 def test_frozen_measure_conflict_rejects_different_measure_identity():

--- a/datajunction-server/tests/models/deployment_test.py
+++ b/datajunction-server/tests/models/deployment_test.py
@@ -50,6 +50,7 @@ from datajunction_server.semantic_fingerprints.engine import (
 )
 from datajunction_server.semantic_fingerprints.normalization import (
     canonical_json,
+    normalize_fixed_grain,
     normalize_sequence,
     normalize_value,
 )
@@ -1706,7 +1707,7 @@ GOLDEN_FINGERPRINTS = {
     "source": "71dcbc388988c2bdd850670427710384687b58565ee38ca392dc220adfed868d",
     "transform": "978e692880c7bcfb1bd78ece85895a1ec1558e85377b064a8dac3f3719cff2a5",
     "dimension": "f7b3c87a61fdadf9997432fd9334befdf43f2488874ef555e3f7d4c4ba86e3e1",
-    "metric": "f0b5356d75b1f6a39a2809581a9167b9e1298a41980ee8e83040cf6bd0996851",
+    "metric": "adf0927eb31f1ff500f064d7b6a7f286aa1381265e61e2e3421920059d9a2922",
     "cube": "9b0a56d974d1e3769bc2db94e2cfbae7a6a4839f664eebd2a4387ef112ceea81",
 }
 
@@ -1991,6 +1992,7 @@ def test_metric_presentation_fields_preserve_semantic_fingerprint():
             "columns",
             "required_dimensions",
             "reaggregate",
+            "fixed_grain",
         }
     )
     assert all(
@@ -2195,3 +2197,32 @@ def test_semantic_fingerprint_combines_sorted_parent_hashes():
     mismatched = SemanticFingerprint.model_construct(version=2, digest="b" * 64)
     with pytest.raises(ValueError, match="Parent fingerprint version"):
         compose_node_fingerprint(node, parent_fingerprints=[mismatched])
+
+
+def test_normalize_fixed_grain_keeps_absent_distinct_from_global():
+    """`None` is the query grain; `[]` is the global grain. Never the same digest."""
+    assert normalize_fixed_grain(None) is None
+    assert normalize_fixed_grain([]) == []
+    assert canonical_json(normalize_fixed_grain(None)) != canonical_json(
+        normalize_fixed_grain([]),
+    )
+
+
+@pytest.mark.parametrize(
+    ("grain", "expected"),
+    [
+        (["b", "a"], ["a", "b"]),
+        (["a", "b", "a"], ["a", "b"]),
+        # Ordering must follow the canonical-JSON key used for every other
+        # sequence field: sorting the raw strings puts "\n" first instead.
+        (["0", "\n"], ["0", "\n"]),
+    ],
+    ids=["reordered", "duplicated", "json-escaped"],
+)
+def test_normalize_fixed_grain_matches_the_canonical_sequence_form(grain, expected):
+    """A declared grain is a set, canonicalised like any other sequence field."""
+    assert normalize_fixed_grain(grain) == expected
+    assert normalize_fixed_grain(grain) == normalize_sequence(
+        normalize_value(grain),
+        preserve_order=False,
+    )

--- a/datajunction-server/tests/sql/decompose_test.py
+++ b/datajunction-server/tests/sql/decompose_test.py
@@ -2676,3 +2676,63 @@ async def test_sum_abs_decomposes(session: AsyncSession, create_metric):
     assert comp.rule.type == Aggregability.FULL
     assert "ABS" in comp.expression
     assert_sql_equal(str(derived_sql), f"SELECT SUM({comp.name}) FROM parent_node")
+
+
+def _combiner(component_name: str = "amount_sum"):
+    """A parsed combiner the broadcast can be written into."""
+    from datajunction_server.sql.parsing.backends.antlr4 import parse
+
+    return parse(f"SELECT SUM({component_name}) FROM parent_node")
+
+
+def _component(name: str, *, aggregability=Aggregability.FULL, merge="SUM"):
+    """A minimal decomposed measure for fixed-grain attachment tests."""
+    return MetricComponent(
+        name=name,
+        expression="amount",
+        aggregation="SUM",
+        merge=merge,
+        rule=AggregationRule(type=aggregability),
+    )
+
+
+def test_fixed_grain_attaches_to_a_single_full_component():
+    """The declaration lands on the one measure the builder will broadcast."""
+    extractor = MetricComponentExtractor(1)
+    components = [_component("amount_sum")]
+
+    extractor._attach_fixed_grain_spec(components, [], _combiner())
+
+    assert components[0].rule.fixed_grain == []
+
+
+def test_fixed_grain_refused_on_multiple_components():
+    """Broadcasting re-applies one merge, so the target must be unambiguous."""
+    extractor = MetricComponentExtractor(1)
+    components = [_component("amount_sum"), _component("other_sum")]
+
+    with pytest.raises(DJInvalidInputException) as exc:
+        extractor._attach_fixed_grain_spec(components, [], _combiner())
+
+    assert "exactly one component" in str(exc.value)
+    assert all(comp.rule.fixed_grain is None for comp in components)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"aggregability": Aggregability.LIMITED},
+        {"merge": None},
+    ],
+    ids=["not-fully-aggregatable", "no-merge-function"],
+)
+def test_fixed_grain_refused_on_a_component_that_cannot_re_merge(kwargs):
+    """A measure that cannot be merged twice cannot be broadcast."""
+    extractor = MetricComponentExtractor(1)
+    components = [_component("amount_sum", **kwargs)]
+
+    with pytest.raises(DJInvalidInputException) as exc:
+        extractor._attach_fixed_grain_spec(components, [], _combiner())
+
+    assert "fully-aggregatable" in str(exc.value)
+    assert components[0].rule.fixed_grain is None

--- a/docs/content/0.1.0/docs/data-modeling/yaml.md
+++ b/docs/content/0.1.0/docs/data-modeling/yaml.md
@@ -125,6 +125,7 @@ The **node name is derived** from the directory structure and file name. For exa
 | `columns` | No | Optional column-level settings (like `attributes` or `partition`) |
 | `tags` | No | A list of tags for this node |
 | `required_dimensions` | No | A list of required dimensions for this metric |
+| `fixed_grain` | No | Dimensions the aggregate is computed at. Omitted means the query grain; `[]` means the global grain. |
 | `direction` | No | Direction of this metric (one of `higher_is_better`, `lower_is_better`, or `neutral`) |
 | `unit` | No | The unit of this metric |
 

--- a/plugins/datajunction/skills/datajunction-semantic-model/SKILL.md
+++ b/plugins/datajunction/skills/datajunction-semantic-model/SKILL.md
@@ -297,6 +297,7 @@ Same shape for MoM (`month_code`), QoQ (`quarter_code`), YoY (`year`).
 | `direction` | ❌ Optional | `higher_is_better` / `lower_is_better` / `neutral` | Indicates performance direction |
 | `unit` | ❌ Optional | `dollar` / `unitless` / **⚠️ NOT `count`** | Server rejects `count` — use `unitless` |
 | `mode` | ❌ Optional | `draft` / `published` | Default: `published` |
+| `fixed_grain` | ❌ Optional | List of dimension names | Grain the aggregate is computed at; omit for query grain, `[]` for global |
 | `required_dimensions` | ❌ Optional | List of dimension names | For time-based / windowed metrics |
 | `owners` | ❌ Optional but strongly recommended | List of email addresses | Prefer team emails |
 


### PR DESCRIPTION
Implements the `fixed_grain` half of [#2245](https://github.com/DataJunction/dj/issues/2245). A base metric can declare the grain at which its aggregate is computed, and DJ broadcasts that value when the query requests a finer grain.

This PR is stacked on [#2502](https://github.com/DataJunction/dj/pull/2502), which implements the complementary `reaggregate` direction. It can be retargeted to `main` after #2502 lands.

```yaml
- name: revenue
  query: SELECT SUM(revenue) FROM sales_f

- name: total_revenue
  query: SELECT SUM(revenue) FROM sales_f
  fixed_grain: []

- name: pct_of_total
  query: SELECT revenue / total_revenue
```

`fixed_grain` has three forms:

- omitted: compute at the query grain, preserving current behavior
- `[]`: compute at the global grain
- `[dimension, ...]`: compute at the declared partition grain

For example, querying `total_revenue` at a finer grain generates the equivalent of:

```sql
SUM(SUM(sales_f_0.revenue_sum)) OVER () AS total_revenue
```

The inner aggregate computes the query-group contribution. The outer window re-merges those contributions within the declared fixed grain. A non-empty grain produces `OVER (PARTITION BY ...)` instead.

## Implementation

- `sql/decompose.py` validates that the declaration belongs to one freely aggregatable base component, propagates it through decomposition, and rejects a later window over a broadcast value.
- The broadcast is written into the combiner during decomposition, naming partition dimensions in unresolved form. Each consumer resolves them as it does any dimension reference — a CTE-qualified column for a query, a bare column for a cube — so the window reaches both query SQL and the SQL stored on a materialized cube.
- `construction/build_v3/cube_matcher.py` skips a cube that does not materialize a metric's partition dimension, mirroring `validate_cube_covers_reaggregate_dimensions`. A cube that does carry it is used normally.
- The declaration is carried through storage, deployment specs, namespace export/copy, REST and GraphQL output, loader allowlists, change classification, and semantic fingerprints.

## Current constraints

The initial implementation accepts only cases where broadcasting can be expressed without changing the metric's meaning.

| Situation | Behavior |
| --- | --- |
| `COUNT(DISTINCT ...)`, a multi-component metric (`AVG`, variance), or a non-decomposable aggregate | Refused; the result cannot be re-merged as a window. Multi-component is unimplemented rather than impossible — it needs every merge windowed, not just the first |
| A declared grain dimension is absent from the query grain | Joined and grouped on as private grain, then projected away — the same treatment a protected `reaggregate` dimension gets. The result stays the shape that was requested |
| A non-empty fixed grain is combined with another fact grain group | Refused; the joined SELECT groups over a `COALESCE`, so a partition naming one group's column is ungrouped |
| A derived metric declares its own fixed grain | Refused; the declaration belongs to the base aggregate |
| A frame accumulates a fixed-grain metric, directly or transitively | Refused; the frame would add the same broadcast value once per row. `MAX`/`AVG` over it are allowed, as is referencing it beside a window — e.g. a trailing sum divided by a global total |
| A cube does not materialize the partition dimension | Cube skipped; DJ builds from the underlying graph. A cube that carries the dimension is used normally |

## Related fixes

- Normalizes both frozen-measure creation paths so metric-level `reaggregate` and `fixed_grain` declarations do not become part of shared measure state or identity.
- Adds both declarations to the GraphQL `extractedMeasures` loader's `load_only`. Reading a field that loader omits raises `MissingGreenlet` on a cold session, which the batch handler turns into a silent null rather than an error.

## Out of scope

- Relative grain declarations such as `{hierarchy, drill_up}`
- The proposed `frame` primitive
- UI support. `reaggregate` gained create/edit fields and node-page display in #2502; the equivalent for `fixed_grain` is deferred to a follow-up, so the declaration is currently settable only through deployment specs and the API.

## Known gaps

- Direct `POST /nodes/metric` validation does not yet reject an unresolvable fixed-grain column, although deployment validation does. The invalid declaration is rejected later when a query attempts to use it.

## Testing

Coverage includes global and partitioned broadcasts, derived ratios, declaration round trips, namespace copying, semantic identity, frozen-measure reuse, GraphQL decomposition loading, window refusal, and cube matching and materialization carrying the broadcast.