### PR TITLE
Distinguish a pre-existing failure from a new one

### DIFF
--- a/datajunction-clients/python/datajunction/models.py
+++ b/datajunction-clients/python/datajunction/models.py
@@ -406,6 +406,9 @@ class DeploymentResult:
     deploy_type: str = ""
     change_tier: Literal["none", "minor", "major"] | None = None
     semantic_fingerprint: SemanticFingerprintValue | None = None
+    # True when the node was re-deployed only to retry a pre-existing failure.
+    # None on responses from servers that predate the field.
+    revalidation_only: bool | None = None
 
     @classmethod
     def from_dict(cls, d: dict) -> DeploymentResult:
@@ -419,6 +422,7 @@ class DeploymentResult:
             deploy_type=d.get("deploy_type", ""),
             change_tier=d.get("change_tier"),
             semantic_fingerprint=_parse_semantic_fingerprint(fingerprint),
+            revalidation_only=d.get("revalidation_only"),
         )
 
 

--- a/datajunction-clients/python/tests/test_deploy.py
+++ b/datajunction-clients/python/tests/test_deploy.py
@@ -1418,6 +1418,7 @@ class TestGetImpact:
                         "version": 1,
                         "digest": "a" * 64,
                     },
+                    "revalidation_only": True,
                 },
             ],
             "downstream_impacts": [
@@ -1448,6 +1449,7 @@ class TestGetImpact:
         parsed = DeploymentInfo.from_dict(result)
         assert parsed.results[0].deploy_type == "node"
         assert parsed.results[0].change_tier == "none"
+        assert parsed.results[0].revalidation_only is True
         assert parsed.results[0].semantic_fingerprint == SemanticFingerprint(
             digest="a" * 64,
         )

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -386,6 +386,8 @@ class DeploymentOrchestrator:
         self._cubes_bumped_by_upstream: dict[str, list[str]] = {}
         # Node name -> the tier its change earned, for those cubes to inherit.
         self._change_tiers: dict[str, ChangeTier] = {}
+        # Unchanged nodes re-deployed only to retry a pre-existing failure.
+        self._revalidation_only: set[str] = set()
         self._current_semantic_fingerprints: FingerprintMap = {}
         self._proposed_semantic_fingerprints: FingerprintMap = {}
 
@@ -3999,6 +4001,7 @@ class DeploymentOrchestrator:
                 semantic_fingerprint=self._proposed_semantic_fingerprints.get(
                     cube_spec.rendered_name,
                 ),
+                revalidation_only=cube_spec.rendered_name in self._revalidation_only,
             )
 
             deployment_results.append(deployment_result)
@@ -4415,6 +4418,10 @@ class DeploymentOrchestrator:
         version. So `force` and the INVALID re-deploy below can re-process a node
         without that implying anything about what changed.
 
+        Nodes re-processed only by that INVALID re-deploy are recorded in
+        `_revalidation_only`, which each node's `DeploymentResult` carries so a
+        caller can tell a failure this deployment caused from one it inherited.
+
         A cube whose own spec is unchanged is still processed when something
         upstream of it is changing, matching what `_propagate_update_downstream`
         does for a `PATCH`: the cube names the same metrics and dimensions, but
@@ -4424,6 +4431,7 @@ class DeploymentOrchestrator:
         to_create: list[NodeSpec] = []
         to_update: list[NodeSpec] = []
         to_skip: list[NodeSpec] = []
+        revalidation_only: set[str] = set()
         force = self.deployment_spec.force
         for node_spec in self.deployment_spec.nodes:
             existing_spec = existing_nodes_map.get(node_spec.rendered_name)
@@ -4461,9 +4469,11 @@ class DeploymentOrchestrator:
                     and existing_node.current.status == NodeStatus.INVALID
                 ):
                     to_update.append(node_spec)
+                    revalidation_only.add(node_spec.rendered_name)
                 else:
                     to_skip.append(node_spec)
 
+        self._revalidation_only = revalidation_only
         changed_names = {spec.rendered_name for spec in to_create + to_update}
         self._cubes_bumped_by_upstream = self._cubes_below_changed_nodes(
             to_skip,
@@ -5089,6 +5099,7 @@ class DeploymentOrchestrator:
             semantic_fingerprint=self._proposed_semantic_fingerprints.get(
                 result.spec.rendered_name,
             ),
+            revalidation_only=result.spec.rendered_name in self._revalidation_only,
         )
         return deployment_result, new_node, new_revision
 

--- a/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
+++ b/datajunction-server/datajunction_server/internal/deployment/orchestrator.py
@@ -4418,9 +4418,8 @@ class DeploymentOrchestrator:
         version. So `force` and the INVALID re-deploy below can re-process a node
         without that implying anything about what changed.
 
-        Nodes re-processed only by that INVALID re-deploy are recorded in
-        `_revalidation_only`, which each node's `DeploymentResult` carries so a
-        caller can tell a failure this deployment caused from one it inherited.
+        Those re-deployed only for that retry are recorded in `_revalidation_only`
+        and marked on their `DeploymentResult`.
 
         A cube whose own spec is unchanged is still processed when something
         upstream of it is changing, matching what `_propagate_update_downstream`

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -1783,6 +1783,14 @@ class DeploymentResult(BaseModel):
     changed_fields: list[str] = Field(default_factory=list)
     change_tier: ChangeTierName | None = None
     semantic_fingerprint: SemanticFingerprintValue | None = None
+    # True when the node carried no change and was re-deployed only to retry a
+    # pre-existing failure, so an INVALID result here is not this deployment's
+    # doing. It is not on its own enough to excuse a failure: failure reasons are
+    # not compared, so a node whose own spec never moved can fail for a new
+    # reason caused by an edit upstream of it -- that shows up in
+    # `downstream_impacts`. Nullable so that rows persisted before the field
+    # existed still rehydrate from JSON.
+    revalidation_only: bool | None = None
 
 
 class DeploymentInfo(BaseModel):

--- a/datajunction-server/datajunction_server/models/deployment.py
+++ b/datajunction-server/datajunction_server/models/deployment.py
@@ -1783,13 +1783,8 @@ class DeploymentResult(BaseModel):
     changed_fields: list[str] = Field(default_factory=list)
     change_tier: ChangeTierName | None = None
     semantic_fingerprint: SemanticFingerprintValue | None = None
-    # True when the node carried no change and was re-deployed only to retry a
-    # pre-existing failure, so an INVALID result here is not this deployment's
-    # doing. It is not on its own enough to excuse a failure: failure reasons are
-    # not compared, so a node whose own spec never moved can fail for a new
-    # reason caused by an edit upstream of it -- that shows up in
-    # `downstream_impacts`. Nullable so that rows persisted before the field
-    # existed still rehydrate from JSON.
+    # True when the node was re-deployed only to retry a pre-existing failure.
+    # Failure reasons are not compared. Nullable for older persisted rows.
     revalidation_only: bool | None = None
 
 

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1331,7 +1331,18 @@ def deployment_payload(deployment_spec: DeploymentSpec) -> dict:
     return deployment_spec.model_dump()
 
 
-async def deploy_and_wait(client, deployment_spec: DeploymentSpec):
+# Fields added to `DeploymentResult` after the exact-dict assertions below were
+# written. Stripped rather than asserted, so one more additive field does not
+# mean editing every expected dict in this file.
+ADDITIVE_RESULT_FIELDS = (
+    "change_tier",
+    "semantic_fingerprint",
+    "revalidation_only",
+)
+
+
+async def deploy_and_poll(client, deployment_spec: DeploymentSpec):
+    """Deploy and wait, keeping every field the API returned."""
     response = await client.post(
         "/deployments",
         json=deployment_payload(deployment_spec),
@@ -1345,11 +1356,15 @@ async def deploy_and_wait(client, deployment_spec: DeploymentSpec):
         await asyncio.sleep(1)
         response = await client.get(f"/deployments/{deployment_uuid}")
         data = response.json()
+    return data
+
+
+async def deploy_and_wait(client, deployment_spec: DeploymentSpec):
+    data = await deploy_and_poll(client, deployment_spec)
     for result in data.get("results", []):
-        assert "change_tier" in result
-        assert "semantic_fingerprint" in result
-        result.pop("change_tier", None)
-        result.pop("semantic_fingerprint", None)
+        for additive in ADDITIVE_RESULT_FIELDS:
+            assert additive in result
+            result.pop(additive)
     return data
 
 
@@ -1434,6 +1449,69 @@ class TestDeployments:
         link_result = next(r for r in data["results"] if r["deploy_type"] == "link")
         assert f"{namespace}.default.us_state" in link_result["name"]
         assert link_result["status"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_revalidation_only_marks_pre_existing_failures(self, client):
+        """
+        An unchanged node re-deployed only to retry a pre-existing failure is
+        marked `revalidation_only`, so a caller can tell the failures this
+        deployment caused from the ones it inherited -- and still sees the
+        recovery when a later deploy fixes the node's upstream.
+        """
+        namespace = "revalidation_only"
+        transform = TransformSpec(
+            name="${prefix}default.repair_totals",
+            query="SELECT repair_order_id, price FROM ${prefix}default.repairs",
+            owners=["dj"],
+        )
+        source = SourceSpec(
+            name="${prefix}default.repairs",
+            table="repairs",
+            catalog="default",
+            schema_="roads",
+            columns=[
+                ColumnSpec(name="repair_order_id", type="int"),
+                ColumnSpec(name="price", type="float"),
+            ],
+            owners=["dj"],
+        )
+
+        # The transform is created broken: its source is not in the deployment.
+        data = await deploy_and_poll(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=[transform]),
+        )
+        created = next(r for r in data["results"] if r["deploy_type"] == "node")
+        assert created["status"] == "invalid"
+        assert created["operation"] == "create"
+        assert created["revalidation_only"] is False
+
+        # Re-deploying the same spec retries the node, which is still broken.
+        data = await deploy_and_poll(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=[transform]),
+        )
+        retried = next(r for r in data["results"] if r["deploy_type"] == "node")
+        assert retried["status"] == "invalid"
+        assert retried["operation"] == "update"
+        assert retried["revalidation_only"] is True
+
+        # Adding the missing source fixes the node, which reports as a success.
+        data = await deploy_and_poll(
+            client,
+            DeploymentSpec(namespace=namespace, nodes=[transform, source]),
+        )
+        recovered = next(
+            r
+            for r in data["results"]
+            if r["name"] == f"{namespace}.default.repair_totals"
+        )
+        assert recovered["status"] == "success"
+        assert recovered["revalidation_only"] is True
+        added_source = next(
+            r for r in data["results"] if r["name"] == f"{namespace}.default.repairs"
+        )
+        assert added_source["revalidation_only"] is False
 
     @pytest.mark.asyncio
     async def test_deploy_failed_on_non_existent_link_deps(

--- a/datajunction-server/tests/api/deployments_test.py
+++ b/datajunction-server/tests/api/deployments_test.py
@@ -1331,9 +1331,7 @@ def deployment_payload(deployment_spec: DeploymentSpec) -> dict:
     return deployment_spec.model_dump()
 
 
-# Fields added to `DeploymentResult` after the exact-dict assertions below were
-# written. Stripped rather than asserted, so one more additive field does not
-# mean editing every expected dict in this file.
+# Additive `DeploymentResult` fields, stripped rather than asserted below.
 ADDITIVE_RESULT_FIELDS = (
     "change_tier",
     "semantic_fingerprint",

--- a/datajunction-server/tests/api/git_test.py
+++ b/datajunction-server/tests/api/git_test.py
@@ -4410,11 +4410,20 @@ class TestCopyNodesToNamespace:
                 result["semantic_fingerprint"]["version"] == 1
                 for result in data["deployment_results"]
             )
+            assert all(
+                result["revalidation_only"] is False
+                for result in data["deployment_results"]
+            )
             deployment_results = [
                 {
                     key: value
                     for key, value in result.items()
-                    if key not in {"change_tier", "semantic_fingerprint"}
+                    if key
+                    not in {
+                        "change_tier",
+                        "semantic_fingerprint",
+                        "revalidation_only",
+                    }
                 }
                 for result in data["deployment_results"]
             ]

--- a/datajunction-server/tests/internal/deployment/orchestration_test.py
+++ b/datajunction-server/tests/internal/deployment/orchestration_test.py
@@ -841,6 +841,35 @@ class TestDeploymentPlanning:
         assert len(to_skip) == len(sample_deployment_spec.nodes)
         assert to_delete == []
 
+    def test_filter_nodes_records_revalidation_only(
+        self,
+        orchestrator,
+        sample_deployment_spec,
+    ):
+        """An unchanged node that is stuck INVALID is queued for revalidation."""
+        existing_specs = {
+            node.rendered_name: node for node in sample_deployment_spec.nodes
+        }
+        stuck = sample_deployment_spec.nodes[1]
+        orchestrator.registry.add_nodes(
+            {
+                stuck.rendered_name: SimpleNamespace(
+                    current=SimpleNamespace(
+                        status=NodeStatus.INVALID,
+                        parents=[],
+                    ),
+                ),
+            },
+        )
+        to_deploy, to_skip, _ = orchestrator.filter_nodes_to_deploy(existing_specs)
+        assert to_deploy == [stuck]
+        assert orchestrator._revalidation_only == {stuck.rendered_name}
+        assert [spec.rendered_name for spec in to_skip] == [
+            spec.rendered_name
+            for spec in sample_deployment_spec.nodes
+            if spec is not stuck
+        ]
+
     def test_filter_nodes_uses_normalized_query_and_source_columns(self):
         incoming = [
             TransformSpec(name="transform", query=" SELECT id\nFROM source "),


### PR DESCRIPTION
### Summary

A node with an unchanged spec but an invalid status gets promoted into the update set on every deployment so that it has a chance to revalidate (since something outside this deployment may have since fixed it), but it also makes an already-broken, untouched node indistinguishable from one the current change actually broke. That meant a deployment could fail on nodes its own diff never touched.

This adds a revalidation_only flag to mark exactly that case, so a caller can tell "this deployment caused the failure" from "this deployment inherited it," while still surfacing the recovery when a later deploy fixes the upstream problem. 

### Test Plan

<!-- How did you test your change? -->

- [ ] PR has an associated issue: #
- [ ] `make check` passes
- [ ] `make test` shows 100% unit test coverage

### Deployment Plan

<!-- Any special instructions around deployment? -->
