### PR TITLE
Report cube column mismatch warning as a structured DeploymentResult

### DIFF
--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -398,15 +398,25 @@ class DeploymentOrchestrator:
             if not isinstance(spec, CubeSpec):
                 continue
             for unmatched in spec.unmatched_column_names:
+                message = (
+                    f"Cube '{spec.rendered_name}' declares column '{unmatched}', "
+                    f"which is not one of its columns, so the settings on "
+                    f"it have no effect. A cube's columns are its metrics "
+                    f"and dimensions, named exactly as they appear there."
+                )
                 self.warnings.append(
                     DJError(
                         code=ErrorCode.INVALID_ARGUMENTS_TO_FUNCTION,
-                        message=(
-                            f"Cube '{spec.name}' declares column '{unmatched}', "
-                            f"which is not one of its columns, so the settings on "
-                            f"it have no effect. A cube's columns are its metrics "
-                            f"and dimensions, named exactly as they appear there."
-                        ),
+                        message=message,
+                    ),
+                )
+                self.deployed_results.append(
+                    DeploymentResult(
+                        name=spec.rendered_name,
+                        deploy_type=DeploymentResult.Type.NODE,
+                        status=DeploymentResult.Status.WARNING,
+                        operation=DeploymentResult.Operation.NOOP,
+                        message=message,
                     ),
                 )
 

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -8613,8 +8613,11 @@ class TestCubeRedeployIdempotence:
         ]
 
         second = await deploy_and_wait(client, deployment())
-        cube_result = next(
+        cube_results = [
             result for result in second["results"] if result["name"] == cube_name
+        ]
+        cube_result = next(
+            result for result in cube_results if result["status"] != "warning"
         )
         assert cube_result["changed_fields"] == [], cube_result["message"]
 
@@ -8628,6 +8631,16 @@ class TestCubeRedeployIdempotence:
             "declares column 'hire_date'" in warning["message"]
             for warning in second["warnings"]
         ), second["warnings"]
+
+        # The same warning is also reported structurally, against the cube's
+        # rendered name (not the raw `${prefix}...` spec name), so a consumer
+        # can attach it to that node without parsing free text.
+        cube_warning_result = next(
+            result for result in cube_results if result["status"] == "warning"
+        )
+        assert cube_warning_result["operation"] == "noop"
+        assert "declares column 'hire_date'" in cube_warning_result["message"]
+        assert "${prefix}" not in cube_warning_result["message"]
 
 
 class TestDeploymentColumnOrdering:


### PR DESCRIPTION
Provide a structured warning with node info for unmatched cube columns.