### PR TITLE
Add `DELETE /tags/{name}/ endpoint`

### DIFF
--- a/datajunction-server/datajunction_server/api/tags.py
+++ b/datajunction-server/datajunction_server/api/tags.py
@@ -3,9 +3,10 @@ Tag related APIs.
 """
 
 from collections.abc import Callable
+from http import HTTPStatus
 
-from fastapi import Depends
-from sqlalchemy import select
+from fastapi import Depends, Response
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import noload
 
@@ -14,7 +15,11 @@ from datajunction_server.database import Node, NodeRevision
 from datajunction_server.database.history import History
 from datajunction_server.database.tag import Tag, TagNodeRelationship
 from datajunction_server.database.user import User
-from datajunction_server.errors import DJAlreadyExistsException, DJDoesNotExistException
+from datajunction_server.errors import (
+    DJActionNotAllowedException,
+    DJAlreadyExistsException,
+    DJDoesNotExistException,
+)
 from datajunction_server.internal.access.authentication.http import SecureAPIRouter
 from datajunction_server.internal.history import ActivityType, EntityType
 from datajunction_server.models.node import NodeMinimumDetail
@@ -63,7 +68,7 @@ async def get_tag_by_name(
         )
     tag = (await session.execute(statement)).scalars().one_or_none()
     if not tag and raise_if_not_exists:
-        raise DJDoesNotExistException(  # pragma: no cover
+        raise DJDoesNotExistException(
             message=(f"A tag with name `{name}` does not exist."),
             http_status_code=404,
         )
@@ -191,6 +196,54 @@ async def update_a_tag(
     await session.commit()
     await session.refresh(tag)
     return tag
+
+
+@router.delete("/tags/{name}/", status_code=HTTPStatus.NO_CONTENT)
+async def delete_a_tag(
+    name: str,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+    save_history: Callable = Depends(get_save_history),
+):
+    """
+    Delete a tag. Only tags with no nodes attached can be deleted.
+    """
+    tag = await get_tag_by_name(
+        session,
+        name,
+        raise_if_not_exists=True,
+        for_update=True,
+    )
+    attached_nodes = (
+        await session.execute(
+            select(func.count())
+            .select_from(TagNodeRelationship)
+            .join(Node, Node.id == TagNodeRelationship.node_id)
+            .where(TagNodeRelationship.tag_id == tag.id)
+            .where(Node.deactivated_at.is_(None)),
+        )
+    ).scalar_one()
+    if attached_nodes:
+        raise DJActionNotAllowedException(
+            message=(
+                f"Cannot delete tag `{name}` as it is still attached to "
+                f"{attached_nodes} node(s). Remove the tag from these nodes first."
+            ),
+            http_status_code=HTTPStatus.CONFLICT,
+        )
+
+    await save_history(
+        event=History(
+            entity_type=EntityType.TAG,
+            entity_name=tag.name,
+            activity_type=ActivityType.DELETE,
+            user=current_user.username,
+        ),
+        session=session,
+    )
+    await session.delete(tag)
+    await session.commit()
+    return Response(status_code=HTTPStatus.NO_CONTENT)
 
 
 @router.get("/tags/{name}/nodes/", response_model=list[NodeMinimumDetail])

--- a/datajunction-server/tests/api/tags_test.py
+++ b/datajunction-server/tests/api/tags_test.py
@@ -187,6 +187,66 @@ class TestTags:
         ] == [("update", "tag"), ("update", "tag"), ("create", "tag")]
 
     @pytest.mark.asyncio
+    async def test_delete_tag(self, module__client: AsyncClient) -> None:
+        """
+        Tests ``DELETE /tags/{name}/``
+        """
+        response = await self.create_tag(module__client)
+        assert response.status_code == 201
+
+        response = await module__client.delete("/tags/sales_report/")
+        assert response.status_code == 204
+
+        response = await module__client.get("/tags/sales_report/")
+        assert response.status_code == 404
+        assert (
+            response.json()["message"]
+            == "A tag with name `sales_report` does not exist."
+        )
+
+        # Check history
+        response = await module__client.get("/history/tag/sales_report/")
+        assert [
+            (activity["activity_type"], activity["entity_type"])
+            for activity in response.json()
+        ] == [("delete", "tag"), ("create", "tag")]
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_tag(self, module__client: AsyncClient) -> None:
+        """
+        Tests ``DELETE /tags/{name}/`` for a tag that doesn't exist
+        """
+        response = await module__client.delete("/tags/does_not_exist/")
+        assert response.status_code == 404
+        assert (
+            response.json()["message"]
+            == "A tag with name `does_not_exist` does not exist."
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_tag_with_nodes(self, client_with_dbt: AsyncClient) -> None:
+        """
+        Tests that ``DELETE /tags/{name}/`` refuses a tag that still has nodes
+        """
+        await self.create_tag(client_with_dbt)
+        response = await client_with_dbt.post(
+            "/nodes/default.items_sold_count/tags/?tag_names=sales_report",
+        )
+        assert response.status_code == 200
+
+        response = await client_with_dbt.delete("/tags/sales_report/")
+        assert response.status_code == 409
+        assert response.json()["message"] == (
+            "Cannot delete tag `sales_report` as it is still attached to 1 node(s). "
+            "Remove the tag from these nodes first."
+        )
+
+        # Deactivated nodes don't block the delete
+        await client_with_dbt.delete("/nodes/default.items_sold_count")
+        response = await client_with_dbt.delete("/tags/sales_report/")
+        assert response.status_code == 204
+
+    @pytest.mark.asyncio
     async def test_list_tags(self, module__client: AsyncClient) -> None:
         """
         Test ``GET /tags``

--- a/datajunction-server/tests/test_route_coverage.py
+++ b/datajunction-server/tests/test_route_coverage.py
@@ -93,6 +93,7 @@ INTENTIONAL_EXCLUSIONS: dict[str, list[tuple[str, str]]] = {
         ("POST", "/engines"),
         ("POST", "/tags"),
         ("PATCH", "/tags/{name}"),
+        ("DELETE", "/tags/{name}"),
         ("POST", "/attributes"),
         ("POST", "/measures"),
         ("PATCH", "/measures/{measure_name}"),


### PR DESCRIPTION
### Summary

Adds an endpoint for deleting tags, which returns 204. A tag that still has active nodes tagged with it will refuse deletion with a 409.

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
